### PR TITLE
fix: per-turn snapshot must use its own cursor (lastSnapshotEventTs),…

### DIFF
--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -141,14 +141,20 @@ export interface InteractiveSubagentState {
 	 * output.md as a user message so the parent LLM processes it in its next turn.
 	 */
 	notifyOnComplete?: "notify" | "inject";
-	/** At-most-once guard for the inject path (mirrors lastDeliveredEventTs). */
 	/**
- * Timestamp of the last artifact `done` event whose output was injected into the parent.
- * Mirrors `lastDeliveredEventTs` but only for the inject path. Compared against the current `done`
- * event's `ts` so each NEW turn re-injects (follow-up support). Set on first inject; `undefined` means
- * "never injected".
- */
+	 * At-most-once guard for the inject path (mirrors lastDeliveredEventTs, inject-only). Compared
+	 * against the current `done` event's `ts` so each NEW turn re-injects (follow-up support). Set on
+	 * first inject; `undefined` means "never injected".
+	 */
 	lastInjectedEventTs?: number;
+	/**
+	 * At-most-once guard for the per-turn `output-N.md` snapshot. Compared against the current `done`
+	 * event's `ts` so each NEW turn snapshots exactly once. Distinct from `lastInjectedEventTs`, which is
+	 * only set in `inject` mode — snapshots run in every notifyOnComplete mode, so they need their own
+	 * cursor or the default `notify` mode would re-snapshot every poll tick and could overwrite an
+	 * earlier turn's snapshot with a later turn's in-progress output.md.
+	 */
+	lastSnapshotEventTs?: number;
 	/**
 	 * Auto-fallback "already notified" flag (PR #11). Set by maybeAutoDone when synthesize-and-inject
 	 * runs, so a late explicit `done` event that lands on the next poll does NOT re-trigger the

--- a/src/subagent-poll.test.ts
+++ b/src/subagent-poll.test.ts
@@ -487,6 +487,47 @@ describe("pollArtifactChanges", () => {
 
 			expect(existsSync(join(art.dir, "output-1.md"))).toBe(true);
 		});
+
+		it("in notify mode, a follow-up overwriting output.md before its done event does NOT corrupt the prior turn's snapshot", async () => {
+			// Regression: the snapshot guard must not reuse lastInjectedEventTs (only set in inject mode).
+			// In the default notify mode that field stays undefined, so a pre-fix poller re-snapshotted
+			// every tick — and once a follow-up turn overwrote output.md before its own done landed, it
+			// clobbered output-1.md (turn 1's history) with the in-progress turn-2 content.
+			vi.resetModules();
+			vi.doMock("node:child_process", () => ({
+				execFileSync: (_file: string, args: string[]) => {
+					if (args[0] === "display-message") return Buffer.from("#99");
+					return "";
+				},
+			}));
+			const mod = await importFresh<typeof import("./subagent")>("./subagent");
+			const { state, artifactDir } = makeState();
+			// notifyOnComplete left undefined (default 'notify') — the broken path.
+			mod.interactiveSubagentRegistry.set(state.id, state);
+			const art = artifactPath(join(artifactDir, ".."), state.id);
+
+			// Turn 1 completes and is snapshotted.
+			appendEvent(art, { ts: 1, type: "started", status: "running" });
+			appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "answer v1");
+			mod.pollArtifactChanges({ sendMessage: vi.fn(), sendUserMessage: vi.fn() } as any);
+			expect(readFileSync(join(art.dir, "output-1.md"), "utf8")).toBe("answer v1");
+
+			// Follow-up turn: the child overwrites output.md but its done event has NOT landed yet
+			// (last event is still the turn-1 done@ts2). A poll lands in this window.
+			writeOutput(art, "answer v2 in progress");
+			mod.pollArtifactChanges({ sendMessage: vi.fn(), sendUserMessage: vi.fn() } as any);
+
+			// output-1.md must still hold turn 1's content — not the in-progress turn-2 output.
+			expect(readFileSync(join(art.dir, "output-1.md"), "utf8")).toBe("answer v1");
+
+			// When turn 2's done finally lands, it snapshots to output-2.md, leaving turn 1 intact.
+			appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 });
+			writeOutput(art, "answer v2 final");
+			mod.pollArtifactChanges({ sendMessage: vi.fn(), sendUserMessage: vi.fn() } as any);
+			expect(readFileSync(join(art.dir, "output-1.md"), "utf8")).toBe("answer v1");
+			expect(readFileSync(join(art.dir, "output-2.md"), "utf8")).toBe("answer v2 final");
+		});
 	});
 });
 

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -562,13 +562,14 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 		}
 
 		// Per-turn snapshot: on a NEW `done` event, copy the latest output.md into output-N.md so turn
-		// history is preserved even though the child overwrites output.md each turn. Runs for any
-		// notifyOnComplete mode because the history is useful regardless of how the parent gets woken up.
-		// Idempotent: if lastInjectedEventTs === last.ts (re-poll), we skip.
-		if (last && last.type === "done" && state.lastInjectedEventTs !== last.ts) {
+		// history survives the child overwriting output.md each turn. Runs in every notifyOnComplete mode,
+		// so it needs its own cursor (`lastSnapshotEventTs`) — see the field doc for why reusing
+		// `lastInjectedEventTs` would corrupt history in the default `notify` mode.
+		if (last && last.type === "done" && state.lastSnapshotEventTs !== last.ts) {
 			const allEvents = readEvents(art);
 			const turnNumber = allEvents.filter((e) => e.type === "done").length;
 			snapshotOutput(art, turnNumber);
+			state.lastSnapshotEventTs = last.ts;
 		}
 
 		// Inject-mode delivery: on a NEW `done` event, push output.md into the parent LLM's next turn.


### PR DESCRIPTION
… not lastInjectedEventTs

In notify mode lastInjectedEventTs stays undefined, so the old guard re-snapshotted every poll tick. A follow-up turn that overwrote output.md before its done event landed would clobber output-1.md with in-progress turn-2 content.

Adds lastSnapshotEventTs as a dedicated cursor for the snapshot path, distinct from the inject-only lastInjectedEventTs.