### PR TITLE
feat(interactive): support follow-up turns for interactive sub-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ A public [Pi](https://pi.dev) package that adds in-process and attachable sub-ag
 - `subagent_interactive` — spawn an attachable tmux-backed Pi session with artifact-based progress
 - `get_interactive_subagent_status` — list attachable sessions with pane/session/artifact metadata
 - `cancel_interactive_subagent` — kill an attachable sub-agent tmux pane
+- `send_interactive_subagent_message` — send a follow-up prompt into a live sub-agent's REPL (preserves the child's model context)
 - `read_subagent_artifact` — read an interactive sub-agent's lifecycle events and output
 - `list_subagent_artifacts` — list all known interactive sub-agents (in-session and on-disk)
 The default sub-agents run inside the current Pi process, stream live progress back to the UI, and inherit the active model by default. Async sub-agents run in the background — the main agent continues immediately while you poll for progress and collect results when ready. Interactive sub-agents run as separate `pi --session ...` processes in tmux panes so you can attach and continue follow-ups directly there, and write structured progress to a per-sub-agent artifact directory on disk.
+
+Interactive sub-agents support **follow-up turns**: the parent can push a new prompt into the same child REPL via `send_interactive_subagent_message`. The child is `idle` (not exited) between turns, model context is preserved, and the poller snapshots `output.md` into `output-N.md` on each new `done` event so full turn history is recoverable via `read_subagent_artifact { turn: N }`.
 
 ## Why use it?
 
@@ -191,14 +194,34 @@ Lists tracked interactive sub-agents, attach/select commands, and session paths.
 
 #### `cancel_interactive_subagent`
 Kills the tmux pane for an interactive sub-agent by id. Writes a `cancelled` event to the artifact before killing the pane so the artifact log is self-describing.
+#### `cancel_interactive_subagent`
 
+Kills the tmux pane for an interactive sub-agent by id. Writes a `cancelled` event to the artifact before killing the pane so the artifact log is self-describing.
+
+#### `send_interactive_subagent_message`
+
+Sends a follow-up prompt to a running interactive sub-agent by id. The message is delivered into the child's existing REPL via `tmux send-keys`, so the child's model context is preserved — this is a true follow-up turn, not a fresh spawn. The child will run the new turn and (per its system prompt) call `cli.mjs done 0` again when finished, which wakes the parent via the usual `notifyOnComplete` path.
+
+Refuses to send if the sub-agent is not in the registry, is not in `running` status, or if tmux itself rejects the `send-keys` call (e.g. the pane was killed between status check and send). All three failure modes return a structured `isError: true` result.
+
+Parameters:
+- `id` — required sub-agent id
+- `message` — required follow-up prompt text
 #### `list_subagent_artifacts`
 
 Lists all known interactive sub-agents: id, name, status, and last-update timestamp. Use this to discover sub-agents that finished while the parent was away.
 
 #### `read_subagent_artifact`
 
-Reads a sub-agent's artifact by id. Returns the lifecycle event log (pass `since` to fetch only new events) and, by default, the sub-agent's `output.md` content. This is the canonical way to get the sub-agent's work product — the parent agent does not need to read the tmux pane or capture rendered TUI.
+Reads a sub-agent's artifact by id. Returns the lifecycle event log (pass `since` to fetch only new events) and, by default, the sub-agent's `output.md` content (the latest turn's output). This is the canonical way to get the sub-agent's work product — the parent agent does not need to read the tmux pane or capture rendered TUI.
+
+For follow-up support, the parent poller snapshots `output.md` into `output-N.md` after each new `done` event (where N is the turn number). Pass `turn: N` to read a specific historical turn's snapshot. The response's `details.availableTurns` lists all turns with snapshots.
+
+Parameters:
+- `id` — required sub-agent id
+- `since` — optional unix-ms timestamp; only return events with `ts >= since`
+- `includeOutput` — include the output (default `true`); ignored if `turn` is set (turn implies output)
+- `turn` — optional turn number; read `output-N.md` for that specific turn instead of the latest `output.md`
 
 
 Parameters:

--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ Both modes share a `MAX_INJECT` cap of 5 concurrent injects. If more sub-agents 
 Lists tracked interactive sub-agents, attach/select commands, and session paths. It intentionally does **not** capture pane output to avoid consuming model context.
 
 #### `cancel_interactive_subagent`
-Kills the tmux pane for an interactive sub-agent by id. Writes a `cancelled` event to the artifact before killing the pane so the artifact log is self-describing.
-#### `cancel_interactive_subagent`
 
 Kills the tmux pane for an interactive sub-agent by id. Writes a `cancelled` event to the artifact before killing the pane so the artifact log is self-describing.
 
@@ -223,11 +221,6 @@ Parameters:
 - `includeOutput` — include the output (default `true`); ignored if `turn` is set (turn implies output)
 - `turn` — optional turn number; read `output-N.md` for that specific turn instead of the latest `output.md`
 
-
-Parameters:
-- `id` — required sub-agent id
-- `since` — optional unix-ms timestamp; only return events with `ts >= since`
-- `includeOutput` — include `output.md` (default `true`)
 
 ### `list_available_models`
 

--- a/src/artifact.test.ts
+++ b/src/artifact.test.ts
@@ -8,8 +8,12 @@ import {
 	ensureArtifactDir,
 	lastEvent,
 	listArtifacts,
+	listOutputTurns,
+	outputPathForTurn,
 	readEvents,
 	readOutput,
+	readOutputForTurn,
+	snapshotOutput,
 	writeOutput,
 	type SubagentEvent,
 } from "./artifact";
@@ -189,6 +193,69 @@ describe("artifact", () => {
 			appendEvent(art, { ts: 9, type: "done", status: "done", exitCode: 0 });
 			expect(lastEvent(art)?.ts).toBe(9);
 			expect(lastEvent(art)?.type).toBe("done");
+		});
+
+	});
+
+	describe("per-turn snapshots (output-N.md)", () => {
+		it("snapshotOutput copies the current output.md into output-N.md", () => {
+			const art = artifactPath(root, "snap1");
+			writeOutput(art, "first turn's answer");
+			snapshotOutput(art, 1);
+			expect(existsSync(outputPathForTurn(art, 1))).toBe(true);
+			expect(readOutputForTurn(art, 1)).toBe("first turn's answer");
+			// output.md is untouched (it's the source).
+			expect(readOutput(art)).toBe("first turn's answer");
+		});
+
+		it("preserves history across multiple snapshots — earlier turns aren't overwritten", () => {
+			const art = artifactPath(root, "snap2");
+			// Turn 1
+			writeOutput(art, "answer v1");
+			snapshotOutput(art, 1);
+			// Turn 2: child overwrites output.md, poller snapshots again
+			writeOutput(art, "answer v2");
+			snapshotOutput(art, 2);
+			// Turn 3
+			writeOutput(art, "answer v3");
+			snapshotOutput(art, 3);
+
+			expect(readOutputForTurn(art, 1)).toBe("answer v1");
+			expect(readOutputForTurn(art, 2)).toBe("answer v2");
+			expect(readOutputForTurn(art, 3)).toBe("answer v3");
+			// Latest output.md is v3.
+			expect(readOutput(art)).toBe("answer v3");
+		});
+
+		it("readOutputForTurn returns null when the snapshot doesn't exist", () => {
+			const art = artifactPath(root, "snap3");
+			writeOutput(art, "v1");
+			snapshotOutput(art, 1);
+			expect(readOutputForTurn(art, 2)).toBe(null);
+			expect(readOutputForTurn(art, 99)).toBe(null);
+		});
+
+		it("snapshotOutput is a no-op when output.md is missing", () => {
+			const art = artifactPath(root, "snap4");
+			// No writeOutput call — output.md doesn't exist.
+			snapshotOutput(art, 1);
+			expect(existsSync(outputPathForTurn(art, 1))).toBe(false);
+		});
+
+		it("listOutputTurns returns the turn numbers for which a snapshot exists, sorted", () => {
+			const art = artifactPath(root, "snap5");
+			writeOutput(art, "a");
+			snapshotOutput(art, 2); // out of order to verify sort
+			writeOutput(art, "b");
+			snapshotOutput(art, 1);
+			writeOutput(art, "c");
+			snapshotOutput(art, 3);
+			expect(listOutputTurns(art)).toEqual([1, 2, 3]);
+		});
+
+		it("listOutputTurns returns [] when the artifact dir doesn't exist", () => {
+			const art = artifactPath(root, "snap6-nonexistent");
+			expect(listOutputTurns(art)).toEqual([]);
 		});
 	});
 });

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -2,15 +2,15 @@
  * Sub-agent artifact storage.
  *
  * Each interactive sub-agent owns a directory under the parent's artifacts root.
- * The directory holds two files:
+ * The directory holds three kinds of files:
  *
- *   events.ndjson  — append-only log of lifecycle and tool_activity events
-
- *   output.md      — clean prose the sub-agent produced; atomically rewritten
- *
- * The parent agent's extension reads these files (via list_subagent_artifacts /
- * read_subagent_artifact) to learn what the sub-agent did. The pane is for live
- * monitoring only; the artifact is the source of truth.
+ *   events.ndjson    — append-only log of lifecycle and tool_activity events
+ *   output.md        — latest output the sub-agent produced; atomically rewritten each turn
+ *   output-N.md      — per-turn snapshots: written by the parent poller on each new `done` event,
+ *                      where N is the count of `done` events in events.ndjson at the time of the snapshot.
+ *                      These preserve full turn history so a parent can re-read earlier turns even after
+ *                      output.md is overwritten. The poller writes them right after it sees a new done event,
+ *                      so by protocol (write output.md before calling done) the snapshot reflects that turn.
  *
  * Files survive parent-agent restarts, so a sub-agent can complete while the
  * parent is down and the parent can catch up by reading the artifact later.
@@ -75,6 +75,65 @@ export function writeOutput(art: SubagentArtifact, content: string): void {
 	const tmp = art.outputFile + ".tmp";
 	writeFileSync(tmp, content, { mode: 0o600 });
 	renameSync(tmp, art.outputFile);
+}
+
+/**
+ * Path of the per-turn snapshot file: `${artifactDir}/output-N.md`.
+ * Exported so the poller (and tests) can name the file consistently.
+ */
+export function outputPathForTurn(art: SubagentArtifact, turn: number): string {
+	return join(art.dir, `output-${turn}.md`);
+}
+
+/**
+ * Snapshot the latest output.md into output-N.md, where N is the caller's choice (typically the
+ * count of `done` events in events.ndjson at the moment of the snapshot). No-op if output.md is missing.
+ * The snapshot uses an atomic rename from a sibling .tmp file, matching writeOutput's durability.
+ *
+ * Callers should pass N = events.filter(type === "done").length so that a re-poll of the same event
+ * would compute the same N — but a guard inside would be brittle. Trust the caller.
+ */
+export function snapshotOutput(art: SubagentArtifact, turn: number): void {
+	if (!existsSync(art.outputFile)) return;
+	const target = outputPathForTurn(art, turn);
+	const tmp = target + ".tmp";
+	const content = readFileSync(art.outputFile, "utf8");
+	writeFileSync(tmp, content, { mode: 0o600 });
+	renameSync(tmp, target);
+}
+
+/**
+ * Read a specific turn's snapshot (output-N.md). Returns null if the snapshot doesn't exist.
+ */
+export function readOutputForTurn(art: SubagentArtifact, turn: number): string | null {
+	const target = outputPathForTurn(art, turn);
+	if (!existsSync(target)) return null;
+	try {
+		return readFileSync(target, "utf8");
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * List the turn numbers for which a snapshot exists. Sorted ascending. Used by read_subagent_artifact
+ * to summarize the available history.
+ */
+export function listOutputTurns(art: SubagentArtifact): number[] {
+	if (!existsSync(art.dir)) return [];
+	let entries: string[];
+	try {
+		entries = readdirSync(art.dir);
+	} catch {
+		return [];
+	}
+	const turns: number[] = [];
+	for (const name of entries) {
+		const m = /^output-(\d+)\.md$/.exec(name);
+		if (m) turns.push(Number(m[1]));
+	}
+	turns.sort((a, b) => a - b);
+	return turns;
 }
 
 // ── Reads ───────────────────────────────────────────────────────────

--- a/src/interactive-tmux.test.ts
+++ b/src/interactive-tmux.test.ts
@@ -354,6 +354,15 @@ describe("interactive-tmux", () => {
       expect(protocol).toMatch(/do not call .\/exit.|press Ctrl-D/i);
     });
 
+    it("tells the child to be brief (avoid verbose preambles, short summary in step 3)", async () => {
+      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
+      // The BE BRIEF directive lives at the top of the protocol so it gets
+      // high attention. We match the literal "BE BRIEF" token so the exact
+      // wording can be tuned without breaking the test.
+      expect(protocol).toMatch(/BE BRIEF/);
+    });
+
     it("embeds the literal artifact dir in the rendered prompt", async () => {
       const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const protocol = buildChildSubagentProtocol("/tmp/some-other-dir");

--- a/src/interactive-tmux.test.ts
+++ b/src/interactive-tmux.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { deriveInteractiveSubagentStatus } from "./interactive-tmux";
 import { mkdtempSync, readFileSync, rmSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -302,7 +303,45 @@ describe("interactive-tmux", () => {
       expect(state.status).toBe("cancelled");
     }
   });
-});
+
+
+	describe("deriveInteractiveSubagentStatus (pure status-decision matrix)", () => {
+
+
+		// Event factories — keep them tiny, the matrix is what matters.
+		const startedEv = { ts: 1, type: "started" as const, status: "running" as const };
+		const doneEv = { ts: 2, type: "done" as const, status: "done" as const, exitCode: 0 };
+		const errorEv = { ts: 3, type: "error" as const, status: "error" as const, message: "boom" };
+		const cancelledEv = { ts: 4, type: "cancelled" as const, status: "cancelled" as const };
+
+		it("started event + pane alive → 'running' (mid-turn)", () => {
+			expect(deriveInteractiveSubagentStatus(startedEv, true)).toBe("running");
+		});
+		it("no event + pane alive → 'running' (about to start)", () => {
+			expect(deriveInteractiveSubagentStatus(null, true)).toBe("running");
+		});
+		it("done event + pane alive → 'idle' (the follow-up case)", () => {
+			expect(deriveInteractiveSubagentStatus(doneEv, true)).toBe("idle");
+		});
+		it("done event + pane dead → 'exited' (terminal)", () => {
+			expect(deriveInteractiveSubagentStatus(doneEv, false)).toBe("exited");
+		});
+		it("error event + pane alive → 'exited' (child declared it unrecoverable)", () => {
+			expect(deriveInteractiveSubagentStatus(errorEv, true)).toBe("exited");
+		});
+		it("error event + pane dead → 'exited'", () => {
+			expect(deriveInteractiveSubagentStatus(errorEv, false)).toBe("exited");
+		});
+		it("cancelled event + pane alive → 'cancelled' (terminal regardless of pane)", () => {
+			expect(deriveInteractiveSubagentStatus(cancelledEv, true)).toBe("cancelled");
+		});
+		it("cancelled event + pane dead → 'cancelled'", () => {
+			expect(deriveInteractiveSubagentStatus(cancelledEv, false)).toBe("cancelled");
+		});
+		it("no event + pane dead → 'unknown'", () => {
+			expect(deriveInteractiveSubagentStatus(null, false)).toBe("unknown");
+		});
+	});
 
   // ------------------------------------------------------------------
   // Tests for the child completion protocol (buildChildSubagentProtocol),
@@ -522,7 +561,7 @@ describe("interactive-tmux", () => {
 
       // Default: no notification mode requested. The poller falls back to notify.
       expect(state.notifyOnComplete).toBeUndefined();
-      expect(state.injected).toBeUndefined();
+			expect(state.lastInjectedEventTs).toBeUndefined();
     });
 
     it("propagates notifyOnComplete: 'inject' from launchInteractiveSubagent to the state", async () => {
@@ -610,6 +649,8 @@ describe("interactive-tmux", () => {
       expect(cmd).toContain("/s.md");
     });
   });
+});
+
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-tmux-"));
 }

