### PR TITLE
feat: add workflow tool — deterministic JS orchestration of isolated sub-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![npm](https://img.shields.io/npm/v/pi-subagentura?label=npm)](https://npmjs.com/package/pi-subagentura) [![GitHub](https://img.shields.io/github/v/tag/lmn451/pi-subagentura?label=github)](https://github.com/lmn451/pi-subagentura)
 
 > **Note:** The `docs/` folder is managed by the [`pi-docs`](https://github.com/lmn451/pi-docs) package.
+>
+> **Tags:** `pi-package` · `pi` · `subagent` · `agent` · `multi-agent` · `swarm` · `crew` · **`workflow`**
 
 A public [Pi](https://pi.dev) package that adds in-process and attachable sub-agent tools:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,52 @@ A public [Pi](https://pi.dev) package that adds in-process and attachable sub-ag
 - `send_interactive_subagent_message` — send a follow-up into a live sub-agent's REPL (preserves child context)
 - `read_subagent_artifact` — read an interactive sub-agent's lifecycle events and output
 - `list_subagent_artifacts` — list all known interactive sub-agents (in-session and on-disk)
+- `workflow` — run an agent-authored JS script that deterministically orchestrates isolated sub-agents (`agent`/`parallel`/`pipeline`)
 The default sub-agents run inside the current Pi process, stream live progress back to the UI, and inherit the active model by default. Async sub-agents run in the background — the main agent continues immediately while you poll for progress and collect results when ready. Interactive sub-agents run as separate `pi --session ...` processes in tmux or zellij panes so you can attach and continue follow-ups directly there, and write structured progress to a per-sub-agent artifact directory on disk.
 
 Interactive sub-agents support **follow-up turns**: the parent can push a new prompt into the same child REPL via `send_interactive_subagent_message`. The child is `idle` (not exited) between turns, model context is preserved, and the poller snapshots `output.md` into `output-N.md` on each new `done` event so full turn history is recoverable via `read_subagent_artifact { turn: N }`.
+
+## Workflows
+
+The `workflow` tool ports Claude Code's *Dynamic Workflows* model: the main agent authors a small
+JavaScript script that deterministically orchestrates **isolated** sub-agents. Intermediate results
+live in script variables rather than the parent's context window, so you can fan out many sub-agents
+(review pipelines, research sweeps, migrations) without context pressure.
+
+```js
+export const meta = { name: "review", description: "review files in parallel", phases: [{ title: "scan" }] };
+
+phase("scan");
+const reviews = await parallel(
+  files.map((f) => () => agent(`Review ${f} for bugs`, { schema: FINDINGS_SCHEMA })),
+);
+return reviews.filter(Boolean);
+```
+
+Injected into the script:
+
+- `agent(prompt, opts?)` — spawn one isolated sub-agent (same path as `subagent_isolated`). `opts`:
+  `{ schema?, label?, phase?, model?, persona? }`. Without `schema` returns the final text; with a
+  JSON Schema it returns a validated object, or `null` after retries. Returns `null` on sub-agent
+  error, so scripts can `.filter(Boolean)`.
+- `parallel(thunks)` — run `() => Promise` thunks concurrently (barrier); failures become `null`.
+- `pipeline(items, ...stages)` — stream each item through stages with no barrier between stages.
+- `phase(title)` / `log(msg)` — progress UI only.
+- `args` — the JSON you pass in the tool's `args` param. `budget` — `{ total, spent(), remaining() }`.
+
+Constraints: `Date.now()`, `Math.random()`, and argless `new Date()` **throw** (determinism);
+concurrency is capped automatically (`min(16, cores−2)`); more than 1000 agents or 4096 items per
+call throws. `meta` must be a pure literal.
+
+**Fidelity note:** unlike Claude Code, Pi sub-agents return free-form text (there is no tool-call
+structured-output layer), so `schema` is enforced by instructing the sub-agent to emit JSON, then
+parsing/validating with bounded retries. It is robust but not 100% — schema misses surface as `null`
+plus a logged warning, never a silent drop.
+
+**v1 scope:** runs to completion before returning (abortable via the parent signal). Deferred to a
+later version: background (non-blocking) execution, tmux/worktree process-backed agents
+(`opts.isolation`), `agentType` routing, saved/named workflows and `workflow()` composition, and
+resume journaling.
 
 ## Why use it?
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,32 @@ the end-to-end result.
 
 
 ```js
+// Self-contained example: pass `args` with the file list, declare the
+// schema inline so the script is copy-pasteable.
 export const meta = { name: "review", description: "review files in parallel", phases: [{ title: "scan" }] };
+
+const FINDINGS_SCHEMA = {
+  type: "object",
+  properties: {
+    severity: { type: "string", enum: ["low", "medium", "high"] },
+    description: { type: "string" },
+  },
+  required: ["severity", "description"],
+};
 
 phase("scan");
 const reviews = await parallel(
-  files.map((f) => () => agent(`Review ${f} for bugs`, { schema: FINDINGS_SCHEMA })),
+  args.files.map((f) => () => agent(`Review ${f} for bugs`, { schema: FINDINGS_SCHEMA })),
 );
 return reviews.filter(Boolean);
 ```
+
+Parent calls the tool with:
+
+```json
+{ "args": { "files": ["src/a.ts", "src/b.ts", "src/c.ts"] } }
+```
+
 
 Injected into the script:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A public [Pi](https://pi.dev) package that adds in-process and attachable sub-ag
 - `send_interactive_subagent_message` — send a follow-up into a live sub-agent's REPL (preserves child context)
 - `read_subagent_artifact` — read an interactive sub-agent's lifecycle events and output
 - `list_subagent_artifacts` — list all known interactive sub-agents (in-session and on-disk)
-- `workflow` — run an agent-authored JS script that deterministically orchestrates isolated sub-agents (`agent`/`parallel`/`pipeline`)
+- `workflow` — run an agent-authored JS script that orchestrates isolated sub-agents with deterministic control flow (`agent`/`parallel`/`pipeline`)
+
 The default sub-agents run inside the current Pi process, stream live progress back to the UI, and inherit the active model by default. Async sub-agents run in the background — the main agent continues immediately while you poll for progress and collect results when ready. Interactive sub-agents run as separate `pi --session ...` processes in tmux or zellij panes so you can attach and continue follow-ups directly there, and write structured progress to a per-sub-agent artifact directory on disk.
 
 Interactive sub-agents support **follow-up turns**: the parent can push a new prompt into the same child REPL via `send_interactive_subagent_message`. The child is `idle` (not exited) between turns, model context is preserved, and the poller snapshots `output.md` into `output-N.md` on each new `done` event so full turn history is recoverable via `read_subagent_artifact { turn: N }`.
@@ -26,9 +27,12 @@ Interactive sub-agents support **follow-up turns**: the parent can push a new pr
 ## Workflows
 
 The `workflow` tool ports Claude Code's *Dynamic Workflows* model: the main agent authors a small
-JavaScript script that deterministically orchestrates **isolated** sub-agents. Intermediate results
-live in script variables rather than the parent's context window, so you can fan out many sub-agents
-(review pipelines, research sweeps, migrations) without context pressure.
+JavaScript script that orchestrates **isolated** sub-agents with deterministic control flow. Intermediate
+results live in script variables rather than the parent's context window, so you can fan out many
+sub-agents (review pipelines, research sweeps, migrations) without context pressure. Note: sub-agent
+outputs are LLM-driven and non-deterministic; "deterministic" here means the orchestration logic, not
+the end-to-end result.
+
 
 ```js
 export const meta = { name: "review", description: "review files in parallel", phases: [{ title: "scan" }] };
@@ -51,9 +55,12 @@ Injected into the script:
 - `phase(title)` / `log(msg)` — progress UI only.
 - `args` — the JSON you pass in the tool's `args` param. `budget` — `{ total, spent(), remaining() }`.
 
-Constraints: `Date.now()`, `Math.random()`, and argless `new Date()` **throw** (determinism);
-concurrency is capped automatically (`min(16, cores−2)`); more than 1000 agents or 4096 items per
-call throws. `meta` must be a pure literal.
+Constraints: `Date.now()`, `Math.random()`, and argless `new Date()` **throw** when called directly
+(the obvious non-determinism footgun for naive script code). `eval`/`Function` are not blocked, so a
+determined script can still reach the real `Date.now()` / `Math.random()` — the script author is the
+trusted main agent. Concurrency is capped automatically (`min(16, cores−2)`); more than 1000 agents
+or 4096 items per call throws. `meta` must be a pure literal.
+
 
 **Fidelity note:** unlike Claude Code, Pi sub-agents return free-form text (there is no tool-call
 structured-output layer), so `schema` is enforced by instructing the sub-agent to emit JSON, then

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "src/multiplexer-tmux.ts",
     "src/multiplexer-zellij.ts",
     "src/subagent.ts",
-    "src/subagent-artifact-cli.ts"
+    "src/subagent-artifact-cli.ts",
+    "src/workflow.ts"
   ],
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "agent",
     "multi-agent",
     "swarm",
-    "crew"
+    "crew",
+    "workflow"
   ],
   "repository": {
     "type": "git",

--- a/src/subagent-extension.test.ts
+++ b/src/subagent-extension.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import registerExtension from "./subagent";
 
 describe("extension registration", () => {
-describe("extension registration", () => {
-  it("registers all tools without throwing", () => {
-    const api = {
-      registerTool: vi.fn(),
-      registerMessageRenderer: vi.fn(),
-      on: vi.fn(),
-    };
+  describe("extension registration", () => {
+    it("registers all tools without throwing", () => {
+      const api = {
+        registerTool: vi.fn(),
+        registerMessageRenderer: vi.fn(),
+        on: vi.fn(),
+      };
 
-    expect(() => registerExtension(api as any)).not.toThrow();
-    expect(api.registerTool).toHaveBeenCalledTimes(13);
+      expect(() => registerExtension(api as any)).not.toThrow();
+      expect(api.registerTool).toHaveBeenCalledTimes(14);
+    });
   });
-});
 });

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -74,6 +74,7 @@ import {
 	type SubagentEvent,
 } from "./artifact";
 import type { Usage } from "./helpers";
+import { registerWorkflowTool } from "./workflow";
 
 import { closeSync, openSync, readdirSync, readSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
@@ -1199,6 +1200,9 @@ export default function (pi: ExtensionAPI) {
 		handle.unref?.();
 		g2.__piSubagenturaInteractivePollerHandle = handle;
 	}
+  // ── Tool: workflow — deterministic JS orchestration of isolated sub-agents ──
+  registerWorkflowTool(pi);
+
   // ── Tool 1: inherits conversation history ────────────────────────
   pi.registerTool({
     name: "subagent_with_context",

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseWorkflow,
+  runWorkflow,
+  extractJson,
+  validateSchema,
+  MAX_ITEMS_PER_CALL,
+  type WorkflowAgentRunner,
+} from "./workflow";
+import type { SubagentResult } from "./helpers";
+
+// ── Mock sub-agent runner ────────────────────────────────────────────
+function ok(output: string, outTokens = 0): SubagentResult {
+  return {
+    isError: false,
+    output,
+    usage: {
+      input: 0,
+      output: outTokens,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    },
+    model: "test/model",
+  };
+}
+function fail(msg = "boom"): SubagentResult {
+  return {
+    isError: true,
+    output: "(no output)",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    },
+    model: undefined,
+    errorMessage: msg,
+  };
+}
+
+/** A runner that echoes the prompt, optionally tracking concurrency. */
+function echoRunner(): WorkflowAgentRunner {
+  return async ({ prompt }) => ok(prompt);
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("parseWorkflow", () => {
+  it("extracts a pure-literal meta and the body", () => {
+    const { meta, body } = parseWorkflow(
+      `export const meta = { name: "flow", description: "does things" };\nreturn 42;`,
+    );
+    expect(meta.name).toBe("flow");
+    expect(meta.description).toBe("does things");
+    expect(body).toContain("return 42;");
+    expect(body).not.toContain("export const meta");
+  });
+
+  it("handles braces and semicolons inside meta string values", () => {
+    const { meta, body } = parseWorkflow(
+      `export const meta = { name: "f", description: "uses { and } and ; chars" };\nlog("hi");`,
+    );
+    expect(meta.description).toBe("uses { and } and ; chars");
+    expect(body).toContain('log("hi");');
+  });
+
+  it("rejects a meta literal that references a helper (not pure)", () => {
+    expect(() =>
+      parseWorkflow(`export const meta = { name: agent, description: "x" };\n`),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("throws when meta is missing", () => {
+    expect(() => parseWorkflow(`return 1;`)).toThrow(/export const meta/);
+  });
+
+  it("throws when name/description are absent", () => {
+    expect(() => parseWorkflow(`export const meta = { name: "x" };\n`)).toThrow(
+      /description/,
+    );
+  });
+});
+
+describe("determinism guards", () => {
+  const meta = `export const meta = { name: "g", description: "d" };\n`;
+  const run = (body: string) =>
+    runWorkflow(meta + body, { runAgent: echoRunner() });
+
+  it("throws on Date.now()", async () => {
+    await expect(run(`return Date.now();`)).rejects.toThrow(/Date\.now/);
+  });
+  it("throws on argless new Date()", async () => {
+    await expect(run(`return new Date();`)).rejects.toThrow(/new Date/);
+  });
+  it("throws on Math.random()", async () => {
+    await expect(run(`return Math.random();`)).rejects.toThrow(/Math\.random/);
+  });
+  it("allows new Date(ts) and Math.floor()", async () => {
+    const r = await run(`return new Date(0).getTime() + Math.floor(1.9);`);
+    expect(r.result).toBe(1);
+  });
+  it("does not inject Node globals", async () => {
+    const r = await run(`return typeof process + "," + typeof require;`);
+    expect(r.result).toBe("undefined,undefined");
+  });
+});
+
+describe("agent() + budget", () => {
+  const meta = `export const meta = { name: "a", description: "d" };\n`;
+
+  it("returns the sub-agent output text", async () => {
+    const r = await runWorkflow(meta + `return await agent("hello");`, {
+      runAgent: echoRunner(),
+    });
+    expect(r.result).toBe("hello");
+    expect(r.agentsSpawned).toBe(1);
+  });
+
+  it("returns null and counts errors when the sub-agent errors", async () => {
+    const r = await runWorkflow(meta + `return await agent("x");`, {
+      runAgent: async () => fail(),
+    });
+    expect(r.result).toBeNull();
+    expect(r.errorCount).toBe(1);
+  });
+
+  it("accumulates token spend and throws once the budget is exhausted", async () => {
+    const runAgent: WorkflowAgentRunner = async () => ok("done", 100);
+    const r = await runWorkflow(
+      meta + `await agent("a"); await agent("b"); return budget.remaining();`,
+      { runAgent, budgetTotal: 150 },
+    );
+    // first agent spends 100 (remaining 50 > 0 ok), second spends 100 (now -50 -> 0 floor)
+    expect(r.tokensSpent).toBe(200);
+    expect(r.result).toBe(0);
+
+    await expect(
+      runWorkflow(
+        meta + `await agent("a"); await agent("b"); await agent("c");`,
+        {
+          runAgent,
+          budgetTotal: 150,
+        },
+      ),
+    ).rejects.toThrow(/budget exhausted/i);
+  });
+});
+
+describe("parallel()", () => {
+  const meta = `export const meta = { name: "p", description: "d" };\n`;
+
+  it("runs thunks concurrently and maps failures to null", async () => {
+    const runAgent: WorkflowAgentRunner = async ({ prompt }) =>
+      prompt === "bad" ? fail() : ok(prompt);
+    const r = await runWorkflow(
+      meta +
+        `return await parallel([() => agent("a"), () => agent("bad"), () => agent("c")]);`,
+      { runAgent },
+    );
+    expect(r.result).toEqual(["a", null, "c"]);
+  });
+
+  it("never exceeds the concurrency cap", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const runAgent: WorkflowAgentRunner = async ({ prompt }) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await tick();
+      active--;
+      return ok(prompt);
+    };
+    const body = `return await parallel(Array.from({length: 10}, (_, i) => () => agent("t" + i)));`;
+    const r = await runWorkflow(meta + body, { runAgent, concurrency: 2 });
+    expect((r.result as unknown[]).length).toBe(10);
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it("throws when item count exceeds the cap", async () => {
+    const body = `return await parallel(Array.from({length: ${MAX_ITEMS_PER_CALL + 1}}, () => () => agent("x")));`;
+    await expect(
+      runWorkflow(meta + body, { runAgent: echoRunner() }),
+    ).rejects.toThrow(/exceeds the/);
+  });
+});
+
+describe("pipeline()", () => {
+  const meta = `export const meta = { name: "pl", description: "d" };\n`;
+
+  it("threads each item through stages independently", async () => {
+    const body = `
+      return await pipeline(
+        [1, 2, 3],
+        (prev) => prev * 10,
+        (prev, item, index) => ({ prev, item, index })
+      );`;
+    const r = await runWorkflow(meta + body, { runAgent: echoRunner() });
+    expect(r.result).toEqual([
+      { prev: 10, item: 1, index: 0 },
+      { prev: 20, item: 2, index: 1 },
+      { prev: 30, item: 3, index: 2 },
+    ]);
+  });
+
+  it("drops an item to null when a stage throws", async () => {
+    const body = `
+      return await pipeline(
+        [1, 2, 3],
+        (prev) => { if (prev === 2) throw new Error("nope"); return prev; }
+      );`;
+    const r = await runWorkflow(meta + body, { runAgent: echoRunner() });
+    expect(r.result).toEqual([1, null, 3]);
+  });
+});
+
+describe("schema enforcement", () => {
+  const meta = `export const meta = { name: "s", description: "d" };\n`;
+  const schema = {
+    type: "object",
+    required: ["n"],
+    properties: { n: { type: "number" } },
+  };
+
+  it("parses and validates structured output", async () => {
+    const runAgent: WorkflowAgentRunner = async () =>
+      ok('```json\n{"n": 7}\n```');
+    const body = `return await agent("give n", { schema: ${JSON.stringify(schema)} });`;
+    const r = await runWorkflow(meta + body, { runAgent });
+    expect(r.result).toEqual({ n: 7 });
+  });
+
+  it("retries on invalid output then succeeds", async () => {
+    let call = 0;
+    const runAgent: WorkflowAgentRunner = async () => {
+      call++;
+      return call === 1 ? ok('{"n": "not-a-number"}') : ok('{"n": 5}');
+    };
+    const body = `return await agent("give n", { schema: ${JSON.stringify(schema)} });`;
+    const r = await runWorkflow(meta + body, { runAgent });
+    expect(r.result).toEqual({ n: 5 });
+    expect(call).toBe(2);
+  });
+
+  it("returns null and counts an error after exhausting retries", async () => {
+    const runAgent: WorkflowAgentRunner = async () => ok("no json here");
+    const body = `return await agent("give n", { schema: ${JSON.stringify(schema)} });`;
+    const r = await runWorkflow(meta + body, { runAgent });
+    expect(r.result).toBeNull();
+    expect(r.errorCount).toBe(1);
+    expect(r.agentsSpawned).toBe(3);
+  });
+});
+
+describe("extractJson", () => {
+  it("strips code fences", () => {
+    expect(extractJson('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+  it("extracts the first balanced object from surrounding prose", () => {
+    expect(extractJson('Sure! Here you go: {"a": {"b": 2}} done')).toBe(
+      '{"a": {"b": 2}}',
+    );
+  });
+  it("extracts arrays", () => {
+    expect(extractJson("result: [1, 2, 3]")).toBe("[1, 2, 3]");
+  });
+  it("returns null when there is no JSON", () => {
+    expect(extractJson("just words")).toBeNull();
+  });
+});
+
+describe("validateSchema", () => {
+  it("passes a conforming object", () => {
+    const s = {
+      type: "object",
+      required: ["x"],
+      properties: { x: { type: "string" } },
+    };
+    expect(validateSchema({ x: "hi" }, s)).toEqual([]);
+  });
+  it("reports a missing required property", () => {
+    const s = {
+      type: "object",
+      required: ["x"],
+      properties: { x: { type: "string" } },
+    };
+    expect(validateSchema({}, s).length).toBeGreaterThan(0);
+  });
+  it("enforces array minItems and item type", () => {
+    const s = { type: "array", minItems: 2, items: { type: "number" } };
+    expect(validateSchema([1], s).length).toBeGreaterThan(0);
+    expect(validateSchema([1, "two"], s).length).toBeGreaterThan(0);
+    expect(validateSchema([1, 2], s)).toEqual([]);
+  });
+  it("enforces enum", () => {
+    const s = { enum: ["a", "b"] };
+    expect(validateSchema("a", s)).toEqual([]);
+    expect(validateSchema("c", s).length).toBeGreaterThan(0);
+  });
+});
+
+describe("workflow() composition", () => {
+  it("throws — unsupported in v1", async () => {
+    const meta = `export const meta = { name: "w", description: "d" };\n`;
+    await expect(
+      runWorkflow(meta + `return await workflow("other");`, {
+        runAgent: echoRunner(),
+      }),
+    ).rejects.toThrow(/not supported in v1/);
+  });
+});

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -37,7 +37,6 @@
 
 //     flow, not deterministic end-to-end results.
 
-
 import { runInNewContext } from "node:vm";
 import { cpus } from "node:os";
 import { startSubagentJob } from "./helpers";
@@ -647,7 +646,6 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
     name: "workflow",
     label: "Workflow",
     description: [
-
       "Run an agent-authored JavaScript workflow that orchestrates ISOLATED sub-agents with",
 
       "deterministic control flow (parallel/pipeline/barrier semantics are exact, but",

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,0 +1,758 @@
+// Workflow runtime — ports Claude Code's "Dynamic Workflows" into pi-subagentura.
+//
+// The main agent authors a JS script of the shape:
+//
+//     export const meta = { name, description, phases };   // pure literal, parsed statically
+//     // top-level body using injected globals:
+//     phase("scan");
+//     const findings = await parallel(files.map(f => () => agent(`review ${f}`, { schema: S })));
+//     return { findings };
+//
+// Helpers (agent/parallel/pipeline/phase/log/workflow) and globals (args/budget) are injected
+// into a `vm` context. Each `agent()` call spawns an ISOLATED in-process sub-agent via the same
+// `startSubagentJob` primitive the other tools use, so intermediate results live in script
+// variables rather than the parent agent's context window.
+//
+// NOTE: `vm.runInNewContext` is NOT an escape-proof jail (`globalThis` is reachable, and
+// constructor escapes are not blockable in `vm`). This is acceptable because the script author is
+// the trusted main agent. The guarantees we actually make: no Node globals (require/process/module)
+// are injected, and Date.now()/Math.random()/argless `new Date()` throw inside a script.
+
+import { runInNewContext } from "node:vm";
+import { cpus } from "node:os";
+import { startSubagentJob } from "./helpers";
+import type { SubagentResult } from "./helpers";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+// ── Limits ───────────────────────────────────────────────────────────
+export const MAX_TOTAL_AGENTS = 1000;
+export const MAX_ITEMS_PER_CALL = 4096;
+export const SCHEMA_RETRIES = 3;
+
+function defaultConcurrency(): number {
+  const n = cpus()?.length ?? 4;
+  return Math.max(1, Math.min(16, n - 2));
+}
+
+// ── Public types ─────────────────────────────────────────────────────
+
+/** Options accepted by the injected `agent()` helper. */
+export interface WorkflowAgentOpts {
+  schema?: unknown;
+  label?: string;
+  phase?: string;
+  model?: string;
+  persona?: string;
+  /** Accepted for fidelity but a no-op in v1. */
+  agentType?: string;
+  /** Accepted for fidelity but a no-op in v1 (tmux/worktree backends are v2). */
+  isolation?: string;
+}
+
+/** Injectable spawn function — the real one wraps startSubagentJob; tests mock it. */
+export type WorkflowAgentRunner = (req: {
+  prompt: string;
+  persona?: string;
+  model?: string;
+  signal?: AbortSignal;
+}) => Promise<SubagentResult>;
+
+export interface WorkflowMeta {
+  name: string;
+  description: string;
+  whenToUse?: string;
+  phases?: Array<{ title: string; detail?: string }>;
+  [k: string]: unknown;
+}
+
+export interface WorkflowProgress {
+  kind: "phase" | "log" | "agent";
+  phase?: string;
+  message?: string;
+  label?: string;
+  agentsSpawned: number;
+  errorCount: number;
+  tokensSpent: number;
+}
+
+export interface WorkflowRunResult {
+  meta: WorkflowMeta;
+  result: unknown;
+  agentsSpawned: number;
+  errorCount: number;
+  tokensSpent: number;
+  phases: string[];
+}
+
+export interface RunWorkflowOptions {
+  args?: unknown;
+  budgetTotal?: number | null;
+  runAgent: WorkflowAgentRunner;
+  signal?: AbortSignal;
+  onProgress?: (p: WorkflowProgress) => void;
+  concurrency?: number;
+}
+
+// ── Script parsing ───────────────────────────────────────────────────
+
+/**
+ * Split a workflow script into its static `meta` literal and the executable body.
+ * `meta` must be a pure literal — it is evaluated in a helperless context, so a literal that
+ * references `agent`/etc. throws.
+ */
+export function parseWorkflow(script: string): {
+  meta: WorkflowMeta;
+  body: string;
+} {
+  const metaRe = /(^|\n)\s*export\s+const\s+meta\s*=\s*/;
+  const m = metaRe.exec(script);
+  if (!m) {
+    throw new Error(
+      "Workflow script must declare `export const meta = { name, description }` as a pure literal.",
+    );
+  }
+  const braceStart = script.indexOf("{", m.index + m[0].length);
+  if (braceStart === -1) {
+    throw new Error(
+      "`export const meta` must be assigned an object literal `{ ... }`.",
+    );
+  }
+  const braceEnd = matchBrace(script, braceStart);
+  const metaText = script.slice(braceStart, braceEnd + 1);
+
+  let meta: WorkflowMeta;
+  try {
+    // Evaluate in a helperless context with determinism guards present — a pure literal needs none
+    // of them, so any reference (to a helper, or to Date/Math) throws and is reported clearly.
+    meta = runInNewContext(`(${metaText})`, {
+      Date: makeGuardedDate(),
+      Math: makeGuardedMath(),
+    }) as WorkflowMeta;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Workflow \`meta\` must be a pure literal (no variables/calls). Eval failed: ${msg}`,
+    );
+  }
+  if (!meta || typeof meta !== "object") {
+    throw new Error("Workflow `meta` did not evaluate to an object.");
+  }
+  if (typeof meta.name !== "string" || !meta.name) {
+    throw new Error("Workflow `meta.name` must be a non-empty string.");
+  }
+  if (typeof meta.description !== "string" || !meta.description) {
+    throw new Error("Workflow `meta.description` must be a non-empty string.");
+  }
+
+  // Remove the whole `export const meta = {...};` span from the body, then defensively strip any
+  // remaining line-anchored `export`/`export default` tokens (workflow bodies are top-level code).
+  let trailing = braceEnd + 1;
+  if (script[trailing] === ";") trailing++;
+  const body = (script.slice(0, m.index) + script.slice(trailing))
+    .replace(/(^|\n)\s*export\s+default\s+/g, "$1")
+    .replace(/(^|\n)\s*export\s+/g, "$1");
+  return { meta, body };
+}
+
+/** Brace-match starting at `openIdx` (which must point at `{`), skipping strings and comments. */
+function matchBrace(src: string, openIdx: number): number {
+  let depth = 0;
+  let i = openIdx;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '"' || c === "'" || c === "`") {
+      i = skipString(src, i);
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "/") {
+      const nl = src.indexOf("\n", i);
+      i = nl === -1 ? src.length : nl;
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "*") {
+      const end = src.indexOf("*/", i + 2);
+      i = end === -1 ? src.length : end + 2;
+      continue;
+    }
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  throw new Error("Unbalanced braces in `export const meta` literal.");
+}
+
+/** Given index of a quote char, return index just past the closing quote. Template strings only
+ * skip top-level — nested `${}` braces inside templates are rare in a meta literal and tolerated
+ * by treating the whole template span up to the matching backtick. */
+function skipString(src: string, start: number): number {
+  const quote = src[start];
+  let i = start + 1;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === quote) return i + 1;
+    i++;
+  }
+  return src.length;
+}
+
+// ── Determinism guards ───────────────────────────────────────────────
+
+function makeGuardedDate(): typeof Date {
+  const Guard = function (this: unknown, ...a: unknown[]) {
+    if (a.length === 0) {
+      throw new Error(
+        "`new Date()` with no args is non-deterministic and unavailable in workflows. Pass a timestamp via `args`.",
+      );
+    }
+    // @ts-expect-error spread into Date constructor
+    return new Date(...a);
+  } as any;
+  Guard.now = () => {
+    throw new Error(
+      "`Date.now()` is non-deterministic and unavailable in workflows. Pass a timestamp via `args`.",
+    );
+  };
+  Guard.parse = Date.parse;
+  Guard.UTC = Date.UTC;
+  Guard.prototype = Date.prototype;
+  return Guard as typeof Date;
+}
+
+function makeGuardedMath(): Math {
+  return new Proxy(Math, {
+    get(target, prop, recv) {
+      if (prop === "random") {
+        return () => {
+          throw new Error(
+            "`Math.random()` is non-deterministic and unavailable in workflows. Vary by index instead.",
+          );
+        };
+      }
+      return Reflect.get(target, prop, recv);
+    },
+  });
+}
+
+// ── Minimal JSON-Schema validation (dependency-free) ─────────────────
+
+/** Strip markdown fences and extract the first balanced JSON value from free-form model text. */
+export function extractJson(text: string): string | null {
+  let s = text.trim();
+  const fence = /```(?:json)?\s*([\s\S]*?)```/i.exec(s);
+  if (fence) s = fence[1].trim();
+  const start = s.search(/[[{]/);
+  if (start === -1) return null;
+  const open = s[start];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let i = start;
+  let inStr: string | null = null;
+  for (; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (c === "\\") i++;
+      else if (c === inStr) inStr = null;
+      continue;
+    }
+    if (c === '"' || c === "'") inStr = c;
+    else if (c === open) depth++;
+    else if (c === close) {
+      depth--;
+      if (depth === 0) return s.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+/** Validate `value` against a small JSON-Schema subset. Returns a list of human-readable errors. */
+export function validateSchema(
+  value: unknown,
+  schema: any,
+  path = "$",
+): string[] {
+  if (!schema || typeof schema !== "object") return [];
+  const errs: string[] = [];
+  const t = schema.type as string | string[] | undefined;
+  if (t) {
+    const types = Array.isArray(t) ? t : [t];
+    if (!types.some((ty) => matchesType(value, ty))) {
+      errs.push(
+        `${path}: expected type ${types.join("|")}, got ${jsType(value)}`,
+      );
+      return errs; // type mismatch — deeper checks are noise
+    }
+  }
+  if (schema.enum && Array.isArray(schema.enum)) {
+    if (!schema.enum.some((e: unknown) => deepEqual(e, value))) {
+      errs.push(`${path}: value not in enum`);
+    }
+  }
+  if (matchesType(value, "object") && schema.properties) {
+    const obj = value as Record<string, unknown>;
+    if (Array.isArray(schema.required)) {
+      for (const r of schema.required) {
+        if (!(r in obj)) errs.push(`${path}.${r}: required property missing`);
+      }
+    }
+    for (const [k, sub] of Object.entries(schema.properties)) {
+      if (k in obj) errs.push(...validateSchema(obj[k], sub, `${path}.${k}`));
+    }
+  }
+  if (matchesType(value, "array") && schema.items) {
+    const arr = value as unknown[];
+    if (typeof schema.minItems === "number" && arr.length < schema.minItems) {
+      errs.push(
+        `${path}: expected >= ${schema.minItems} items, got ${arr.length}`,
+      );
+    }
+    if (typeof schema.maxItems === "number" && arr.length > schema.maxItems) {
+      errs.push(
+        `${path}: expected <= ${schema.maxItems} items, got ${arr.length}`,
+      );
+    }
+    arr.forEach((el, idx) =>
+      errs.push(...validateSchema(el, schema.items, `${path}[${idx}]`)),
+    );
+  }
+  return errs;
+}
+
+function matchesType(v: unknown, ty: string): boolean {
+  switch (ty) {
+    case "object":
+      return v !== null && typeof v === "object" && !Array.isArray(v);
+    case "array":
+      return Array.isArray(v);
+    case "string":
+      return typeof v === "string";
+    case "number":
+      return typeof v === "number" && !Number.isNaN(v);
+    case "integer":
+      return typeof v === "number" && Number.isInteger(v);
+    case "boolean":
+      return typeof v === "boolean";
+    case "null":
+      return v === null;
+    default:
+      return true;
+  }
+}
+
+function jsType(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (
+    typeof a !== typeof b ||
+    a === null ||
+    b === null ||
+    typeof a !== "object"
+  )
+    return false;
+  const ka = Object.keys(a as object);
+  const kb = Object.keys(b as object);
+  if (ka.length !== kb.length) return false;
+  return ka.every((k) => deepEqual((a as any)[k], (b as any)[k]));
+}
+
+// ── Concurrency semaphore ────────────────────────────────────────────
+
+function createSemaphore(max: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const acquire = (): Promise<void> =>
+    new Promise((resolve) => {
+      const tryRun = () => {
+        if (active < max) {
+          active++;
+          resolve();
+        } else {
+          queue.push(tryRun);
+        }
+      };
+      tryRun();
+    });
+  const release = () => {
+    active--;
+    const next = queue.shift();
+    if (next) next();
+  };
+  return { acquire, release };
+}
+
+// ── The runtime ──────────────────────────────────────────────────────
+
+export async function runWorkflow(
+  script: string,
+  opts: RunWorkflowOptions,
+): Promise<WorkflowRunResult> {
+  const { meta, body } = parseWorkflow(script);
+  const cap = opts.concurrency ?? defaultConcurrency();
+  const sem = createSemaphore(cap);
+
+  let agentsSpawned = 0;
+  let errorCount = 0;
+  let tokensSpent = 0;
+  const phases: string[] = [];
+
+  const checkAbort = () => {
+    if (opts.signal?.aborted) throw new Error("Workflow aborted.");
+  };
+
+  const budget = {
+    total: opts.budgetTotal ?? null,
+    spent: () => tokensSpent,
+    remaining: () =>
+      opts.budgetTotal == null
+        ? Infinity
+        : Math.max(0, opts.budgetTotal - tokensSpent),
+  };
+
+  const emit = (
+    p: Omit<WorkflowProgress, "agentsSpawned" | "errorCount" | "tokensSpent">,
+  ) => opts.onProgress?.({ ...p, agentsSpawned, errorCount, tokensSpent });
+
+  async function agent(
+    prompt: unknown,
+    agentOpts: WorkflowAgentOpts = {},
+  ): Promise<unknown> {
+    checkAbort();
+    if (typeof prompt !== "string" || prompt.trim() === "") {
+      throw new Error("agent(prompt): prompt must be a non-empty string.");
+    }
+    if (agentsSpawned >= MAX_TOTAL_AGENTS) {
+      throw new Error(
+        `Workflow exceeded the ${MAX_TOTAL_AGENTS}-agent lifetime cap.`,
+      );
+    }
+    if (budget.total != null && budget.remaining() <= 0) {
+      throw new Error("Workflow token budget exhausted.");
+    }
+
+    const hasSchema = agentOpts.schema != null;
+    await sem.acquire();
+    try {
+      let lastErr = "";
+      const attempts = hasSchema ? SCHEMA_RETRIES : 1;
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        checkAbort();
+        agentsSpawned++;
+        const finalPrompt = hasSchema
+          ? buildSchemaPrompt(prompt, agentOpts.schema, attempt, lastErr)
+          : prompt;
+        const res = await opts.runAgent({
+          prompt: finalPrompt,
+          persona: agentOpts.persona,
+          model: agentOpts.model,
+          signal: opts.signal,
+        });
+        tokensSpent += res.usage?.output ?? 0;
+        emit({ kind: "agent", label: agentOpts.label, phase: agentOpts.phase });
+
+        if (res.isError) {
+          errorCount++;
+          return null;
+        }
+        if (!hasSchema) return res.output;
+
+        const raw = extractJson(res.output);
+        if (raw != null) {
+          try {
+            const parsed = JSON.parse(raw);
+            const verrs = validateSchema(parsed, agentOpts.schema);
+            if (verrs.length === 0) return parsed;
+            lastErr = verrs.slice(0, 5).join("; ");
+          } catch (e) {
+            lastErr = `JSON parse error: ${e instanceof Error ? e.message : String(e)}`;
+          }
+        } else {
+          lastErr = "no JSON object/array found in output";
+        }
+      }
+      errorCount++;
+      opts.onProgress?.({
+        kind: "log",
+        message: `agent(schema) failed after ${attempts} attempts: ${lastErr}`,
+        agentsSpawned,
+        errorCount,
+        tokensSpent,
+      });
+      return null;
+    } finally {
+      sem.release();
+    }
+  }
+
+  async function parallel(thunks: unknown): Promise<unknown[]> {
+    if (!Array.isArray(thunks))
+      throw new Error("parallel(thunks): expected an array of functions.");
+    if (thunks.length > MAX_ITEMS_PER_CALL) {
+      throw new Error(
+        `parallel(): ${thunks.length} thunks exceeds the ${MAX_ITEMS_PER_CALL} cap.`,
+      );
+    }
+    return Promise.all(
+      thunks.map((t) =>
+        Promise.resolve()
+          .then(() => {
+            if (typeof t !== "function")
+              throw new Error(
+                "parallel(): each item must be a thunk () => Promise.",
+              );
+            return t();
+          })
+          .catch(() => null),
+      ),
+    );
+  }
+
+  async function pipeline(
+    items: unknown,
+    ...stages: unknown[]
+  ): Promise<unknown[]> {
+    if (!Array.isArray(items))
+      throw new Error("pipeline(items, ...stages): items must be an array.");
+    if (items.length > MAX_ITEMS_PER_CALL) {
+      throw new Error(
+        `pipeline(): ${items.length} items exceeds the ${MAX_ITEMS_PER_CALL} cap.`,
+      );
+    }
+    const fns = stages.filter((s) => typeof s === "function") as Array<
+      (prev: unknown, item: unknown, index: number) => unknown
+    >;
+    return Promise.all(
+      items.map(async (item, index) => {
+        let acc: unknown = item;
+        try {
+          for (const stage of fns) {
+            acc = await stage(acc, item, index);
+          }
+          return acc;
+        } catch {
+          return null;
+        }
+      }),
+    );
+  }
+
+  function phase(title: unknown): void {
+    const t = String(title ?? "");
+    phases.push(t);
+    emit({ kind: "phase", phase: t });
+  }
+
+  function log(message: unknown): void {
+    emit({ kind: "log", message: String(message ?? "") });
+  }
+
+  function workflow(): never {
+    throw new Error("workflow() composition is not supported in v1.");
+  }
+
+  const sandbox: Record<string, unknown> = {
+    agent,
+    parallel,
+    pipeline,
+    phase,
+    log,
+    workflow,
+    args: opts.args,
+    budget,
+    console: {
+      log: (...a: unknown[]) => log(a.map((x) => stringify(x)).join(" ")),
+      error: (...a: unknown[]) => log(a.map((x) => stringify(x)).join(" ")),
+      warn: (...a: unknown[]) => log(a.map((x) => stringify(x)).join(" ")),
+    },
+    Date: makeGuardedDate(),
+    Math: makeGuardedMath(),
+  };
+
+  const wrapped = `(async () => {\n${body}\n})()`;
+  let result: unknown;
+  try {
+    result = await runInNewContext(wrapped, sandbox, {
+      filename: `workflow:${meta.name}.js`,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Workflow "${meta.name}" failed: ${msg}`);
+  }
+
+  return { meta, result, agentsSpawned, errorCount, tokensSpent, phases };
+}
+
+function stringify(x: unknown): string {
+  if (typeof x === "string") return x;
+  try {
+    return JSON.stringify(x);
+  } catch {
+    return String(x);
+  }
+}
+
+function buildSchemaPrompt(
+  prompt: string,
+  schema: unknown,
+  attempt: number,
+  lastErr: string,
+): string {
+  const schemaText = JSON.stringify(schema, null, 2);
+  const retry =
+    attempt > 0
+      ? `\n\nYour previous response did not satisfy the schema (${lastErr}). Return corrected JSON only.`
+      : "";
+  return (
+    `${prompt}\n\n` +
+    `Respond with ONLY a single JSON value that conforms to this JSON Schema. ` +
+    `No prose, no markdown fences, no commentary.\n\nJSON Schema:\n${schemaText}${retry}`
+  );
+}
+
+// ── Tool registration ────────────────────────────────────────────────
+
+export function registerWorkflowTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "workflow",
+    label: "Workflow",
+    description: [
+      "Run an agent-authored JavaScript workflow that deterministically orchestrates ISOLATED",
+      "sub-agents. The script's intermediate results live in script variables, not in your context",
+      "window — use this to fan out dozens of sub-agents (review pipelines, research sweeps,",
+      "migrations) without context pressure.",
+      "",
+      "Script shape:",
+      "  export const meta = { name: 'my-flow', description: '...', phases: [{ title: 'Scan' }] };",
+      "  // top-level body using injected globals — top-level await is allowed:",
+      "  phase('Scan');",
+      "  const out = await parallel([() => agent('task A'), () => agent('task B')]);",
+      "  return out;",
+      "",
+      "Injected helpers/globals:",
+      "  agent(prompt, opts?)   -> spawn one isolated sub-agent. opts: { schema?, label?, phase?,",
+      "                            model?, persona? }. Without schema returns the final text string;",
+      "                            with schema (a JSON Schema) returns a validated object, or null",
+      "                            after retries. Returns null on sub-agent error (filter with Boolean).",
+      "  parallel(thunks)       -> run `() => Promise` thunks concurrently (barrier); failures -> null.",
+      "  pipeline(items, ...st) -> stream each item through stages, no barrier between stages.",
+      "  phase(title) / log(msg)-> progress UI only.",
+      "  args                   -> the JSON you pass in `args`.",
+      "  budget                 -> { total, spent(), remaining() } token accounting.",
+      "",
+      "Constraints: Date.now()/Math.random()/argless new Date() throw (determinism). Concurrency is",
+      `capped automatically; >${MAX_TOTAL_AGENTS} agents or >${MAX_ITEMS_PER_CALL} items per call throws.`,
+      "v1 runs to completion before returning (abortable). meta MUST be a pure literal.",
+    ].join("\n"),
+    parameters: Type.Object({
+      script: Type.String({
+        description:
+          "The JavaScript workflow script (export const meta + top-level body).",
+      }),
+      args: Type.Optional(
+        Type.Unknown({
+          description: "JSON value exposed to the script as `args`.",
+        }),
+      ),
+      budget: Type.Optional(
+        Type.Number({
+          description:
+            "Optional total output-token target; agent() throws once exhausted.",
+        }),
+      ),
+    }),
+
+    async execute(
+      _toolCallId: string,
+      params: any,
+      signal: AbortSignal | undefined,
+      onUpdate: any,
+      ctx: any,
+    ): Promise<any> {
+      const runAgent: WorkflowAgentRunner = async ({
+        prompt,
+        persona,
+        model,
+        signal: sig,
+      }) => {
+        const { jobPromise } = await startSubagentJob({
+          task: prompt,
+          persona,
+          modelOverride: model,
+          cwd: ctx.cwd,
+          contextText: null, // isolated — fresh context per agent
+          signal: sig,
+          onUpdate: undefined,
+          defaultModel: ctx.model,
+          parentModelRegistry: ctx.modelRegistry,
+        });
+        return jobPromise;
+      };
+
+      try {
+        const run = await runWorkflow(params.script, {
+          args: params.args,
+          budgetTotal: params.budget ?? null,
+          runAgent,
+          signal,
+          onProgress: (p) => {
+            try {
+              onUpdate?.({
+                content: [{ type: "text", text: renderProgress(p) }],
+                details: {
+                  status: "running",
+                  agentsSpawned: p.agentsSpawned,
+                  errorCount: p.errorCount,
+                  tokensSpent: p.tokensSpent,
+                },
+              });
+            } catch {
+              /* onUpdate is best-effort */
+            }
+          },
+        });
+
+        const resultText =
+          typeof run.result === "string" ? run.result : stringify(run.result);
+        const summary =
+          `Workflow "${run.meta.name}" complete — ${run.agentsSpawned} agent(s), ` +
+          `${run.errorCount} error(s), ${run.tokensSpent} output tokens.`;
+        return {
+          content: [{ type: "text", text: `${summary}\n\n${resultText}` }],
+          details: {
+            status: "done",
+            name: run.meta.name,
+            agentsSpawned: run.agentsSpawned,
+            errorCount: run.errorCount,
+            tokensSpent: run.tokensSpent,
+            phases: run.phases,
+          },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Workflow failed: ${msg}` }],
+          details: { status: "error", error: msg },
+          isError: true,
+        };
+      }
+    },
+  });
+}
+
+function renderProgress(p: WorkflowProgress): string {
+  const head = `● workflow — ${p.agentsSpawned} agent(s), ${p.errorCount} error(s)`;
+  if (p.kind === "phase") return `${head}\n  phase: ${p.phase}`;
+  if (p.kind === "log") return `${head}\n  ${p.message}`;
+  return `${head}${p.label ? `\n  → ${p.label}` : ""}`;
+}

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -13,10 +13,30 @@
 // `startSubagentJob` primitive the other tools use, so intermediate results live in script
 // variables rather than the parent agent's context window.
 //
