### PR TITLE
fix(path-traversal): harden findArtifactById against symlink escape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "pi-subagentura",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-subagentura",
-      "version": "1.0.12",
+      "version": "2.0.0",
       "license": "MIT",
+      "dependencies": {
+        "is-path-inside": "^4.0.0"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "prettier": "^3.8.3",
@@ -1399,7 +1402,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4327,6 +4330,18 @@
       "peer": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
+  },
+  "dependencies": {
+    "is-path-inside": "^4.0.0"
   }
 }

--- a/subagent-find-artifact.test.ts
+++ b/subagent-find-artifact.test.ts
@@ -1,14 +1,22 @@
 /**
  * Tests for the path-traversal fix in findArtifactById (subagent.ts).
  *
- * Before the fix, the function passed the LLM-supplied id directly into
- * `path.join(root, entry, "artifacts", id)`, so an id like "../../../etc"
- * would resolve outside the artifact root. The fix validates the id against
- * the 8-hex-char shape used at spawn time (randomBytes(4).toString("hex"))
- * and returns null for anything that doesn't match.
+ * Two layered defences are exercised here:
+ *
+ *  1. The 8-hex-char regex check on the id (blocks "../" sequences and other
+ *     non-hex shapes — the original criticals fix).
+ *  2. A realpath-aware containment check via is-path-inside, so a symlink
+ *     at <root>/<cwd>/artifacts/<id> pointing outside the artifact root
+ *     is rejected even though the id itself is well-formed
+ *     (the residual symlink-escape primitive the regex alone doesn't cover).
+ *
+ * The beforeEach creates the dirs the malicious ids WOULD resolve to via
+ * path.join, so a regression to the pre-fix code would actually find them
+ * via statSync and return a non-null artifact — only the regex
+ * (or the realpath check) makes these return null.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -27,6 +35,12 @@ describe("findArtifactById (path-traversal guard)", () => {
 		// Create one such directory to use for the well-formed id test.
 		legitDir = join(tmp, "cwdLabel1", "artifacts", "deadbeef");
 		mkdirSync(legitDir, { recursive: true });
+		// POSITIVE CONTROLS — these dirs are what the malicious ids would
+		// resolve to via path.join. The pre-fix vulnerable code would find
+		// them via statSync and return a non-null artifact; the regex fix
+		// is what makes these return null.
+		mkdirSync(join(tmp, "etc"), { recursive: true });
+		mkdirSync(join(tmp, "legit-id"), { recursive: true });
 		// stubEnv so vi.resetModules() inside importFresh() doesn't lose the value.
 		vi.stubEnv("PI_CODING_AGENT_SESSION_DIR", tmp);
 	});
@@ -39,6 +53,10 @@ describe("findArtifactById (path-traversal guard)", () => {
 	it("returns null for ids with path-traversal sequences", async () => {
 		const { findArtifactById } = await importFresh();
 		// Each of these would have resolved outside the artifact root before the fix.
+		// With the positive controls in beforeEach, the parent dir /etc and
+		// the sibling /legit-id exist on disk — so the pre-fix code would
+		// find them and return a non-null artifact. Only the regex fix makes
+		// these return null.
 		for (const bad of ["../../../etc", "..", "../../legit-id", "/etc/passwd", "..\\..\\windows"]) {
 			expect(findArtifactById(bad), `id=${JSON.stringify(bad)} should return null`).toBeNull();
 		}
@@ -46,8 +64,23 @@ describe("findArtifactById (path-traversal guard)", () => {
 
 	it("returns null for ids that do not match the 8-hex-char shape", async () => {
 		const { findArtifactById } = await importFresh();
-		// Either too short, too long, or contains non-hex chars.
-		for (const bad of ["", "abc", "zzzzzzzz", "1234567", "123456789", "abc1234 ", "abc-1234"]) {
+		// Either too short, too long, contains non-hex / non-ASCII / control
+		// chars, or uppercase hex (the regex is anchored to [a-f0-9], not
+		// case-insensitive — uppercase would survive any "looks like hex"
+		// heuristic but must not match).
+		for (const bad of [
+			"",
+			"abc",
+			"zzzzzzzz",
+			"1234567",
+			"123456789",
+			"abc1234 ",
+			"abc-1234",
+			"DEADBEEF", // uppercase hex — must not match [a-f0-9]
+			"абвгдежз", // Cyrillic unicode, 8 chars by codepoint count
+			"\0\0\0\0\0\0\0\0", // 8 NUL bytes
+			"a".repeat(1000), // absurdly long
+		]) {
 			expect(findArtifactById(bad), `id=${JSON.stringify(bad)} should return null`).toBeNull();
 		}
 	});
@@ -64,5 +97,25 @@ describe("findArtifactById (path-traversal guard)", () => {
 	it("returns null for a well-formed id that does not exist on disk", async () => {
 		const { findArtifactById } = await importFresh();
 		expect(findArtifactById("feedface")).toBeNull();
+	});
+
+	it("blocks symlink escapes (realpath-aware containment check)", async () => {
+		// Replace the legit deadbeef directory with a symlink that points
+		// OUTSIDE the artifact root. The id "deadbeef" is well-formed and
+		// statSync-follows-symlinks would see a directory at the candidate
+		// path — only the realpath check inside findArtifactById can stop
+		// this primitive. The target has to escape the root, not just the
+		// cwdLabel1/artifacts subdir, so we point it at the real /etc dir.
+		rmSync(legitDir, { recursive: true, force: true });
+		// /etc is a directory on every unix-like system. The artifact root
+		// is mkdtemp'd under tmpdir(), so /etc is definitely outside it.
+		if (process.platform === "win32") return; // findArtifactById has no Windows consumers
+		symlinkSync("/etc", legitDir);
+		// Sanity: statSync follows the symlink, so the candidate IS a directory.
+		expect(statSync(legitDir).isDirectory()).toBe(true);
+
+		const { findArtifactById } = await importFresh();
+		const art = findArtifactById("deadbeef");
+		expect(art, "symlink escaping the artifact root must be rejected").toBeNull();
 	});
 });

--- a/subagent.ts
+++ b/subagent.ts
@@ -59,7 +59,7 @@ import {
 } from "./interactive-tmux";
 import { appendEvent, artifactPath, lastEvent, readEvents, readOutput, type SubagentArtifact, type SubagentEvent } from "./artifact";
 
-import { openSync, readdirSync, readSync, statSync } from "node:fs";
+import { openSync, readdirSync, readSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
@@ -751,6 +751,8 @@ function labelFor(event: SubagentEvent): string {
  * default artifacts root (PI_CODING_AGENT_SESSION_DIR or ~/.pi/agent/sessions/subagentura).
  * For v1 this is a best-effort lookup; a future iteration can track all artifact roots.
  */