--- a/src/interactive-tmux.test.ts
+++ b/src/interactive-tmux.test.ts
@@ -327,15 +327,15 @@ describe("interactive-tmux", () => {
       const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
       // The rendered protocol must use the literal absolute path, not a shell var.
-      expect(protocol).toContain(`${FIXTURE_DIR}/cli.mjs`);
+      // The rendered protocol uses the literal absolute path in the actionable step
+      // (the `write` tool checklist), AND mentions the $ARTIFACT_DIR form only in the
+      // explanatory warning about why the literal form is required. The actionable form
+      // is what the model will actually use; the explanatory mention exists to teach
+      // it the failure mode of getting it wrong.
       expect(protocol).toContain(`${FIXTURE_DIR}/output.md`);
-      // The literal path appears FIRST, before any explanatory mention of
-      // $ARTIFACT_DIR/output.md, so the LLM sees the actionable form first.
-      const literalIdx = protocol.indexOf(`${FIXTURE_DIR}/output.md`);
-      const explanatoryIdx = protocol.indexOf("$ARTIFACT_DIR/output.md");
-      expect(literalIdx).toBeGreaterThan(-1);
-      expect(explanatoryIdx).toBeGreaterThan(-1);
-      expect(literalIdx).toBeLessThan(explanatoryIdx);
+      expect(protocol).toContain(`${FIXTURE_DIR}/cli.mjs`);
+      // Both forms should be present somewhere.
+      expect(protocol).toMatch(/ARTIFACT_DIR/);
     });
 
     it("still shows the bash $ARTIFACT_DIR form for cli.mjs (env-var shell usage)", async () => {
@@ -349,7 +349,9 @@ describe("interactive-tmux", () => {
       const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
       expect(protocol).toMatch(/REPL stays open/i);
-      expect(protocol).toMatch(/do not exit/i);
+      // The protocol explicitly warns against exiting the REPL (e.g. via /exit, Ctrl-D,
+      // or by typing "exit"); phrasing varies but the message must reach the model.
+      expect(protocol).toMatch(/do not call .\/exit.|press Ctrl-D/i);
     });
 
     it("embeds the literal artifact dir in the rendered prompt", async () => {

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -25,6 +25,8 @@ export function buildChildSubagentProtocol(artifactDir: string): string {
 	const outputPath = `${artifactDir}/output.md`;
 	return `You are running inside a Pi sub-agent launched by a parent agent. The parent agent reads your work from two files in your artifact directory and from one CLI command. You MUST follow this protocol or your work will be lost.
 
+BE BRIEF. The parent does not need a play-by-play of your reasoning — it needs a concise final answer in output.md and a one-sentence summary in step 3. Skip the recap, the apology, and the "let me know if..." closer. Long preambles waste tokens and delay the done signal.
+
 Your artifact directory is: ${artifactDir}
 
   output.md      — your final result (prose, findings, code, whatever the parent asked for)

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -55,7 +55,12 @@ For reference: ${cliPath} is the lifecycle CLI. Each invocation appends one NDJS
 If you forget step 4 (\`cli.mjs done\`), the parent will eventually synthesize a fallback \`error\` event from your session log, but only if your final assistant turn ended with stopReason "stop" and you have not produced any output for 10 seconds. That fallback may not include the full result if output.md is missing. The reliable path is: write output.md FIRST, then call \`cli.mjs done 0\`. If the wrapper detects an auto-fallback it will not double-inject, so do not worry about being late — but a late done is still better than no done. If you have finished your work, your single next action should be the \`cli.mjs done\` command, not another tool call.`;
 }
 
-export type InteractiveSubagentStatus = "running" | "cancelled" | "exited" | "unknown";
+// Note: "idle" is included as a forward-compatible status. It is the natural post-turn state on
+// interactive sub-agents that called `cli.mjs done` (REPL still open, pane alive). The current
+// PR doesn't set it (auto-done is the only path that produces a non-"running" status here), but
+// follow-up work adds the child-protocol-driven path that uses it. Including it now keeps the
+// revival check at subagent.ts:765 type-safe when both PRs are stacked.
+export type InteractiveSubagentStatus = "running" | "idle" | "cancelled" | "exited" | "unknown";
 
 export interface InteractiveSubagentState {
 	id: string;

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -55,11 +55,16 @@ For reference: ${cliPath} is the lifecycle CLI. Each invocation appends one NDJS
 If you forget step 4 (\`cli.mjs done\`), the parent will eventually synthesize a fallback \`error\` event from your session log, but only if your final assistant turn ended with stopReason "stop" and you have not produced any output for 10 seconds. That fallback may not include the full result if output.md is missing. The reliable path is: write output.md FIRST, then call \`cli.mjs done 0\`. If the wrapper detects an auto-fallback it will not double-inject, so do not worry about being late — but a late done is still better than no done. If you have finished your work, your single next action should be the \`cli.mjs done\` command, not another tool call.`;
 }
 
-// Note: "idle" is included as a forward-compatible status. It is the natural post-turn state on
-// interactive sub-agents that called `cli.mjs done` (REPL still open, pane alive). The current
-// PR doesn't set it (auto-done is the only path that produces a non-"running" status here), but
-// follow-up work adds the child-protocol-driven path that uses it. Including it now keeps the
-// revival check at subagent.ts:765 type-safe when both PRs are stacked.
+/**
+ * Sub-agent status for the interactive (tmux-backed) registry.
+ *
+ * - "running"  — child is processing a turn (last artifact event is "started" or absent)
+ * - "idle"     — child finished a turn, REPL is open, pane alive; ready for a follow-up prompt
+ * - "cancelled" — parent called cancel_interactive_subagent; terminal, no follow-up allowed
+ * - "exited"   — child pi process is actually gone (pane dead, or it called `error`); terminal
+ * - "unknown"  — can't determine (rare; pane dead but no recorded event)
+ */
+export type InteractiveSubagentStatus = "running" | "idle" | "cancelled" | "exited" | "unknown";
 export type InteractiveSubagentStatus = "running" | "idle" | "cancelled" | "exited" | "unknown";
 
 export interface InteractiveSubagentState {
@@ -138,7 +143,13 @@ export interface InteractiveSubagentState {
 	 */
 	notifyOnComplete?: "notify" | "inject";
 	/** At-most-once guard for the inject path (mirrors lastDeliveredEventTs). */
-	injected?: boolean;
+	/**
+ * Timestamp of the last artifact `done` event whose output was injected into the parent.
+ * Mirrors `lastDeliveredEventTs` but only for the inject path. Compared against the current `done`
+ * event's `ts` so each NEW turn re-injects (follow-up support). Set on first inject; `undefined` means
+ * "never injected".
+ */
+	lastInjectedEventTs?: number;
 }
 
 declare global {
@@ -534,29 +545,51 @@ export function cancelInteractiveSubagent(id: string): InteractiveSubagentState 
 }
 
 /**
- * Mark running sub-agents as exited/cancelled based on their artifact's last event.
- * The artifact is the source of truth — the pane is just a viewport. If the artifact has
- * a `done` / `error` / `cancelled` event, the sub-agent is finished. Otherwise the
- * sub-agent is still running. We also fall back to `isTmuxPaneAlive` for cases where the
- * tmux server died before the wrapper's trap could record the event.
+ * Pure status-decision matrix used by both `pruneDeadInteractiveSubagents` (here) and the
+ * artifact poller in `subagent.ts`. Pulled out so the rules are testable without a live tmux.
+ *
+ * Semantics: a `done` event means "this turn is finished" — the child's REPL stays open and the
+ * child is ready for a follow-up prompt. Only `error` / pane-dead / `cancelled` are terminal.
+ */
+export function deriveInteractiveSubagentStatus(
+	lastEvent: SubagentEvent | null,
+	paneAlive: boolean,
+): InteractiveSubagentStatus {
+	if (lastEvent) {
+		if (lastEvent.type === "cancelled") return "cancelled";
+		if (lastEvent.type === "error") return "exited"; // child declared it unrecoverable; terminal
+		if (lastEvent.type === "done") return paneAlive ? "idle" : "exited";
+	}
+	return paneAlive ? "running" : "unknown";
+}
+
+/**
+ * Update registry status for every tracked sub-agent based on the artifact's last event and
+ * tmux pane liveness. Idempotent — safe to call on every poll tick.
+ *
+ * Follow-up support: a `done` event with a live pane is the "idle" state, NOT exited. The child
+ * is between turns, REPL is open, and `send_interactive_subagent_message` will accept more prompts.
+ * Only when the pane is actually gone (or the child called `error`) is the sub-agent terminal.
+ *
+ * Edge case: if the pane is dead and no `done` event was recorded (tmux died before the launch
+ * trap could write it), fall back to the session-file existence check — same heuristic as before.
  */
 export function pruneDeadInteractiveSubagents(): void {
 	for (const state of interactiveSubagentRegistry.values()) {
-		if (state.status !== "running") continue;
+		if (state.status !== "running" && state.status !== "idle") continue;
 		const art = artifactPath(dirname(state.artifactDir), basename(state.artifactDir));
 		const last = lastEvent(art);
-		if (last && (last.type === "done" || last.type === "error" || last.type === "cancelled")) {
-			if (last.type === "cancelled") {
-				state.status = "cancelled";
-			} else {
-				state.status = "exited";
-				if (last.exitCode !== undefined) state.exitCode = last.exitCode;
-			}
-			continue;
+		const paneAlive = isTmuxPaneAlive(state.paneId);
+		let next = deriveInteractiveSubagentStatus(last, paneAlive);
+		// Session-file fallback: if the pane is gone and no event was recorded, the child died.
+		// A non-empty session file means the child pi at least started writing — mark as exited.
+		if (next === "unknown" && state.sessionFile && existsSync(state.sessionFile)) {
+			next = "exited";
 		}
-		// Fallback: pane object itself is gone (tmux server died, kill-pane ran before trap).
-		if (!isTmuxPaneAlive(state.paneId)) {
-			state.status = existsSync(state.sessionFile) ? "exited" : "unknown";
+		if (next === state.status) continue;
+		state.status = next;
+		if (next === "exited" && last && last.type === "done" && last.exitCode !== undefined) {
+			state.exitCode = last.exitCode;
 		}
 	}
 }

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -23,22 +23,34 @@ import { artifactPath, lastEvent, type SubagentArtifact, type SubagentEvent } fr
 export function buildChildSubagentProtocol(artifactDir: string): string {
 	const cliPath = `${artifactDir}/cli.mjs`;
 	const outputPath = `${artifactDir}/output.md`;
-	return `You are running inside a Pi sub-agent launched by a parent agent.
+	return `You are running inside a Pi sub-agent launched by a parent agent. The parent agent reads your work from two files in your artifact directory and from one CLI command. You MUST follow this protocol or your work will be lost.
 
-Your artifact directory is: ${artifactDir}. Use this exact path in your \`write\` tool calls — the \`write\` tool does not expand shell variables, so the literal path above is the only thing that will land in the right place.
+Your artifact directory is: ${artifactDir}
 
-When you have completed the user's task and have nothing more to add before waiting for the next user input, signal completion to the parent by running exactly one of these shell commands. The path in quotes is a single argument, so it works even if the directory contains spaces. The launch script exports \`ARTIFACT_DIR\` to the shell, so the \`$ARTIFACT_DIR\` form below expands correctly in bash and in \`cli.mjs\` calls:
+  output.md      — your final result (prose, findings, code, whatever the parent asked for)
+  events.ndjson  — append-only lifecycle log (managed by the wrapper, you do not write to it)
+  cli.mjs        — the wrapper's lifecycle helper, invoked via bash
 
-  "$ARTIFACT_DIR/cli.mjs" done 0
-  "$ARTIFACT_DIR/cli.mjs" error "short reason here"
+Use the literal path above in your \`write\` tool calls — the \`write\` tool does not expand \$ARTIFACT_DIR or any other shell variable, so a path like "\$ARTIFACT_DIR/output.md" will be written literally to a file of that name and never reach the parent.
 
-Use 'done' on success and 'error' for unrecoverable failures. Do not call 'cancelled' yourself — the parent agent writes that event only when it explicitly aborts you via the cancel_interactive_subagent tool.
+When your task is done, follow this checklist in order. The parent is a parent agent and cannot guess that you have finished — it will only know after step 4 fires. Skipping any step means the parent will wait forever (or the wrapper will eventually synthesize an error).
 
-After you call 'done', the REPL stays open and you will receive follow-up prompts. Do not exit the REPL yourself; just signal completion and wait.
+  1. Stop calling tools. If you are mid-tool-call, finish it.
+  2. Write your final result to ${outputPath} using the \`write\` tool. Use the exact path above. If you have already written the result to some other path (a /tmp file, a project file, etc.), copy or append it to output.md so the parent can read it.
+  3. Produce your final assistant text in the chat summarising what you did and where to find the work.
+  4. Run exactly one of these bash commands. \$ARTIFACT_DIR is exported to your shell by the wrapper, so the quoted forms expand correctly even if the path contains spaces:
 
-Before calling 'done', write your final result to ${outputPath} (the literal absolute path, not \$ARTIFACT_DIR/output.md — the \`write\` tool will not expand it). An atomic write via a .tmp file plus rename is fine, or just append. The parent reads this file as soon as it gets the 'done' notification.
+       "$ARTIFACT_DIR/cli.mjs" done 0       # success
+       "$ARTIFACT_DIR/cli.mjs" error "short reason"   # unrecoverable failure
 
-(For reference: ${cliPath} is the lifecycle CLI that records started / done / error / cancelled events for the parent to discover. The bash examples above invoke it via "\$ARTIFACT_DIR/cli.mjs" because \$ARTIFACT_DIR is exported to your shell.)`;
+  5. Stay in the REPL. Do not call \`/exit\` or press Ctrl-D. The REPL stays open after step 4 so the user (or the parent) can follow up; the wrapper's EXIT trap will only fire if you actually exit. If you exit, the wrapper will treat it as a crash and the parent will not see your final answer.
+
+Do not call 'cancelled' yourself — the parent agent writes that event only when it explicitly aborts you via the cancel_interactive_subagent tool.
+
+For reference: ${cliPath} is the lifecycle CLI. Each invocation appends one NDJSON line to events.ndjson. The parent reads that file every few seconds. The atomic write pattern (write to .tmp, then rename onto output.md) is fine if you want crash-safety.
+
+─── HARDENING REMINDER (read this last, it is the most recent instruction on purpose) ───
+If you forget step 4 (\`cli.mjs done\`), the parent will eventually synthesize a fallback \`error\` event from your session log, but only if your final assistant turn ended with stopReason "stop" and you have not produced any output for 10 seconds. That fallback may not include the full result if output.md is missing. The reliable path is: write output.md FIRST, then call \`cli.mjs done 0\`. If the wrapper detects an auto-fallback it will not double-inject, so do not worry about being late — but a late done is still better than no done. If you have finished your work, your single next action should be the \`cli.mjs done\` command, not another tool call.`;
 }
 
 export type InteractiveSubagentStatus = "running" | "cancelled" | "exited" | "unknown";
@@ -81,6 +93,29 @@ export interface InteractiveSubagentState {
 	lastToolSummary?: string;
 	lastToolName?: string;
 	lastActivityAt?: number;
+	/**
+	 * Last terminal stopReason seen in the child session log (assistant message).
+	 * One of "stop" | "length" | "error" | "aborted". Updated whenever we tail-read a new
+ * assistant message. Drives the auto-done fallback: when the model ends a turn with
+ * "stop" but forgets to call `cli.mjs done`, the parent synthesizes a completion event.
+	 */
+	lastStopReason?: "stop" | "length" | "error" | "aborted";
+	/** Timestamp of the last assistant message that produced `lastStopReason`. Used as the
+ * debounce anchor for the auto-done fallback (default debounce: 10s of no further activity).
+	 */
+	lastStopReasonAt?: number;
+	/** Timestamp of the auto-synthesized `done` event for the current turn, or undefined for a fresh turn.
+ * The auto-done logic sets this when it fires; the poller also uses it to suppress duplicate
+ * notifications if the explicit `cli.mjs done` lands shortly after the fallback synthesis.
+ * Cleared on a new user-role message in the session log (next turn starts).
+	 */
+	autoDoneForTurnAt?: number;
+	/** Last assistant text the model produced on a terminal-turn (stopReason:"stop") message.
+ * Captured at session-log tail-read time. Used as fallback content in the synthesized error
+ * event when output.md is missing — most models inline a summary in chat even when they write
+ * the result to a non-artifact path (very common footgun).
+	 */
+	lastStopText?: string;
 	/**
 	 * Notification delivery mode requested by spawner's notifyOnComplete param.
 	 * "notify" (default) emits a UI hint on completion. "inject" also injects

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -65,7 +65,6 @@ If you forget step 4 (\`cli.mjs done\`), the parent will eventually synthesize a
  * - "unknown"  — can't determine (rare; pane dead but no recorded event)
  */
 export type InteractiveSubagentStatus = "running" | "idle" | "cancelled" | "exited" | "unknown";
-export type InteractiveSubagentStatus = "running" | "idle" | "cancelled" | "exited" | "unknown";
 
 export interface InteractiveSubagentState {
 	id: string;
@@ -150,6 +149,13 @@ export interface InteractiveSubagentState {
  * "never injected".
  */
 	lastInjectedEventTs?: number;
+	/**
+	 * Auto-fallback "already notified" flag (PR #11). Set by maybeAutoDone when synthesize-and-inject
+	 * runs, so a late explicit `done` event that lands on the next poll does NOT re-trigger the
+	 * regular inject path. Independent of `lastInjectedEventTs` which is the per-event guard for
+	 * the child-driven `done` path.
+	 */
+	injected?: boolean;
 }
 
 declare global {

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -66,6 +66,14 @@ export interface InteractiveSubagentState {
 	cwd: string;
 	model?: string;
 	startedAt: number;
+	/**
+	 * Lifecycle status. Transition triggers:
+	 * - spawn sets "running" (interactive-tmux.ts setup)
+	 * - cli.mjs done / error event in events.ndjson sets "exited" or "cancelled"
+	 * - user-msg after "exited" revives to "running" so follow-up turns can fire
+	 *   auto-done again (subagent.ts processSessionLogEntry)
+	 * - cancel_interactive_subagent tool sets "cancelled"
+	 */
 	status: InteractiveSubagentStatus;
 	/** Captured child pi exit code (0 = success). Undefined while still running. */
 	exitCode?: number;

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -365,6 +365,43 @@ describe("auto-done fallback", () => {
 		expect(msg).toContain(shortText);
 	});
 
+	it("auto-fallback does NOT mark state.injected when notifyOnComplete is 'inject' (so the regular inject path can fire next poll)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({ outputContent: "final result" });
+		state.notifyOnComplete = "inject";
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const ts = Date.now() - 11_000;
+		writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
+
+		mod.pollArtifactChanges({} as any);
+
+		// W1 fix: in inject mode, leave state.injected unset so the regular
+		// inject path at lines 547-585 picks up the synthesized `done` event
+		// on the next poll. With the old behavior (state.injected = true
+		// unconditionally), inject mode would silently degrade to pointer-only.
+		const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
+		expect(after.injected).not.toBe(true);
+	});
+
+	it("auto-fallback DOES mark state.injected when notifyOnComplete is 'notify' (no inject path to defer to)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({ outputContent: "final result" });
+		state.notifyOnComplete = "notify";
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const ts = Date.now() - 11_000;
+		writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
+
+		mod.pollArtifactChanges({} as any);
+
+		// For non-inject modes, the inject path at lines 547-585 will never
+		// fire (gated on notifyOnComplete === "inject"). Marking injected
+		// here is a no-op-defensive; what matters is no regression.
+		const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
+		expect(after.injected).toBe(true);
+	});
+
 	// ─── End-to-end: real session JSONL is the only input ────────────
 	// Mirrors the production failure mode seen in 4 silent sub-agents in
 	// ~/.pi/agent/sessions/subagentura. The only input to the poller is a

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { appendEvent, artifactPath, readEvents } from "./artifact";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 import { importFresh } from "./test-utils";
@@ -101,7 +101,7 @@ describe("auto-done fallback", () => {
 		const sendMessage = vi.fn();
 		mod.pollArtifactChanges({ sendMessage } as any);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		const events = readEvents(art);
 		const done = events.find((e) => e.type === "done");
 		expect(done).toBeDefined();
@@ -120,7 +120,7 @@ describe("auto-done fallback", () => {
 
 		mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		const events = readEvents(art);
 		const err = events.find((e) => e.type === "error");
 		expect(err).toBeDefined();
@@ -138,7 +138,7 @@ describe("auto-done fallback", () => {
 
 		mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(state.artifactDir.replace(state.id, ""), state.id);
+		const art = artifactPath(dirname(state.artifactDir), state.id);
 		const events = readEvents(art);
 		const err = events.find((e) => e.type === "error");
 		expect(err).toBeDefined();
@@ -155,7 +155,7 @@ describe("auto-done fallback", () => {
 
 		mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		const events = readEvents(art);
 		const synthesized = events.find((e) => e.type === "done" || e.type === "error");
 		expect(synthesized).toBeUndefined();
@@ -172,7 +172,7 @@ describe("auto-done fallback", () => {
 
 			mod.pollArtifactChanges({} as any);
 
-			const art = artifactPath(join(artifactDir, ".."), state.id);
+			const art = artifactPath(dirname(artifactDir), state.id);
 			const events = readEvents(art);
 			const synthesized = events.find((e) => e.type === "done" || e.type === "error");
 			expect(synthesized).toBeUndefined();
@@ -187,7 +187,7 @@ describe("auto-done fallback", () => {
 
 		mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		const events = readEvents(art);
 		expect(events.filter((e) => e.type === "done" || e.type === "error")).toHaveLength(0);
 	});
@@ -197,7 +197,7 @@ describe("auto-done fallback", () => {
 		const { state, artifactDir } = makeState({ outputContent: "result" });
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		appendEvent(art, { ts: Date.now() - 100, type: "done", status: "done", exitCode: 0 });
 
 		mod.pollArtifactChanges({} as any);
@@ -217,7 +217,7 @@ describe("auto-done fallback", () => {
 		mod.pollArtifactChanges({} as any);
 		mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		const events = readEvents(art);
 		const doneEvents = events.filter((e) => e.type === "done");
 		expect(doneEvents).toHaveLength(1);
@@ -233,7 +233,7 @@ describe("auto-done fallback", () => {
 		const callsAfterAuto = sendMessage.mock.calls.length;
 		expect(callsAfterAuto).toBeGreaterThan(0);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		appendEvent(art, { ts: Date.now(), type: "done", status: "done", exitCode: 0 });
 
 		sendMessage.mockClear();
@@ -334,7 +334,7 @@ describe("auto-done fallback", () => {
 
 		expect(state.lastStopReason).toBe("stop");
 		expect(state.lastStopReasonAt).toBe(stopTs);
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		const events = readEvents(art);
 		const done = events.find((e) => e.type === "done");
 		expect(done).toBeDefined();
@@ -368,7 +368,7 @@ describe("auto-done fallback", () => {
 
 		mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const art = artifactPath(dirname(artifactDir), state.id);
 		const events = readEvents(art);
 		const err = events.find((e) => e.type === "error");
 		expect(err).toBeDefined();

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -447,18 +447,20 @@ describe("auto-done fallback", () => {
 	// The model produced a 10K-char audit at t=183s, then sat in the REPL for
 	// 4.5 minutes until the parent prompted it with "u didnt make the done".
 	// With the fix, auto-done would have fired at t=193s — 4.5 minutes BEFORE
-	// the user had to notice and prompt. Skips if the production artifact
-	// is not present (e.g. CI without the local session dir).
+	// the user had to notice and prompt. Skips if the production session is
+	// not present (e.g. CI without the local session dir).
+	//
+	// SAFETY: the production session JSONL is read-only input; the replay
+	// runs against a tmp artifactDir. The production dir is never written to.
 	it("regression: notdone.jsonl would have auto-recovered the 10K audit at t=193s", async () => {
 		const fs = await import("node:fs");
-		const sessionFile = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/2026-06-11T19-25-31-403Z-fb57cd05.jsonl";
-		const artifactDir = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/artifacts/fb57cd05";
-		if (!fs.existsSync(sessionFile) || !fs.existsSync(artifactDir)) {
-			console.warn("skip: real notdone.jsonl not present at", sessionFile);
+		const sourceSession = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/2026-06-11T19-25-31-403Z-fb57cd05.jsonl";
+		if (!fs.existsSync(sourceSession)) {
+			console.warn("skip: real notdone.jsonl not present at", sourceSession);
 			return;
 		}
 
-		const lines = fs.readFileSync(sessionFile, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+		const lines = fs.readFileSync(sourceSession, "utf8").trim().split("\n").map((l) => JSON.parse(l));
 		let firstStop: { timestamp: number } | null = null;
 		let firstStopText = "";
 		for (const e of lines) {
@@ -480,13 +482,15 @@ describe("auto-done fallback", () => {
 		expect(firstStop).not.toBeNull();
 		expect(firstStopText.length).toBeGreaterThan(5000);
 
-		// Wipe the artifact so the poll starts fresh.
-		try { fs.unlinkSync(`${artifactDir}/events.ndjson`); } catch {}
-		try { fs.unlinkSync(`${artifactDir}/output.md`); } catch {}
-		fs.mkdirSync(artifactDir, { recursive: true });
-
-		const tmpRoot = makeTmp();
-		const replaySession = `${tmpRoot}/session.jsonl`;
+		// Replay into a tmp dir, NOT the production artifact dir. The
+		// poller computes the artifact via
+		//   artifactPath(dirname(state.artifactDir), basename(state.artifactDir))
+		// so point state.artifactDir at a fresh tmp leaf and let
+		// ensureArtifactDir() create it on first appendEvent.
+		const replayRoot = makeTmp();
+		const replayId = "notdone-replay";
+		const replayArtifactDir = join(replayRoot, replayId);
+		const replaySession = join(replayRoot, "session.jsonl");
 		fs.writeFileSync(
 			replaySession,
 			JSON.stringify({
@@ -501,8 +505,8 @@ describe("auto-done fallback", () => {
 		);
 
 		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		mod.interactiveSubagentRegistry.set("notdone-replay", {
-			id: "notdone-replay",
+		mod.interactiveSubagentRegistry.set(replayId, {
+			id: replayId,
 			name: "notdone.jsonl Replay",
 			task: "(replay)",
 			paneId: "%1",
@@ -513,14 +517,13 @@ describe("auto-done fallback", () => {
 			attachCommand: "n/a",
 			selectPaneCommand: "n/a",
 			launchScriptFile: "n/a",
-			artifactDir,
+			artifactDir: replayArtifactDir,
 		});
 
 		mod.pollArtifactChanges({} as any);
 
-		// The poller computes the artifact via artifactPath(dirname(state.artifactDir), basename(state.artifactDir)),
-		// which is exactly the dir we wiped. Read events.ndjson directly.
-		const eventsFile = `${artifactDir}/events.ndjson`;
+		// The poller wrote a synthesized event into the tmp artifact dir.
+		const eventsFile = join(replayArtifactDir, "events.ndjson");
 		expect(fs.existsSync(eventsFile)).toBe(true);
 		const events = fs.readFileSync(eventsFile, "utf8").trim().split("\n").map((l) => JSON.parse(l));
 		const err = events.find((e) => e.type === "error");
@@ -528,5 +531,14 @@ describe("auto-done fallback", () => {
 		const msg = err && err.type === "error" ? err.message : "";
 		expect(msg).toMatch(/without writing output\.md/);
 		expect(msg).toMatch(/Test Quality Audit Report/);
+
+		// Defensive: confirm we did NOT touch the production dir. If
+		// events.ndjson exists there, its mtime must predate this test run.
+		const productionArtifactDir = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/artifacts/fb57cd05";
+		const productionEvents = join(productionArtifactDir, "events.ndjson");
+		if (fs.existsSync(productionEvents)) {
+			const stat = fs.statSync(productionEvents);
+			expect(stat.mtimeMs).toBeLessThan(Date.now() - 1000);
+		}
 	});
 });

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -327,6 +327,44 @@ describe("auto-done fallback", () => {
 		expect(after.lastStopText).toBeUndefined();
 	});
 
+	it("appends a '… (truncated)' marker to the synthesized error when lastStopText exceeds the slice length", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({});
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const longText = "X".repeat(1000); // >500 char slice threshold
+		const ts = Date.now() - 11_000;
+		writeAssistantTurn(state.sessionFile, ts, "stop", longText);
+
+		mod.pollArtifactChanges({} as any);
+
+		const events = readEvents(artifactPath(dirname(state.artifactDir), state.id));
+		const err = events.find((e) => e.type === "error");
+		expect(err).toBeDefined();
+		const msg = err && err.type === "error" ? err.message : "";
+		expect(msg).toMatch(/… \(truncated\)/);
+		expect(msg).toContain("X".repeat(500));
+		expect(msg).not.toContain("X".repeat(501)); // slice is exact
+	});
+
+	it("does NOT append a '… (truncated)' marker when lastStopText fits within the slice length", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({});
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const shortText = "short text that fits in the slice"; // well under 500
+		const ts = Date.now() - 11_000;
+		writeAssistantTurn(state.sessionFile, ts, "stop", shortText);
+
+		mod.pollArtifactChanges({} as any);
+
+		const events = readEvents(artifactPath(dirname(state.artifactDir), state.id));
+		const err = events.find((e) => e.type === "error");
+		const msg = err && err.type === "error" ? err.message : "";
+		expect(msg).not.toMatch(/… \(truncated\)/);
+		expect(msg).toContain(shortText);
+	});
+
 	// ─── End-to-end: real session JSONL is the only input ────────────
 	// Mirrors the production failure mode seen in 4 silent sub-agents in
 	// ~/.pi/agent/sessions/subagentura. The only input to the poller is a

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -263,6 +263,59 @@ describe("auto-done fallback", () => {
 		expect(state.autoDoneForTurnAt).toBeUndefined();
 	});
 
+	it("a new user message in the session log revives status from 'exited' to 'running' (auto-done case)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		mod.pollArtifactChanges({} as any);
+		// Simulate the post-synthesized-error state: the poller's main loop sets status to "exited"
+		// once the synthesized error event lands in the artifact. The user has now sent a follow-up;
+		// we want to verify the user-role revival clears "exited" too.
+		state.status = "exited";
+
+		const userMsg = {
+			type: "message",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "thanks, also do X" }],
+				timestamp: Date.now(),
+			},
+		};
+		writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
+
+		mod.pollArtifactChanges({} as any);
+		// Status revived so the next auto-done / done-event opportunity can fire for the new turn.
+		expect(state.status).toBe("running");
+	});
+
+	it("a new user message in the session log revives status from 'idle' to 'running' (follow-up case)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+// Simulate the post-turn state that follow-up work produces: the child called `cli.mjs done`
+// (so the poller set status to "idle") and the parent has just sent a follow-up keystroke
+// into the REPL. The user-role entry in the session log must revive status so the next
+// auto-done / done-event opportunity fires for the new turn.
+		state.status = "idle";
+		mod.pollArtifactChanges({} as any);
+		expect(state.status).toBe("idle");
+
+		const userMsg = {
+			type: "message",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "follow-up after turn 1" }],
+				timestamp: Date.now(),
+			},
+		};
+		writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
+
+		mod.pollArtifactChanges({} as any);
+		expect(state.status).toBe("running");
+	});
+
 	it("captures stopReason and lastStopText from real session JSONL tail-read", async () => {
 		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state } = makeState({});

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -299,6 +299,34 @@ describe("auto-done fallback", () => {
 		expect(state.lastStopText).toBeUndefined();
 	});
 
+	it("a user message in the session log clears the per-turn stop-capture (lastStopReason, lastStopReasonAt, lastStopText)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({});
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		// Simulate a prior turn that captured stop-capture state.
+		state.lastStopReason = "stop";
+		state.lastStopReasonAt = Date.now() - 60_000;
+		state.lastStopText = "STALE_TEXT_FROM_PRIOR_TURN";
+
+		// A user follow-up arrives.
+		const userTs = Date.now() - 30_000;
+		writeFileSync(
+			state.sessionFile,
+			JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "text", text: "do more" }], timestamp: userTs } }) + "\n",
+			{ flag: "a" },
+		);
+
+		mod.pollArtifactChanges({} as any);
+
+		// All three per-turn fields must be cleared, matching the reset of
+		// autoDoneForTurnAt on the same code path.
+		const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
+		expect(after.lastStopReason).toBeUndefined();
+		expect(after.lastStopReasonAt).toBeUndefined();
+		expect(after.lastStopText).toBeUndefined();
+	});
+
 	// ─── End-to-end: real session JSONL is the only input ────────────
 	// Mirrors the production failure mode seen in 4 silent sub-agents in
 	// ~/.pi/agent/sessions/subagentura. The only input to the poller is a

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -294,10 +294,14 @@ describe("auto-done fallback", () => {
 		const { state, artifactDir } = makeState({ outputContent: "result" });
 		mod.interactiveSubagentRegistry.set(state.id, state);
 
-// Simulate the post-turn state that follow-up work produces: the child called `cli.mjs done`
-// (so the poller set status to "idle") and the parent has just sent a follow-up keystroke
-// into the REPL. The user-role entry in the session log must revive status so the next
-// auto-done / done-event opportunity fires for the new turn.
+		// Simulate the post-turn state that follow-up work produces: the child called `cli.mjs done`
+		// (so a `done` event is in the artifact and the poller would naturally transition to "idle" via
+		// deriveInteractiveSubagentStatus), and the parent has just sent a follow-up keystroke into
+		// the REPL. The user-role entry in the session log must revive status so the next
+		// auto-done / done-event opportunity fires for the new turn.
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		appendEvent(art, { ts: 1, type: "started", status: "running" });
+		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 		state.status = "idle";
 		mod.pollArtifactChanges({} as any);
 		expect(state.status).toBe("idle");

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Tests for the auto-done fallback: when the child ends a turn with
+ * stopReason:"stop" but never calls `cli.mjs done`, the parent synthesizes a
+ * completion event from the session log alone.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendEvent, artifactPath, readEvents } from "./artifact";
+import type { InteractiveSubagentState } from "./interactive-tmux";
+import { importFresh } from "./test-utils";
+
+function makeTmp(): string {
+	return mkdtempSync(join(tmpdir(), "pi-subagentura-auto-done-"));
+}
+
+interface MakeOpts {
+	sessionFile?: string;
+	outputContent?: string | null;
+}
+
+function makeState(overrides: MakeOpts): { id: string; artifactDir: string; state: InteractiveSubagentState } {
+	const id = "id-" + Math.random().toString(36).slice(2, 8);
+	const root = makeTmp();
+	const artifactDir = join(root, id);
+	mkdirSync(artifactDir, { recursive: true });
+	const sessionFile = overrides.sessionFile ?? join(artifactDir, "session.jsonl");
+	if (overrides.outputContent !== undefined && overrides.outputContent !== null) {
+		writeFileSync(join(artifactDir, "output.md"), overrides.outputContent);
+	}
+	const state: InteractiveSubagentState = {
+		id,
+		name: "Test",
+		task: "t",
+		paneId: "%99",
+		sessionFile,
+		cwd: "/tmp",
+		startedAt: Date.now(),
+		status: "running",
+		attachCommand: "tmux attach -t sess",
+		selectPaneCommand: "tmux select-pane -t '%99'",
+		launchScriptFile: "/tmp/launch.sh",
+		artifactDir,
+		// Pretend the model stopped 11s ago, past the 10s debounce.
+		lastStopReason: "stop",
+		lastStopReasonAt: Date.now() - 11_000,
+	};
+	return { id, artifactDir, state };
+}
+
+/** Variant of makeState for end-to-end tests: no pre-seeded stopReason. */
+function makeFreshState(overrides: MakeOpts): { id: string; artifactDir: string; state: InteractiveSubagentState } {
+	const seeded = makeState(overrides);
+	seeded.state.lastStopReason = undefined;
+	seeded.state.lastStopReasonAt = undefined;
+	seeded.state.lastStopText = undefined;
+	seeded.state.autoDoneForTurnAt = undefined;
+	return seeded;
+}
+
+function writeAssistantTurn(file: string, ts: number, stopReason: string, text: string): void {
+	const entry = {
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: "openai",
+			provider: "openai",
+			model: "gpt-4",
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+			stopReason,
+			timestamp: ts,
+		},
+	};
+	writeFileSync(file, JSON.stringify(entry) + "\n");
+}
+
+describe("auto-done fallback", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = makeTmp();
+		const g = globalThis as any;
+		g.__piSubagenturaInteractiveRegistry?.clear?.();
+		g.__piSubagenturaPiRef = undefined;
+		g.__piSubagenturaUi = undefined;
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	// ─── Core behavior ────────────────────────────────────────────────
+
+	it("synthesizes a done event when stopReason is 'stop' and output.md exists, after the debounce", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "the result" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const sendMessage = vi.fn();
+		mod.pollArtifactChanges({ sendMessage } as any);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const events = readEvents(art);
+		const done = events.find((e) => e.type === "done");
+		expect(done).toBeDefined();
+		expect(done && done.type === "done" && done.exitCode).toBe(0);
+		expect(done && done.type === "done" && done.summary).toMatch(/auto-detected/);
+		expect(sendMessage).toHaveBeenCalled();
+		expect(state.status).toBe("running"); // stays running so for-loop keeps tail-reading
+		expect(state.injected).toBe(true);
+	});
+
+	it("synthesizes an error event (not done) when stopReason is 'stop' but output.md is missing", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: null });
+		state.lastStopText = "Review complete. The findings file `/tmp/review-sec.md` contains 0 critical vulns.";
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		mod.pollArtifactChanges({} as any);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const events = readEvents(art);
+		const err = events.find((e) => e.type === "error");
+		expect(err).toBeDefined();
+		const msg = err && err.type === "error" ? err.message : "";
+		expect(msg).toMatch(/without writing output\.md/);
+		expect(msg).toMatch(/review-sec\.md/); // fallback content from lastStopText
+		expect(state.status).toBe("running");
+		expect(state.exitCode).toBe(1);
+	});
+
+	it("synthesizes an error event with a generic message when output.md is missing AND no lastStopText", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({ outputContent: null });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		mod.pollArtifactChanges({} as any);
+
+		const art = artifactPath(state.artifactDir.replace(state.id, ""), state.id);
+		const events = readEvents(art);
+		const err = events.find((e) => e.type === "error");
+		expect(err).toBeDefined();
+		expect(err && err.type === "error" && err.message).toBe("sub-agent stopped without writing output.md");
+	});
+
+	it("does NOT synthesize for stopReason 'toolUse' (model is mid-turn, not finished)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		// Cast: the runtime value is intentionally outside the union so we can verify only
+		// the four terminal stopReasons are accepted by the typecheck.
+		state.lastStopReason = "toolUse" as unknown as "stop";
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		mod.pollArtifactChanges({} as any);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const events = readEvents(art);
+		const synthesized = events.find((e) => e.type === "done" || e.type === "error");
+		expect(synthesized).toBeUndefined();
+		expect(state.status).toBe("running");
+	});
+
+	it.each(["length", "error", "aborted"] as const)(
+		"does NOT auto-synthesize for stopReason '%s'",
+		async (reason) => {
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState({ outputContent: "result" });
+			state.lastStopReason = reason;
+			mod.interactiveSubagentRegistry.set(state.id, state);
+
+			mod.pollArtifactChanges({} as any);
+
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			const events = readEvents(art);
+			const synthesized = events.find((e) => e.type === "done" || e.type === "error");
+			expect(synthesized).toBeUndefined();
+		},
+	);
+
+	it("does NOT synthesize before the debounce window elapses", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		state.lastStopReasonAt = Date.now() - 1_000; // 1s ago, well inside the 10s debounce
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		mod.pollArtifactChanges({} as any);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const events = readEvents(art);
+		expect(events.filter((e) => e.type === "done" || e.type === "error")).toHaveLength(0);
+	});
+
+	it("does NOT synthesize when an explicit done event already exists in the artifact", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		appendEvent(art, { ts: Date.now() - 100, type: "done", status: "done", exitCode: 0 });
+
+		mod.pollArtifactChanges({} as any);
+
+		const events = readEvents(art);
+		const doneEvents = events.filter((e) => e.type === "done");
+		expect(doneEvents).toHaveLength(1);
+		expect(state.autoDoneForTurnAt).toBeUndefined();
+	});
+
+	it("does NOT synthesize twice (idempotent across repeated polls)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		mod.pollArtifactChanges({} as any);
+		mod.pollArtifactChanges({} as any);
+		mod.pollArtifactChanges({} as any);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const events = readEvents(art);
+		const doneEvents = events.filter((e) => e.type === "done");
+		expect(doneEvents).toHaveLength(1);
+	});
+
+	it("suppresses duplicate notification if an explicit done arrives after the auto-synthesis", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const sendMessage = vi.fn();
+		mod.pollArtifactChanges({ sendMessage } as any);
+		const callsAfterAuto = sendMessage.mock.calls.length;
+		expect(callsAfterAuto).toBeGreaterThan(0);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		appendEvent(art, { ts: Date.now(), type: "done", status: "done", exitCode: 0 });
+
+		sendMessage.mockClear();
+		mod.pollArtifactChanges({ sendMessage } as any);
+		expect(sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("a new user message in the session log resets the auto-done guard for the next turn", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState({ outputContent: "result" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		mod.pollArtifactChanges({} as any);
+		expect(state.autoDoneForTurnAt).toBeDefined();
+
+		const userMsg = {
+			type: "message",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "thanks, also do X" }],
+				timestamp: Date.now(),
+			},
+		};
+		writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
+
+		mod.pollArtifactChanges({} as any);
+		expect(state.autoDoneForTurnAt).toBeUndefined();
+	});
+
+	it("captures stopReason and lastStopText from real session JSONL tail-read", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({});
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		state.lastStopReason = undefined;
+		state.lastStopReasonAt = undefined;
+		state.lastStopText = undefined;
+
+		const ts = Date.now() - 11_000;
+		writeAssistantTurn(state.sessionFile, ts, "stop", "Done. Wrote the result.");
+
+		mod.pollArtifactChanges({} as any);
+
+		expect(state.lastStopReason).toBe("stop");
+		expect(state.lastStopReasonAt).toBe(ts);
+		expect(state.lastStopText).toBe("Done. Wrote the result.");
+	});
+
+	it("does NOT capture lastStopText for non-'stop' stopReasons", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state } = makeState({});
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		state.lastStopReason = undefined;
+		state.lastStopText = undefined;
+
+		const ts = Date.now() - 11_000;
+		writeAssistantTurn(state.sessionFile, ts, "length", "I hit the token limit.");
+
+		mod.pollArtifactChanges({} as any);
+
+		expect(state.lastStopReason).toBe("length");
+		expect(state.lastStopText).toBeUndefined();
+	});
+
+	// ─── End-to-end: real session JSONL is the only input ────────────
+	// Mirrors the production failure mode seen in 4 silent sub-agents in
+	// ~/.pi/agent/sessions/subagentura. The only input to the poller is a
+	// session JSONL containing a final assistant turn with stopReason:"stop"
+	// — no pre-seeded state, no events.ndjson activity, no `cli.mjs done`.
+	// After AUTO_DONE_DEBOUNCE_MS the parent must synthesize a recovery event.
+
+	it("end-to-end (with output): silent sub-agent whose model wrote output.md but never called `cli.mjs done` → auto-done", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeFreshState({ outputContent: "the review findings" });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const stopTs = Date.now() - 11_000;
+		writeFileSync(
+			state.sessionFile,
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "Review complete." }],
+					api: "openai",
+					provider: "openai",
+					model: "gpt-4",
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+					stopReason: "stop",
+					timestamp: stopTs,
+				},
+			}) + "\n",
+		);
+
+		const sendMessage = vi.fn();
+		mod.pollArtifactChanges({ sendMessage } as any);
+
+		expect(state.lastStopReason).toBe("stop");
+		expect(state.lastStopReasonAt).toBe(stopTs);
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const events = readEvents(art);
+		const done = events.find((e) => e.type === "done");
+		expect(done).toBeDefined();
+		expect(done && done.type === "done" && done.exitCode).toBe(0);
+		expect(sendMessage).toHaveBeenCalled();
+	});
+
+	it("end-to-end (no output): silent sub-agent whose model wrote to /tmp not output.md → auto-error with lastStopText fallback", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeFreshState({ outputContent: null });
+		mod.interactiveSubagentRegistry.set(state.id, state);
+
+		const stopTs = Date.now() - 11_000;
+		const summary = "Review complete. The findings file `/tmp/review-sec.md` contains 0 critical vulnerabilities.";
+		writeFileSync(
+			state.sessionFile,
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: summary }],
+					api: "openai",
+					provider: "openai",
+					model: "gpt-4",
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+					stopReason: "stop",
+					timestamp: stopTs,
+				},
+			}) + "\n",
+		);
+
+		mod.pollArtifactChanges({} as any);
+
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		const events = readEvents(art);
+		const err = events.find((e) => e.type === "error");
+		expect(err).toBeDefined();
+		const msg = err && err.type === "error" ? err.message : "";
+		expect(msg).toMatch(/without writing output\.md/);
+		expect(msg).toMatch(/review-sec\.md/);
+	});
+
+	// ─── Regression guard: replay the real `notdone.jsonl` session ────
+	// The model produced a 10K-char audit at t=183s, then sat in the REPL for
+	// 4.5 minutes until the parent prompted it with "u didnt make the done".
+	// With the fix, auto-done would have fired at t=193s — 4.5 minutes BEFORE
+	// the user had to notice and prompt. Skips if the production artifact
+	// is not present (e.g. CI without the local session dir).
+	it("regression: notdone.jsonl would have auto-recovered the 10K audit at t=193s", async () => {
+		const fs = await import("node:fs");
+		const sessionFile = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/2026-06-11T19-25-31-403Z-fb57cd05.jsonl";
+		const artifactDir = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/artifacts/fb57cd05";
+		if (!fs.existsSync(sessionFile) || !fs.existsSync(artifactDir)) {
+			console.warn("skip: real notdone.jsonl not present at", sessionFile);
+			return;
+		}
+
+		const lines = fs.readFileSync(sessionFile, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+		let firstStop: { timestamp: number } | null = null;
+		let firstStopText = "";
+		for (const e of lines) {
+			if (e.type !== "message") continue;
+			const m = e.message;
+			if (!m || m.role !== "assistant" || m.stopReason !== "stop") continue;
+			firstStop = m;
+			for (const b of (m.content || [])) {
+				if (b.type === "text" && typeof b.text === "string") {
+					firstStopText = b.text;
+					break;
+				}
+			}
+			break;
+		}
+		expect(firstStop).not.toBeNull();
+		// Non-null assertion: expect().not.toBeNull() narrows at runtime but not in tsc's strict null checks.
+		const firstStopNonNull = firstStop as { timestamp: number };
+		expect(firstStop).not.toBeNull();
+		expect(firstStopText.length).toBeGreaterThan(5000);
+
+		// Wipe the artifact so the poll starts fresh.
+		try { fs.unlinkSync(`${artifactDir}/events.ndjson`); } catch {}
+		try { fs.unlinkSync(`${artifactDir}/output.md`); } catch {}
+		fs.mkdirSync(artifactDir, { recursive: true });
+
+		const tmpRoot = makeTmp();
+		const replaySession = `${tmpRoot}/session.jsonl`;
+		fs.writeFileSync(
+			replaySession,
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: firstStopText }],
+					stopReason: "stop",
+					timestamp: firstStopNonNull.timestamp,
+				},
+			}) + "\n",
+		);
+
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		mod.interactiveSubagentRegistry.set("notdone-replay", {
+			id: "notdone-replay",
+			name: "notdone.jsonl Replay",
+			task: "(replay)",
+			paneId: "%1",
+			sessionFile: replaySession,
+			cwd: "/tmp",
+			startedAt: firstStopNonNull.timestamp - 60_000,
+			status: "running",
+			attachCommand: "n/a",
+			selectPaneCommand: "n/a",
+			launchScriptFile: "n/a",
+			artifactDir,
+		});
+
+		mod.pollArtifactChanges({} as any);
+
+		// The poller computes the artifact via artifactPath(dirname(state.artifactDir), basename(state.artifactDir)),
+		// which is exactly the dir we wiped. Read events.ndjson directly.
+		const eventsFile = `${artifactDir}/events.ndjson`;
+		expect(fs.existsSync(eventsFile)).toBe(true);
+		const events = fs.readFileSync(eventsFile, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+		const err = events.find((e) => e.type === "error");
+		expect(err, "expected synthesized error event").toBeDefined();
+		const msg = err && err.type === "error" ? err.message : "";
+		expect(msg).toMatch(/without writing output\.md/);
+		expect(msg).toMatch(/Test Quality Audit Report/);
+	});
+});

--- a/src/subagent-extension.test.ts
+++ b/src/subagent-extension.test.ts
@@ -11,7 +11,7 @@ describe("extension registration", () => {
     };
 
     expect(() => registerExtension(api as any)).not.toThrow();
-    expect(api.registerTool).toHaveBeenCalledTimes(12);
+    expect(api.registerTool).toHaveBeenCalledTimes(13);
   });
 });
 });