-// NOTE: `vm.runInNewContext` is NOT an escape-proof jail (`globalThis` is reachable, and
-// constructor escapes are not blockable in `vm`). This is acceptable because the script author is
-// the trusted main agent. The guarantees we actually make: no Node globals (require/process/module)
-// are injected, and Date.now()/Math.random()/argless `new Date()` throw inside a script.
+// NOTE: `vm.runInNewContext` is NOT an escape-proof jail. The script author is the trusted main
+
+// agent, so we don't try to be one. The guarantees we actually make:
+
+//   - No Node globals (process/require/module/Buffer/...) are injected into the sandbox.
+
+//   - `Date.now()`, `Math.random()`, and argless `new Date()` throw when called DIRECTLY
+
+//     (i.e. as bare identifiers resolved in the sandbox scope). This blocks the obvious
+
+//     non-determinism footguns for a model writing naive script code.
+
+//   - `eval(code)` and `new Function(code)` are NOT blocked: the code they evaluate runs in
+
+//     the real global scope and can reach the real `Date.now()` / `Math.random()`. A script
+
+//     author who goes out of their way to be non-deterministic can be — and the script
+
+//     author is trusted, so that's fine. Sub-agent results are non-deterministic too
+
+//     (LLM output), so "deterministic orchestration" below only means deterministic control
+
+//     flow, not deterministic end-to-end results.
+
 
 import { runInNewContext } from "node:vm";
 import { cpus } from "node:os";
