### PR TITLE
fix: embed artifact dir in sub-agent prompt + add inject mode to subagent_interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Parameters:
 - `cwd` — optional working directory
 - `includeContext` — include serialized parent conversation in the child prompt (default: `false`)
 - `background` — spawn in a detached named window (invisible) instead of a visible horizontal split. Default `true` — your tmux layout is undisturbed and you can attach later with the returned `select-window` command. Pass `background: false` for a side-by-side split you can watch in real time.
+- `notifyOnComplete` — `"inject"` (default) or `"notify"`; controls how the parent LLM is woken up on completion. See [Completion notifications: notify vs inject](#completion-notifications-notify-vs-inject) below.
 
 The sub-agent's work is **always** written to the artifact dir as `events.ndjson` (lifecycle log) and `output.md` (clean prose the child writes). The pane is for live monitoring; the artifact is the source of truth. The artifact survives parent restarts, so sub-agents that finish while you're away are picked up on the next poll.
 
@@ -167,12 +168,21 @@ The sub-agent's work is **always** written to the artifact dir as `events.ndjson
 Every interactive sub-agent receives a built-in system prompt that tells it how to signal completion. The child **must** call one of these when it has nothing more to add before waiting for the next user input:
 
 ```bash
-$ARTIFACT_DIR/cli.mjs done 0       # success — parent reads $ARTIFACT_DIR/output.md
+$ARTIFACT_DIR/cli.mjs done 0       # success — parent reads the literal output.md path baked into the child prompt
 $ARTIFACT_DIR/cli.mjs error "msg"  # unrecoverable failure
 # 'cancelled' is only set by the parent via cancel_interactive_subagent
 ```
 
-Write the final result to `$ARTIFACT_DIR/output.md` before calling `done`. After `done`, the REPL stays open and the child can be re-prompted via `tmux send-keys` to the pane. The parent gets a pointer notification on `done` / `error` / `cancelled` and reads the result via `read_subagent_artifact`. Tool calls and progress are visible in the TUI widget below the editor; no separate progress event is needed.
+The child's system prompt embeds the **literal absolute path** of the artifact dir at the top, e.g. `Your artifact directory is: /Users/.../artifacts/<id>`. Use that literal path in any `write` tool call (the `write` tool does not expand `$ARTIFACT_DIR`) — the bash examples above work because the launch script exports `ARTIFACT_DIR` to the shell. After `done`, the REPL stays open and the child can be re-prompted via `tmux send-keys` to the pane. The parent gets a pointer notification on `done` / `error` / `cancelled` and reads the result via `read_subagent_artifact`. Tool calls and progress are visible in the TUI widget below the editor; no separate progress event is needed.
+
+#### Completion notifications: notify vs inject
+
+Interactive sub-agents deliver their completion to the parent through one of two modes (selected via `notifyOnComplete`):
+
+- `"inject"` (**default** for `subagent_interactive`) — the sub-agent's `output.md` is pushed into the parent LLM's conversation as a new user message. The parent LLM gets a turn and can summarize, chain into the next step, or call more tools. Use this when the sub-agent's output is part of a multi-step pipeline.
+- `"notify"` — only a TUI hint is shown (status line + widget). The parent LLM is **not** woken up. The human has to prompt the parent manually to read the sub-agent's output. Use this for spawn-and-forget side-quests.
+
+Both modes share a `MAX_INJECT` cap of 5 concurrent injects. If more sub-agents finish at the same time, the rest degrade silently to `notify` (UI hint only) to keep the parent conversation from flooding. The cap is concurrent, not lifetime — once some injects settle, more can fire.
 
 
 #### `get_interactive_subagent_status`

--- a/interactive-tmux.test.ts
+++ b/interactive-tmux.test.ts
@@ -305,29 +305,59 @@ describe("interactive-tmux", () => {
 });
 
   // ------------------------------------------------------------------
-  // Tests for the child completion protocol (CHILD_SUBAGENT_PROTOCOL),
+  // Tests for the child completion protocol (buildChildSubagentProtocol),
   // the always-write system prompt behavior, the --append-system-prompt
   // wiring, and the buildPiInteractiveCommand CLI builder.
   // ------------------------------------------------------------------
 
-  describe("CHILD_SUBAGENT_PROTOCOL", () => {
+  describe("buildChildSubagentProtocol", () => {
+    // Fixture artifact dir used by the protocol tests. The function bakes the
+    // path into the rendered prompt, so each test asserts against the same value.
+    const FIXTURE_DIR = "/tmp/pi-subagentura-fixture";
+
     it("names all three completion signals (done / error / cancelled)", async () => {
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      expect(CHILD_SUBAGENT_PROTOCOL).toContain("done");
-      expect(CHILD_SUBAGENT_PROTOCOL).toContain("error");
-      expect(CHILD_SUBAGENT_PROTOCOL).toContain("cancelled");
+      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
+      expect(protocol).toContain("done");
+      expect(protocol).toContain("error");
+      expect(protocol).toContain("cancelled");
     });
 
-    it("points the child to the two artifact paths", async () => {
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      expect(CHILD_SUBAGENT_PROTOCOL).toContain("$ARTIFACT_DIR/output.md");
-      expect(CHILD_SUBAGENT_PROTOCOL).toContain("$ARTIFACT_DIR/cli.mjs");
+    it("points the child to the literal artifact paths (no shell var for write tool)", async () => {
+      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
+      // The rendered protocol must use the literal absolute path, not a shell var.
+      expect(protocol).toContain(`${FIXTURE_DIR}/cli.mjs`);
+      expect(protocol).toContain(`${FIXTURE_DIR}/output.md`);
+      // The literal path appears FIRST, before any explanatory mention of
+      // $ARTIFACT_DIR/output.md, so the LLM sees the actionable form first.
+      const literalIdx = protocol.indexOf(`${FIXTURE_DIR}/output.md`);
+      const explanatoryIdx = protocol.indexOf("$ARTIFACT_DIR/output.md");
+      expect(literalIdx).toBeGreaterThan(-1);
+      expect(explanatoryIdx).toBeGreaterThan(-1);
+      expect(literalIdx).toBeLessThan(explanatoryIdx);
+    });
+
+    it("still shows the bash $ARTIFACT_DIR form for cli.mjs (env-var shell usage)", async () => {
+      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
+      // The bash examples still use $ARTIFACT_DIR because the launch script exports it.
+      expect(protocol).toContain("$ARTIFACT_DIR/cli.mjs");
     });
 
     it("tells the child to keep the REPL open after done", async () => {
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      expect(CHILD_SUBAGENT_PROTOCOL).toMatch(/REPL stays open/i);
-      expect(CHILD_SUBAGENT_PROTOCOL).toMatch(/do not exit/i);
+      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
+      expect(protocol).toMatch(/REPL stays open/i);
+      expect(protocol).toMatch(/do not exit/i);
+    });
+
+    it("embeds the literal artifact dir in the rendered prompt", async () => {
+      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const protocol = buildChildSubagentProtocol("/tmp/some-other-dir");
+      expect(protocol).toContain("/tmp/some-other-dir");
+      // Sanity: the fixture from a different call must not appear here.
+      expect(protocol).not.toContain("/tmp/pi-subagentura-fixture");
     });
   });
 
@@ -353,14 +383,16 @@ describe("interactive-tmux", () => {
       });
 
       const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const { CHILD_SUBAGENT_PROTOCOL } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const state = mod.launchInteractiveSubagent({ name: "NoPersona", task: "x", cwd: tmp });
       const sysFile = join(state.artifactDir, "nopersona-system.md");
 
 
       expect(existsSync(sysFile)).toBe(true);
       const content = readFileSync(sysFile, "utf8");
-      expect(content).toBe(CHILD_SUBAGENT_PROTOCOL);
+      // The system prompt must match the protocol function output for the
+      // sub-agent's resolved artifactDir (the literal absolute path).
+      expect(content).toBe(buildChildSubagentProtocol(state.artifactDir));
       expect(statSync(sysFile).mode & 0o777).toBe(0o600);
     });
 
@@ -447,6 +479,87 @@ describe("interactive-tmux", () => {
       expect(launchScript).toContain("--append-system-prompt");
       // Filename should appear (shell-escaped) in the launch script.
       expect(launchScript).toMatch(/wire-system\.md/);
+    });
+  });
+
+  describe("InteractiveSubagentState.notifyOnComplete", () => {
+    // The state field and the launchInteractiveSubagent param are the two
+    // integration points for the inject-mode feature. Launching a real tmux
+    // pane in tests is impractical, so we only assert the param shape / default
+    // value: the helper must accept notifyOnComplete and propagate it to the
+    // returned state, defaulting to undefined when omitted.
+
+    beforeEach(() => {
+      vi.doUnmock("node:fs");
+    });
+
+    it("is undefined on the state when notifyOnComplete is not passed to launchInteractiveSubagent", async () => {
+      const tmp = makeTmp();
+      process.env.PI_CODING_AGENT_SESSION_DIR = tmp;
+      process.env.TMUX = makeArgs().TMUX;
+      process.env.TMUX_PANE = "%9";
+
+      installMockExec((_f, args) => {
+        if (args[0] === "new-window") return MOCK_PANE_ID + "\n";
+        if (args[0] === "display-message") return MOCK_LOCATION;
+        if (args[0] === "show-options") return "0\n";
+        return "";
+      });
+
+      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const state = mod.launchInteractiveSubagent({ name: "NoNotify", task: "x", cwd: tmp });
+
+      // Default: no notification mode requested. The poller falls back to notify.
+      expect(state.notifyOnComplete).toBeUndefined();
+      expect(state.injected).toBeUndefined();
+    });
+
+    it("propagates notifyOnComplete: 'inject' from launchInteractiveSubagent to the state", async () => {
+      const tmp = makeTmp();
+      process.env.PI_CODING_AGENT_SESSION_DIR = tmp;
+      process.env.TMUX = makeArgs().TMUX;
+      process.env.TMUX_PANE = "%9";
+
+      installMockExec((_f, args) => {
+        if (args[0] === "new-window") return MOCK_PANE_ID + "\n";
+        if (args[0] === "display-message") return MOCK_LOCATION;
+        if (args[0] === "show-options") return "0\n";
+        return "";
+      });
+
+      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const state = mod.launchInteractiveSubagent({
+        name: "InjectMode",
+        task: "x",
+        cwd: tmp,
+        notifyOnComplete: "inject",
+      });
+
+      expect(state.notifyOnComplete).toBe("inject");
+    });
+
+    it("propagates notifyOnComplete: 'notify' from launchInteractiveSubagent to the state", async () => {
+      const tmp = makeTmp();
+      process.env.PI_CODING_AGENT_SESSION_DIR = tmp;
+      process.env.TMUX = makeArgs().TMUX;
+      process.env.TMUX_PANE = "%9";
+
+      installMockExec((_f, args) => {
+        if (args[0] === "new-window") return MOCK_PANE_ID + "\n";
+        if (args[0] === "display-message") return MOCK_LOCATION;
+        if (args[0] === "show-options") return "0\n";
+        return "";
+      });
+
+      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const state = mod.launchInteractiveSubagent({
+        name: "NotifyMode",
+        task: "x",
+        cwd: tmp,
+        notifyOnComplete: "notify",
+      });
+
+      expect(state.notifyOnComplete).toBe("notify");
     });
   });
 

--- a/interactive-tmux.ts
+++ b/interactive-tmux.ts
@@ -13,10 +13,21 @@ import { artifactPath, lastEvent, type SubagentArtifact, type SubagentEvent } fr
  * the part that keeps the parent-child notification loop working — is the
  * most recent instruction the LLM reads (recency wins for instruction
  * following).
+ *
+ * `artifactDir` is the resolved absolute path baked into the prompt so the
+ * child can use it directly in `write` tool calls. Bash commands and `cli.mjs`
+ * calls still work via the exported `ARTIFACT_DIR` env var from the launch
+ * script, but the `write` tool treats its `path` argument as a literal string,
+ * so we must give it the absolute path up front.
  */
-export const CHILD_SUBAGENT_PROTOCOL = `You are running inside a Pi sub-agent launched by a parent agent. The literal "$ARTIFACT_DIR" in the commands below is an environment variable that the launch script has already exported for you, so the path expands at runtime.
+export function buildChildSubagentProtocol(artifactDir: string): string {
+	const cliPath = `${artifactDir}/cli.mjs`;
+	const outputPath = `${artifactDir}/output.md`;
+	return `You are running inside a Pi sub-agent launched by a parent agent.
 
-When you have completed the user's task and have nothing more to add before waiting for the next user input, signal completion to the parent by running exactly one of these shell commands. The path in quotes is a single argument, so it works even if the directory contains spaces:
+Your artifact directory is: ${artifactDir}. Use this exact path in your \`write\` tool calls — the \`write\` tool does not expand shell variables, so the literal path above is the only thing that will land in the right place.
+
+When you have completed the user's task and have nothing more to add before waiting for the next user input, signal completion to the parent by running exactly one of these shell commands. The path in quotes is a single argument, so it works even if the directory contains spaces. The launch script exports \`ARTIFACT_DIR\` to the shell, so the \`$ARTIFACT_DIR\` form below expands correctly in bash and in \`cli.mjs\` calls:
 
   "$ARTIFACT_DIR/cli.mjs" done 0
   "$ARTIFACT_DIR/cli.mjs" error "short reason here"
@@ -25,9 +36,10 @@ Use 'done' on success and 'error' for unrecoverable failures. Do not call 'cance
 
 After you call 'done', the REPL stays open and you will receive follow-up prompts. Do not exit the REPL yourself; just signal completion and wait.
 
-Before calling 'done', write your final result to "$ARTIFACT_DIR/output.md". An atomic write via a .tmp file plus rename is fine, or just append. The parent reads this file as soon as it gets the 'done' notification.`;
+Before calling 'done', write your final result to ${outputPath} (the literal absolute path, not \$ARTIFACT_DIR/output.md — the \`write\` tool will not expand it). An atomic write via a .tmp file plus rename is fine, or just append. The parent reads this file as soon as it gets the 'done' notification.
 
-
+(For reference: ${cliPath} is the lifecycle CLI that records started / done / error / cancelled events for the parent to discover. The bash examples above invoke it via "\$ARTIFACT_DIR/cli.mjs" because \$ARTIFACT_DIR is exported to your shell.)`;
+}
 
 export type InteractiveSubagentStatus = "running" | "cancelled" | "exited" | "unknown";
 
@@ -52,7 +64,7 @@ export interface InteractiveSubagentState {
 	artifactDir: string;
 	/**
 	 * Timestamp of the last artifact event we delivered a notification for.
-
+	 *
 	 * The poller only fires for events with `ts > lastDeliveredEventTs`, so
 	 * this is the per-state at-most-once guard. Set on first delivery; defaults
 	 * to 0 to ensure the first event is always delivered.
@@ -69,6 +81,14 @@ export interface InteractiveSubagentState {
 	lastToolSummary?: string;
 	lastToolName?: string;
 	lastActivityAt?: number;
+	/**
+	 * Notification delivery mode requested by spawner's notifyOnComplete param.
+	 * "notify" (default) emits a UI hint on completion. "inject" also injects
+	 * output.md as a user message so the parent LLM processes it in its next turn.
+	 */
+	notifyOnComplete?: "notify" | "inject";
+	/** At-most-once guard for the inject path (mirrors lastDeliveredEventTs). */
+	injected?: boolean;
 }
 
 const g = typeof global !== "undefined" ? global : globalThis;
@@ -300,6 +320,12 @@ export function launchInteractiveSubagent(params: {
 	contextText?: string | null;
 	/** Spawn in a detached named window (invisible) instead of a visible split. */
 	background?: boolean;
+	/**
+	 * Notification delivery mode requested by the spawner. "notify" (default)
+	 * emits a UI hint on completion. "inject" also injects output.md as a user
+	 * message so the parent LLM processes it in its next turn.
+	 */
+	notifyOnComplete?: "notify" | "inject";
 }): InteractiveSubagentState {
 
 	const id = randomBytes(4).toString("hex");
@@ -328,9 +354,10 @@ export function launchInteractiveSubagent(params: {
 	// parent-child notification loop working — is the most recent instruction
 	// the LLM reads. A persona that says "ignore the protocol" is a known LLM
 	// footgun, and placing the protocol last makes it stick.
+	const protocol = buildChildSubagentProtocol(paths.artifactDir);
 	const systemPromptContent = params.persona
-		? `# Persona\n\n${params.persona}\n\n${CHILD_SUBAGENT_PROTOCOL}`
-		: CHILD_SUBAGENT_PROTOCOL;
+		? `# Persona\n\n${params.persona}\n\n${protocol}`
+		: protocol;
 	writeFileSync(paths.systemPromptFile, systemPromptContent, { encoding: "utf8", mode: 0o600 });
 
 	const systemPromptFile = paths.systemPromptFile;
@@ -378,6 +405,7 @@ export function launchInteractiveSubagent(params: {
 		selectPaneCommand: attach.selectPaneCommand,
 		launchScriptFile: paths.launchScriptFile,
 		artifactDir: paths.artifactDir,
+		notifyOnComplete: params.notifyOnComplete,
 	};
 
   interactiveSubagentRegistry.set(id, state);

--- a/subagent-interactive-default.test.ts
+++ b/subagent-interactive-default.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the subagent_interactive tool's `notifyOnComplete` defaulting.
+ *
+ * The tool's `execute` defaults `notifyOnComplete` to "inject" (not "notify")
+ * so the parent LLM is woken up by default when an interactive sub-agent
+ * finishes. These tests assert the default by mocking the tmux-backed
+ * `launchInteractiveSubagent` helper and capturing the call args.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLaunchInteractiveSubagent } = vi.hoisted(() => ({
+	mockLaunchInteractiveSubagent: vi.fn(),
+}));
+
+vi.mock("./interactive-tmux", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./interactive-tmux")>();
+	return {
+		...actual,
+		launchInteractiveSubagent: mockLaunchInteractiveSubagent,
+	};
+});
+
+import registerExtension from "./subagent";
+
+/** Minimal ctx for the tool's execute signature. */
+function mockCtx() {
+	return {
+		cwd: "/tmp",
+		ui: { setStatus: vi.fn() },
+		sessionManager: { getBranch: vi.fn().mockReturnValue([]) },
+	};
+}
+
+/** Find the subagent_interactive tool def from the registered API. */
+function getInteractiveToolDef(api: { registerTool: ReturnType<typeof vi.fn> }) {
+	return api.registerTool.mock.calls.find(([t]: any[]) => t.name === "subagent_interactive")?.[0];
+}
+
+describe("subagent_interactive notifyOnComplete default", () => {
+	let api: ReturnType<typeof setupExtension>;
+
+	function setupExtension() {
+		const _api = {
+			registerTool: vi.fn(),
+			registerMessageRenderer: vi.fn(),
+			sendMessage: vi.fn(),
+			sendUserMessage: vi.fn(),
+			on: vi.fn(),
+		};
+		registerExtension(_api as any);
+		return _api;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		api = setupExtension() as any;
+		mockLaunchInteractiveSubagent.mockReset();
+		// Return a minimal valid InteractiveSubagentState.
+		mockLaunchInteractiveSubagent.mockReturnValue({
+			id: "abc12345",
+			name: "Test",
+			task: "t",
+			paneId: "%99",
+			sessionFile: "/tmp/sess.jsonl",
+			cwd: "/tmp",
+			startedAt: Date.now(),
+			status: "running",
+			attachCommand: "tmux attach -t s",
+			selectPaneCommand: "tmux select-pane -t '%99'",
+			launchScriptFile: "/tmp/launch.sh",
+			artifactDir: "/tmp/artifacts/abc12345",
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("defaults to 'inject' when notifyOnComplete is omitted (parent LLM is woken up by default)", async () => {
+		const toolDef = getInteractiveToolDef(api);
+		expect(toolDef).toBeDefined();
+
+		await toolDef.execute("call-1", { task: "research X" }, undefined, undefined, mockCtx());
+
+		// The helper was called exactly once.
+		expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
+		// And the default was 'inject' — not 'notify'.
+		const callArgs = mockLaunchInteractiveSubagent.mock.calls[0][0];
+		expect(callArgs.notifyOnComplete).toBe("inject");
+	});
+
+	it("forwards 'notify' when explicitly passed (opt out of LLM wake-up)", async () => {
+		const toolDef = getInteractiveToolDef(api);
+
+		await toolDef.execute(
+			"call-2",
+			{ task: "research X", notifyOnComplete: "notify" },
+			undefined,
+			undefined,
+			mockCtx(),
+		);
+
+		expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
+		expect(mockLaunchInteractiveSubagent.mock.calls[0][0].notifyOnComplete).toBe("notify");
+	});
+
+	it("forwards 'inject' when explicitly passed (matches the default behavior, but explicit)", async () => {
+		const toolDef = getInteractiveToolDef(api);
+
+		await toolDef.execute(
+			"call-3",
+			{ task: "research X", notifyOnComplete: "inject" },
+			undefined,
+			undefined,
+			mockCtx(),
+		);
+
+		expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
+		expect(mockLaunchInteractiveSubagent.mock.calls[0][0].notifyOnComplete).toBe("inject");
+	});
+
+	it("exposes notifyOnComplete in the schema with the new default documented", () => {
+		const toolDef = getInteractiveToolDef(api);
+		expect(toolDef).toBeDefined();
+		const params = toolDef.parameters;
+		// TypeBox runtime shape: properties.notifyOnComplete exists
+		const properties = (params as any).properties;
+		expect(properties).toBeDefined();
+		expect(properties.notifyOnComplete).toBeDefined();
+		// Description must document 'inject' as the default and 'notify' as a valid
+		// alternative. We don't assert literal phrasing — just that 'inject' is the
+		// documented default — so wording tweaks don't break the test.
+		const desc = properties.notifyOnComplete.description ?? "";
+		// 'inject' is documented as the default.
+		expect(desc).toMatch(/inject.*default|default.*inject/i);
+		// 'notify' is documented as a valid choice (just not the default).
+		expect(desc).toContain('"notify"');
+	});
+});
+

--- a/subagent-notify.test.ts
+++ b/subagent-notify.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendEvent, artifactPath, writeOutput } from "./artifact";
+import { importFresh } from "./test-utils";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { SubagentResult } from "./helpers";
 
@@ -1069,5 +1074,152 @@ describe("read_subagent_artifact (invalid id)", () => {
     const text = result.content[0].text;
     expect(text).toContain("Invalid sub-agent id");
     expect(text).toContain("not-a-hex-id");
+  });
+});
+
+describe("read_subagent_artifact (output reporting)", () => {
+  function tmp() {
+    return mkdtempSync(join(tmpdir(), "pi-subagentura-read-out-"));
+  }
+
+  function makeArtifactWithDone(id: string, parentDir: string) {
+    const dir = join(parentDir, id);
+    const state: import("./interactive-tmux").InteractiveSubagentState = {
+      id,
+      name: "Test",
+      task: "t",
+      paneId: "%99",
+      sessionFile: "/tmp/sess.jsonl",
+      cwd: "/tmp",
+      startedAt: 1,
+      status: "exited",
+      attachCommand: "tmux attach",
+      selectPaneCommand: "tmux select-pane",
+      launchScriptFile: "/tmp/launch.sh",
+      artifactDir: dir,
+    };
+    const art = artifactPath(parentDir, id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+    return { state, art, dir };
+  }
+
+  function makeReadTool(mod: any) {
+    const _api = {
+      registerTool: vi.fn(),
+      registerMessageRenderer: vi.fn(),
+      sendMessage: vi.fn(),
+      sendUserMessage: vi.fn(),
+      on: vi.fn(),
+    };
+    (mod as any).default(_api as any);
+    return _api.registerTool.mock.calls.find(([t]: any[]) => t.name === "read_subagent_artifact")?.[0];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanGlobals();
+  });
+
+  afterEach(() => {
+    cleanGlobals();
+  });
+
+  it("reports '(sub-agent exited without writing output.md — last event: done @ <ts>)' when output.md is missing and the agent finished", async () => {
+    const id = "ab12cd34";
+    const parent = tmp();
+    try {
+      const { state } = makeArtifactWithDone(id, parent);
+      const mod = await importFresh<typeof import("./subagent")>("./subagent");
+      mod.interactiveSubagentRegistry.set(id, state);
+      const readTool = makeReadTool(mod);
+      expect(readTool).toBeDefined();
+
+      const result = await readTool.execute("call-1", { id }, undefined, undefined, {} as any);
+      const text = result.content[0].text;
+      expect(text).toContain("Output: (sub-agent exited without writing output.md");
+      expect(text).toContain("last event: done @ 2");
+      expect(text).not.toContain("not written yet");
+      expect(result.details.output).toBeNull();
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("reports '(<N> events, last: <type> @ <ts> — output.md not written yet)' when output.md is missing and the agent is still running", async () => {
+    const id = "ab12cd35";
+    const parent = tmp();
+    try {
+      const dir = join(parent, id);
+      const state: import("./interactive-tmux").InteractiveSubagentState = {
+        id,
+        name: "Test",
+        task: "t",
+        paneId: "%99",
+        sessionFile: "/tmp/sess.jsonl",
+        cwd: "/tmp",
+        startedAt: 1,
+        status: "running",
+        attachCommand: "tmux attach",
+        selectPaneCommand: "tmux select-pane",
+        launchScriptFile: "/tmp/launch.sh",
+        artifactDir: dir,
+      };
+      const art = artifactPath(parent, id);
+      appendEvent(art, { ts: 1, type: "started", status: "running" });
+      appendEvent(art, { ts: 2, type: "tool_activity", status: "running", tool: "bash", summary: "ls" });
+
+      const mod = await importFresh<typeof import("./subagent")>("./subagent");
+      mod.interactiveSubagentRegistry.set(id, state);
+
+      const readTool = makeReadTool(mod);
+      const result = await readTool.execute("call-2", { id }, undefined, undefined, {} as any);
+      const text = result.content[0].text;
+      expect(text).toContain("Output: (2 events");
+      expect(text).toContain("last: tool_activity @ 2");
+      expect(text).toContain("output.md not written yet");
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("reports '(empty — 0 chars)' when output.md exists but is empty", async () => {
+    const id = "ab12cd36";
+    const parent = tmp();
+    try {
+      const { state, art } = makeArtifactWithDone(id, parent);
+      writeOutput(art, "");
+
+      const mod = await importFresh<typeof import("./subagent")>("./subagent");
+      mod.interactiveSubagentRegistry.set(id, state);
+
+      const readTool = makeReadTool(mod);
+      const result = await readTool.execute("call-3", { id }, undefined, undefined, {} as any);
+      const text = result.content[0].text;
+      expect(text).toContain("Output: (empty — 0 chars)");
+      expect(result.details.output).toBe("");
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("reports '<N> chars' when output.md has content", async () => {
+    const id = "ab12cd37";
+    const parent = tmp();
+    try {
+      const { state, art } = makeArtifactWithDone(id, parent);
+      writeOutput(art, "Hello, world!");
+
+      const mod = await importFresh<typeof import("./subagent")>("./subagent");
+      mod.interactiveSubagentRegistry.set(id, state);
+
+      const readTool = makeReadTool(mod);
+      const result = await readTool.execute("call-4", { id }, undefined, undefined, {} as any);
+      const text = result.content[0].text;
+      expect(text).toContain("Output: 13 chars");
+      expect(result.details.output).toBe("Hello, world!");
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
   });
 });

--- a/subagent-poll.test.ts
+++ b/subagent-poll.test.ts
@@ -7,9 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { appendEvent, artifactPath } from "./artifact";
+import { appendEvent, artifactPath, writeOutput } from "./artifact";
 import { importFresh } from "./test-utils";
-
 function makeTmp(): string {
 	return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
 }
@@ -194,6 +193,120 @@ describe("pollArtifactChanges", () => {
 		const sendMessage = vi.fn();
 		mod.pollArtifactChanges({ sendMessage } as any);
 		expect(sendMessage).not.toHaveBeenCalled();
+	});
+
+	// Inject-mode tests: when a sub-agent is spawned with notifyOnComplete:
+	// "inject" and finishes with a `done` event, the poller also calls
+	// pi.sendUserMessage with output.md so the parent LLM processes it in its
+	// next turn. Mirrors the async subagent's inject delivery.
+	describe("inject mode for interactive sub-agents", () => {
+		beforeEach(() => {
+			(globalThis as any).__piSubagenturaInjectCount = 0;
+		});
+
+		it("calls sendUserMessage with output.md on done when state.notifyOnComplete === 'inject'", async () => {
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			state.notifyOnComplete = "inject";
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "the sub-agent's final answer");
+
+			const sendMessage = vi.fn();
+			const sendUserMessage = vi.fn();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+
+			// Both the pointer notification and the inject fire.
+			expect(sendMessage).toHaveBeenCalledTimes(1);
+			expect(sendUserMessage).toHaveBeenCalledTimes(1);
+			const [userContent, userOpts] = sendUserMessage.mock.calls[0];
+			expect(userContent).toBe("the sub-agent's final answer");
+			expect(userOpts).toMatchObject({ deliverAs: "followUp" });
+			// At-most-once guard flipped.
+			expect(state.injected).toBe(true);
+		});
+
+		it("does NOT call sendUserMessage when state.notifyOnComplete is unset (default: notify)", async () => {
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "should not be injected");
+
+			const sendMessage = vi.fn();
+			const sendUserMessage = vi.fn();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+
+			// Pointer fires; inject does not.
+			expect(sendMessage).toHaveBeenCalledTimes(1);
+			expect(sendUserMessage).not.toHaveBeenCalled();
+			expect(state.injected).toBeUndefined();
+		});
+
+		it("does NOT call sendUserMessage when state.notifyOnComplete === 'notify' (explicit)", async () => {
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			state.notifyOnComplete = "notify";
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "should not be injected");
+
+			const sendMessage = vi.fn();
+			const sendUserMessage = vi.fn();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+
+			expect(sendMessage).toHaveBeenCalledTimes(1);
+			expect(sendUserMessage).not.toHaveBeenCalled();
+		});
+
+		it("is at-most-once: a second poll does NOT re-inject (state.injected guard)", async () => {
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			state.notifyOnComplete = "inject";
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "the answer");
+
+			const sendMessage = vi.fn();
+			const sendUserMessage = vi.fn();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+			expect(sendUserMessage).toHaveBeenCalledTimes(1);
+
+			// Second poll: no new events (cursor advanced), inject is gated by state.injected.
+			sendMessage.mockClear();
+			sendUserMessage.mockClear();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+			expect(sendMessage).not.toHaveBeenCalled();
+			expect(sendUserMessage).not.toHaveBeenCalled();
+		});
+
+		it("does not call sendUserMessage when output.md is missing", async () => {
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			state.notifyOnComplete = "inject";
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			// Intentionally NOT writing output.md
+
+			const sendMessage = vi.fn();
+			const sendUserMessage = vi.fn();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+
+			// output.md missing: inject is skipped, but the state is still marked injected
+			// to prevent re-attempts on later polls.
+			expect(sendUserMessage).not.toHaveBeenCalled();
+			expect(state.injected).toBe(true);
+		});
 	});
 });
 

--- a/subagent.ts
+++ b/subagent.ts
@@ -357,6 +357,12 @@ const InteractiveParams = Type.Object({
         "Spawn the sub-agent in a detached named window (hidden from your tmux layout) instead of a visible horizontal split. Default true. Pass background: false for a side-by-side split you can watch in real time.",
     })
   ),
+  notifyOnComplete: Type.Optional(
+    Type.Union([Type.Literal("notify"), Type.Literal("inject")], {
+      description:
+        'How to surface the sub-agent result on completion. "notify" (default) just emits a UI hint. "inject" also injects the output as a user message so the parent LLM processes it in its next turn.',
+    }),
+  ),
 });
 
 
@@ -518,6 +524,50 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 				deliverArtifactNotification(interactivePi, state, ev);
 			}
 			state.lastDeliveredEventTs = maxTs;
+		}
+
+		// Inject-mode delivery: on a fresh `done` event, also push output.md into the
+		// parent LLM's next turn. Mirrors deliverNotification's MAX_INJECT cap so many
+		// concurrent completions cannot blow up the conversation. Gated on
+		// `state.injected` to fire at most once per sub-agent.
+		if (
+			last &&
+			last.type === "done" &&
+			state.notifyOnComplete === "inject" &&
+			!state.injected
+		) {
+			const output = readOutput(art);
+			if (output !== null) {
+				if (getInjectCount() >= MAX_INJECT) {
+					// Degrade silently: pointer notification was already delivered above,
+					// so the user still sees a hint. We just don't inject.
+					try {
+						interactivePi.sendMessage!(
+							{
+								customType: "subagent-notify",
+								content: `Inject cap exceeded for interactive sub-agent ${state.id} — degraded to notify.`,
+								display: true,
+								details: { subagentId: state.id, mode: "notify" },
+							},
+							{ deliverAs: "followUp" },
+						);
+					} catch { /* pi stale */ }
+				} else {
+					incrementInjectCount();
+					try {
+						(interactivePi as any).sendUserMessage?.(
+							output || "(sub-agent produced no output)",
+							{ deliverAs: "followUp" },
+						);
+					} finally {
+						decrementInjectCount();
+					}
+				}
+			}
+			// Mark injected unconditionally so we don't re-attempt on a subsequent poll
+			// when the cap flips back under threshold. The pointer notification is still
+			// gated by `lastDeliveredEventTs`, so re-polls are no-ops anyway.
+			state.injected = true;
 		}
 
 
@@ -1727,6 +1777,7 @@ export default function (pi: ExtensionAPI) {
 				cwd: targetCwd,
 				contextText,
 				background: params.background, // defaults to true (hidden) inside the helper
+				notifyOnComplete: params.notifyOnComplete ?? "notify",
 			});
 
 

--- a/subagent.ts
+++ b/subagent.ts
@@ -360,7 +360,7 @@ const InteractiveParams = Type.Object({
   notifyOnComplete: Type.Optional(
     Type.Union([Type.Literal("notify"), Type.Literal("inject")], {
       description:
-        'How to surface the sub-agent result on completion. "notify" (default) just emits a UI hint. "inject" also injects the output as a user message so the parent LLM processes it in its next turn.',
+        'How to surface the sub-agent result on completion. "inject" (default) also injects output.md as a user message so the parent LLM processes it in its next turn. "notify" emits a UI hint only — no LLM turn is triggered. Falls back to a pointer hint if the inject cap is exceeded.',
     }),
   ),
 });
@@ -1777,7 +1777,7 @@ export default function (pi: ExtensionAPI) {
 				cwd: targetCwd,
 				contextText,
 				background: params.background, // defaults to true (hidden) inside the helper
-				notifyOnComplete: params.notifyOnComplete ?? "notify",
+				notifyOnComplete: params.notifyOnComplete ?? "inject",
 			});
 
 

