### PR TITLE
fix: append protocol footer to interactive sub-agent task prompts

### DIFF
--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -290,7 +290,13 @@ export function buildInteractivePrompt(params: {
 	task: string;
 	contextText?: string | null;
 }): string {
-	if (!params.contextText) return params.task;
+	const footer =
+		"\n\n" +
+		"When you finish, write your result to output.md " +
+		"(path from the system prompt), then run:\n" +
+		'  "$ARTIFACT_DIR/cli.mjs" done 0';
+
+	if (!params.contextText) return params.task + footer;
 	return [
 		"You are an interactive sub-agent running in your own Pi session.",
 		"The parent session context is included below for reference.",
@@ -301,7 +307,7 @@ export function buildInteractivePrompt(params: {
 		"",
 		"Task:",
 		params.task,
-	].join("\n");
+	].join("\n") + footer;
 }
 
 export function buildPiInteractiveCommand(params: {


### PR DESCRIPTION
## Problem

Interactive sub-agents with conversational task prompts (e.g. 'say hello') routinely skip the lifecycle protocol — they answer in chat, never write `output.md`, and never call `cli.mjs done 0`. The parent then synthesizes a fallback error after 10s.

The system prompt already contains the protocol, but LLMs treat the task prompt as the primary instruction and the system prompt as background noise.

## Fix

Append a protocol reminder to every generated task prompt in `buildInteractivePrompt()`. Now even simple tasks end with:

> When you finish, write your result to output.md (path from the system prompt), then run:
>   "$ARTIFACT_DIR/cli.mjs" done 0

## Testing

- All 34 existing tests pass
- Manual verification: run an interactive sub-agent with a conversational task — it now completes with a proper `done` event