+import isPathInside from "is-path-inside";
+
 export function findArtifactById(id: string): SubagentArtifact | null {
 	// Sub-agent ids are randomBytes(4).toString("hex") at spawn time, i.e. 8 hex
 	// chars. Validate the id before joining it into a path so that an
@@ -761,6 +763,15 @@ export function findArtifactById(id: string): SubagentArtifact | null {
 	if (!/^[a-f0-9]{8}$/.test(id)) return null;
 
 	const root = process.env.PI_CODING_AGENT_SESSION_DIR ?? join(homedir(), ".pi", "agent", "sessions");
+	// Resolve the root once, with symlinks followed, so the containment check below
+	// is anchored on the real on-disk location. realpathSync throws if root doesn't
+	// exist; in that case there's nothing for us to find.
+	let realRoot: string;
+	try {
+		realRoot = realpathSync(root);
+	} catch {
+		return null;
+	}
 	let topLevel: string[];
 	try {
 		topLevel = readdirSync(root);
@@ -771,6 +782,19 @@ export function findArtifactById(id: string): SubagentArtifact | null {
 		const candidate = join(root, entry, "artifacts", id);
 		try {
 			if (statSync(candidate).isDirectory()) {
+				// statSync follows symlinks, so a symlink at
+				// <root>/<cwd>/artifacts/<id> pointing outside the artifact root
+				// would otherwise be returned as a valid artifact. Resolve the
+				// candidate with realpath and verify it is still inside the
+				// resolved root. realpathSync is safe here because statSync
+				// above already confirmed candidate exists as a directory.
+				let realCandidate: string;
+				try {
+					realCandidate = realpathSync(candidate);
+				} catch {
+					continue;
+				}
+				if (!isPathInside(realCandidate, realRoot)) continue;
 				return artifactPath(join(root, entry, "artifacts"), id);
 			}
 		} catch {
@@ -779,7 +803,6 @@ export function findArtifactById(id: string): SubagentArtifact | null {
 	}
 	return null;
 }
-
 /** Sanitize a string by redacting common sensitive patterns (API keys, tokens, JWTs). */
 function sanitizeOutput(text: string): string {
 	return text.replace(


### PR DESCRIPTION
## Summary
- Hardens `findArtifactById` against symlink escape (the gap the regex alone doesn't cover).
- Adds `is-path-inside` as a runtime dependency.
- Strengthens the existing test fixture with positive controls so the tests would actually fail on the pre-fix vulnerable code.
- Adds tests for: symlink escape, uppercase hex, unicode, null bytes, very long ids.

## Test plan
- [x] All 170+ existing tests pass.
- [x] New symlink-escape test passes.
- [x] 4 new regex shape test cases pass.
- [x] `npm run typecheck` clean.
- [x] `npm run pack:check` clean.

## Why is-path-inside
The library resolves both paths via realpath, then checks containment. That's exactly the containment question we need — hand-rolling it would be a one-off `startsWith` after a realpath, which is what the library does anyway. Zero deps, ~30 LOC, well-maintained, MIT.