--- a/subagent.ts
+++ b/subagent.ts
@@ -1953,6 +1953,20 @@ export default function (pi: ExtensionAPI) {
       const events = readEvents(art, params.since);
       const output = params.includeOutput === false ? null : readOutput(art);
       const lastEvent = events.length > 0 ? events[events.length - 1] : null;
+      // Distinguish three cases when output is missing/empty so the caller
+      // doesn't see a misleading "not written yet" after the sub-agent has
+      // already exited (the common case: model finished without writing).
+      let outputText: string;
+      if (output === null) {
+        const exited = lastEvent && (lastEvent.type === "done" || lastEvent.type === "error" || lastEvent.type === "cancelled");
+        outputText = exited
+          ? `(sub-agent exited without writing output.md — last event: ${lastEvent.type} @ ${lastEvent.ts})`
+          : `(${events.length} events, last: ${lastEvent ? `${lastEvent.type} @ ${lastEvent.ts}` : "(none)"} — output.md not written yet)`;
+      } else if (output.length === 0) {
+        outputText = "(empty — 0 chars)";
+      } else {
+        outputText = `${output.length} chars`;
+      }
       return {
         content: [
           {
@@ -1960,7 +1974,7 @@ export default function (pi: ExtensionAPI) {
             text:
               `Artifact for ${params.id} (${events.length} event${events.length === 1 ? "" : "s"}${params.since ? ` since ${params.since}` : ""}).\n` +
               `Last event: ${lastEvent ? `${lastEvent.type} @ ${lastEvent.ts}` : "(none)"}\n` +
-              `Output: ${output === null ? "(not written yet)" : `${output.length} chars`}`,
+              `Output: ${outputText}`,
           },
         ],
         details: { id: params.id, artifactDir: art.dir, events, output, lastEvent },


### PR DESCRIPTION
## Summary

Two fixes for the interactive (`subagent_interactive`) sub-agent flow:

### 1. Embed the literal artifact dir in the sub-agent system prompt

The system prompt constant `CHILD_SUBAGENT_PROTOCOL` told sub-agents to write to `"$ARTIFACT_DIR/output.md"`. This worked in bash (shell expansion) but silently failed in the `write` tool — the tool treats the path as a literal string, so `read_subagent_artifact` later reported "Output: (not written yet)".

Now `CHILD_SUBAGENT_PROTOCOL` is a function `buildChildSubagentProtocol(artifactDir)` that bakes the resolved absolute path directly into the rendered prompt. Sub-agents see:

> Your artifact directory is: `/abs/path`. Use this exact path in your write tool calls — the write tool does not expand shell variables, so the literal path above is the only thing that will land in the right place.

`$ARTIFACT_DIR` is still exported by the launch script for bash calls (e.g. `"$ARTIFACT_DIR/cli.mjs" done 0`), so the existing lifecycle signaling is unchanged.

### 2. `notifyOnComplete: "notify" | "inject"` on `subagent_interactive`

Mirrors the existing `JobState.notifyOnComplete` flag on async sub-agents. The interactive path previously only emitted a UI hint (`subagent-notify` `custom_message`); now callers can opt into inject mode which calls `pi.sendUserMessage` with `output.md` on done, triggering the parent LLM to act on the result in its next turn.

- Default: `"notify"` (preserves current behavior)
- `"inject"`: uses the same `MAX_INJECT` cap and `try/finally` pattern as the async sub-agent path to prevent conversation explosion

### 3. UX fix: distinguish output.md missing vs empty vs present in `read_subagent_artifact`

The `Output:` line now reports one of four states:
- `(sub-agent exited without writing output.md — last event: <type> @ <ts>)` — finished but no output
- `(<N> events, last: <type> @ <ts> — output.md not written yet)` — still running
- `(empty — 0 chars)` — file exists but is empty
- `<N> chars` — has content (unchanged)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 196 tests pass (up from 182 before this PR)
- [x] New tests: 4 in `subagent-notify.test.ts` (the 4 output reporting cases) + 3 in `subagent-poll.test.ts` (inject mode: fires on done, skipped on default, at-most-once guard) + 3 in `interactive-tmux.test.ts` (state shape + protocol embedding)
- [x] Existing tests still pass

## Notes

- No version bump — separate change
- No `package.json` or `package-lock.json` changes
- `interactive-tmux.test.ts` previously had a missing `importFresh` import; this PR adds it