@@ -627,10 +647,19 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
     name: "workflow",
     label: "Workflow",
     description: [
-      "Run an agent-authored JavaScript workflow that deterministically orchestrates ISOLATED",
-      "sub-agents. The script's intermediate results live in script variables, not in your context",
-      "window — use this to fan out dozens of sub-agents (review pipelines, research sweeps,",
-      "migrations) without context pressure.",
+
+      "Run an agent-authored JavaScript workflow that orchestrates ISOLATED sub-agents with",
+
+      "deterministic control flow (parallel/pipeline/barrier semantics are exact, but",
+
+      "sub-agent outputs themselves are LLM-driven and non-deterministic). The script's",
+
+      "intermediate results live in script variables, not in your context window — use this to",
+
+      "fan out dozens of sub-agents (review pipelines, research sweeps, migrations) without",
+
+      "context pressure.",
+
       "",
       "Script shape:",
       "  export const meta = { name: 'my-flow', description: '...', phases: [{ title: 'Scan' }] };",
@@ -650,8 +679,12 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       "  args                   -> the JSON you pass in `args`.",
       "  budget                 -> { total, spent(), remaining() } token accounting.",
       "",
-      "Constraints: Date.now()/Math.random()/argless new Date() throw (determinism). Concurrency is",
+      "Constraints: Date.now()/Math.random()/argless new Date() throw when called directly",
+
+      "(a determined script can still reach the real ones via eval/Function). Concurrency is",
+
       `capped automatically; >${MAX_TOTAL_AGENTS} agents or >${MAX_ITEMS_PER_CALL} items per call throws.`,
+
       "v1 runs to completion before returning (abortable). meta MUST be a pure literal.",
     ].join("\n"),
     parameters: Type.Object({


### PR DESCRIPTION
## Superseded by #22

This PR is closed in favor of #22, which is the same v1 scope rebased onto current `master` (2.2.5) with all review blockers fixed:

- HEADLINE BUG (abort swallow in `parallel()` / `pipeline()`) — fixed
- Prettier violation in `src/subagent.ts` — fixed
- Stale base (11 commits behind) — rebased
- Abort regression test coverage — added (6 tests in a new `abort signal propagation` describe block)

The original PR body is preserved below for the historical record.

---

## Summary

Adds the `workflow` tool — a small, dependency-free JavaScript runtime that lets the main agent author a script to deterministically orchestrate isolated sub-agents. The script's intermediate results live in script variables, not the parent's context window, so the agent can fan out dozens of sub-agents (review pipelines, research sweeps, migrations) without context pressure.

Ports Claude Code's "Dynamic Workflows" model into pi-subagentura. v1 scope: runs to completion before returning, abortable via the parent signal.

## What's in the box

- **`workflow` tool** registered by `registerWorkflowTool(pi)` in `src/workflow.ts` (758 LOC)
- **`runWorkflow(script, opts)` runtime** — `vm.runInNewContext` with `agent`, `parallel`, `pipeline`, `phase`, `log`, `workflow` injected helpers and `args`, `budget` injected globals
- **Determinism guards** — guarded `Date` and `Math` (Proxy) throw on `Date.now()`, `Math.random()`, and argless `new Date()` when called directly
- **JSON-Schema validation** — dependency-free subset (`extractJson`, `validateSchema`) so `agent(prompt, { schema })` returns a validated object or `null` after bounded retries (3 attempts)
- **Concurrency control** — automatic `min(16, cpus() - 2)` cap with a semaphore
- **Token budget** — `agent()` throws once the per-workflow output-token target is exhausted
- **Tests** — 30 tests in `src/workflow.test.ts` covering parseWorkflow, determinism guards, agent+budget, parallel, pipeline, schema enforcement, extractJson, validateSchema, and the v1 `workflow()` composition guard
- **README** — full Workflows section with a worked example, injected-helpers list, fidelity note, and v1 scope
- **Doc clarification** (commit `f0c8904`) — the eval/Function bypass of the determinism guards is real (not a sandbox escape — Node globals stay inaccessible), and sub-agent outputs are LLM-driven so "deterministic" means deterministic control flow, not deterministic end-to-end. The comment block, tool description, and README now state this honestly.

## Known v1 limitations (deferred to v2)

- No background (non-blocking) execution
- No tmux/worktree process-backed agents (`opts.isolation` accepted but no-op)
- No `agentType` routing
- No saved/named workflows or `workflow()` composition (the call site throws "not supported in v1")
- No resume journaling