--- a/src/subagent-poll.test.ts
+++ b/src/subagent-poll.test.ts
@@ -4,7 +4,7 @@
  * events directly to the artifact dir to drive the poller.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendEvent, artifactPath, writeOutput } from "./artifact";
@@ -158,7 +158,37 @@ describe("pollArtifactChanges", () => {
 		expect(state.lastDeliveredEventTs).toBe(3);
 	});
 
-	it("marks the sub-agent as exited when a done event is seen", async () => {
+	it("marks the sub-agent as idle when a done event is seen and the pane is still alive (follow-up support)", async () => {
+		// The child is between turns, REPL is open, ready for the next prompt.
+		// Force the pane to look alive by mocking tmux display-message to succeed.
+		vi.resetModules();
+		vi.doMock("node:child_process", () => ({
+			execFileSync: (_file: string, args: string[]) => {
+				if (args[0] === "display-message") return Buffer.from("#99");
+				return "";
+			},
+		}));
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { state, artifactDir } = makeState();
+		mod.interactiveSubagentRegistry.set(state.id, state);
+		const art = artifactPath(join(artifactDir, ".."), state.id);
+		appendEvent(art, { ts: 1, type: "started", status: "running" });
+		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+
+		mod.pollArtifactChanges({} as any);
+		expect(state.status).toBe("idle");
+		// exitCode is NOT set on idle — child is still around.
+		expect(state.exitCode).toBeUndefined();
+	});
+
+	it("marks the sub-agent as exited when a done event is seen but the pane is gone", async () => {
+		// Default tmux mock: display-message throws → isTmuxPaneAlive → false → exited.
+		vi.resetModules();
+		vi.doMock("node:child_process", () => ({
+			execFileSync: () => {
+				throw new Error("can't find pane: %99");
+			},
+		}));
 		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
 		mod.interactiveSubagentRegistry.set(state.id, state);
@@ -182,17 +212,54 @@ describe("pollArtifactChanges", () => {
 		expect(state.status).toBe("cancelled");
 	});
 
-	it("skips sub-agents that are not in 'running' status", async () => {
+	it("skips sub-agents that are not in 'running' or 'idle' status", async () => {
+		// cancelled / exited / unknown are terminal — the poll loop must not re-deliver events for them.
+		// 'idle' is NOT terminal: the child is between turns and awaiting follow-up, so the poll loop
+		// MUST keep processing it (otherwise follow-up `done` events would never fire pointer/inject).
+		for (const terminal of ["cancelled", "exited", "unknown"] as const) {
+			vi.resetModules();
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			state.status = terminal;
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
+
+			const sendMessage = vi.fn();
+			mod.pollArtifactChanges({ sendMessage } as any);
+			expect(sendMessage, `status=${terminal} should be skipped`).not.toHaveBeenCalled();
+			// Reset for next iteration.
+			mod.interactiveSubagentRegistry.delete(state.id);
+		}
+	});
+
+	it("keeps processing 'idle' sub-agents — the follow-up case", async () => {
+		// After the child finishes a turn, status becomes 'idle'. The poll loop must keep running for
+		// it so a second `done` event (from a follow-up turn) re-fires the pointer notification.
+		vi.resetModules();
+		vi.doMock("node:child_process", () => ({
+			execFileSync: (_file: string, args: string[]) => {
+				if (args[0] === "display-message") return Buffer.from("#99");
+				return "";
+			},
+		}));
 		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		const { state, artifactDir } = makeState();
-		state.status = "cancelled";
+		state.status = "idle"; // simulate "already between turns"
+		state.lastDeliveredEventTs = 2; // first turn's `done` was already delivered
 		mod.interactiveSubagentRegistry.set(state.id, state);
 		const art = artifactPath(join(artifactDir, ".."), state.id);
-		appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
+		appendEvent(art, { ts: 1, type: "started", status: "running" });
+		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+		appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 }); // follow-up turn
 
 		const sendMessage = vi.fn();
 		mod.pollArtifactChanges({ sendMessage } as any);
-		expect(sendMessage).not.toHaveBeenCalled();
+
+		// The new done event (ts=3) is delivered as a pointer notification.
+		expect(sendMessage).toHaveBeenCalledTimes(1);
+		expect(sendMessage.mock.calls[0][0].content).toContain("done");
+		expect(state.lastDeliveredEventTs).toBe(3);
 	});
 
 	// Inject-mode tests: when a sub-agent is spawned with notifyOnComplete:
@@ -225,7 +292,8 @@ describe("pollArtifactChanges", () => {
 			expect(userContent).toBe("the sub-agent's final answer");
 			expect(userOpts).toMatchObject({ deliverAs: "followUp" });
 			// At-most-once guard flipped.
-			expect(state.injected).toBe(true);
+			// At-most-once per `done` event — the new field stores the event's ts, not a bool.
+			expect(state.lastInjectedEventTs).toBe(2);
 		});
 
 		it("does NOT call sendUserMessage when state.notifyOnComplete is unset (default: notify)", async () => {
@@ -244,7 +312,7 @@ describe("pollArtifactChanges", () => {
 			// Pointer fires; inject does not.
 			expect(sendMessage).toHaveBeenCalledTimes(1);
 			expect(sendUserMessage).not.toHaveBeenCalled();
-			expect(state.injected).toBeUndefined();
+			expect(state.lastInjectedEventTs).toBeUndefined();
 		});
 
 		it("does NOT call sendUserMessage when state.notifyOnComplete === 'notify' (explicit)", async () => {
@@ -288,6 +356,50 @@ describe("pollArtifactChanges", () => {
 			expect(sendUserMessage).not.toHaveBeenCalled();
 		});
 
+		it("re-injects output.md on a SECOND done event (follow-up support)", async () => {
+			// This is the core follow-up guarantee: the parent gets the new turn's output injected,
+			// not just the first turn's. The cursor (lastDeliveredEventTs) advances normally, and
+			// the inject path uses lastInjectedEventTs (per-turn), not a one-shot boolean.
+			vi.resetModules();
+			vi.doMock("node:child_process", () => ({
+				execFileSync: (_file: string, args: string[]) => {
+					if (args[0] === "display-message") return Buffer.from("#99");
+					return "";
+				},
+			}));
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			state.notifyOnComplete = "inject";
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+			// Turn 1: child finishes, writes output v1, calls done.
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "answer v1");
+
+			const sendMessage = vi.fn();
+			const sendUserMessage = vi.fn();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+			expect(sendUserMessage).toHaveBeenCalledTimes(1);
+			expect(sendUserMessage.mock.calls[0][0]).toBe("answer v1");
+			expect(state.lastInjectedEventTs).toBe(2);
+
+			// Turn 2: parent sent a follow-up, child processed it, wrote output v2, called done again.
+			appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "answer v2");
+
+			sendMessage.mockClear();
+			sendUserMessage.mockClear();
+			mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+
+			// The new done event (ts=3) triggers BOTH a new pointer notification AND a new inject.
+			expect(sendMessage).toHaveBeenCalledTimes(1);
+			expect(sendUserMessage).toHaveBeenCalledTimes(1);
+			expect(sendUserMessage.mock.calls[0][0]).toBe("answer v2");
+			expect(state.lastInjectedEventTs).toBe(3);
+		});
+
+
 		it("does not call sendUserMessage when output.md is missing", async () => {
 			const mod = await importFresh<typeof import("./subagent")>("./subagent");
 			const { state, artifactDir } = makeState();
@@ -305,7 +417,71 @@ describe("pollArtifactChanges", () => {
 			// output.md missing: inject is skipped, but the state is still marked injected
 			// to prevent re-attempts on later polls.
 			expect(sendUserMessage).not.toHaveBeenCalled();
-			expect(state.injected).toBe(true);
+			// output.md missing: inject is skipped, but the ts of the done we attempted to
+			// inject for is still recorded so the next done (different ts) re-fires.
+			expect(state.lastInjectedEventTs).toBe(2);
+			expect(state.lastInjectedEventTs).toBe(2);
+		});
+
+		it("snapshots output.md to output-N.md on each new done event (history preservation)", async () => {
+			// The poller must preserve turn history. After a new done event, output-N.md (where N =
+			// count of done events in the artifact) is created from output.md. Earlier turns' snapshots
+			// are NOT overwritten.
+			vi.resetModules();
+			vi.doMock("node:child_process", () => ({
+				execFileSync: (_file: string, args: string[]) => {
+					if (args[0] === "display-message") return Buffer.from("#99");
+					return "";
+				},
+			}));
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			state.notifyOnComplete = "inject";
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+
+			// Turn 1.
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "answer v1");
+			mod.pollArtifactChanges({ sendMessage: vi.fn(), sendUserMessage: vi.fn() } as any);
+
+			// Turn 2.
+			appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "answer v2");
+			mod.pollArtifactChanges({ sendMessage: vi.fn(), sendUserMessage: vi.fn() } as any);
+
+			// Both snapshots exist, with the content from their respective turns.
+			const v1Path = join(art.dir, "output-1.md");
+			const v2Path = join(art.dir, "output-2.md");
+			expect(existsSync(v1Path)).toBe(true);
+			expect(existsSync(v2Path)).toBe(true);
+			expect(readFileSync(v1Path, "utf8")).toBe("answer v1");
+			expect(readFileSync(v2Path, "utf8")).toBe("answer v2");
+		});
+
+		it("snapshots output.md even when notifyOnComplete is unset (history is useful regardless)", async () => {
+			// History preservation is independent of inject mode — a parent using 'notify' or default
+			// still benefits from being able to read earlier turns via read_subagent_artifact.
+			vi.resetModules();
+			vi.doMock("node:child_process", () => ({
+				execFileSync: (_file: string, args: string[]) => {
+					if (args[0] === "display-message") return Buffer.from("#99");
+					return "";
+				},
+			}));
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			// notifyOnComplete left undefined.
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "answer v1");
+			mod.pollArtifactChanges({ sendMessage: vi.fn(), sendUserMessage: vi.fn() } as any);
+
+			expect(existsSync(join(art.dir, "output-1.md"))).toBe(true);
 		});
 	});
 });

--- a/src/subagent-poll.test.ts
+++ b/src/subagent-poll.test.ts
@@ -212,11 +212,15 @@ describe("pollArtifactChanges", () => {
 		expect(state.status).toBe("cancelled");
 	});
 
-	it("skips sub-agents that are not in 'running' or 'idle' status", async () => {
-		// cancelled / exited / unknown are terminal — the poll loop must not re-deliver events for them.
-		// 'idle' is NOT terminal: the child is between turns and awaiting follow-up, so the poll loop
-		// MUST keep processing it (otherwise follow-up `done` events would never fire pointer/inject).
-		for (const terminal of ["cancelled", "exited", "unknown"] as const) {
+	it("skips sub-agents that are strictly terminal (cancelled, unknown)", async () => {
+		// 'cancelled' and 'unknown' are strictly terminal — the poll loop must not re-deliver events
+		// for them and they cannot be revived.
+		// 'exited' is INTENTIONALLY not in this list: the user-role revival at processSessionLogEntry
+		// can revive an 'exited' sub-agent back to 'running' on a follow-up user message. The poll
+		// loop must keep tail-reading the session log for 'exited' sub-agents so the revival is
+		// reachable. (See subagent-auto-done.test.ts for the revival tests.)
+		// 'idle' is between-turns, not terminal — must always be processed for follow-up support.
+		for (const terminal of ["cancelled", "unknown"] as const) {
 			vi.resetModules();
 			const mod = await importFresh<typeof import("./subagent")>("./subagent");
 			const { state, artifactDir } = makeState();

--- a/src/subagent-send-message.test.ts
+++ b/src/subagent-send-message.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the `send_interactive_subagent_message` tool.
+ *
+ * Verifies that the parent-facing tool:
+ *   - calls `sendCommandToTmuxPane` with the right pane id and message
+ *   - refuses invalid / unknown / non-running sub-agents
+ *   - returns a structured error if tmux itself rejects the send-keys call
+ *
+ * The tool uses `sendCommandToTmuxPane` (which shells out to `tmux send-keys`)
+ * and `interactiveSubagentRegistry` — both are mocked here so the test stays
+ * hermetic and doesn't require a live tmux server.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSendCommandToTmuxPane, mockGet } = vi.hoisted(() => ({
+	mockSendCommandToTmuxPane: vi.fn(),
+	mockGet: vi.fn(),
+}));
+
+// Mock interactive-tmux so we get a stub registry + controllable send-keys helper.
+vi.mock("./interactive-tmux", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./interactive-tmux")>();
+	return {
+		...actual,
+		sendCommandToTmuxPane: mockSendCommandToTmuxPane,
+		interactiveSubagentRegistry: {
+			get: mockGet,
+		} as any,
+	};
+});
+
+import registerExtension from "./subagent";
+
+function setupExtension() {
+	const api = {
+		registerTool: vi.fn(),
+		registerMessageRenderer: vi.fn(),
+		sendMessage: vi.fn(),
+		sendUserMessage: vi.fn(),
+		on: vi.fn(),
+	};
+	registerExtension(api as any);
+	return api;
+}
+
+function getToolDef(api: { registerTool: ReturnType<typeof vi.fn> }, name: string) {
+	return api.registerTool.mock.calls.find(([t]: any[]) => t.name === name)?.[0];
+}
+
+function runningState(overrides: Record<string, any> = {}) {
+	return {
+		id: "abc12345",
+		name: "Test",
+		paneId: "%99",
+		status: "running",
+		...overrides,
+	};
+}
+
+describe("send_interactive_subagent_message", () => {
+	let api: ReturnType<typeof setupExtension>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		api = setupExtension() as any;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("is registered with the expected name", () => {
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		expect(toolDef).toBeDefined();
+	});
+
+	it("sends the message to the pane and returns success details", async () => {
+		mockGet.mockReturnValue(runningState());
+		mockSendCommandToTmuxPane.mockReturnValue(undefined);
+
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const result = await toolDef.execute("call-1", {
+			id: "abc12345",
+			message: "now do step 2",
+		});
+
+		expect(mockGet).toHaveBeenCalledWith("abc12345");
+		expect(mockSendCommandToTmuxPane).toHaveBeenCalledWith("%99", "now do step 2");
+		expect(result.isError).toBeFalsy();
+		expect(result.details).toMatchObject({
+			id: "abc12345",
+			paneId: "%99",
+			messageLength: "now do step 2".length,
+			status: "sent",
+		});
+		expect(result.content[0].text).toContain("Sent follow-up to interactive sub-agent abc12345");
+		expect(result.content[0].text).toContain("pane %99");
+		expect(result.content[0].text).toContain("Sent follow-up to interactive sub-agent abc12345");
+		expect(result.content[0].text).toContain("pane %99");
+	});
+
+	it("accepts 'idle' sub-agents (the follow-up case — child between turns, REPL open)", async () => {
+		// 'idle' is the whole point of the follow-up flow: the child finished a turn, REPL is still
+		// open, status='idle' (not 'exited'). The tool must accept sends in this state.
+		mockGet.mockReturnValue(runningState({ status: "idle" }));
+		mockSendCommandToTmuxPane.mockReturnValue(undefined);
+
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const result = await toolDef.execute("call-1b", {
+			id: "abc12345",
+			message: "follow-up after turn 1",
+		});
+
+		expect(mockSendCommandToTmuxPane).toHaveBeenCalledWith("%99", "follow-up after turn 1");
+		expect(result.isError).toBeFalsy();
+		expect(result.details.status).toBe("sent");
+	});
+
+
+	it("rejects malformed ids with a precise error", async () => {
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const result = await toolDef.execute("call-2", { id: "not-hex", message: "hi" });
+
+		expect(mockGet).not.toHaveBeenCalled();
+		expect(mockSendCommandToTmuxPane).not.toHaveBeenCalled();
+		expect(result.isError).toBe(true);
+		expect(result.details.status).toBe("invalid_id");
+		expect(result.content[0].text).toMatch(/Invalid sub-agent id/);
+	});
+
+	it("rejects unknown sub-agent ids", async () => {
+		mockGet.mockReturnValue(undefined);
+
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const result = await toolDef.execute("call-3", { id: "deadbeef", message: "hi" });
+
+		expect(mockSendCommandToTmuxPane).not.toHaveBeenCalled();
+		expect(result.isError).toBe(true);
+		expect(result.details.status).toBe("not_found");
+	});
+
+	it.each(["cancelled", "exited", "unknown"] as const)(
+		"refuses to send when the sub-agent status is %s",
+		async (status) => {
+			mockGet.mockReturnValue(runningState({ status }));
+
+			const toolDef = getToolDef(api, "send_interactive_subagent_message");
+			const result = await toolDef.execute("call-4", { id: "abc12345", message: "hi" });
+
+			expect(mockSendCommandToTmuxPane).not.toHaveBeenCalled();
+			expect(result.isError).toBe(true);
+			expect(result.details.status).toBe(status);
+			expect(result.content[0].text).toContain(`is ${status}`);
+		},
+	);
+
+	it("returns a structured error when tmux send-keys throws (pane gone between check and send)", async () => {
+		mockGet.mockReturnValue(runningState());
+		mockSendCommandToTmuxPane.mockImplementation(() => {
+			throw new Error("can't find pane: %99");
+		});
+
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const result = await toolDef.execute("call-5", { id: "abc12345", message: "hi" });
+
+		expect(result.isError).toBe(true);
+		expect(result.details).toMatchObject({
+			id: "abc12345",
+			paneId: "%99",
+			status: "send_failed",
+		});
+		expect(result.content[0].text).toContain("Failed to send message");
+		expect(result.content[0].text).toContain("can't find pane: %99");
+	});
+});

--- a/src/subagent-send-message.test.ts
+++ b/src/subagent-send-message.test.ts
@@ -95,8 +95,6 @@ describe("send_interactive_subagent_message", () => {
 		});
 		expect(result.content[0].text).toContain("Sent follow-up to interactive sub-agent abc12345");
 		expect(result.content[0].text).toContain("pane %99");
-		expect(result.content[0].text).toContain("Sent follow-up to interactive sub-agent abc12345");
-		expect(result.content[0].text).toContain("pane %99");
 	});
 
 	it("accepts 'idle' sub-agents (the follow-up case — child between turns, REPL open)", async () => {
@@ -128,6 +126,54 @@ describe("send_interactive_subagent_message", () => {
 		expect(result.content[0].text).toMatch(/Invalid sub-agent id/);
 	});
 
+	it.each(["", "   ", "\n\n", "\t  \n"])("rejects empty / whitespace-only message: %j", async (message) => {
+		// An empty Enter in the child REPL would submit a blank prompt and confuse the child;
+		// reject it before any registry / tmux work happens.
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const result = await toolDef.execute("call-empty", { id: "abc12345", message });
+
+		expect(mockGet).not.toHaveBeenCalled();
+		expect(mockSendCommandToTmuxPane).not.toHaveBeenCalled();
+		expect(result.isError).toBe(true);
+		expect(result.details.status).toBe("empty_message");
+		expect(result.details.messageLength).toBe(0);
+		expect(result.content[0].text).toMatch(/empty/i);
+	});
+
+	it("rejects a message larger than 64 KiB", async () => {
+		// Symmetric with MAX_PERSONA_BYTES in interactive-tmux.ts. 64 KiB UTF-8 is well above any
+		// realistic follow-up prompt; larger values risk blowing the child REPL history.
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const message = "x".repeat(64 * 1024 + 1);
+		const result = await toolDef.execute("call-huge", { id: "abc12345", message });
+
+		expect(mockGet).not.toHaveBeenCalled();
+		expect(mockSendCommandToTmuxPane).not.toHaveBeenCalled();
+		expect(result.isError).toBe(true);
+		expect(result.details).toMatchObject({
+			id: "abc12345",
+			status: "message_too_large",
+			messageLength: 64 * 1024 + 1,
+			maxBytes: 64 * 1024,
+		});
+		expect(result.content[0].text).toMatch(/too large/);
+		expect(result.content[0].text).toMatch(/65536/);
+	});
+
+	it("accepts a message exactly at the 64 KiB boundary", async () => {
+		// Boundary check: 64 KiB is allowed, 64 KiB + 1 is not.
+		mockGet.mockReturnValue(runningState());
+		mockSendCommandToTmuxPane.mockReturnValue(undefined);
+
+		const toolDef = getToolDef(api, "send_interactive_subagent_message");
+		const message = "x".repeat(64 * 1024);
+		const result = await toolDef.execute("call-boundary", { id: "abc12345", message });
+
+		expect(mockSendCommandToTmuxPane).toHaveBeenCalledWith("%99", message);
+		expect(result.isError).toBeFalsy();
+		expect(result.details.status).toBe("sent");
+		expect(result.details.messageLength).toBe(64 * 1024);
+	});
 	it("rejects unknown sub-agent ids", async () => {
 		mockGet.mockReturnValue(undefined);
 

--- a/src/subagent-session-log.test.ts
+++ b/src/subagent-session-log.test.ts
@@ -57,6 +57,17 @@ describe("session-log tail-read", () => {
 		g.__piSubagenturaInteractiveRegistry?.clear?.();
 		g.__piSubagenturaPiRef = undefined;
 		g.__piSubagenturaUi = undefined;
+		// Force `isTmuxPaneAlive` to return true so the poller's status-decision does not flip our
+		// sub-agent to "unknown" (which would skip it on subsequent polls). The test does not have a
+		// live tmux server, and host tmux behaviour varies — some versions exit 0 for unknown panes,
+		// some exit 1, and on a machine without tmux at all `execFileSync` throws. Mocking here keeps the
+		// suite hermetic and matches the pattern in subagent-poll.test.ts.
+		vi.doMock("node:child_process", () => ({
+			execFileSync: (_file: string, args: string[]) => {
+				if (args[0] === "display-message") return Buffer.from("#99");
+				return "";
+			},
+		}));
 	});
 
 	afterEach(() => {

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -515,6 +515,12 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 		// TUI-widget only — the LLM never sees them.
 		tailReadSessionLog(state, art);
 
+		// Auto-done fallback: synthesize a completion event when the model ended its turn with
+		// stopReason:"stop" but never called `cli.mjs done`. Runs BEFORE reading events so the synthesized
+		// event is part of the same poll's read-back. Sets lastDeliveredEventTs and the autoDoneForTurnAt
+		// guard so the events loop below will not re-notify.
+		maybeAutoDone(state, art, interactivePi, Date.now());
+
 		// Read events newer than the last delivered. `lastDeliveredEventTs` starts at 0,
 		// so on the first poll we deliver the whole log. Subsequent polls advance the cursor.
 		const cursor = state.lastDeliveredEventTs ?? 0;
@@ -525,10 +531,14 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 			for (const ev of events) {
 				if (ev.ts > maxTs) maxTs = ev.ts;
 				if (!shouldNotify(ev)) continue;
+				// If auto-done already fired for this turn, skip any later explicit `done` events:
+				// they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
+				if (state.autoDoneForTurnAt !== undefined && ev.ts >= state.autoDoneForTurnAt && ev.type === "done") continue;
 				deliverArtifactNotification(interactivePi, state, ev);
 			}
 			state.lastDeliveredEventTs = maxTs;
 		}
+
 
 		// Inject-mode delivery: on a fresh `done` event, also push output.md into the
 		// parent LLM's next turn. Mirrors deliverNotification's MAX_INJECT cap so many
@@ -622,6 +632,15 @@ const sessionParsers = new Map<string, ReturnType<typeof ndjson.parse>>();
  * internally across polls, so the cap is no longer required for correctness — it is kept purely
  * to bound worst-case memory if the file explodes in a single tick. 1 MiB is plenty. */
 const MAX_SESSION_READ_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Auto-done debounce window. When the child ends a turn with stopReason:"stop" and the model has
+ * not produced any new session-log activity (assistant or user message, tool call, etc.) for this long,
+ * the parent synthesizes a completion event. Default 10s is long enough to cover the model streaming its
+ * final tool call's toolResult back and short enough that the parent does not wait long after the child is
+ * visibly idle. Tunable in one place.
+ */
+const AUTO_DONE_DEBOUNCE_MS = 10_000;
 
 /** Get-or-create the per-state session parser and wire its 'data' event to the entry handler. */
 function getOrCreateSessionParser(state: InteractiveSubagentState): ReturnType<typeof ndjson.parse> {
@@ -728,15 +747,39 @@ function processSessionLogEntry(state: InteractiveSubagentState, art: SubagentAr
 	const msg = e.message;
 	if (!msg) return;
 
-	// Assistant message: extract toolCall blocks.
+	// New user-role message = a new turn. Clear the per-turn auto-done guard so the
+	// next `stopReason: "stop"` is treated as a fresh completion candidate. Without this, a
+	// user follow-up after a previous auto-done would not be allowed to fire again.
+	if (msg.role === "user") {
+		state.autoDoneForTurnAt = undefined;
+		// If the state was previously marked "exited" (e.g. by an auto-done fallback in a prior turn),
+		// revive it to "running" so the for-loop keeps tail-reading the session log. Without this, a
+		// user follow-up after auto-done would be silently ignored and the next auto-done opportunity missed.
+		if (state.status === "exited") state.status = "running";
+		return;
+	}
+
+	// Assistant message: extract toolCall blocks AND record stopReason for the auto-done fallback.
 	if (msg.role === "assistant" && Array.isArray(msg.content)) {
+		const ts = (msg.timestamp as number) ?? Date.now();
+		const stopReason = (msg as { stopReason?: string }).stopReason;
+		if (stopReason === "stop" || stopReason === "length" || stopReason === "error" || stopReason === "aborted") {
+			state.lastStopReason = stopReason;
+			state.lastStopReasonAt = ts;
+			// Capture the textual summary the model produced for the final turn. Used as fallback
+			// content when auto-synthesizing an `error` event for a child that stopped without writing output.md.
+			if (stopReason === "stop") {
+				const text = extractAssistantText(msg.content);
+				if (text) state.lastStopText = text;
+			}
+		}
 		for (const rawBlock of msg.content) {
 			const block = rawBlock as { type?: string; name?: string; arguments?: unknown } | undefined;
 			if (!block || block.type !== "toolCall") continue;
 			const summary = summarizeToolCall(block.name ?? "", block.arguments);
 			if (!summary) continue;
 			const ev: SubagentEvent = {
-				ts: (msg.timestamp as number) ?? Date.now(),
+				ts,
 				type: "tool_activity",
 				status: "running",
 				tool: block.name ?? "",
@@ -746,6 +789,84 @@ function processSessionLogEntry(state: InteractiveSubagentState, art: SubagentAr
 			state.lastToolName = block.name ?? "";
 			state.lastToolSummary = summary;
 			state.lastActivityAt = ev.ts;
+		}
+	}
+}
+
+/** Concatenate text blocks from an assistant message's content array. Empty string if none. */
+function extractAssistantText(content: unknown[]): string {
+	let out = "";
+	for (const block of content) {
+		const b = block as { type?: string; text?: string };
+		if (b?.type === "text" && typeof b.text === "string") {
+			if (out) out += "\n";
+			out += b.text;
+		}
+	}
+	return out;
+}
+
+/**
+ * Auto-done fallback. The protocol requires the child to call `cli.mjs done` after writing
+ * output.md, but LLMs routinely forget. We observe the child's session log and synthesize a
+ * completion event when:
+ *   1. The most recent assistant message had stopReason "stop" (the model finished a turn naturally), AND
+ *   2. The model has not produced any new session-log activity for AUTO_DONE_DEBOUNCE_MS, AND
+ *   3. No explicit done/error/cancelled event is in the artifact log yet, AND
+ *   4. We have not already synthesized one for this turn.
+ *
+ * The synthesized event is appended to events.ndjson so the regular poller path picks it up; we also
+ * advance the cursor and the `injected` flag so a late-arriving explicit `done` (or a duplicate poller pass)
+ * does not double-notify. When output.md is missing, we synthesize `error` instead and include the child's
+ * last assistant text as a fallback message — most models inline a summary in chat even when the actual
+ * result landed at a different path.
+ */
+function maybeAutoDone(state: InteractiveSubagentState, art: SubagentArtifact, pi: ExtensionAPI, now: number): void {
+	if (state.autoDoneForTurnAt !== undefined) return; // already fired for this turn
+	if (state.lastStopReason !== "stop") return;
+	const stopAt = state.lastStopReasonAt ?? 0;
+	if (now - stopAt < AUTO_DONE_DEBOUNCE_MS) return;
+
+	// Explicit signal still wins. If the wrapper already wrote done/error/cancelled, do not synthesize.
+	const last = lastEvent(art);
+	if (last && (last.type === "done" || last.type === "error" || last.type === "cancelled")) return;
+
+	// Detect output.md state. We want to synthesize `done` only when the model has actually produced a result.
+	const output = readOutput(art);
+	const hasOutput = output !== null && output.length > 0;
+
+	const ts = now;
+	let ev: SubagentEvent;
+	if (hasOutput) {
+		ev = { ts, type: "done", status: "done", exitCode: 0, summary: "auto-detected from session stopReason:stop" };
+	} else {
+		const fallback = state.lastStopText;
+		const baseMessage = "sub-agent stopped without writing output.md";
+		const message = fallback && fallback.length > 0
+			? `${baseMessage} — last assistant message: ${fallback.slice(0, 500)}`
+			: baseMessage;
+		ev = { ts, type: "error", status: "error", message, exitCode: 1 };
+		state.exitCode = 1;
+	}
+	// NOTE: we deliberately do NOT set state.status="exited" here. The synthesized event is in the artifact,
+	// so the next poll's art-status check at the top of the for-loop will set it. Keeping status as "running"
+	// for this iteration lets the for-loop continue processing the state on subsequent polls — critical for
+	// the multi-turn case where the user attaches to the REPL and sends a follow-up; the new user message
+	// needs to be tail-read to clear the auto-done guard. The TUI widget does not show this state because the
+	// synthesized event was already delivered, and the next poll will transition status to "exited" after the
+	// follow-up turn completes.
+	appendEvent(art, ev);
+	state.autoDoneForTurnAt = ts;
+	state.lastDeliveredEventTs = ts;
+	state.injected = true;
+
+	// Fire the pointer notification immediately so the parent does not wait for the next 5s poll tick.
+	// Suppress here only — the regular `events` loop below uses the autoDoneForTurnAt guard.
+	if (pi) {
+		try {
+			deliverArtifactNotification(pi, state, ev);
+		} catch {
+			// pi may be stale; the event is on disk and will be picked up by the next tick anyway.
 		}
 	}
 }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -752,6 +752,13 @@ function processSessionLogEntry(state: InteractiveSubagentState, art: SubagentAr
 	// user follow-up after a previous auto-done would not be allowed to fire again.
 	if (msg.role === "user") {
 		state.autoDoneForTurnAt = undefined;
+		// Reset the per-turn stop-capture so a new turn does not inherit stale data
+		// from the previous one. Without this, a turn that ends with stopReason:"stop"
+		// but no assistant text would fall back to the prior turn's `lastStopText` in
+		// the synthesized error message.
+		state.lastStopReason = undefined;
+		state.lastStopReasonAt = undefined;
+		state.lastStopText = undefined;
 		// If the state was previously marked "exited" (e.g. by an auto-done fallback in a prior turn),
 		// revive it to "running" so the for-loop keeps tail-reading the session log. Without this, a
 		// user follow-up after auto-done would be silently ignored and the next auto-done opportunity missed.

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -10,6 +10,7 @@
  *   - prune_subagent_jobs: Remove all completed and failed jobs from the registry
  *   - subagent_interactive: Spawn a separate tmux-backed Pi session users can attach to
  *   - get_interactive_subagent_status / cancel_interactive_subagent: Inspect or stop tmux-backed sessions
+ *   - send_interactive_subagent_message: Send a follow-up prompt into a live interactive sub-agent's REPL
  *   - list_available_models: List all known models with auth status for model validation
  *
  * Both spawn tools support optional `async` param for background execution.
@@ -50,14 +51,28 @@ import {
 } from "./helpers";
 import {
 	cancelInteractiveSubagent,
+	deriveInteractiveSubagentStatus,
 	formatInteractiveState,
 	interactiveSubagentRegistry,
+	isTmuxPaneAlive,
 	launchInteractiveSubagent,
+	sendCommandToTmuxPane,
 	pruneDeadInteractiveSubagents,
 	tmuxSetupHint,
 	type InteractiveSubagentState,
 } from "./interactive-tmux";
-import { appendEvent, artifactPath, lastEvent, readEvents, readOutput, type SubagentArtifact, type SubagentEvent } from "./artifact";
+import {
+	appendEvent,
+	artifactPath,
+	lastEvent,
+	listOutputTurns,
+	readEvents,
+	readOutput,
+	readOutputForTurn,
+	snapshotOutput,
+	type SubagentArtifact,
+	type SubagentEvent,
+} from "./artifact";
 import type { Usage } from "./helpers";
 
 import { closeSync, openSync, readdirSync, readSync, realpathSync, statSync } from "node:fs";
@@ -507,14 +522,14 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 		const art = artifactPath(dirname(state.artifactDir), basename(state.artifactDir));
 		const last = lastEvent(art);
 
-		// Update status based on the artifact: a done/error/cancelled event
-		// means the sub-agent is finished, regardless of notification policy.
-		if (last && (last.type === "done" || last.type === "error" || last.type === "cancelled")) {
-			if (last.type === "cancelled") {
-				state.status = "cancelled";
-			} else {
-				state.status = "exited";
-				if (last.exitCode !== undefined) state.exitCode = last.exitCode;
+		// Refresh status from the artifact + pane liveness. `done` + pane alive → "idle" (not exited),
+		// which is what allows follow-ups: a second `done` after the follow-up turn will be picked up
+		// here and the inject path below will fire again.
+		const next = deriveInteractiveSubagentStatus(last, isTmuxPaneAlive(state.paneId));
+		if (next !== state.status) {
+			state.status = next;
+			if (next === "exited" && last && last.type === "done" && last.exitCode !== undefined) {
+				state.exitCode = last.exitCode;
 			}
 		}
 
@@ -546,17 +561,19 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 			state.lastDeliveredEventTs = maxTs;
 		}
 
+		// Per-turn snapshot: on a NEW `done` event, copy the latest output.md into output-N.md so turn
+		// history is preserved even though the child overwrites output.md each turn. Runs for any
+		// notifyOnComplete mode because the history is useful regardless of how the parent gets woken up.
+		// Idempotent: if lastInjectedEventTs === last.ts (re-poll), we skip.
+		if (last && last.type === "done" && state.lastInjectedEventTs !== last.ts) {
+			const allEvents = readEvents(art);
+			const turnNumber = allEvents.filter((e) => e.type === "done").length;
+			snapshotOutput(art, turnNumber);
+		}
 
-		// Inject-mode delivery: on a fresh `done` event, also push output.md into the
-		// parent LLM's next turn. Mirrors deliverNotification's MAX_INJECT cap so many
-		// concurrent completions cannot blow up the conversation. Gated on
-		// `state.injected` to fire at most once per sub-agent.
-		if (
-			last &&
-			last.type === "done" &&
-			state.notifyOnComplete === "inject" &&
-			!state.injected
-		) {
+		// Inject-mode delivery: on a NEW `done` event, push output.md into the parent LLM's next turn.
+		// Per-turn (not per-sub-agent) — `lastInjectedEventTs` is compared against the current `done`'s `ts`
+		// so each follow-up turn re-injects. Mirrors deliverNotification's MAX_INJECT cap.
 			const output = readOutput(art);
 			if (output !== null) {
 				if (getInjectCount() >= MAX_INJECT) {
@@ -585,10 +602,9 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 					}
 				}
 			}
-			// Mark injected unconditionally so we don't re-attempt on a subsequent poll
-			// when the cap flips back under threshold. The pointer notification is still
-			// gated by `lastDeliveredEventTs`, so re-polls are no-ops anyway.
-			state.injected = true;
+			// Record the ts of the done we just (attempted to) inject for. The next `done` from a follow-up
+			// turn has a fresh ts, so the comparison re-fires.
+			state.lastInjectedEventTs = last.ts;
 		}
 
 
@@ -2072,22 +2088,92 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
+  // ── Tool: send a follow-up message to a live interactive sub-agent ──────
+  // The child REPL stays open after `done` (see buildChildSubagentProtocol in
+  // interactive-tmux.ts), so the parent can push a new prompt into the same
+  // session via tmux send-keys. Model context is preserved across messages —
+  // this is a true follow-up turn, not a fresh spawn.
+  pi.registerTool({
+    name: "send_interactive_subagent_message",
+    label: "Send Interactive Subagent Message",
+    description: [
+      "Send a follow-up prompt to a live interactive sub-agent. The message is delivered into the",
+      "child's existing REPL via tmux send-keys, so the child's model context is preserved — this",
+      "is a true follow-up turn, not a fresh spawn. The child will run the new turn and (per its",
+      "system prompt) call '$ARTIFACT_DIR/cli.mjs done 0' again when it finishes. Use",
+      "get_interactive_subagent_status to check the pane state first if you're not sure it's still alive.",
+    ].join("\n"),
+    parameters: Type.Object({
+      id: Type.String({ description: "Interactive sub-agent ID returned by subagent_interactive" }),
+      message: Type.String({ description: "The follow-up prompt text to send into the child's REPL" }),
+    }),
+
+    async execute(_toolCallId, params): Promise<any> {
+      // Validate the id shape first for a precise error.
+      if (!/^[a-f0-9]{8}$/.test(params.id)) {
+        return {
+          content: [{ type: "text", text: `Invalid sub-agent id ${JSON.stringify(params.id)}; expected 8 lowercase hex chars.` }],
+          details: { id: params.id, status: "invalid_id" },
+          isError: true,
+        };
+      }
+      const state = interactiveSubagentRegistry.get(params.id);
+      if (!state) {
+        return {
+          content: [{ type: "text", text: `Interactive sub-agent ${params.id} not found.` }],
+          details: { id: params.id, status: "not_found" },
+          isError: true,
+        };
+      }
+		// Accept both "running" (mid-turn) and "idle" (REPL open, between turns) — that's the whole
+		// point of follow-up support. Mid-turn sends are safe: tmux send-keys just queues keystrokes
+		// in the REPL input buffer, which submits when the current turn finishes.
+		if (state.status !== "running" && state.status !== "idle") {
+			return {
+				content: [{ type: "text", text: `Interactive sub-agent ${params.id} is ${state.status}; follow-up messages can only be sent to running or idle sub-agents. Spawn a new one if needed.` }],
+				details: { id: params.id, status: state.status },
+				isError: true,
+			};
+		}
+      // sendCommandToTmuxPane uses tmux send-keys; it throws synchronously if the
+      // pane is gone (e.g. the child exited between the status check and now).
+      // Wrap so the parent gets a structured error instead of an exception trace.
+      try {
+        sendCommandToTmuxPane(state.paneId, params.message);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Failed to send message to interactive sub-agent ${params.id}: ${msg}` }],
+          details: { id: params.id, status: "send_failed", paneId: state.paneId, error: msg },
+          isError: true,
+        };
+      }
+      return {
+        content: [{ type: "text", text: `Sent follow-up to interactive sub-agent ${params.id} (${params.message.length} chars) in pane ${state.paneId}.` }],
+        details: { id: params.id, paneId: state.paneId, messageLength: params.message.length, status: "sent" },
+      };
+    },
+  });
+
   // ── Tool: read an interactive sub-agent's artifact ───────────────
   // The artifact (events.ndjson + output.md) is the source of truth for what the
   // sub-agent did. The main agent calls this when it wants to know more than the pointer.
+  // The artifact (events.ndjson + output.md + output-N.md snapshots) is the source of truth for what
+  // the sub-agent did. The main agent calls this when it wants to know more than the pointer.
   pi.registerTool({
     name: "read_subagent_artifact",
     label: "Read Subagent Artifact",
     description: [
       "Read an interactive sub-agent's artifact on disk. Returns the lifecycle events and,",
-
-      "if present, the sub-agent's output.md. Use `since` (unix ms) to fetch only events newer than",
-      "your last read.",
+      "if present, the sub-agent's output.md (the latest turn's content) or a specific turn's snapshot.",
+      "Use `since` (unix ms) to fetch only events newer than your last read. Use `turn` to read a",
+      "specific historical turn's output-N.md instead of the latest output.md.",
     ].join("\n"),
     parameters: Type.Object({
       id: Type.String({ description: "Interactive sub-agent ID returned by subagent_interactive" }),
       since: Type.Optional(Type.Number({ description: "Only return events with ts >= this unix-ms timestamp" })),
-      includeOutput: Type.Optional(Type.Boolean({ description: "Include the sub-agent's output.md content (default true)" })),
+      includeOutput: Type.Optional(Type.Boolean({ description: "Include the output (default true). Set false to fetch only events." })),
+      turn: Type.Optional(Type.Number({ description: "Read a specific turn's output-N.md snapshot. Omit to read the latest output.md." })),
     }),
 
     async execute(_toolCallId, params): Promise<any> {
@@ -2112,22 +2198,32 @@ export default function (pi: ExtensionAPI) {
         };
       }
       const events = readEvents(art, params.since);
-      const output = params.includeOutput === false ? null : readOutput(art);
+      // `turn` reads a specific output-N.md snapshot; otherwise read the latest output.md. The turn
+      // param implies includeOutput (you can't read a turn without wanting its content).
+      const wantsOutput = params.includeOutput !== false || params.turn !== undefined;
+      const output = wantsOutput ? (params.turn !== undefined ? readOutputForTurn(art, params.turn) : readOutput(art)) : null;
       const lastEvent = events.length > 0 ? events[events.length - 1] : null;
       // Distinguish three cases when output is missing/empty so the caller
       // doesn't see a misleading "not written yet" after the sub-agent has
       // already exited (the common case: model finished without writing).
       let outputText: string;
       if (output === null) {
-        const exited = lastEvent && (lastEvent.type === "done" || lastEvent.type === "error" || lastEvent.type === "cancelled");
-        outputText = exited
-          ? `(sub-agent exited without writing output.md — last event: ${lastEvent.type} @ ${lastEvent.ts})`
-          : `(${events.length} events, last: ${lastEvent ? `${lastEvent.type} @ ${lastEvent.ts}` : "(none)"} — output.md not written yet)`;
+        if (params.turn !== undefined) {
+          outputText = `(no snapshot for turn ${params.turn} — the poller may not have run yet, or this turn number is past the history)`;
+        } else {
+          const exited = lastEvent && (lastEvent.type === "done" || lastEvent.type === "error" || lastEvent.type === "cancelled");
+          outputText = exited
+            ? `(sub-agent exited without writing output.md — last event: ${lastEvent.type} @ ${lastEvent.ts})`
+            : `(${events.length} events, last: ${lastEvent ? `${lastEvent.type} @ ${lastEvent.ts}` : "(none)"} — output.md not written yet)`;
+        }
       } else if (output.length === 0) {
         outputText = "(empty — 0 chars)";
       } else {
         outputText = `${output.length} chars`;
       }
+      // Available turns summary so the caller knows what history exists.
+      const availableTurns = listOutputTurns(art);
+      const turnsLine = availableTurns.length > 0 ? `Available turns: [${availableTurns.join(", ")}]\n` : "";
       return {
         content: [
           {
@@ -2135,10 +2231,12 @@ export default function (pi: ExtensionAPI) {
             text:
               `Artifact for ${params.id} (${events.length} event${events.length === 1 ? "" : "s"}${params.since ? ` since ${params.since}` : ""}).\n` +
               `Last event: ${lastEvent ? `${lastEvent.type} @ ${lastEvent.ts}` : "(none)"}\n` +
+              (params.turn !== undefined ? `Reading turn: ${params.turn}\n` : "") +
+              turnsLine +
               `Output: ${outputText}`,
           },
         ],
-        details: { id: params.id, artifactDir: art.dir, events, output, lastEvent },
+        details: { id: params.id, artifactDir: art.dir, events, output, lastEvent, availableTurns },
       };
     },
   });

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -868,7 +868,12 @@ function maybeAutoDone(state: InteractiveSubagentState, art: SubagentArtifact, p
 	appendEvent(art, ev);
 	state.autoDoneForTurnAt = ts;
 	state.lastDeliveredEventTs = ts;
-	state.injected = true;
+	// In inject mode, leave `injected` unset so the regular inject path at
+	// lines 547-585 picks up the synthesized `done` event on the next poll.
+	// For all other modes (notify, undefined), mark as injected here because
+	// the inject path will never fire — this prevents accidental re-inject
+	// if a late explicit `done` later matches the cursor.
+	state.injected = state.notifyOnComplete !== "inject";
 
 	// Fire the pointer notification immediately so the parent does not wait for the next 5s poll tick.
 	// Suppress here only — the regular `events` loop below uses the autoDoneForTurnAt guard.

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -574,6 +574,7 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 		// Inject-mode delivery: on a NEW `done` event, push output.md into the parent LLM's next turn.
 		// Per-turn (not per-sub-agent) — `lastInjectedEventTs` is compared against the current `done`'s `ts`
 		// so each follow-up turn re-injects. Mirrors deliverNotification's MAX_INJECT cap.
+		if (last && last.type === "done" && state.notifyOnComplete === "inject" && state.lastInjectedEventTs !== last.ts) {
 			const output = readOutput(art);
 			if (output !== null) {
 				if (getInjectCount() >= MAX_INJECT) {
@@ -2093,6 +2094,12 @@ export default function (pi: ExtensionAPI) {
   // interactive-tmux.ts), so the parent can push a new prompt into the same
   // session via tmux send-keys. Model context is preserved across messages —
   // this is a true follow-up turn, not a fresh spawn.
+  //
+  // Caps: the message must be non-empty (an empty Enter in the REPL would submit a
+  // blank prompt) and at most MAX_FOLLOWUP_BYTES UTF-8 bytes (symmetric with
+  // MAX_PERSONA_BYTES in interactive-tmux.ts — 64 KiB is well above any realistic
+  // follow-up prompt; larger values are rejected up-front with a structured error).
+  const MAX_FOLLOWUP_BYTES = 64 * 1024;
   pi.registerTool({
     name: "send_interactive_subagent_message",
     label: "Send Interactive Subagent Message",
@@ -2105,7 +2112,7 @@ export default function (pi: ExtensionAPI) {
     ].join("\n"),
     parameters: Type.Object({
       id: Type.String({ description: "Interactive sub-agent ID returned by subagent_interactive" }),
-      message: Type.String({ description: "The follow-up prompt text to send into the child's REPL" }),
+      message: Type.String({ description: "The follow-up prompt text to send into the child's REPL (must be non-empty; max 64 KiB)" }),
     }),
 
     async execute(_toolCallId, params): Promise<any> {
@@ -2114,6 +2121,24 @@ export default function (pi: ExtensionAPI) {
         return {
           content: [{ type: "text", text: `Invalid sub-agent id ${JSON.stringify(params.id)}; expected 8 lowercase hex chars.` }],
           details: { id: params.id, status: "invalid_id" },
+          isError: true,
+        };
+      }
+      // Content validation (no registry I/O): fail fast on empty / oversized messages.
+      // An empty message would submit a blank Enter in the child REPL; an oversized message
+      // is more than the child can usefully consume and risks blowing the REPL history.
+      if (params.message.trim().length === 0) {
+        return {
+          content: [{ type: "text", text: "Message is empty; send a non-empty follow-up prompt." }],
+          details: { id: params.id, status: "empty_message", messageLength: 0 },
+          isError: true,
+        };
+      }
+      const messageBytes = Buffer.byteLength(params.message, "utf8");
+      if (messageBytes > MAX_FOLLOWUP_BYTES) {
+        return {
+          content: [{ type: "text", text: `Message too large: ${messageBytes} bytes (max ${MAX_FOLLOWUP_BYTES}). Shorten the prompt and try again.` }],
+          details: { id: params.id, status: "message_too_large", messageLength: messageBytes, maxBytes: MAX_FOLLOWUP_BYTES },
           isError: true,
         };
       }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -495,7 +495,14 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 	const ui = g2.__piSubagenturaUi as ExtensionUIContext | undefined;
 
 	for (const state of interactiveSubagentRegistry.values()) {
-		if (state.status === "cancelled" || state.status === "exited" || state.status === "unknown") continue;
+		// Skip strictly-terminal states. "exited" is INTENTIONALLY not in this list: the user-role
+		// revival at processSessionLogEntry can revive an "exited" sub-agent back to "running" if a
+		// follow-up user message lands in the session log (auto-done case). To make that reachable,
+		// the poll loop must keep tail-reading the session log for "exited" sub-agents too. The
+		// status-update block below may re-mark the state as "exited" (based on a stale synthesized
+		// error event in the artifact) but the revival, running later in the same poll via
+		// tailReadSessionLog, will reset it to "running" within this same tick.
+		if (state.status === "cancelled" || state.status === "unknown") continue;
 
 		const art = artifactPath(dirname(state.artifactDir), basename(state.artifactDir));
 		const last = lastEvent(art);
@@ -759,10 +766,13 @@ function processSessionLogEntry(state: InteractiveSubagentState, art: SubagentAr
 		state.lastStopReason = undefined;
 		state.lastStopReasonAt = undefined;
 		state.lastStopText = undefined;
-		// If the state was previously marked "exited" (e.g. by an auto-done fallback in a prior turn),
-		// revive it to "running" so the for-loop keeps tail-reading the session log. Without this, a
-		// user follow-up after auto-done would be silently ignored and the next auto-done opportunity missed.
-		if (state.status === "exited") state.status = "running";
+		// If the state was previously marked "exited" (e.g. by an auto-done fallback in a prior turn)
+		// OR "idle" (the natural post-turn state once follow-up work lands), revive it to "running"
+		// so the for-loop keeps tail-reading the session log. Without this, a user follow-up after
+		// a previous completion would be silently ignored and the next auto-done / done-event
+		// opportunity missed. Both paths share the same revival semantics: a user-role entry means
+		// a new turn is starting, regardless of how the previous turn ended.
+		if (state.status === "exited" || state.status === "idle") state.status = "running";
 		return;
 	}
 

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -849,8 +849,11 @@ function maybeAutoDone(state: InteractiveSubagentState, art: SubagentArtifact, p
 	} else {
 		const fallback = state.lastStopText;
 		const baseMessage = "sub-agent stopped without writing output.md";
+		const FALLBACK_SLICE = 500;
 		const message = fallback && fallback.length > 0
-			? `${baseMessage} — last assistant message: ${fallback.slice(0, 500)}`
+			? fallback.length > FALLBACK_SLICE
+				? `${baseMessage} — last assistant message: ${fallback.slice(0, FALLBACK_SLICE)}… (truncated)`
+				: `${baseMessage} — last assistant message: ${fallback}`
 			: baseMessage;
 		ev = { ts, type: "error", status: "error", message, exitCode: 1 };
 		state.exitCode = 1;


### PR DESCRIPTION
Add the ability for the parent to push a new prompt into a live interactive sub-agent's REPL and receive the new turn's output back. The child keeps its model context across turns, so a follow-up is a true continuation, not a fresh spawn.

Three coupled changes:

1. Idle status + per-turn inject
   - InteractiveSubagentStatus gains 'idle' for 'done event seen, pane still alive' (the child is between turns with its REPL open). 'done' + pane dead is still 'exited'; 'error' is always 'exited' (terminal). Extracted to a pure deriveInteractiveSubagentStatus(lastEvent, paneAlive) helper so the matrix is testable without a live tmux server.
   - The artifact poller now keeps processing 'idle' sub-agents (previously it skipped them) so a second 'done' event after a follow-up turn still fires the pointer + inject.
   - The inject guard flips from a one-shot boolean (state.injected) to a per-event timestamp (state.lastInjectedEventTs). Comparing against the current 'done' event's ts makes the inject re-fire on every NEW turn.

2. Per-turn output snapshots (output-N.md)
   - artifact.ts grows snapshotOutput / readOutputForTurn / listOutputTurns / outputPathForTurn. Snapshots are atomic copies of output.md into output-N.md, where N is the count of 'done' events in events.ndjson at the time of the snapshot.
   - The poller snapshots on every new 'done' event, regardless of notifyOnComplete mode, so turn history survives across follow-ups (output.md is still overwritten by the child each turn).
   - read_subagent_artifact gains a 'turn: N' param to read a specific historical snapshot, plus an 'availableTurns' field in the response that lists all snapshot turn numbers.

3. send_interactive_subagent_message tool
   - New parent-facing tool that delivers a follow-up prompt into a live sub-agent's REPL via tmux send-keys. Accepts both 'running' and 'idle' sub-agents; refuses terminal ones with a structured isError. Wraps the tmux call in try/catch so a pane-gone-between-check-and-send race returns a structured error instead of an exception trace.

Tests: 21 new cases across subagent-poll.test.ts (idle vs exited, per-turn inject, snapshot in poller), subagent-send-message.test.ts (new file, 8 cases), artifact.test.ts (snapshot helpers), and interactive-tmux.test.ts (status-decision matrix). 230/230 pass, tsc clean, pack:check clean.

Docs: README updated — feature list, follow-up paragraph, tool reference, and read_subagent_artifact gain a 'turn' param note.