### PR TITLE
fix: truncation handling, invalid-id error, test util dedup

### DIFF
--- a/interactive-tmux.test.ts
+++ b/interactive-tmux.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, readFileSync, rmSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { importFresh } from "./test-utils";
 
 /** Standard tmux pane id returned by mocks when "new-window"/"split-window" is called. */
 const MOCK_PANE_ID = "%42";
@@ -37,7 +38,7 @@ describe("interactive-tmux", () => {
 
   it("is unavailable when TMUX env var is missing", async () => {
     process.env.TMUX = "";
-    const { isTmuxAvailable } = await importFresh();
+    const { isTmuxAvailable } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     expect(isTmuxAvailable()).toBe(false);
   });
 
@@ -56,7 +57,7 @@ describe("interactive-tmux", () => {
       return "";
     });
 
-    const mod = await importFresh();
+    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     // No `background` flag — should default to true (hidden).
     const state = mod.launchInteractiveSubagent({
       name: "Demo",
@@ -111,7 +112,7 @@ describe("interactive-tmux", () => {
       return "";
     });
 
-    const mod = await importFresh();
+    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     const state = mod.launchInteractiveSubagent({
       name: "Demo",
       task: "Run tests",
@@ -161,7 +162,7 @@ describe("interactive-tmux", () => {
       };
     });
 
-    const mod = await importFresh();
+    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     expect(() =>
       mod.launchInteractiveSubagent({
         name: "Demo",
@@ -189,7 +190,7 @@ describe("interactive-tmux", () => {
       if (args[0] === "show-options") return "0\n";
       return "";
     });
-    const mod1 = await importFresh();
+    const mod1 = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     expect(mod1.readPaneExitCode(MOCK_PANE_ID)).toBe(0);
 
     // Mock returning empty string (option not yet set).
@@ -197,7 +198,7 @@ describe("interactive-tmux", () => {
       if (args[0] === "show-options") return "\n";
       return "";
     });
-    const mod2 = await importFresh();
+    const mod2 = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     expect(mod2.readPaneExitCode(MOCK_PANE_ID)).toBeNull();
 
     // Mock throwing (pane dead / option unset).
@@ -205,7 +206,7 @@ describe("interactive-tmux", () => {
       if (args[0] === "show-options") throw new Error("no such pane");
       return "";
     });
-    const mod3 = await importFresh();
+    const mod3 = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     expect(mod3.readPaneExitCode(MOCK_PANE_ID)).toBeNull();
   });
 
@@ -226,7 +227,7 @@ describe("interactive-tmux", () => {
       },
     }));
 
-    const mod = await importFresh();
+    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     expect(mod.readPaneExitCode(MOCK_PANE_ID)).toBeNull();
 
     // The execFileSync call must use stdio that explicitly ignores stderr.
@@ -245,7 +246,7 @@ describe("interactive-tmux", () => {
     process.env.PI_CODING_AGENT_SESSION_DIR = makeTmp();
     process.env.TMUX = makeArgs().TMUX;
 
-    const mod = await importFresh();
+    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
     const { appendEvent, artifactPath } = await import("./artifact");
     const { mkdirSync } = await import("node:fs");
 
@@ -311,20 +312,20 @@ describe("interactive-tmux", () => {
 
   describe("CHILD_SUBAGENT_PROTOCOL", () => {
     it("names all three completion signals (done / error / cancelled)", async () => {
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh();
+      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       expect(CHILD_SUBAGENT_PROTOCOL).toContain("done");
       expect(CHILD_SUBAGENT_PROTOCOL).toContain("error");
       expect(CHILD_SUBAGENT_PROTOCOL).toContain("cancelled");
     });
 
     it("points the child to the two artifact paths", async () => {
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh();
+      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       expect(CHILD_SUBAGENT_PROTOCOL).toContain("$ARTIFACT_DIR/output.md");
       expect(CHILD_SUBAGENT_PROTOCOL).toContain("$ARTIFACT_DIR/cli.mjs");
     });
 
     it("tells the child to keep the REPL open after done", async () => {
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh();
+      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       expect(CHILD_SUBAGENT_PROTOCOL).toMatch(/REPL stays open/i);
       expect(CHILD_SUBAGENT_PROTOCOL).toMatch(/do not exit/i);
     });
@@ -351,8 +352,8 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh();
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh();
+      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const state = mod.launchInteractiveSubagent({ name: "NoPersona", task: "x", cwd: tmp });
       const sysFile = join(state.artifactDir, "nopersona-system.md");
 
@@ -376,7 +377,7 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh();
+      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const state = mod.launchInteractiveSubagent({
         name: "WithPersona",
         task: "x",
@@ -402,7 +403,7 @@ describe("interactive-tmux", () => {
 
       installMockExec(() => MOCK_PANE_ID + "\n");
 
-      const mod = await importFresh();
+      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const tooBig = "x".repeat(64 * 1024 + 1);
       let threw = false;
       try {
@@ -439,7 +440,7 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh();
+      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const state = mod.launchInteractiveSubagent({ name: "Wire", task: "x", cwd: tmp });
 
       const launchScript = readFileSync(state.launchScriptFile, "utf8");
@@ -451,13 +452,13 @@ describe("interactive-tmux", () => {
 
   describe("buildPiInteractiveCommand", () => {
     it("starts with `cd <cwd> &&` and shell-escapes the cwd", async () => {
-      const { buildPiInteractiveCommand } = await importFresh();
+      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/tmp/has space" });
       expect(cmd).toMatch(/^cd '\/tmp\/has space' &&/);
     });
 
     it("includes --session, --name, and the @<promptFile>", async () => {
-      const { buildPiInteractiveCommand } = await importFresh();
+      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c" });
       expect(cmd).toContain("--session '/s.jsonl'");
       expect(cmd).toContain("--name 'n'");
@@ -467,19 +468,19 @@ describe("interactive-tmux", () => {
     });
 
     it("omits --model when undefined", async () => {
-      const { buildPiInteractiveCommand } = await importFresh();
+      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c" });
       expect(cmd).not.toContain("--model");
     });
 
     it("includes --model when set, escaped", async () => {
-      const { buildPiInteractiveCommand } = await importFresh();
+      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c", model: "p/m" });
       expect(cmd).toContain("--model 'p/m'");
     });
 
     it("includes --append-system-prompt when systemPromptFile is set", async () => {
-      const { buildPiInteractiveCommand } = await importFresh();
+      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c", systemPromptFile: "/s.md" });
       expect(cmd).toContain("--append-system-prompt");
       expect(cmd).toContain("/s.md");
@@ -487,9 +488,4 @@ describe("interactive-tmux", () => {
   });
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-tmux-"));
-}
-
-async function importFresh() {
-  vi.resetModules();
-  return import("./interactive-tmux");
 }

--- a/subagent-find-artifact.test.ts
+++ b/subagent-find-artifact.test.ts
@@ -11,11 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-async function importFresh() {
-	vi.resetModules();
-	return import("./subagent");
-}
+import { importFresh } from "./test-utils";
 
 describe("findArtifactById (path-traversal guard)", () => {
 	let tmp: string;
@@ -37,7 +33,7 @@ describe("findArtifactById (path-traversal guard)", () => {
 	});
 
 	it("returns null for ids with path-traversal sequences", async () => {
-		const { findArtifactById } = await importFresh();
+		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
 		// Each of these would have resolved outside the artifact root before the fix.
 		for (const bad of ["../../../etc", "..", "../../legit-id", "/etc/passwd", "..\\..\\windows"]) {
 			expect(findArtifactById(bad), `id=${JSON.stringify(bad)} should return null`).toBeNull();
@@ -45,7 +41,7 @@ describe("findArtifactById (path-traversal guard)", () => {
 	});
 
 	it("returns null for ids that do not match the 8-hex-char shape", async () => {
-		const { findArtifactById } = await importFresh();
+		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
 		// Either too short, too long, or contains non-hex chars.
 		for (const bad of ["", "abc", "zzzzzzzz", "1234567", "123456789", "abc1234 ", "abc-1234"]) {
 			expect(findArtifactById(bad), `id=${JSON.stringify(bad)} should return null`).toBeNull();
@@ -55,14 +51,14 @@ describe("findArtifactById (path-traversal guard)", () => {
 	it("returns the artifact for a well-formed id when present on disk", async () => {
 		// Sanity-check the fixture: the directory we created should be a directory.
 		expect(statSync(legitDir).isDirectory()).toBe(true);
-		const { findArtifactById } = await importFresh();
+		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
 		const art = findArtifactById("deadbeef");
 		expect(art, "well-formed id with matching dir on disk should be found").not.toBeNull();
 		expect(art!.id).toBe("deadbeef");
 	});
 
 	it("returns null for a well-formed id that does not exist on disk", async () => {
-		const { findArtifactById } = await importFresh();
+		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
 		expect(findArtifactById("feedface")).toBeNull();
 	});
 });

--- a/subagent-notify.test.ts
+++ b/subagent-notify.test.ts
@@ -1033,3 +1033,41 @@ describe("notifyOnComplete", () => {
     });
   });
 });
+
+describe("read_subagent_artifact (invalid id)", () => {
+  /** Build the minimal ExtensionAPI mock and capture the tool def. */
+  function setupReadArtifactTool() {
+    const _api = {
+      registerTool: vi.fn(),
+      registerMessageRenderer: vi.fn(),
+      sendMessage: vi.fn(),
+      sendUserMessage: vi.fn(),
+      on: vi.fn(),
+    };
+    registerExtension(_api as any);
+    return _api.registerTool.mock.calls.find(([t]: any[]) => t.name === "read_subagent_artifact")?.[0];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanGlobals();
+  });
+
+  afterEach(() => {
+    cleanGlobals();
+  });
+
+  it("returns status:invalid_id with a precise message for a malformed id", async () => {
+    const toolDef = setupReadArtifactTool();
+    expect(toolDef).toBeDefined();
+
+    const result = await toolDef.execute("call-malformed", { id: "not-a-hex-id" }, undefined, undefined, {} as any);
+
+    expect(result.isError).toBe(true);
+    expect(result.details.status).toBe("invalid_id");
+    expect(result.details.id).toBe("not-a-hex-id");
+    const text = result.content[0].text;
+    expect(text).toContain("Invalid sub-agent id");
+    expect(text).toContain("not-a-hex-id");
+  });
+});

--- a/subagent-poll.test.ts
+++ b/subagent-poll.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendEvent, artifactPath } from "./artifact";
+import { importFresh } from "./test-utils";
 
 function makeTmp(): string {
 	return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
@@ -49,14 +50,14 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("does nothing when registry is empty", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const sendMessage = vi.fn();
 		mod.pollArtifactChanges({ sendMessage } as any);
 		expect(sendMessage).not.toHaveBeenCalled();
 	});
 
 	it("fires a pointer notification on done. Started is silent.", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		mod.interactiveSubagentRegistry.set(state.id, state);
 		const art = artifactPath(join(artifactDir, ".."), state.id);
@@ -80,7 +81,7 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("does NOT fire on tool_activity/started", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		mod.interactiveSubagentRegistry.set(state.id, state);
 		const art = artifactPath(join(artifactDir, ".."), state.id);
@@ -97,7 +98,7 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("fires on error and cancelled too", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		mod.interactiveSubagentRegistry.set(state.id, state);
 		const art = artifactPath(join(artifactDir, ".."), state.id);
@@ -114,7 +115,7 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("is at-most-once per event (cursor advances)", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		mod.interactiveSubagentRegistry.set(state.id, state);
 		const art = artifactPath(join(artifactDir, ".."), state.id);
@@ -133,7 +134,7 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("delivers only events newer than lastDeliveredEventTs (backlog catch-up)", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		// Simulate a sub-agent that finished while the parent was down — events
 		// were already on disk before this poller started.
@@ -159,7 +160,7 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("marks the sub-agent as exited when a done event is seen", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		mod.interactiveSubagentRegistry.set(state.id, state);
 		const art = artifactPath(join(artifactDir, ".."), state.id);
@@ -172,7 +173,7 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("marks the sub-agent as cancelled when a cancelled event is seen", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		mod.interactiveSubagentRegistry.set(state.id, state);
 		const art = artifactPath(join(artifactDir, ".."), state.id);
@@ -183,7 +184,7 @@ describe("pollArtifactChanges", () => {
 	});
 
 	it("skips sub-agents that are not in 'running' status", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		state.status = "cancelled";
 		mod.interactiveSubagentRegistry.set(state.id, state);
@@ -196,7 +197,3 @@ describe("pollArtifactChanges", () => {
 	});
 });
 
-async function importFresh() {
-	vi.resetModules();
-	return import("./subagent");
-}

--- a/subagent-session-log.test.ts
+++ b/subagent-session-log.test.ts
@@ -11,11 +11,12 @@
  * at it, then call `pollArtifactChanges` and assert the appended events.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendEvent, artifactPath, readEvents } from "./artifact";
 import type { InteractiveSubagentState } from "./interactive-tmux";
+import { importFresh } from "./test-utils";
 
 function makeTmp(): string {
 	return mkdtempSync(join(tmpdir(), "pi-subagentura-session-log-"));
@@ -46,10 +47,6 @@ function makeState(overrides: {
 }
 
 
-async function importFresh() {
-	vi.resetModules();
-	return import("./subagent");
-}
 
 describe("session-log tail-read", () => {
 	let root: string;
@@ -67,7 +64,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("appends a tool_activity event for a bash tool call", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -110,7 +107,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("appends tool_activity for write, edit, read with file paths", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -140,7 +137,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("skips tools with no summary (grep, find, ls, custom)", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -166,7 +163,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("truncates long bash commands to 80 chars", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -192,7 +189,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("cursor advances — second poll with no new lines does not duplicate", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -219,7 +216,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("picks up new lines written between polls", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -258,7 +255,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("tolerates a partial trailing line without crashing", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -287,7 +284,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("re-reads a partial line once it is completed on a later poll", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -310,7 +307,6 @@ describe("session-log tail-read", () => {
 		// Second poll: child finishes writing the partial. We need to APPEND to
 		// the file (not rewrite) so the byte offset after the partial is
 		// unchanged.
-		const { appendFileSync } = await import("node:fs");
 		appendFileSync(state.sessionFile, "age\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"toolCall\",\"id\":\"t2\",\"name\":\"bash\",\"arguments\":{\"command\":\"ls\"}}]}}\n");
 
 
@@ -322,7 +318,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("does nothing when the session file does not exist yet", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state } = makeState({
 			sessionFile: "/tmp/does-not-exist-" + Math.random() + ".jsonl",
 		});
@@ -333,7 +329,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("updates state.lastToolSummary and lastActivityAt for the widget", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -355,7 +351,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("paints the TUI widget when ui ref is set", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state } = makeState({});
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
@@ -387,7 +383,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("clears the widget and footer when no sub-agents are running", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		// Empty registry.
 		const setStatus = vi.fn();
 		const setWidget = vi.fn();
@@ -400,7 +396,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("inlines the error message in the LLM notification but uses pointers on success", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 
 		mod.interactiveSubagentRegistry.set(state.id, state);
@@ -435,7 +431,7 @@ describe("session-log tail-read", () => {
 	});
 
 	it("truncates the inline error message to 500 chars", async () => {
-		const mod = await importFresh();
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState({});
 
 		mod.interactiveSubagentRegistry.set(state.id, state);
@@ -452,5 +448,20 @@ describe("session-log tail-read", () => {
 		const match = content.match(/x+/);
 		expect(match).not.toBeNull();
 		expect(match![0].length).toBeLessThanOrEqual(500);
+	});
+
+	it("resets the cursor when the session log is truncated below it", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({});
+		mod.interactiveSubagentRegistry.set(state.id, state);
+		// write 1KB of content, poll to advance cursor
+		writeFileSync(state.sessionFile, "x".repeat(1024) + "\n");
+		mod.pollArtifactChanges({} as any);
+		expect(state.lastDeliveredSessionByte).toBe(1025);
+		// truncate to 0, then write new content
+		writeFileSync(state.sessionFile, "new\n");
+		mod.pollArtifactChanges({} as any);
+		// cursor should have been reset, so it now points past the new content
+		expect(state.lastDeliveredSessionByte).toBe(4);
 	});
 });

--- a/subagent.ts
+++ b/subagent.ts
@@ -561,6 +561,12 @@ function tailReadSessionLog(state: InteractiveSubagentState, art: SubagentArtifa
 		return; // file not yet created by the child
 	}
 
+	// Truncation/rotation: if the file shrank below the cursor, reset.
+	// Otherwise the next read from the stale cursor would skip the new
+	// content written after rotation.
+	if (state.lastDeliveredSessionByte && size < state.lastDeliveredSessionByte) {
+		state.lastDeliveredSessionByte = 0;
+	}
 	const cursor = state.lastDeliveredSessionByte ?? 0;
 	if (size <= cursor) return;
 
@@ -1803,6 +1809,15 @@ export default function (pi: ExtensionAPI) {
     }),
 
     async execute(_toolCallId, params): Promise<any> {
+      // Validate the id shape FIRST so a malformed id gets a precise error
+      // instead of being collapsed into the generic "not found" message.
+      if (!/^[a-f0-9]{8}$/.test(params.id)) {
+        return {
+          content: [{ type: "text", text: `Invalid sub-agent id ${JSON.stringify(params.id)}; expected 8 lowercase hex chars.` }],
+          details: { id: params.id, status: "invalid_id" },
+          isError: true,
+        };
+      }
       const state = interactiveSubagentRegistry.get(params.id);
       const art = state
         ? artifactPath(dirname(state.artifactDir), basename(state.artifactDir))

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+
+/**
+ * Re-import a module under vitest, clearing the module cache first.
+ * Use this in tests that stub process.env or globalThis before import,
+ * or that need to re-evaluate module-level state.
+ */
+export async function importFresh<T = unknown>(specifier: string): Promise<T> {
+    vi.resetModules();
+    return import(specifier) as Promise<T>;
+}


### PR DESCRIPTION
## Summary
- `tailReadSessionLog`: reset cursor when the file shrinks below it.
- `read_subagent_artifact`: split `invalid_id` and `not_found` errors.
- Extract `importFresh` to a shared `test-utils.ts` (4 files deduped).
- Move a dynamic `appendFileSync` import to top-level.

## Test plan
- [x] All existing tests pass.
- [x] 2 new tests pass (truncation, invalid-id).
- [x] `npm run typecheck` clean.
- [x] `npm run pack:check` clean.