### PR TITLE
fix(interactive): swallow stale-ctx errors in pollArtifactChanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A public [Pi](https://pi.dev) package that adds in-process and attachable sub-ag
 - `send_interactive_subagent_message` — send a follow-up into a live sub-agent's REPL (preserves child context)
 - `read_subagent_artifact` — read an interactive sub-agent's lifecycle events and output
 - `list_subagent_artifacts` — list all known interactive sub-agents (in-session and on-disk)
-The default sub-agents run inside the current Pi process, stream live progress back to the UI, and inherit the active model by default. Async sub-agents run in the background — the main agent continues immediately while you poll for progress and collect results when ready. Interactive sub-agents run as separate `pi --session ...` processes in tmux or zellij panes so you can attach and continue follow-ups directly there, and write structured progress to a per-sub-agent artifact directory on disk.
+  The default sub-agents run inside the current Pi process, stream live progress back to the UI, and inherit the active model by default. Async sub-agents run in the background — the main agent continues immediately while you poll for progress and collect results when ready. Interactive sub-agents run as separate `pi --session ...` processes in tmux or zellij panes so you can attach and continue follow-ups directly there, and write structured progress to a per-sub-agent artifact directory on disk.
 
 Interactive sub-agents support **follow-up turns**: the parent can push a new prompt into the same child REPL via `send_interactive_subagent_message`. The child is `idle` (not exited) between turns, model context is preserved, and the poller snapshots `output.md` into `output-N.md` on each new `done` event so full turn history is recoverable via `read_subagent_artifact { turn: N }`.
 
@@ -136,7 +136,6 @@ Parameters:
 
 Remove all completed and failed subagent jobs from the registry. Running and cancelled jobs are preserved.
 
-
 ### Interactive Sub-agent Tools
 
 Use these when observability and manual follow-up matter more than in-process execution. They require a terminal multiplexer (tmux or zellij). If the parent Pi session is not running inside one, the sub-agent is automatically spawned in a new detached session that you attach to later. Interactive sub-agents write their progress to a per-sub-agent artifact directory on disk; the pane is for live monitoring, the artifact is the source of truth.
@@ -188,7 +187,6 @@ Interactive sub-agents deliver their completion to the parent through one of two
 
 Both modes share a `MAX_INJECT` cap of 5 concurrent injects. If more sub-agents finish at the same time, the rest degrade silently to `notify` (UI hint only) to keep the parent conversation from flooding. The cap is concurrent, not lifetime — once some injects settle, more can fire.
 
-
 #### `get_interactive_subagent_status`
 
 Lists tracked interactive sub-agents, attach/select commands, and session paths. It intentionally does **not** capture pane output to avoid consuming model context.
@@ -203,8 +201,10 @@ Sends a follow-up prompt to a running interactive sub-agent by id. The message i
 Refuses to send if the sub-agent is not in the registry, is not in `running` status, or if the mux itself rejects the send call (e.g. the pane was killed between status check and send). All three failure modes return a structured `isError: true` result.
 
 Parameters:
+
 - `id` — required sub-agent id
 - `message` — required follow-up prompt text
+
 #### `list_subagent_artifacts`
 
 Lists all known interactive sub-agents: id, name, status, and last-update timestamp. Use this to discover sub-agents that finished while the parent was away.
@@ -216,11 +216,11 @@ Reads a sub-agent's artifact by id. Returns the lifecycle event log (pass `since
 For follow-up support, the parent poller snapshots `output.md` into `output-N.md` after each new `done` event (where N is the turn number). Pass `turn: N` to read a specific historical turn's snapshot. The response's `details.availableTurns` lists all turns with snapshots.
 
 Parameters:
+
 - `id` — required sub-agent id
 - `since` — optional unix-ms timestamp; only return events with `ts >= since`
 - `includeOutput` — include the output (default `true`); ignored if `turn` is set (turn implies output)
 - `turn` — optional turn number; read `output-N.md` for that specific turn instead of the latest `output.md`
-
 
 ### `list_available_models`
 
@@ -230,6 +230,7 @@ Parameters:
 
 - `filter` — optional substring filter for provider or model name
 - `authOnly` — if true (default), only return models with configured auth
+
 ## Example prompts
 
 - “Use a sub-agent to review this change and list risks.”
@@ -263,18 +264,13 @@ SUBAGENT_DEBUG_LOG_DIR=./.pi-debug pi   # writes ./pi-debug/debug-2026-06-10.jso
 
 ## Contributing
 
-
-
 Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md).
-
-
 
 A pre-push hook runs `prettier --check` on staged files (via `simple-git-hooks` + `lint-staged`).
 
 It auto-installs on `npm install`. To skip once: `SKIP_SIMPLE_GIT_HOOKS=1 git push`. To reformat:
 
 `npm run format`.
-
 
 ## License
 

--- a/context.md
+++ b/context.md
@@ -1,10 +1,7 @@
-
 ---
-
 ### 🧑 User (line 949)
 
 what if we want to add the zellij support?
-
 ---
 
 ### 🤖 Assistant (line 950)
@@ -14,6 +11,7 @@ Yes, makes sense. Zellij users exist and tmux lock-in is a friction point. Let m
 ## Current state: tmux-everywhere
 
 The codebase has zero abstraction. Every mux operation is hard-coded `tmux ...` in `src/interactive-tmux.ts`:
+
 - `execFileSync("tmux", ["new-window", ...])` / `split-window` (line 264)
 - `execFileSync("tmux", ["display-message", "-p", ...])` for `isPaneAlive` (line 417)
 - `execFileSync("tmux", ["send-keys", ...])` + `Enter` (line 281-282)
@@ -26,10 +24,14 @@ The codebase has zero abstraction. Every mux operation is hard-coded `tmux ...` 
 ```ts
 // src/multiplexer.ts
 export interface Multiplexer {
-  readonly name: 'tmux' | 'zellij';
+  readonly name: "tmux" | "zellij";
   isAvailable(): boolean;
-  createPane(opts: { name: string; cwd: string; background: boolean; parentPane?: string }):
-    { paneId: string; windowName?: string };
+  createPane(opts: {
+    name: string;
+    cwd: string;
+    background: boolean;
+    parentPane?: string;
+  }): { paneId: string; windowName?: string };
   isPaneAlive(paneId: string): boolean;
   sendKeys(paneId: string, command: string): void;
   killPane(paneId: string): void;
@@ -39,6 +41,7 @@ export interface Multiplexer {
 ```
 
 Plus a thin `getMux(opts?): Multiplexer` that resolves which to use:
+
 - `PI_SUBAGENT_MUX=tmux|zellij` env var → force
 - otherwise: prefer the mux already attached to this session (heuristic: parse `$ZELLIJ_SESSION_NAME` / `$TMUX` from `process.env`)
 - otherwise: prefer tmux (backward compat)
@@ -46,17 +49,17 @@ Plus a thin `getMux(opts?): Multiplexer` that resolves which to use:
 
 ## Zellij mapping (the rough edges)
 
-| Concept | tmux | zellij |
-|---|---|---|
-| New split pane | `tmux split-window -d -h -P -F '#{pane_id}' -t <parent>` | `zellij action new-pane --direction right --close-on-exit` (pane id in stdout) |
-| New detached window | `tmux new-window -d -n <name> -P -F '#{pane_id}' -c <cwd>` | `zellij action new-tab --name <name> --cwd <cwd>` (then create a pane inside) |
-| Pane id format | `%123` (string) | integer (need to stringify for `InteractiveSubagentState.paneId: string`) |
-| Send text + Enter | `send-keys -t <pane> -l <text>` + `send-keys -t <pane> Enter` | `zellij action write-chars <text>` + `zellij action write 13` |
-| Pane alive check | `tmux display-message -p -t <pane> '#{pane_id}'` (throws if dead) | `zellij action query-tab-info --tab-name <name>` (parse JSON; pane missing → dead) |
-| Kill pane | `tmux kill-pane -t <pane>` | `zellij action close-pane --pane-id <id>` or `zellij kill-session <sess>` |
-| Attach from outside | `tmux attach -t <sess>` | `zellij attach <sess>` |
-| Focus from inside | `tmux select-window -t <name>` | `zellij action go-to-tab-name <name>` |
-| Exit code of child | pane option `@pi-exit-code` (tmux-only trick) | **doesn't exist** — but we don't need it! The launch script's EXIT trap already writes `cli.mjs done <code>` to the artifact, which is the source of truth |
+| Concept             | tmux                                                              | zellij                                                                                                                                                     |
+| ------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New split pane      | `tmux split-window -d -h -P -F '#{pane_id}' -t <parent>`          | `zellij action new-pane --direction right --close-on-exit` (pane id in stdout)                                                                             |
+| New detached window | `tmux new-window -d -n <name> -P -F '#{pane_id}' -c <cwd>`        | `zellij action new-tab --name <name> --cwd <cwd>` (then create a pane inside)                                                                              |
+| Pane id format      | `%123` (string)                                                   | integer (need to stringify for `InteractiveSubagentState.paneId: string`)                                                                                  |
+| Send text + Enter   | `send-keys -t <pane> -l <text>` + `send-keys -t <pane> Enter`     | `zellij action write-chars <text>` + `zellij action write 13`                                                                                              |
+| Pane alive check    | `tmux display-message -p -t <pane> '#{pane_id}'` (throws if dead) | `zellij action query-tab-info --tab-name <name>` (parse JSON; pane missing → dead)                                                                         |
+| Kill pane           | `tmux kill-pane -t <pane>`                                        | `zellij action close-pane --pane-id <id>` or `zellij kill-session <sess>`                                                                                  |
+| Attach from outside | `tmux attach -t <sess>`                                           | `zellij attach <sess>`                                                                                                                                     |
+| Focus from inside   | `tmux select-window -t <name>`                                    | `zellij action go-to-tab-name <name>`                                                                                                                      |
+| Exit code of child  | pane option `@pi-exit-code` (tmux-only trick)                     | **doesn't exist** — but we don't need it! The launch script's EXIT trap already writes `cli.mjs done <code>` to the artifact, which is the source of truth |
 
 The exit-code issue is the only true gotcha — and it's already solved by the launch script's trap. We just delete the `readPaneExitCode` helper and rely on the artifact.
 
@@ -82,7 +85,7 @@ The exit-code issue is the only true gotcha — and it's already solved by the l
 
 ## Trade-offs to call out
 
-1. **Mux mixing is messy.** A parent in tmux spawning a child in zellij (or vice versa) works mechanically but is weird for users. The resolver should pick *one* and stick with it for the session.
+1. **Mux mixing is messy.** A parent in tmux spawning a child in zellij (or vice versa) works mechanically but is weird for users. The resolver should pick _one_ and stick with it for the session.
 2. **Zellij pane id type.** tmux uses `%123` strings; zellij uses integers. We keep `paneId: string` everywhere and stringify zellij ids (`"42"`) — clean but a small abstraction cost.
 3. **Zellij attach UX.** Outside-tmux attach is `tmux attach -t <sess>` which always works. Outside-zellij attach needs the session name, and zellij session naming is more variable. The `attachCommand` string in `InteractiveSubagentState` will be mux-specific (already is).
 4. **CI testing.** Need a zellij install in CI, or mock the zellij CLI commands (like we mock tmux). The zellij tests would mirror the tmux tests structurally.
@@ -104,13 +107,14 @@ Let me think about what this would entail:
    - `zellij action write 13` (or similar) for Enter key
    - `zellij list-clients` to check if server is running
    - `zellij attach <session>` to attach
-   - `zellij action focus-pane <direction> <pane_id>` 
+   - `zellij action focus-pane <direction> <pane_id>`
 
 3. Zellij also has a JSON-RPC/WebSocket interface for programmatic control, but the CLI should work for our needs.
 
 4. The user is exploring a feature. This is a design discussion question, not a "do it now" request. Let me think about the design considerations and trade-offs.
 
 Things to think about:
+
 - Backward compatibility: tmux must still work (or we abstract the multiplexer)
 - User choice: which multiplexer to use (env var, config, per-spawn)
 - Code structure: refactor to a multiplexer abstraction layer
@@ -120,22 +124,26 @@ Things to think about:
 This is a significant refactor. Let me lay out the design:
 
 **Approach 1: Abstraction layer**
+
 - Define an `IMultiplexer` interface with methods: `isAvailable()`, `newPane()`, `sendKeys()`, `killPane()`, `isPaneAlive()`, `attachCommand()`, `selectPaneCommand()`
 - Two implementations: `TmuxMultiplexer` and `ZellijMultiplexer`
 - Choose at spawn time based on env var or default
 
 **Approach 2: Parallel implementations**
+
 - Keep tmux-specific code as-is
 - Add zellij-specific code alongside
 - Tool param selects which to use
 
 **Approach 3: Just delegate**
+
 - Add a `ZELLIJ_MODE` env var
 - If set, use zellij code paths; else use tmux
 
 I think Approach 1 is cleanest. Let me think about what the interface needs to support:
 
 Looking at the current code in `interactive-tmux.ts`:
+
 - `isTmuxAvailable()` — check if tmux is running
 - `buildChildSubagentProtocol(artifactDir)` — text prompt, not mux-specific
 - `readPaneExitCode(paneId)` — get exit code from pane
@@ -149,6 +157,7 @@ Looking at the current code in `interactive-tmux.ts`:
 - `launchInteractiveSubagent(params)` — creates pane, writes launch script, sends keys
 
 The tmux-specific parts:
+
 1. **Pane creation**: `tmux new-window -d -n <name> ...` or `tmux split-window -d -h ...`
 2. **Pane alive check**: `tmux display-message -p -t <pane_id> "#{pane_id}"`
 3. **Send keys**: `tmux send-keys -t <pane_id> -l <text>` + `tmux send-keys -t <pane_id> Enter`
@@ -157,6 +166,7 @@ The tmux-specific parts:
 6. **Exit code**: `tmux show-options -p -t <pane_id> @pi-exit-code`
 
 Zellij equivalents:
+
 1. **Pane creation**: `zellij action new-pane --direction right --close-on-exit` (creates split); or `zellij --new-session-with-layout <layout>` for new tab
 2. **Pane alive check**: `zellij action query-tab-info` (lists panes)
 3. **Send keys**: `zellij action write-chars <text>` + `zellij action write 13` (Enter)
@@ -172,22 +182,33 @@ OK so the design:
 
 ```ts
 interface IMultiplexer {
-  readonly name: 'tmux' | 'zellij';
+  readonly name: "tmux" | "zellij";
   isAvailable(): boolean;
-  createPane(opts: { name: string; cwd: string; background: boolean; tmuxPane?: string }): { paneId: string; windowName?: string };
+  createPane(opts: {
+    name: string;
+    cwd: string;
+    background: boolean;
+    tmuxPane?: string;
+  }): { paneId: string; windowName?: string };
   isPaneAlive(paneId: string): boolean;
   sendKeys(paneId: string, command: string): void;
   killPane(paneId: string): void;
-  attachCommand(opts: { sessionName?: string; windowName?: string; paneId: string }): string;
+  attachCommand(opts: {
+    sessionName?: string;
+    windowName?: string;
+    paneId: string;
+  }): string;
   selectPaneCommand(opts: { windowName?: string; paneId: string }): string;
 }
 ```
 
 Then:
+
 - `TmuxMultiplexer` (current logic, extracted)
 - `ZellijMultiplexer` (new)
 
 The launcher chooses the multiplexer:
+
 - If `PI_SUBAGENT_MUX=tmux` or unset + tmux available → tmux
 - If `PI_SUBAGENT_MUX=zellij` → zellij
 - Auto-detect: if only one is available, use it; if both, prefer tmux (backward compat); if neither, error
@@ -195,6 +216,7 @@ The launcher chooses the multiplexer:
 Actually thinking more, a simpler approach: detect on launch, store the mux choice on the state. That way each sub-agent has a known mux (could mix if user switches mid-session, though that's edge case).
 
 Let me also think about zellij-specific quirks:
+
 - Zellij's CLI is a bit awkward for automation. Some operations are interactive (the `zellij` command without args starts the session in current terminal).
 - The `zellij action` subcommand is for scripting.
 - Pane IDs in zellij are integers, not `%N` like tmux. The state would need a string field for paneId.
@@ -205,6 +227,7 @@ Let me also think about testing. The current tmux tests mock `node:child_process
 This is a substantial chunk of work. The user is asking "what if we want to add zellij support?" — they want to know if it makes sense, what the approach is, what's the scope.
 
 Let me give a structured answer:
+
 1. Yes, makes sense for users who prefer zellij
 2. Approach: abstraction layer with two impls
 3. Scope: significant refactor (~500-1000 lines + tests)
@@ -219,9 +242,10 @@ Actually, the user's tone is "what if we want to" — exploratory. They want a d
 
 > 🛠️ Tool call: **ask_user**
 > Arguments: ```json
-{
-  "question": "How do you want to scope the zellij work?",
-  "options": [
+> {
+> "question": "How do you want to scope the zellij work?",
+> "options": [
+
     {
       "title": "Single PR: refactor + zellij together",
       "description": "One PR: extract the Mux interface, ship the tmux implementation as the extracted layer (no behavior change), ship the zellij implementation, add the tool param + env var, update docs. ~850 lines, ~3 days. Bigger PR but atomic — review is one pass, merge is one event."
@@ -234,9 +258,11 @@ Actually, the user's tone is "what if we want to" — exploratory. They want a d
       "title": "Defer — explore a prototype first",
       "description": "Don't start the refactor yet. First write a 100-line zellij PoC against the current tmux-everywhere code (no interface extraction) to validate the zellij CLI calls and pin down the rough edges. If the PoC works, then commit to one of the two refactor plans."
     }
-  ]
+
+]
 }
-```
+
+````
 
 ---
 
@@ -275,7 +301,7 @@ The user wants to create a branch for the zellij support work. They want to star
 {
   "command": "cd /Users/applesucks/dev/pi-agents && git checkout -b feat/zellij-multiplexer-support 2>&1 | tail -3 && git --no-pager log --oneline -1"
 }
-```
+````
 
 ---
 
@@ -283,7 +309,6 @@ The user wants to create a branch for the zellij support work. They want to star
 
 Switched to a new branch 'feat/zellij-multiplexer-support'
 07d282b chore: bump version to 2.2.0
-
 
 ---
 
@@ -320,15 +345,18 @@ Let me use web search and fetch tools to gather current information.
 
 > 🛠️ Tool call: **web_search**
 > Arguments: ```json
-{
-  "queries": [
+> {
+> "queries": [
+
     "zellij latest version 2026 CLI action subcommand",
     "zellij action write-chars write 13 send keys CLI",
     "zellij action new-pane direction right syntax 2026",
     "zellij session attach go-to-tab-name pane id format"
-  ]
+
+]
 }
-```
+
+````
 
 ### [Web Search Results]
 
@@ -346,7 +374,7 @@ Summary based on the currently selected search results.
 {
   "url": "https://zellij.dev/documentation/cli-actions.html"
 }
-```
+````
 
 ---
 
@@ -360,7 +388,7 @@ Summary based on the currently selected search results.
 
 ## CLI Actions
 
-*A note about pane ids:*...
+_A note about pane ids:_...
 
 <details>
 <summary>💭 Thinking (line 963)</summary>
@@ -371,14 +399,17 @@ Excellent! I have very detailed information about the zellij CLI. Let me also ch
 
 > 🛠️ Tool call: **web_search**
 > Arguments: ```json
-{
-  "queries": [
+> {
+> "queries": [
+
     "tmux latest version 2026 release",
     "tmux 3.5 send-keys new features 2025 2026",
     "tmux display-message pane id format deprecated 2026"
-  ]
+
+]
 }
-```
+
+````
 
 ### [Web Search Results]
 
@@ -396,7 +427,7 @@ Summary based on the currently selected search results.
 {
   "url": "https://github.com/tmux/tmux/releases/tag/3.6b"
 }
-```
+````
 
 ---
 
@@ -410,14 +441,15 @@ Summary based on the currently selected search results.
 > Words: 61
 > Browser: chrome_145/windows
 
-/ **[tmux](https://github.com/t...
+/ \*\*[tmux](https://github.com/t...
 
 > 🛠️ Tool call: **web_fetch**
 > Arguments: ```json
-{
-  "url": "https://raw.githubusercontent.com/tmux/tmux/3.6b/CHANGES"
-}
-```
+> {
+> "url": "https://raw.githubusercontent.com/tmux/tmux/3.6b/CHANGES"
+> }
+
+````
 
 ---
 
@@ -446,7 +478,7 @@ Let me also verify zellij version info and check if there are any pitfalls.
 {
   "url": "https://github.com/zellij-org/zellij/releases"
 }
-```
+````
 
 ---
 
@@ -473,14 +505,17 @@ Let me also check on any zellij pane attach quirks and the env var for session d
 
 > 🛠️ Tool call: **web_search**
 > Arguments: ```json
-{
-  "queries": [
+> {
+> "queries": [
+
     "zellij ZELLIJ_SESSION_NAME env var attach from outside session",
     "zellij new-session --background detach hidden pane",
     "zellij dump-screen capture pane programmatically exit code"
-  ]
+
+]
 }
-```
+
+````
 
 ### [Web Search Results]
 
@@ -498,7 +533,7 @@ Summary based on the currently selected search results.
 {
   "url": "https://zellij.dev/documentation/integration"
 }
-```
+````
 
 ---
 
@@ -523,10 +558,11 @@ Now I have comprehensive info. Let me also check how the tmux vs zellij env var 
 
 > 🛠️ Tool call: **web_fetch**
 > Arguments: ```json
-{
-  "url": "https://zellij.dev/documentation/cli-recipes.html"
-}
-```
+> {
+> "url": "https://zellij.dev/documentation/cli-recipes.html"
+> }
+
+````
 
 ---
 
@@ -642,19 +678,20 @@ interface Multiplexer {
   attachCommand(opts: { paneId: string; windowName?: string; sessionName?: string }): string;
   focusCommand(opts: { paneId: string; windowName?: string }): string;
 }
-```
+````
 
 `sendKeys` is what the launch script uses (single chars at a time). `paste` is for `send_interactive_subagent_message` (potentially long messages). tmux's `paste` falls back to `sendKeys` (or could just always use sendKeys — paste is only an advantage for zellij).
 
 **Resolution for the Mux resolver:**
+
 ```ts
-function getMux(preference?: 'tmux' | 'zellij' | 'auto'): Multiplexer {
+function getMux(preference?: "tmux" | "zellij" | "auto"): Multiplexer {
   const tmux = new TmuxMultiplexer();
   const zellij = new ZellijMultiplexer();
 
   // Explicit preference wins.
-  if (preference === 'tmux') return tmux;
-  if (preference === 'zellij') return zellij;
+  if (preference === "tmux") return tmux;
+  if (preference === "zellij") return zellij;
 
   // Auto: prefer the mux already attached to this session.
   if (process.env.ZELLIJ_SESSION_NAME && zellij.isAvailable()) return zellij;
@@ -664,13 +701,16 @@ function getMux(preference?: 'tmux' | 'zellij' | 'auto'): Multiplexer {
   if (tmux.isAvailable()) return tmux;
   if (zellij.isAvailable()) return zellij;
 
-  throw new Error('No multiplexer available. Start pi inside tmux or zellij, or install one.');
+  throw new Error(
+    "No multiplexer available. Start pi inside tmux or zellij, or install one.",
+  );
 }
 ```
 
 **Resolution for the state field:**
+
 ```ts
-mux: 'tmux' | 'zellij'  // set at spawn time, never changes
+mux: "tmux" | "zellij"; // set at spawn time, never changes
 ```
 
 Stored alongside the existing `paneId`, `windowName`, etc. in `InteractiveSubagentState`.
@@ -681,16 +721,16 @@ Stored alongside the existing `paneId`, `windowName`, etc. in `InteractiveSubage
 
 With the actual zellij v0.44 API and the resolved design points:
 
-| Component | Lines | Notes |
-|---|---|---|
-| `src/multiplexer.ts` (interface + resolver) | ~120 | Pure type, no platform code |
-| `src/multiplexer-tmux.ts` (extracted) | ~250 | All current `interactive-tmux.ts` mux-specific code |
-| `src/multiplexer-zellij.ts` (new) | ~200 | New code, mirrors tmux structure |
-| `src/interactive-tmux.ts` (rewrite) | ~150 | Becomes a thin wrapper that picks a mux |
-| `src/subagent.ts` (tool surface) | ~30 | New `mux` param on `subagent_interactive`, field on state |
-| Tests | ~400 | Mirror the tmux test pattern for zellij |
-| README | ~50 | Add Zellij section, env var, `mux` param |
-| **Total** | **~1200** | Down from initial ~850 estimate (interface adds ~50%, but the extraction forces proper structure) |
+| Component                                   | Lines     | Notes                                                                                             |
+| ------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| `src/multiplexer.ts` (interface + resolver) | ~120      | Pure type, no platform code                                                                       |
+| `src/multiplexer-tmux.ts` (extracted)       | ~250      | All current `interactive-tmux.ts` mux-specific code                                               |
+| `src/multiplexer-zellij.ts` (new)           | ~200      | New code, mirrors tmux structure                                                                  |
+| `src/interactive-tmux.ts` (rewrite)         | ~150      | Becomes a thin wrapper that picks a mux                                                           |
+| `src/subagent.ts` (tool surface)            | ~30       | New `mux` param on `subagent_interactive`, field on state                                         |
+| Tests                                       | ~400      | Mirror the tmux test pattern for zellij                                                           |
+| README                                      | ~50       | Add Zellij section, env var, `mux` param                                                          |
+| **Total**                                   | **~1200** | Down from initial ~850 estimate (interface adds ~50%, but the extraction forces proper structure) |
 
 **Realistic timeline:** 3-4 days. Single PR is feasible but review-heavy. Two PRs (refactor, then zellij) is cleaner.
 
@@ -699,6 +739,7 @@ With the actual zellij v0.44 API and the resolved design points:
 ### Recommendation: Two PRs (refactor first)
 
 **PR #1: `refactor: extract-multiplexer-interface`** (~600 lines)
+
 - Add `src/multiplexer.ts`, `src/multiplexer-tmux.ts`
 - Move all tmux code from `interactive-tmux.ts` into `multiplexer-tmux.ts`
 - Rewrite `interactive-tmux.ts` as a thin wrapper (`isTmuxAvailable` → `getMux().isAvailable()`)
@@ -706,6 +747,7 @@ With the actual zellij v0.44 API and the resolved design points:
 - Reviewer can diff side-by-side with the old code.
 
 **PR #2: `feat: zellij-multiplexer-backend`** (~600 lines, on top of PR #1)
+
 - Add `src/multiplexer-zellij.ts`
 - Add `mux` field to `InteractiveSubagentState`
 - Add `mux` param to `subagent_interactive` tool
@@ -725,6 +767,7 @@ Now I have comprehensive info. Let me write up a thorough research summary with 
 Key findings:
 
 **tmux 3.6b (May 2026) — current stable:**
+
 - `send-keys -l <text>` + `send-keys Enter` — still the canonical way
 - `display-message -p -t <pane> '#{pane_id}'` — pane liveness check
 - `new-window -d -n <name> -P -F '#{pane_id}'` — new detached window
@@ -736,6 +779,7 @@ Key findings:
 - `TMUX` env var set when inside a tmux session
 
 **zellij v0.44.3 (latest) — most current:**
+
 - `zellij action new-pane --direction right --close-on-exit -- bash ...` — new split; returns pane ID
 - `zellij action new-tab --name "X" --cwd /path` — new tab; returns tab ID
 - `zellij action write-chars <text>` + `zellij action write 13` — send chars + Enter
@@ -762,7 +806,7 @@ Key findings:
    - zellij: `zellij attach --create-background <name>` + `--session <name> action ...` for control
 
 3. **Session targeting from outside**:
-   - tmux: `attach -t <session>` 
+   - tmux: `attach -t <session>`
    - zellij: `attach <session>` or use `--session <name>` for actions
 
 4. **Pane alive check**:
@@ -804,6 +848,7 @@ Key findings:
 **Scope estimate revision:**
 
 With the actual zellij v0.44 capabilities, the work is cleaner than initially scoped:
+
 - `paste` is a perfect fit for follow-up messages (one call instead of two)
 - `subscribe` could replace `dump-screen` for real-time tailing (but we don't need that for the core feature)
 - `--block-until-exit-success` is interesting for the launch script's CLI (we could use it in tests, not production)
@@ -831,6 +876,7 @@ Good question. There are two interpretations:
 ## Stacked parallel (PR #2 branches off PR #1's branch — both branches live, work sequenced by deps not wall time)
 
 **Yes, this works cleanly.** The technical dependency chain is:
+
 - PR #2 needs the `Multiplexer` interface → defined in PR #1
 - PR #2 needs `TmuxMultiplexer` class → created in PR #1
 - PR #2 needs `getMux()` resolver → created in PR #1
@@ -854,12 +900,12 @@ master
 
 **Workplan:**
 
-| Phase | Branch | What happens |
-|---|---|---|
-| 1 | `feat/zellij-multiplexer-refactor` (off master) | Extract interface + tmux impl. Push. Open PR #1. All 261 tests pass unchanged. |
-| 2 | `feat/zellij-multiplexer-backend` (off PR #1) | Add zellij impl + `mux` param on tool + state field. Push. Open PR #2 (now pointing at PR #1's head). |
-| 3 | (you merge PR #1) | PR #2's base moves to master. |
-| 4 | (you merge PR #2) | Ship. |
+| Phase | Branch                                          | What happens                                                                                          |
+| ----- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1     | `feat/zellij-multiplexer-refactor` (off master) | Extract interface + tmux impl. Push. Open PR #1. All 261 tests pass unchanged.                        |
+| 2     | `feat/zellij-multiplexer-backend` (off PR #1)   | Add zellij impl + `mux` param on tool + state field. Push. Open PR #2 (now pointing at PR #1's head). |
+| 3     | (you merge PR #1)                               | PR #2's base moves to master.                                                                         |
+| 4     | (you merge PR #2)                               | Ship.                                                                                                 |
 
 The "parallel" benefit is real: I can have PR #1 reviewable within 1-2 days, and PR #2 ready-to-review within 2-3 days, even though the merged code lands on day 4-5. If PR #1 review needs revisions, the diff is small and PR #2 rebase is trivial.
 
@@ -871,12 +917,14 @@ Want me to start phase 1 (refactor)? I'll do that, push, and then move to phase 
 The user is asking if the two PRs can be worked on in parallel. Let me think about this:
 
 PR #1: refactor: extract-multiplexer-interface
+
 - Adds `src/multiplexer.ts` (interface)
 - Adds `src/multiplexer-tmux.ts` (extracts existing code)
 - Rewrites `src/interactive-tmux.ts` as thin wrapper
 - Zero behavior change
 
 PR #2: feat: zellij-multiplexer-backend
+
 - Adds `src/multiplexer-zellij.ts`
 - Adds `mux` field to `InteractiveSubagentState`
 - Adds `mux` param to `subagent_interactive` tool
@@ -886,6 +934,7 @@ PR #2: feat: zellij-multiplexer-backend
 Can they be worked on in parallel? Let me think about the dependencies:
 
 PR #2 depends on PR #1 because:
+
 1. It needs the `Multiplexer` interface defined in PR #1
 2. It needs the `TmuxMultiplexer` class to exist
 3. It needs the `getMux()` resolver to exist
@@ -894,15 +943,18 @@ PR #2 depends on PR #1 because:
 But could we structure them so PR #2 doesn't strictly need PR #1 merged first? Some options:
 
 Option A: PR #2 branches off PR #1's branch
+
 - Both work in parallel from the same base
 - PR #2 has PR #1 as its base
 - Merge order: PR #1 first, then PR #2
 
 Option B: PR #2 doesn't depend on PR #1, builds its own interface
+
 - More work, more divergence, harder to merge
 - Not recommended
 
 Option C: Sequence the work
+
 - PR #1 lands first
 - PR #2 starts when PR #1 is merged
 - Slower but cleaner
@@ -910,6 +962,7 @@ Option C: Sequence the work
 The user is asking about "in parallel" — they want speed. But the technical dependency is real: PR #2 needs PR #1's interface, classes, and the registry pattern.
 
 However, since both PRs would be on the same `feat/zellij-multiplexer-support` branch conceptually, we could:
+
 - Have PR #1 land first (refactor)
 - Then PR #2 on top (zellij)
 - Or: do the work serially on the same branch with a single PR (option A from before)
@@ -917,12 +970,14 @@ However, since both PRs would be on the same `feat/zellij-multiplexer-support` b
 The user chose "2 PRs" earlier. Now they're asking if parallel work is possible. The answer is:
 
 **They CAN be worked on in parallel IF:**
+
 - PR #2 branches off PR #1's branch (not master)
 - They share the same feature branch
 - Each PR is small and focused
 - A second developer/agent takes PR #2 while PR #1 is in review
 
 **They CANNOT be fully parallelized in the traditional sense because:**
+
 - PR #2 needs PR #1's interface
 - Both touch `src/interactive-tmux.ts` and `src/subagent.ts`
 - Merge conflicts are likely if they both modify the same files
@@ -930,12 +985,14 @@ The user chose "2 PRs" earlier. Now they're asking if parallel work is possible.
 The user mentioned "work on in parallel" — they're asking if I can do both at once. The answer is yes if I treat them as a sequential pipeline on the same branch. I can do PR #1 work, then PR #2 work, then commit them as two separate PRs.
 
 Wait, but I should think about this more carefully. If I commit them on the SAME branch as two commits, they become one PR. To have two PRs:
+
 - Branch 1: feat/zellij-refactor (PR #1)
 - Branch 2: feat/zellij-backend (PR #2, based on #1)
 
 I can do them sequentially on the same branch and then split via rebase. OR I can work on them as two separate branches with one stacked on the other.
 
-Best approach: 
+Best approach:
+
 1. Create `feat/zellij-refactor` branch (from master)
 2. Do PR #1 work, commit, push, mark ready
 3. Once PR #1 is merged (or while it's in review), create `feat/zellij-backend` from `feat/zellij-refactor`
@@ -944,6 +1001,7 @@ Best approach:
 For "parallel" work, I can do PR #1 work, then immediately start PR #2 on top of PR #1's branch (without waiting for merge). The two branches coexist.
 
 Actually since I'm an agent working solo, the most pragmatic approach is:
+
 - Do PR #1 work and commit on `feat/zellij-refactor`
 - Push and create PR #1
 - Then create `feat/zellij-backend` from `feat/zellij-refactor`
@@ -963,6 +1021,7 @@ Let me answer the user clearly:
 3. **Fully serial** (PR #1 merged, then PR #2 on master): **YES** but slower.
 
 Recommend option 2. I'll set up the work to be ready in this order:
+
 - Phase 1: `feat/zellij-refactor` — extract interface, ship tmux implementation, no behavior change
 - Phase 2: `feat/zellij-backend` — branches off phase 1, add zellij + tool param + tests
 
@@ -971,6 +1030,7 @@ Both branches can be on disk and pushed at the same time. A human reviewer can r
 Let me also think about what to commit on each:
 
 **Branch 1: `feat/zellij-multiplexer-refactor`**
+
 - New: `src/multiplexer.ts` (interface + resolver)
 - New: `src/multiplexer-tmux.ts` (extracted)
 - Modified: `src/interactive-tmux.ts` (thin wrapper)
@@ -978,6 +1038,7 @@ Let me also think about what to commit on each:
 - All 261 tests pass unchanged
 
 **Branch 2: `feat/zellij-multiplexer-backend`**
+
 - Branched from: `feat/zellij-multiplexer-refactor`
 - New: `src/multiplexer-zellij.ts`
 - Modified: `src/multiplexer.ts` (no changes; interface already in branch 1)
@@ -1005,7 +1066,7 @@ Good question — this is a real UX constraint that affects how the feature gets
 
 ## Current constraint
 
-The tool refuses to spawn unless pi is *already* running inside a tmux/zellij session. The check is at `interactive-tmux.ts:115`:
+The tool refuses to spawn unless pi is _already_ running inside a tmux/zellij session. The check is at `interactive-tmux.ts:115`:
 
 ```ts
 export function isTmuxAvailable(): boolean {
@@ -1016,6 +1077,7 @@ export function isTmuxAvailable(): boolean {
 The `process.env.TMUX` half is the restrictive part — it requires the **parent** to be in tmux. The reason: the spawn uses `$TMUX_PANE` (for splits) and `$TMUX` (for new windows) to know where to put the child. If those are unset, the spawn path falls over.
 
 **What this means for users today:**
+
 - `pi` started from a regular terminal → interactive sub-agents are disabled, tool errors with "Start pi inside tmux"
 - Workaround: `Ctrl-C` pi, then `tmux new -A -s pi 'pi'` to restart pi inside tmux
 
@@ -1027,10 +1089,10 @@ The right fix is: **the backend just needs the binary available, not the parent 
 
 This works on both backends:
 
-| Mode | Parent in mux | Parent NOT in mux |
-|---|---|---|
+| Mode                                | Parent in mux                   | Parent NOT in mux                  |
+| ----------------------------------- | ------------------------------- | ---------------------------------- |
 | `background: false` (visible split) | split-window in current session | **fallback: new detached session** |
-| `background: true` (new window) | new-window in current session | **fallback: new detached session** |
+| `background: true` (new window)     | new-window in current session   | **fallback: new detached session** |
 
 The fallback is the same in both rows: spawn a fresh detached session, put the child there, return the attach command. The user runs `tmux attach -t pi-subagent-<id>` (or `zellij attach pi-subagent-<id>`) to see it.
 
@@ -1042,7 +1104,7 @@ We **cannot** kill our own parent process to restart pi in tmux — that's a for
 
 1. **Document the one-liner** (`tmux new -A -s pi 'pi'`) in the README
 2. **Print a hint** when the user tries to spawn a sub-agent without being in tmux, telling them how to restart
-3. **Implement the auto-spawn-new-session fallback** (described above) so the user doesn't *need* to restart — they just attach to the new session afterwards
+3. **Implement the auto-spawn-new-session fallback** (described above) so the user doesn't _need_ to restart — they just attach to the new session afterwards
 
 Option 3 is the real fix. It makes the "restart pi in tmux" step **optional** — only useful if the user wants the sub-agent to share their current tmux session. For everyone else, the auto-spawn-new-session path Just Works.
 
@@ -1058,12 +1120,14 @@ It's strictly more permissive (a strict superset of the old behavior), so zero r
 ## What it looks like in practice
 
 **Today** (parent not in tmux):
+
 ```
 Tool: subagent_interactive
 → Error: Start pi inside tmux, for example: tmux new -A -s pi 'pi'
 ```
 
 **After PR #1** (parent not in tmux):
+
 ```
 Tool: subagent_interactive
 → Subagent abc12345 started in new tmux session "pi-subagent-abc12345".
@@ -1073,6 +1137,7 @@ Tool: subagent_interactive
 ```
 
 **After PR #1** (parent in tmux, same as today):
+
 ```
 Tool: subagent_interactive
 → Subagent abc12345 started in tmux pane %42 (background new window).
@@ -1085,14 +1150,14 @@ Three different UX paths, all driven by the same `mux` config, no user intervent
 
 ## Updated PR #1 scope
 
-| Component | Lines | What |
-|---|---|---|
-| `multiplexer.ts` (interface + resolver) | ~120 | 6 methods, `getMux()` with env-var auto-detect |
-| `multiplexer-tmux.ts` (extracted + relaxed) | ~280 | Includes the "create new session" fallback when parent not in tmux |
-| `interactive-tmux.ts` (rewrite) | ~150 | Thin wrapper |
-| `subagent.ts` (tool surface) | ~30 | Use `getMux()`, surface `attachCommand` from the chosen mux |
-| Tests | ~150 | New: spawn-without-parent-in-tmux fallback test |
-| **Total** | **~730** | Slight bump from initial 600 — the relaxed check is net new |
+| Component                                   | Lines    | What                                                               |
+| ------------------------------------------- | -------- | ------------------------------------------------------------------ |
+| `multiplexer.ts` (interface + resolver)     | ~120     | 6 methods, `getMux()` with env-var auto-detect                     |
+| `multiplexer-tmux.ts` (extracted + relaxed) | ~280     | Includes the "create new session" fallback when parent not in tmux |
+| `interactive-tmux.ts` (rewrite)             | ~150     | Thin wrapper                                                       |
+| `subagent.ts` (tool surface)                | ~30      | Use `getMux()`, surface `attachCommand` from the chosen mux        |
+| Tests                                       | ~150     | New: spawn-without-parent-in-tmux fallback test                    |
+| **Total**                                   | **~730** | Slight bump from initial 600 — the relaxed check is net new        |
 
 Want me to include the relaxed check in PR #1, or keep PR #1 minimal (just the refactor) and ship the relaxed check as a follow-up?
 
@@ -1108,7 +1173,9 @@ The user is asking a really important question about the workflow:
 This is a fundamental architectural question. Let me think through the current state and the implications.
 
 ### Current state
+
 The current code (`isTmuxAvailable` in `interactive-tmux.ts` line 115) checks:
+
 - `process.env.TMUX` is set (we're inside a tmux session)
 - `tmux` binary is on PATH
 
@@ -1117,16 +1184,17 @@ If either is false, the tool errors with "Start pi inside tmux, for example: tmu
 So the answer to (1) is currently **NO** — the sub-agent spawn fails if the main Pi session isn't inside tmux.
 
 ### Why is this a constraint?
+
 - `TMUX_PANE` env var tells us the parent pane, so we can do `split-window -t $TMUX_PANE` to get a side-by-side split, or `new-window -t $TMUX` to get a new window in the same session.
 - If we're not inside tmux, we don't have a session to put the new pane in.
 - We could create a brand-new detached tmux session, but then the user can't easily see/attach to it.
 
 ### The user's two questions
+
 1. **Start sub-agents in tmux/zellij when Pi isn't there?** — This is a UX question. Should we:
    - a) Refuse (current behavior)
    - b) Auto-create a new tmux session and put the child there
    - c) Auto-spawn the child in a detached tmux server (similar to background mode)
-   
 2. **Can we restart the Pi main session in tmux/zellij?** — This is a session-management question. Pi is the editor. Restarting it would lose all the conversation context. The user might be asking:
    - a) Can we launch a NEW pi inside tmux and migrate?
    - b) Can the user manually restart their pi inside tmux to enable the feature?
@@ -1135,6 +1203,7 @@ So the answer to (1) is currently **NO** — the sub-agent spawn fails if the ma
 Let me think about this more carefully. The user is asking BEFORE we start the implementation. They want to know what the constraint is and whether we can relax it.
 
 The honest answer:
+
 - **Current constraint:** Pi must be running inside tmux. This is a friction point.
 - **Workaround:** `tmux new -A -s pi 'pi'` (or zellij equivalent) — start a tmux session, then start pi inside it.
 - **Auto-create option:** We could detect "pi is not in a tmux session" and create one programmatically. This is doable but has UX implications:
@@ -1145,6 +1214,7 @@ The honest answer:
 ### The architectural decision
 
 Looking at the current code more carefully, the `isTmuxAvailable` check is:
+
 ```ts
 export function isTmuxAvailable(): boolean {
   return Boolean(process.env.TMUX && commandExists("tmux"));
@@ -1154,6 +1224,7 @@ export function isTmuxAvailable(): boolean {
 It checks `process.env.TMUX` — this is set ONLY when pi is running inside a tmux session. So the check is "is the parent in tmux?"
 
 But the code can spawn in two modes:
+
 - `split-window` (visible side-by-side) — needs `$TMUX_PANE` to know where to split
 - `new-window` (new window in same session) — needs `$TMUX` to know which session to add to
 
@@ -1164,12 +1235,14 @@ Both modes REQUIRE the parent to be in tmux. There's no "spawn in a different tm
 I think the user is asking: should we make the tool more permissive? Can the sub-agent work even if pi isn't currently in tmux?
 
 The answer is yes, and it's actually easy:
+
 - **Mode A: attachable from outside** — create a brand-new detached tmux session (different from the parent's), put the child there, return attach commands. Today the tool's `attachCommand` already supports `tmux attach -t <sess>` from outside, so this would Just Work if we relaxed the `isTmuxAvailable` check.
 - **Mode B: orphan** — same as A but the parent doesn't need to be in tmux.
 
 Both are achievable. The current code's "you must be in tmux" check is overly restrictive. The `subagent_interactive` tool could just create a new detached session and let the user attach.
 
 This is actually a meaningful improvement that can ship alongside zellij support. The flow would be:
+
 1. User runs `pi` (not in tmux)
 2. User invokes `subagent_interactive`
 3. Tool creates a new detached tmux session (e.g., named `pi-subagent-<id>`)
@@ -1178,6 +1251,7 @@ This is actually a meaningful improvement that can ship alongside zellij support
 6. The poller continues to work because the new session is independent of the parent's
 
 This is actually a BIG improvement. Let me think about the constraints:
+
 - Zellij has a similar pattern: `zellij attach --create-background <name>` (new in v0.44)
 - Both backends support creating a new detached session from outside
 - The artifact dir is still under the parent's `PI_CODING_AGENT_SESSION_DIR` so the parent can read it
@@ -1186,6 +1260,7 @@ This is actually a BIG improvement. Let me think about the constraints:
 ### Restart pi in tmux — viable?
 
 Restarting pi to put it in tmux is a real workflow:
+
 - User: `Ctrl-C` to stop the current pi
 - User: `tmux new -A -s pi 'pi'` to start a new tmux session with pi inside
 - User is now in a tmux session with pi
@@ -1211,6 +1286,7 @@ For the "background mode" (new-window -d), the child goes to a new window in the
 For the "visible split mode" (split-window -h), this REQUIRES the parent to be in tmux. If the parent isn't in tmux, we'd need to fall back to "new detached session" mode.
 
 So the new behavior:
+
 - If parent in tmux/zellij AND background=false → visible split (current)
 - If parent in tmux/zellij AND background=true → new window in same session (current)
 - If parent NOT in tmux/zellij AND background=false → create new detached session (new fallback)
@@ -1228,9 +1304,10 @@ OK let me draft a clear, focused answer.
 
 > 🛠️ Tool call: **ask_user**
 > Arguments: ```json
-{
-  "question": "Should PR #1 include the relaxed spawn check?",
-  "options": [
+> {
+> "question": "Should PR #1 include the relaxed spawn check?",
+> "options": [
+
     {
       "title": "Yes, bundle the relaxed check into PR #1",
       "description": "PR #1 ships the refactor AND the new fallback (auto-spawn in a fresh detached session when parent isn't in tmux/zellij). One PR, one merge, one user-visible improvement. PR #2 just adds zellij backend on top."
@@ -1239,9 +1316,11 @@ OK let me draft a clear, focused answer.
       "title": "Keep PR #1 minimal (refactor only)",
       "description": "PR #1 ships only the refactor with zero behavior change. The relaxed-spawn UX improvement goes into a separate small PR (call it #0 or #1.5) between #1 and #2. More PRs but each is tightly focused."
     }
-  ]
+
+]
 }
-```
+
+````
 
 ---
 
@@ -1277,7 +1356,7 @@ No, communication is unaffected. Let me show why by walking through the actual c
 ```bash
 trap 'if [ -f "${artifactDir}/.cancelled" ]; then "${cliPath}" cancelled; else "${cliPath}" done "$?"; fi;
        tmux set-option -p -t "$TMUX_PANE" @pi-exit-code "$?" 2>/dev/null || true' EXIT
-```
+````
 
 The `tmux set-option` line is the **only** place session env vars matter. And it already has `2>/dev/null || true` to fail silently. The `done <code>` write to the artifact happens BEFORE the set-option call and is the actual source of truth for the exit code.
 
@@ -1285,13 +1364,13 @@ For the zellij backend, we'd skip the set-option call entirely (zellij has no eq
 
 ## What this means concretely
 
-| Scenario | Today's behavior | After relaxed check |
-|---|---|---|
-| Parent in tmux, spawn child in same session | ✅ works | ✅ same |
-| Parent in tmux, spawn child in new detached session | ✅ works (background mode) | ✅ same |
-| Parent NOT in tmux, spawn child | ❌ error: "start pi inside tmux" | ✅ creates new detached session, returns attach cmd |
-| Child in new session, parent in different session | n/a | ✅ parent reads child's output.md normally |
-| Child in new session, parent exits (Ctrl-C pi) | n/a | ✅ child continues running in its session; user re-attaches later |
+| Scenario                                                                     | Today's behavior                 | After relaxed check                                                                   |
+| ---------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
+| Parent in tmux, spawn child in same session                                  | ✅ works                         | ✅ same                                                                               |
+| Parent in tmux, spawn child in new detached session                          | ✅ works (background mode)       | ✅ same                                                                               |
+| Parent NOT in tmux, spawn child                                              | ❌ error: "start pi inside tmux" | ✅ creates new detached session, returns attach cmd                                   |
+| Child in new session, parent in different session                            | n/a                              | ✅ parent reads child's output.md normally                                            |
+| Child in new session, parent exits (Ctrl-C pi)                               | n/a                              | ✅ child continues running in its session; user re-attaches later                     |
 | Parent in tmux spawns child in new detached session, then detaches from tmux | n/a (parent had to stay in tmux) | ✅ parent can leave tmux, child continues, poller still reads artifact via filesystem |
 
 The last row is actually a **new capability** that falls out for free: the parent can now spawn-and-forget sub-agents that outlive the parent's terminal session. The child keeps working because it owns its own tmux/zellij server. The user can come back hours later, re-attach, and read the result.
@@ -1336,7 +1415,7 @@ Let me think carefully about the communication paths:
    - Actually, the launch script just runs bash in the pane. The pane exists because the spawn created it. The script doesn't care which session it spawned in.
 
 5. **The EXIT trap:**
-   - The trap calls `cli.mjs done <code>` 
+   - The trap calls `cli.mjs done <code>`
    - This writes to the artifact dir
    - Then `tmux set-option -p -t "$TMUX_PANE" @pi-exit-code "$?"` — this is the ONLY place that uses the session env vars
    - In the new detached session, `$TMUX_PANE` is the child's pane
@@ -1348,6 +1427,7 @@ Wait, there's a subtle issue: the launch script uses `TMUX_PANE` to set the exit
 So communication is via filesystem (artifact dir), not via the session. The session is just a "where the child's terminal lives" thing. As long as the child can be created in any session (parent's or new), and the child writes to a shared artifact dir, communication works.
 
 Let me also think about edge cases:
+
 - What if the user closes the new detached session while the child is running? The child is killed, the artifact is partially written. Same as if the user killed the parent's tmux session. Not a new problem.
 - What if the user has two pi sessions running, one in tmux and one not, both spawning to the same artifact root? The artifact dir is per-spawn-id, so no conflict. The poller in each pi instance tracks its own spawns via the in-memory registry.
 - What if the parent dies (Ctrl-C the pi process) but the child is still running in the new detached session? The child continues until its own session is killed or the command finishes. The user can re-attach to see progress. This is actually a feature: child outlives parent.
@@ -1355,9 +1435,11 @@ Let me also think about edge cases:
 So no, the relaxed check does NOT affect communication. The artifact dir is the source of truth, and both parent and child can read/write it regardless of session membership.
 
 Let me also think about what specifically could break:
+
 - The `writeLaunchScript` writes a bash script. The script uses `TMUX_PANE` and `TMUX` for the exit-code trick. If neither is set (parent not in tmux), the `set-option` call would fail. We can guard it with `if [ -n "$TMUX" ]; then ... fi`.
 
 Actually, looking at the launch script:
+
 ```bash
 trap 'if [ -f "${artifactDir}/.cancelled" ]; then "${cliPath}" cancelled; else "${cliPath}" done "$?"; fi; tmux set-option -p -t "$TMUX_PANE" @pi-exit-code "$?" 2>/dev/null || true' EXIT
 ```
@@ -1376,5 +1458,4 @@ Let me write a clear answer with the specific communication paths.
 
 ### 🧑 User (line 988)
 
-sounds like a plan, lets do what we planned, lets understand how we can do the parallel work and use  freemodel/big-pickle for subagents
-
+sounds like a plan, lets do what we planned, lets understand how we can do the parallel work and use freemodel/big-pickle for subagents

--- a/smoke-interactive.mjs
+++ b/smoke-interactive.mjs
@@ -54,4 +54,7 @@ console.log("detected:", detected || "TIMEOUT");
 const final = cancelInteractiveSubagent(state.id);
 console.log("cancelled:", final?.status);
 const all = [...interactiveSubagentRegistry.values()];
-console.log("registry:", all.map((s) => ({ id: s.id, status: s.status, pane: s.paneId })));
+console.log(
+  "registry:",
+  all.map((s) => ({ id: s.id, status: s.status, pane: s.paneId })),
+);

--- a/src/artifact.test.ts
+++ b/src/artifact.test.ts
@@ -1,261 +1,284 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-	appendEvent,
-	artifactPath,
-	ensureArtifactDir,
-	lastEvent,
-	listArtifacts,
-	listOutputTurns,
-	outputPathForTurn,
-	readEvents,
-	readOutput,
-	readOutputForTurn,
-	snapshotOutput,
-	writeOutput,
-	type SubagentEvent,
+  appendEvent,
+  artifactPath,
+  ensureArtifactDir,
+  lastEvent,
+  listArtifacts,
+  listOutputTurns,
+  outputPathForTurn,
+  readEvents,
+  readOutput,
+  readOutputForTurn,
+  snapshotOutput,
+  writeOutput,
+  type SubagentEvent,
 } from "./artifact";
 
 function makeTmp(): string {
-	return mkdtempSync(join(tmpdir(), "pi-subagentura-artifact-"));
+  return mkdtempSync(join(tmpdir(), "pi-subagentura-artifact-"));
 }
 
 describe("artifact", () => {
-	let root: string;
+  let root: string;
 
-	beforeEach(() => {
-		root = makeTmp();
-	});
+  beforeEach(() => {
+    root = makeTmp();
+  });
 
-	afterEach(() => {
-		rmSync(root, { recursive: true, force: true });
-	});
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
 
-	describe("artifactPath", () => {
-		it("builds expected paths under the root", () => {
-			const art = artifactPath(root, "abc123");
-			expect(art.id).toBe("abc123");
-			expect(art.dir).toBe(join(root, "abc123"));
-			expect(art.statusFile).toBe(join(root, "abc123", "events.ndjson"));
-			expect(art.outputFile).toBe(join(root, "abc123", "output.md"));
-		});
-	});
+  describe("artifactPath", () => {
+    it("builds expected paths under the root", () => {
+      const art = artifactPath(root, "abc123");
+      expect(art.id).toBe("abc123");
+      expect(art.dir).toBe(join(root, "abc123"));
+      expect(art.statusFile).toBe(join(root, "abc123", "events.ndjson"));
+      expect(art.outputFile).toBe(join(root, "abc123", "output.md"));
+    });
+  });
 
-	describe("ensureArtifactDir", () => {
-		it("creates the directory with 0o700 perms", () => {
-			const art = artifactPath(root, "x");
-			ensureArtifactDir(art);
-			expect(existsSync(art.dir)).toBe(true);
-			expect(statSync(art.dir).mode & 0o777).toBe(0o700);
-		});
+  describe("ensureArtifactDir", () => {
+    it("creates the directory with 0o700 perms", () => {
+      const art = artifactPath(root, "x");
+      ensureArtifactDir(art);
+      expect(existsSync(art.dir)).toBe(true);
+      expect(statSync(art.dir).mode & 0o777).toBe(0o700);
+    });
 
-		it("is idempotent", () => {
-			const art = artifactPath(root, "x");
-			ensureArtifactDir(art);
-			expect(() => ensureArtifactDir(art)).not.toThrow();
-		});
-	});
+    it("is idempotent", () => {
+      const art = artifactPath(root, "x");
+      ensureArtifactDir(art);
+      expect(() => ensureArtifactDir(art)).not.toThrow();
+    });
+  });
 
-	describe("appendEvent", () => {
-		it("creates dir and writes one NDJSON line", () => {
-			const art = artifactPath(root, "a");
-			const ev: SubagentEvent = { ts: 1000, type: "started", status: "running" };
-			appendEvent(art, ev);
-			expect(existsSync(art.statusFile)).toBe(true);
-			const content = readFileSync(art.statusFile, "utf8");
-			expect(content).toBe(JSON.stringify(ev) + "\n");
-		});
+  describe("appendEvent", () => {
+    it("creates dir and writes one NDJSON line", () => {
+      const art = artifactPath(root, "a");
+      const ev: SubagentEvent = {
+        ts: 1000,
+        type: "started",
+        status: "running",
+      };
+      appendEvent(art, ev);
+      expect(existsSync(art.statusFile)).toBe(true);
+      const content = readFileSync(art.statusFile, "utf8");
+      expect(content).toBe(JSON.stringify(ev) + "\n");
+    });
 
-		it("appends multiple events in order", () => {
-			const art = artifactPath(root, "a");
-			appendEvent(art, { ts: 1, type: "started", status: "running" });
-			appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 });
-			const content = readFileSync(art.statusFile, "utf8");
-			const lines = content.trim().split("\n");
-			expect(lines).toHaveLength(2);
-			expect(JSON.parse(lines[0]).type).toBe("started");
-			expect(JSON.parse(lines[1]).exitCode).toBe(0);
-		});
+    it("appends multiple events in order", () => {
+      const art = artifactPath(root, "a");
+      appendEvent(art, { ts: 1, type: "started", status: "running" });
+      appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 });
+      const content = readFileSync(art.statusFile, "utf8");
+      const lines = content.trim().split("\n");
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).type).toBe("started");
+      expect(JSON.parse(lines[1]).exitCode).toBe(0);
+    });
 
-		it("creates the status file with 0o600 perms", () => {
-			const art = artifactPath(root, "a");
-			appendEvent(art, { ts: 1, type: "started", status: "running" });
-			expect(statSync(art.statusFile).mode & 0o777).toBe(0o600);
-		});
-	});
+    it("creates the status file with 0o600 perms", () => {
+      const art = artifactPath(root, "a");
+      appendEvent(art, { ts: 1, type: "started", status: "running" });
+      expect(statSync(art.statusFile).mode & 0o777).toBe(0o600);
+    });
+  });
 
-	describe("writeOutput", () => {
-		it("writes content atomically (no .tmp left behind)", () => {
-			const art = artifactPath(root, "a");
-			writeOutput(art, "hello world");
-			expect(existsSync(art.outputFile)).toBe(true);
-			expect(existsSync(art.outputFile + ".tmp")).toBe(false);
-			expect(readFileSync(art.outputFile, "utf8")).toBe("hello world");
-		});
+  describe("writeOutput", () => {
+    it("writes content atomically (no .tmp left behind)", () => {
+      const art = artifactPath(root, "a");
+      writeOutput(art, "hello world");
+      expect(existsSync(art.outputFile)).toBe(true);
+      expect(existsSync(art.outputFile + ".tmp")).toBe(false);
+      expect(readFileSync(art.outputFile, "utf8")).toBe("hello world");
+    });
 
-		it("overwrites previous content", () => {
-			const art = artifactPath(root, "a");
-			writeOutput(art, "first");
-			writeOutput(art, "second");
-			expect(readFileSync(art.outputFile, "utf8")).toBe("second");
-		});
+    it("overwrites previous content", () => {
+      const art = artifactPath(root, "a");
+      writeOutput(art, "first");
+      writeOutput(art, "second");
+      expect(readFileSync(art.outputFile, "utf8")).toBe("second");
+    });
 
-		it("creates the output file with 0o600 perms", () => {
-			const art = artifactPath(root, "a");
-			writeOutput(art, "secret");
-			expect(statSync(art.outputFile).mode & 0o777).toBe(0o600);
-		});
-	});
+    it("creates the output file with 0o600 perms", () => {
+      const art = artifactPath(root, "a");
+      writeOutput(art, "secret");
+      expect(statSync(art.outputFile).mode & 0o777).toBe(0o600);
+    });
+  });
 
-	describe("readEvents", () => {
-		it("returns empty array when no status file", () => {
-			const art = artifactPath(root, "missing");
-			expect(readEvents(art)).toEqual([]);
-		});
+  describe("readEvents", () => {
+    it("returns empty array when no status file", () => {
+      const art = artifactPath(root, "missing");
+      expect(readEvents(art)).toEqual([]);
+    });
 
-		it("parses all events in order", () => {
-			const art = artifactPath(root, "a");
-			appendEvent(art, { ts: 100, type: "started", status: "running" });
-			appendEvent(art, { ts: 200, type: "error", status: "error", message: "m" });
-			const events = readEvents(art);
-			expect(events).toHaveLength(2);
-			expect(events[0].ts).toBe(100);
-			expect(events[1].message).toBe("m");
-		});
+    it("parses all events in order", () => {
+      const art = artifactPath(root, "a");
+      appendEvent(art, { ts: 100, type: "started", status: "running" });
+      appendEvent(art, {
+        ts: 200,
+        type: "error",
+        status: "error",
+        message: "m",
+      });
+      const events = readEvents(art);
+      expect(events).toHaveLength(2);
+      expect(events[0].ts).toBe(100);
+      expect(events[1].message).toBe("m");
+    });
 
-		it("filters by `since` (inclusive)", () => {
-			const art = artifactPath(root, "a");
-			appendEvent(art, { ts: 100, type: "started", status: "running" });
-			appendEvent(art, { ts: 300, type: "done", status: "done", exitCode: 0 });
-			const events = readEvents(art, 200);
-			expect(events.map((e) => e.ts)).toEqual([300]);
-		});
+    it("filters by `since` (inclusive)", () => {
+      const art = artifactPath(root, "a");
+      appendEvent(art, { ts: 100, type: "started", status: "running" });
+      appendEvent(art, { ts: 300, type: "done", status: "done", exitCode: 0 });
+      const events = readEvents(art, 200);
+      expect(events.map((e) => e.ts)).toEqual([300]);
+    });
 
-		it("silently skips malformed lines", () => {
-			const art = artifactPath(root, "a");
-			ensureArtifactDir(art);
-			appendFileSync(art.statusFile, '{"ts":1,"type":"started","status":"running"}\n');
-			appendFileSync(art.statusFile, "this is not json\n");
-			appendFileSync(art.statusFile, '{"ts":2,"type":"done","status":"done","exitCode":0}\n');
-			const events = readEvents(art);
-			expect(events).toHaveLength(2);
-		});
-	});
+    it("silently skips malformed lines", () => {
+      const art = artifactPath(root, "a");
+      ensureArtifactDir(art);
+      appendFileSync(
+        art.statusFile,
+        '{"ts":1,"type":"started","status":"running"}\n',
+      );
+      appendFileSync(art.statusFile, "this is not json\n");
+      appendFileSync(
+        art.statusFile,
+        '{"ts":2,"type":"done","status":"done","exitCode":0}\n',
+      );
+      const events = readEvents(art);
+      expect(events).toHaveLength(2);
+    });
+  });
 
-	describe("readOutput", () => {
-		it("returns null when output.md doesn't exist", () => {
-			const art = artifactPath(root, "a");
-			expect(readOutput(art)).toBeNull();
-		});
+  describe("readOutput", () => {
+    it("returns null when output.md doesn't exist", () => {
+      const art = artifactPath(root, "a");
+      expect(readOutput(art)).toBeNull();
+    });
 
-		it("returns content when present", () => {
-			const art = artifactPath(root, "a");
-			writeOutput(art, "the result");
-			expect(readOutput(art)).toBe("the result");
-		});
-	});
+    it("returns content when present", () => {
+      const art = artifactPath(root, "a");
+      writeOutput(art, "the result");
+      expect(readOutput(art)).toBe("the result");
+    });
+  });
 
-	describe("listArtifacts", () => {
-		it("returns empty when root is missing", () => {
-			expect(listArtifacts(join(root, "nope"))).toEqual([]);
-		});
+  describe("listArtifacts", () => {
+    it("returns empty when root is missing", () => {
+      expect(listArtifacts(join(root, "nope"))).toEqual([]);
+    });
 
-		it("returns empty when root is empty", () => {
-			expect(listArtifacts(root)).toEqual([]);
-		});
+    it("returns empty when root is empty", () => {
+      expect(listArtifacts(root)).toEqual([]);
+    });
 
-		it("lists subdirs as artifacts, ignores loose files", () => {
-			mkdirSync(join(root, "id1"));
-			mkdirSync(join(root, "id2"));
-			writeFileSync(join(root, "stray.txt"), "ignore me");
-			const arts = listArtifacts(root);
-			expect(arts.map((a) => a.id).sort()).toEqual(["id1", "id2"]);
-		});
+    it("lists subdirs as artifacts, ignores loose files", () => {
+      mkdirSync(join(root, "id1"));
+      mkdirSync(join(root, "id2"));
+      writeFileSync(join(root, "stray.txt"), "ignore me");
+      const arts = listArtifacts(root);
+      expect(arts.map((a) => a.id).sort()).toEqual(["id1", "id2"]);
+    });
 
-		it("each entry has the expected paths", () => {
-			mkdirSync(join(root, "id1"));
-			const arts = listArtifacts(root);
-			expect(arts[0].statusFile).toBe(join(root, "id1", "events.ndjson"));
-			expect(arts[0].outputFile).toBe(join(root, "id1", "output.md"));
-		});
-	});
+    it("each entry has the expected paths", () => {
+      mkdirSync(join(root, "id1"));
+      const arts = listArtifacts(root);
+      expect(arts[0].statusFile).toBe(join(root, "id1", "events.ndjson"));
+      expect(arts[0].outputFile).toBe(join(root, "id1", "output.md"));
+    });
+  });
 
-	describe("lastEvent", () => {
-		it("returns null when no events", () => {
-			expect(lastEvent(artifactPath(root, "a"))).toBeNull();
-		});
+  describe("lastEvent", () => {
+    it("returns null when no events", () => {
+      expect(lastEvent(artifactPath(root, "a"))).toBeNull();
+    });
 
-		it("returns the most recent event", () => {
-			const art = artifactPath(root, "a");
-			appendEvent(art, { ts: 1, type: "started", status: "running" });
-			appendEvent(art, { ts: 9, type: "done", status: "done", exitCode: 0 });
-			expect(lastEvent(art)?.ts).toBe(9);
-			expect(lastEvent(art)?.type).toBe("done");
-		});
+    it("returns the most recent event", () => {
+      const art = artifactPath(root, "a");
+      appendEvent(art, { ts: 1, type: "started", status: "running" });
+      appendEvent(art, { ts: 9, type: "done", status: "done", exitCode: 0 });
+      expect(lastEvent(art)?.ts).toBe(9);
+      expect(lastEvent(art)?.type).toBe("done");
+    });
+  });
 
-	});
+  describe("per-turn snapshots (output-N.md)", () => {
+    it("snapshotOutput copies the current output.md into output-N.md", () => {
+      const art = artifactPath(root, "snap1");
+      writeOutput(art, "first turn's answer");
+      snapshotOutput(art, 1);
+      expect(existsSync(outputPathForTurn(art, 1))).toBe(true);
+      expect(readOutputForTurn(art, 1)).toBe("first turn's answer");
+      // output.md is untouched (it's the source).
+      expect(readOutput(art)).toBe("first turn's answer");
+    });
 
-	describe("per-turn snapshots (output-N.md)", () => {
-		it("snapshotOutput copies the current output.md into output-N.md", () => {
-			const art = artifactPath(root, "snap1");
-			writeOutput(art, "first turn's answer");
-			snapshotOutput(art, 1);
-			expect(existsSync(outputPathForTurn(art, 1))).toBe(true);
-			expect(readOutputForTurn(art, 1)).toBe("first turn's answer");
-			// output.md is untouched (it's the source).
-			expect(readOutput(art)).toBe("first turn's answer");
-		});
+    it("preserves history across multiple snapshots — earlier turns aren't overwritten", () => {
+      const art = artifactPath(root, "snap2");
+      // Turn 1
+      writeOutput(art, "answer v1");
+      snapshotOutput(art, 1);
+      // Turn 2: child overwrites output.md, poller snapshots again
+      writeOutput(art, "answer v2");
+      snapshotOutput(art, 2);
+      // Turn 3
+      writeOutput(art, "answer v3");
+      snapshotOutput(art, 3);
 
-		it("preserves history across multiple snapshots — earlier turns aren't overwritten", () => {
-			const art = artifactPath(root, "snap2");
-			// Turn 1
-			writeOutput(art, "answer v1");
-			snapshotOutput(art, 1);
-			// Turn 2: child overwrites output.md, poller snapshots again
-			writeOutput(art, "answer v2");
-			snapshotOutput(art, 2);
-			// Turn 3
-			writeOutput(art, "answer v3");
-			snapshotOutput(art, 3);
+      expect(readOutputForTurn(art, 1)).toBe("answer v1");
+      expect(readOutputForTurn(art, 2)).toBe("answer v2");
+      expect(readOutputForTurn(art, 3)).toBe("answer v3");
+      // Latest output.md is v3.
+      expect(readOutput(art)).toBe("answer v3");
+    });
 
-			expect(readOutputForTurn(art, 1)).toBe("answer v1");
-			expect(readOutputForTurn(art, 2)).toBe("answer v2");
-			expect(readOutputForTurn(art, 3)).toBe("answer v3");
-			// Latest output.md is v3.
-			expect(readOutput(art)).toBe("answer v3");
-		});
+    it("readOutputForTurn returns null when the snapshot doesn't exist", () => {
+      const art = artifactPath(root, "snap3");
+      writeOutput(art, "v1");
+      snapshotOutput(art, 1);
+      expect(readOutputForTurn(art, 2)).toBe(null);
+      expect(readOutputForTurn(art, 99)).toBe(null);
+    });
 
-		it("readOutputForTurn returns null when the snapshot doesn't exist", () => {
-			const art = artifactPath(root, "snap3");
-			writeOutput(art, "v1");
-			snapshotOutput(art, 1);
-			expect(readOutputForTurn(art, 2)).toBe(null);
-			expect(readOutputForTurn(art, 99)).toBe(null);
-		});
+    it("snapshotOutput is a no-op when output.md is missing", () => {
+      const art = artifactPath(root, "snap4");
+      // No writeOutput call — output.md doesn't exist.
+      snapshotOutput(art, 1);
+      expect(existsSync(outputPathForTurn(art, 1))).toBe(false);
+    });
 
-		it("snapshotOutput is a no-op when output.md is missing", () => {
-			const art = artifactPath(root, "snap4");
-			// No writeOutput call — output.md doesn't exist.
-			snapshotOutput(art, 1);
-			expect(existsSync(outputPathForTurn(art, 1))).toBe(false);
-		});
+    it("listOutputTurns returns the turn numbers for which a snapshot exists, sorted", () => {
+      const art = artifactPath(root, "snap5");
+      writeOutput(art, "a");
+      snapshotOutput(art, 2); // out of order to verify sort
+      writeOutput(art, "b");
+      snapshotOutput(art, 1);
+      writeOutput(art, "c");
+      snapshotOutput(art, 3);
+      expect(listOutputTurns(art)).toEqual([1, 2, 3]);
+    });
 
-		it("listOutputTurns returns the turn numbers for which a snapshot exists, sorted", () => {
-			const art = artifactPath(root, "snap5");
-			writeOutput(art, "a");
-			snapshotOutput(art, 2); // out of order to verify sort
-			writeOutput(art, "b");
-			snapshotOutput(art, 1);
-			writeOutput(art, "c");
-			snapshotOutput(art, 3);
-			expect(listOutputTurns(art)).toEqual([1, 2, 3]);
-		});
-
-		it("listOutputTurns returns [] when the artifact dir doesn't exist", () => {
-			const art = artifactPath(root, "snap6-nonexistent");
-			expect(listOutputTurns(art)).toEqual([]);
-		});
-	});
+    it("listOutputTurns returns [] when the artifact dir doesn't exist", () => {
+      const art = artifactPath(root, "snap6-nonexistent");
+      expect(listOutputTurns(art)).toEqual([]);
+    });
+  });
 });

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -16,53 +16,80 @@
  * parent is down and the parent can catch up by reading the artifact later.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import ndjson from "ndjson";
-
 
 // ── Types ───────────────────────────────────────────────────────────
 
 export type SubagentStatus = "running" | "done" | "error" | "cancelled";
 
 export type SubagentEvent =
-	| { ts: number; type: "started"; status: "running"; message?: string }
-	| { ts: number; type: "tool_activity"; status: "running"; tool?: string; summary?: string; message?: string }
-	| { ts: number; type: "done"; status: "done"; exitCode?: number; message?: string; summary?: string }
-	| { ts: number; type: "error"; status: "error"; message?: string; exitCode?: number }
-	| { ts: number; type: "cancelled"; status: "cancelled"; message?: string };
-
+  | { ts: number; type: "started"; status: "running"; message?: string }
+  | {
+      ts: number;
+      type: "tool_activity";
+      status: "running";
+      tool?: string;
+      summary?: string;
+      message?: string;
+    }
+  | {
+      ts: number;
+      type: "done";
+      status: "done";
+      exitCode?: number;
+      message?: string;
+      summary?: string;
+    }
+  | {
+      ts: number;
+      type: "error";
+      status: "error";
+      message?: string;
+      exitCode?: number;
+    }
+  | { ts: number; type: "cancelled"; status: "cancelled"; message?: string };
 
 export interface SubagentArtifact {
-	id: string;
-	dir: string;
-	statusFile: string;
-	outputFile: string;
+  id: string;
+  dir: string;
+  statusFile: string;
+  outputFile: string;
 }
 
 // ── Paths ───────────────────────────────────────────────────────────
 
 export function artifactPath(rootDir: string, id: string): SubagentArtifact {
-	const dir = join(rootDir, id);
-	return {
-		id,
-		dir,
-		statusFile: join(dir, "events.ndjson"),
-		outputFile: join(dir, "output.md"),
-	};
+  const dir = join(rootDir, id);
+  return {
+    id,
+    dir,
+    statusFile: join(dir, "events.ndjson"),
+    outputFile: join(dir, "output.md"),
+  };
 }
 
 /** Create the artifact directory with owner-only perms. Idempotent. */
 export function ensureArtifactDir(art: SubagentArtifact): void {
-	mkdirSync(art.dir, { recursive: true, mode: 0o700 });
+  mkdirSync(art.dir, { recursive: true, mode: 0o700 });
 }
 
 // ── Writes ──────────────────────────────────────────────────────────
 
 /** Append one event to the NDJSON log. Creates the dir if needed. */
 export function appendEvent(art: SubagentArtifact, event: SubagentEvent): void {
-	ensureArtifactDir(art);
-	appendFileSync(art.statusFile, JSON.stringify(event) + "\n", { mode: 0o600 });
+  ensureArtifactDir(art);
+  appendFileSync(art.statusFile, JSON.stringify(event) + "\n", { mode: 0o600 });
 }
 
 /**
@@ -71,10 +98,10 @@ export function appendEvent(art: SubagentArtifact, event: SubagentEvent): void {
  * concurrent reader sees either the old content or the new — never partial.
  */
 export function writeOutput(art: SubagentArtifact, content: string): void {
-	ensureArtifactDir(art);
-	const tmp = art.outputFile + ".tmp";
-	writeFileSync(tmp, content, { mode: 0o600 });
-	renameSync(tmp, art.outputFile);
+  ensureArtifactDir(art);
+  const tmp = art.outputFile + ".tmp";
+  writeFileSync(tmp, content, { mode: 0o600 });
+  renameSync(tmp, art.outputFile);
 }
 
 /**
@@ -82,7 +109,7 @@ export function writeOutput(art: SubagentArtifact, content: string): void {
  * Exported so the poller (and tests) can name the file consistently.
  */
 export function outputPathForTurn(art: SubagentArtifact, turn: number): string {
-	return join(art.dir, `output-${turn}.md`);
+  return join(art.dir, `output-${turn}.md`);
 }
 
 /**
@@ -94,25 +121,28 @@ export function outputPathForTurn(art: SubagentArtifact, turn: number): string {
  * would compute the same N — but a guard inside would be brittle. Trust the caller.
  */
 export function snapshotOutput(art: SubagentArtifact, turn: number): void {
-	if (!existsSync(art.outputFile)) return;
-	const target = outputPathForTurn(art, turn);
-	const tmp = target + ".tmp";
-	const content = readFileSync(art.outputFile, "utf8");
-	writeFileSync(tmp, content, { mode: 0o600 });
-	renameSync(tmp, target);
+  if (!existsSync(art.outputFile)) return;
+  const target = outputPathForTurn(art, turn);
+  const tmp = target + ".tmp";
+  const content = readFileSync(art.outputFile, "utf8");
+  writeFileSync(tmp, content, { mode: 0o600 });
+  renameSync(tmp, target);
 }
 
 /**
  * Read a specific turn's snapshot (output-N.md). Returns null if the snapshot doesn't exist.
  */
-export function readOutputForTurn(art: SubagentArtifact, turn: number): string | null {
-	const target = outputPathForTurn(art, turn);
-	if (!existsSync(target)) return null;
-	try {
-		return readFileSync(target, "utf8");
-	} catch {
-		return null;
-	}
+export function readOutputForTurn(
+  art: SubagentArtifact,
+  turn: number,
+): string | null {
+  const target = outputPathForTurn(art, turn);
+  if (!existsSync(target)) return null;
+  try {
+    return readFileSync(target, "utf8");
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -120,20 +150,20 @@ export function readOutputForTurn(art: SubagentArtifact, turn: number): string |
  * to summarize the available history.
  */
 export function listOutputTurns(art: SubagentArtifact): number[] {
-	if (!existsSync(art.dir)) return [];
-	let entries: string[];
-	try {
-		entries = readdirSync(art.dir);
-	} catch {
-		return [];
-	}
-	const turns: number[] = [];
-	for (const name of entries) {
-		const m = /^output-(\d+)\.md$/.exec(name);
-		if (m) turns.push(Number(m[1]));
-	}
-	turns.sort((a, b) => a - b);
-	return turns;
+  if (!existsSync(art.dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(art.dir);
+  } catch {
+    return [];
+  }
+  const turns: number[] = [];
+  for (const name of entries) {
+    const m = /^output-(\d+)\.md$/.exec(name);
+    if (m) turns.push(Number(m[1]));
+  }
+  turns.sort((a, b) => a - b);
+  return turns;
 }
 
 // ── Reads ───────────────────────────────────────────────────────────
@@ -149,63 +179,65 @@ export function listOutputTurns(art: SubagentArtifact): number[] {
  * did not end with a newline) is buffered by the parser and dropped on `end()`; it is treated as a
  * in-progress write that the next reader will pick up once completed.
  */
-export function readEvents(art: SubagentArtifact, since?: number): SubagentEvent[] {
-	if (!existsSync(art.statusFile)) return [];
-	let content: string;
-	try {
-		content = readFileSync(art.statusFile, "utf8");
-	} catch {
-		return [];
-	}
-	const parser = ndjson.parse({ strict: false });
-	const events: SubagentEvent[] = [];
-	parser.on("data", (obj: unknown) => {
-		const ev = obj as SubagentEvent;
-		if (since === undefined || ev.ts >= since) events.push(ev);
-	});
-	// Non-strict mode never emits 'error' for bad JSON; attach a no-op so an unhandled error event
-	// can never crash the parent process.
-	parser.on("error", () => {});
-	parser.end(Buffer.from(content, "utf8"));
-	return events;
+export function readEvents(
+  art: SubagentArtifact,
+  since?: number,
+): SubagentEvent[] {
+  if (!existsSync(art.statusFile)) return [];
+  let content: string;
+  try {
+    content = readFileSync(art.statusFile, "utf8");
+  } catch {
+    return [];
+  }
+  const parser = ndjson.parse({ strict: false });
+  const events: SubagentEvent[] = [];
+  parser.on("data", (obj: unknown) => {
+    const ev = obj as SubagentEvent;
+    if (since === undefined || ev.ts >= since) events.push(ev);
+  });
+  // Non-strict mode never emits 'error' for bad JSON; attach a no-op so an unhandled error event
+  // can never crash the parent process.
+  parser.on("error", () => {});
+  parser.end(Buffer.from(content, "utf8"));
+  return events;
 }
 
 /** Returns output.md content, or null if it doesn't exist yet. */
 export function readOutput(art: SubagentArtifact): string | null {
-	if (!existsSync(art.outputFile)) return null;
-	try {
-		return readFileSync(art.outputFile, "utf8");
-	} catch {
-		return null;
-	}
+  if (!existsSync(art.outputFile)) return null;
+  try {
+    return readFileSync(art.outputFile, "utf8");
+  } catch {
+    return null;
+  }
 }
 
 /** List all sub-agent artifacts under `rootDir`. Ignores loose files. */
 export function listArtifacts(rootDir: string): SubagentArtifact[] {
-	if (!existsSync(rootDir)) return [];
-	let entries: string[];
-	try {
-		entries = readdirSync(rootDir);
-	} catch {
-		return [];
-	}
-	const out: SubagentArtifact[] = [];
-	for (const name of entries) {
-		const full = join(rootDir, name);
-		try {
-			if (statSync(full).isDirectory()) {
-				out.push(artifactPath(rootDir, name));
-			}
-		} catch {
-			// skip unreadable
-		}
-	}
-	return out;
+  if (!existsSync(rootDir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(rootDir);
+  } catch {
+    return [];
+  }
+  const out: SubagentArtifact[] = [];
+  for (const name of entries) {
+    const full = join(rootDir, name);
+    try {
+      if (statSync(full).isDirectory()) {
+        out.push(artifactPath(rootDir, name));
+      }
+    } catch {
+      // skip unreadable
+    }
+  }
+  return out;
 }
 
 /** Most recent event, or null if no events yet. */
 export function lastEvent(art: SubagentArtifact): SubagentEvent | null {
-	const events = readEvents(art);
-	return events.length > 0 ? events[events.length - 1] : null;
+  const events = readEvents(art);
+  return events.length > 0 ? events[events.length - 1] : null;
 }
-

--- a/src/debug-log.test.ts
+++ b/src/debug-log.test.ts
@@ -1,9 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { existsSync, readFileSync, unlinkSync, mkdirSync, rmdirSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  mkdirSync,
+  rmdirSync,
+} from "node:fs";
 import { join } from "node:path";
 
 // Use dynamic import after setting env var
-const testDir = join(process.env.TEMP_DIR || "/tmp", `debug-log-test-${Date.now()}`);
+const testDir = join(
+  process.env.TEMP_DIR || "/tmp",
+  `debug-log-test-${Date.now()}`,
+);
 const currentLogFile = () =>
   join(testDir, `debug-${new Date().toISOString().slice(0, 10)}.jsonl`);
 
@@ -60,7 +69,10 @@ describe("debugLog", () => {
     vi.resetModules();
     const { debugLog } = await import("./helpers");
 
-    debugLog("error", "subagent_error", { jobId: "test-job", error: "something broke" });
+    debugLog("error", "subagent_error", {
+      jobId: "test-job",
+      error: "something broke",
+    });
 
     const logFile = currentLogFile();
     const content = readFileSync(logFile, "utf-8");

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -30,19 +30,27 @@ const DEBUG_LOG_DIR = process.env.SUBAGENT_DEBUG_LOG_DIR
   ? resolve(process.env.SUBAGENT_DEBUG_LOG_DIR)
   : undefined;
 
-export function debugLog(level: string, event: string, data: Record<string, unknown> = {}) {
+export function debugLog(
+  level: string,
+  event: string,
+  data: Record<string, unknown> = {},
+) {
   if (!DEBUG_LOG_DIR) return;
   try {
     if (!existsSync(DEBUG_LOG_DIR)) {
       mkdirSync(DEBUG_LOG_DIR, { recursive: true });
     }
-    const entry = JSON.stringify({
-      timestamp: new Date().toISOString(),
-      level,
-      event,
-      ...data,
-    }) + "\n";
-    const fileName = resolve(DEBUG_LOG_DIR, `debug-${new Date().toISOString().slice(0, 10)}.jsonl`);
+    const entry =
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level,
+        event,
+        ...data,
+      }) + "\n";
+    const fileName = resolve(
+      DEBUG_LOG_DIR,
+      `debug-${new Date().toISOString().slice(0, 10)}.jsonl`,
+    );
     appendFileSync(fileName, entry);
   } catch {
     // Silently fail to avoid polluting output
@@ -52,8 +60,12 @@ export function debugLog(level: string, event: string, data: Record<string, unkn
 export function extractTextFromContent(content: unknown): string {
   if (Array.isArray(content)) {
     return content
-      .filter((c): c is { type: "text"; text: string } =>
-        typeof c === "object" && c !== null && c.type === "text" && typeof c.text === "string"
+      .filter(
+        (c): c is { type: "text"; text: string } =>
+          typeof c === "object" &&
+          c !== null &&
+          c.type === "text" &&
+          typeof c.text === "string",
       )
       .map((c) => c.text)
       .join("\n");
@@ -94,7 +106,13 @@ export interface Usage {
 
 export type SubagentResult =
   | { isError: false; output: string; usage: Usage; model?: string }
-  | { isError: true; output: string; usage: Usage; model?: undefined; errorMessage: string };
+  | {
+      isError: true;
+      output: string;
+      usage: Usage;
+      model?: undefined;
+      errorMessage: string;
+    };
 
 export interface SubagentLiveStatus {
   turn: number;
@@ -153,11 +171,15 @@ export const jobRegistry = g.__piSubagenturaRegistry as Map<string, JobState>;
 
 declare global {
   var __piSubagenturaRegistry: Map<string, JobState> | undefined;
-  var __piSubagenturaInteractiveRegistry: Map<string, InteractiveSubagentState> | undefined;
+  var __piSubagenturaInteractiveRegistry:
+    | Map<string, InteractiveSubagentState>
+    | undefined;
   var __piSubagenturaPiRef: ExtensionAPI | undefined;
   var __piSubagenturaUi: ExtensionUIContext | undefined;
   var __piSubagenturaInjectCount: number | undefined;
-  var __piSubagenturaInteractivePollerHandle: ReturnType<typeof setInterval> | undefined;
+  var __piSubagenturaInteractivePollerHandle:
+    | ReturnType<typeof setInterval>
+    | undefined;
 }
 
 // Initialize the global pi ref
@@ -274,10 +296,7 @@ export function formatTokens(count: number): string {
   return `${(count / 1000000).toFixed(1)}M`;
 }
 
-export function formatUsage(
-  u: Usage,
-  model?: string,
-): string {
+export function formatUsage(u: Usage, model?: string): string {
   const parts: string[] = [];
   if (u.turns) parts.push(`${u.turns} turn${u.turns > 1 ? "s" : ""}`);
   if (u.input) parts.push(`↑${formatTokens(u.input)}`);
@@ -364,7 +383,11 @@ export async function startSubagentJob(
 
   // Resolve model: exact match only, fallback to default
   // Uses parent's modelRegistry to find extension-added models (e.g. minimax)
-  const targetModel = resolveModel(modelOverride, defaultModel, parentModelRegistry);
+  const targetModel = resolveModel(
+    modelOverride,
+    defaultModel,
+    parentModelRegistry,
+  );
   const modelLabel = targetModel
     ? `${targetModel.provider}/${targetModel.id}`
     : undefined;
@@ -446,7 +469,9 @@ export async function startSubagentJob(
   ).session;
   debugLog("info", "session_created", {
     jobId,
-    sessionModel: session.model ? `${session.model.provider}/${session.model.id}` : null,
+    sessionModel: session.model
+      ? `${session.model.provider}/${session.model.id}`
+      : null,
   });
 
   // Wire abort signal
@@ -486,7 +511,10 @@ export async function startSubagentJob(
         break;
       }
       case "tool_execution_end": {
-        debugLog("info", "tool_end", { jobId, toolName: liveStatus.activeTool?.name });
+        debugLog("info", "tool_end", {
+          jobId,
+          toolName: liveStatus.activeTool?.name,
+        });
         setActiveToolDebounced(undefined);
         break;
       }
@@ -514,8 +542,12 @@ export async function startSubagentJob(
             delta: evt.delta.slice(0, 200),
             outputLength: liveStatus.output.length,
           }),
-          ...(evt.type === "thinking_delta" && { delta: evt.delta.slice(0, 200) }),
-          ...(evt.type === "toolcall_delta" && { partial: String(evt.partial).slice(0, 200) }),
+          ...(evt.type === "thinking_delta" && {
+            delta: evt.delta.slice(0, 200),
+          }),
+          ...(evt.type === "toolcall_delta" && {
+            partial: String(evt.partial).slice(0, 200),
+          }),
           ...(evt.type === "toolcall_end" && { toolCallId: evt.toolCall?.id }),
         });
         if (evt.type === "text_delta") {
@@ -557,8 +589,11 @@ export async function startSubagentJob(
         jobId,
         messageCount: messages.length,
         messageRoles: messages.map((m) => m.role),
-        lastMessageContentType: typeof (messages[messages.length - 1] as any)?.content,
-        lastMessageContentIsArray: Array.isArray((messages[messages.length - 1] as any)?.content),
+        lastMessageContentType: typeof (messages[messages.length - 1] as any)
+          ?.content,
+        lastMessageContentIsArray: Array.isArray(
+          (messages[messages.length - 1] as any)?.content,
+        ),
       });
 
       let finalOutput = liveStatus.output;

--- a/src/interactive-tmux.test.ts
+++ b/src/interactive-tmux.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { deriveInteractiveSubagentStatus } from "./interactive-tmux";
-import { mkdtempSync, readFileSync, rmSync, existsSync, statSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+  statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { importFresh } from "./test-utils";
@@ -13,7 +19,8 @@ const MOCK_LOCATION = "sess\t1\t0\n";
 function installMockExec(scenario: (file: string, args: string[]) => string) {
   vi.resetModules();
   vi.doMock("node:child_process", () => ({
-    execFileSync: (_file: string, args: string[]) => scenario("tmux", args as string[]),
+    execFileSync: (_file: string, args: string[]) =>
+      scenario("tmux", args as string[]),
   }));
 }
 
@@ -37,16 +44,23 @@ describe("interactive-tmux", () => {
     vi.doUnmock("node:child_process");
   });
 
-	it("is unavailable when tmux binary is not on PATH", async () => {
-		process.env.TMUX = "";
-		vi.doMock("node:child_process", () => ({
-			execFileSync: () => {
-				throw new Error("command not found");
-			},
-		} as unknown as typeof import("node:child_process")));
-		const { isTmuxAvailable } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-		expect(isTmuxAvailable()).toBe(false);
-	});
+  it("is unavailable when tmux binary is not on PATH", async () => {
+    process.env.TMUX = "";
+    vi.doMock(
+      "node:child_process",
+      () =>
+        ({
+          execFileSync: () => {
+            throw new Error("command not found");
+          },
+        }) as unknown as typeof import("node:child_process"),
+    );
+    const { isTmuxAvailable } =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
+    expect(isTmuxAvailable()).toBe(false);
+  });
 
   it("launches in background mode by default (new-window) and stores window-name attach commands", async () => {
     const tmp = makeTmp();
@@ -63,7 +77,10 @@ describe("interactive-tmux", () => {
       return "";
     });
 
-    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     // No `background` flag — should default to true (hidden).
     const state = mod.launchInteractiveSubagent({
       name: "Demo",
@@ -101,7 +118,9 @@ describe("interactive-tmux", () => {
     expect(state.artifactDir).toBeTruthy();
     expect(existsSync(state.artifactDir)).toBe(true);
     expect(existsSync(join(state.artifactDir, "cli.mjs"))).toBe(true);
-    expect(statSync(join(state.artifactDir, "cli.mjs")).mode & 0o777).toBe(0o700);
+    expect(statSync(join(state.artifactDir, "cli.mjs")).mode & 0o777).toBe(
+      0o700,
+    );
   });
 
   it("launches in visible-split mode when background: false", async () => {
@@ -118,7 +137,10 @@ describe("interactive-tmux", () => {
       return "";
     });
 
-    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     const state = mod.launchInteractiveSubagent({
       name: "Demo",
       task: "Run tests",
@@ -168,7 +190,10 @@ describe("interactive-tmux", () => {
       };
     });
 
-    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     expect(() =>
       mod.launchInteractiveSubagent({
         name: "Demo",
@@ -179,7 +204,10 @@ describe("interactive-tmux", () => {
 
     // F2 fix: the pane should have been killed (no orphan left in tmux).
     const killedPane = calls.some(
-      (args) => args[0] === "kill-pane" && args.includes("-t") && args.includes(MOCK_PANE_ID),
+      (args) =>
+        args[0] === "kill-pane" &&
+        args.includes("-t") &&
+        args.includes(MOCK_PANE_ID),
     );
     expect(killedPane).toBe(true);
 
@@ -196,7 +224,10 @@ describe("interactive-tmux", () => {
       if (args[0] === "show-options") return "0\n";
       return "";
     });
-    const mod1 = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod1 =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     expect(mod1.readPaneExitCode(MOCK_PANE_ID)).toBe(0);
 
     // Mock returning empty string (option not yet set).
@@ -204,7 +235,10 @@ describe("interactive-tmux", () => {
       if (args[0] === "show-options") return "\n";
       return "";
     });
-    const mod2 = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod2 =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     expect(mod2.readPaneExitCode(MOCK_PANE_ID)).toBeNull();
 
     // Mock throwing (pane dead / option unset).
@@ -212,7 +246,10 @@ describe("interactive-tmux", () => {
       if (args[0] === "show-options") throw new Error("no such pane");
       return "";
     });
-    const mod3 = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod3 =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     expect(mod3.readPaneExitCode(MOCK_PANE_ID)).toBeNull();
   });
 
@@ -233,7 +270,10 @@ describe("interactive-tmux", () => {
       },
     }));
 
-    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     expect(mod.readPaneExitCode(MOCK_PANE_ID)).toBeNull();
 
     // The execFileSync call must use stdio that explicitly ignores stderr.
@@ -243,7 +283,10 @@ describe("interactive-tmux", () => {
     for (const opts of capturedOptions) {
       expect(opts).toBeDefined();
       const stdio = opts!.stdio as [string, string, string] | undefined;
-      expect(stdio, "stdio must be specified to avoid inheriting stderr").toBeDefined();
+      expect(
+        stdio,
+        "stdio must be specified to avoid inheriting stderr",
+      ).toBeDefined();
       expect(stdio![2]).toBe("ignore");
     }
   });
@@ -252,7 +295,10 @@ describe("interactive-tmux", () => {
     process.env.PI_CODING_AGENT_SESSION_DIR = makeTmp();
     process.env.TMUX = makeArgs().TMUX;
 
-    const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+    const mod =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
     const { appendEvent, artifactPath } = await import("./artifact");
     const { mkdirSync } = await import("node:fs");
 
@@ -311,44 +357,63 @@ describe("interactive-tmux", () => {
     }
   });
 
+  describe("deriveInteractiveSubagentStatus (pure status-decision matrix)", () => {
+    // Event factories — keep them tiny, the matrix is what matters.
+    const startedEv = {
+      ts: 1,
+      type: "started" as const,
+      status: "running" as const,
+    };
+    const doneEv = {
+      ts: 2,
+      type: "done" as const,
+      status: "done" as const,
+      exitCode: 0,
+    };
+    const errorEv = {
+      ts: 3,
+      type: "error" as const,
+      status: "error" as const,
+      message: "boom",
+    };
+    const cancelledEv = {
+      ts: 4,
+      type: "cancelled" as const,
+      status: "cancelled" as const,
+    };
 
-	describe("deriveInteractiveSubagentStatus (pure status-decision matrix)", () => {
-
-
-		// Event factories — keep them tiny, the matrix is what matters.
-		const startedEv = { ts: 1, type: "started" as const, status: "running" as const };
-		const doneEv = { ts: 2, type: "done" as const, status: "done" as const, exitCode: 0 };
-		const errorEv = { ts: 3, type: "error" as const, status: "error" as const, message: "boom" };
-		const cancelledEv = { ts: 4, type: "cancelled" as const, status: "cancelled" as const };
-
-		it("started event + pane alive → 'running' (mid-turn)", () => {
-			expect(deriveInteractiveSubagentStatus(startedEv, true)).toBe("running");
-		});
-		it("no event + pane alive → 'running' (about to start)", () => {
-			expect(deriveInteractiveSubagentStatus(null, true)).toBe("running");
-		});
-		it("done event + pane alive → 'idle' (the follow-up case)", () => {
-			expect(deriveInteractiveSubagentStatus(doneEv, true)).toBe("idle");
-		});
-		it("done event + pane dead → 'exited' (terminal)", () => {
-			expect(deriveInteractiveSubagentStatus(doneEv, false)).toBe("exited");
-		});
-		it("error event + pane alive → 'exited' (child declared it unrecoverable)", () => {
-			expect(deriveInteractiveSubagentStatus(errorEv, true)).toBe("exited");
-		});
-		it("error event + pane dead → 'exited'", () => {
-			expect(deriveInteractiveSubagentStatus(errorEv, false)).toBe("exited");
-		});
-		it("cancelled event + pane alive → 'cancelled' (terminal regardless of pane)", () => {
-			expect(deriveInteractiveSubagentStatus(cancelledEv, true)).toBe("cancelled");
-		});
-		it("cancelled event + pane dead → 'cancelled'", () => {
-			expect(deriveInteractiveSubagentStatus(cancelledEv, false)).toBe("cancelled");
-		});
-		it("no event + pane dead → 'unknown'", () => {
-			expect(deriveInteractiveSubagentStatus(null, false)).toBe("unknown");
-		});
-	});
+    it("started event + pane alive → 'running' (mid-turn)", () => {
+      expect(deriveInteractiveSubagentStatus(startedEv, true)).toBe("running");
+    });
+    it("no event + pane alive → 'running' (about to start)", () => {
+      expect(deriveInteractiveSubagentStatus(null, true)).toBe("running");
+    });
+    it("done event + pane alive → 'idle' (the follow-up case)", () => {
+      expect(deriveInteractiveSubagentStatus(doneEv, true)).toBe("idle");
+    });
+    it("done event + pane dead → 'exited' (terminal)", () => {
+      expect(deriveInteractiveSubagentStatus(doneEv, false)).toBe("exited");
+    });
+    it("error event + pane alive → 'exited' (child declared it unrecoverable)", () => {
+      expect(deriveInteractiveSubagentStatus(errorEv, true)).toBe("exited");
+    });
+    it("error event + pane dead → 'exited'", () => {
+      expect(deriveInteractiveSubagentStatus(errorEv, false)).toBe("exited");
+    });
+    it("cancelled event + pane alive → 'cancelled' (terminal regardless of pane)", () => {
+      expect(deriveInteractiveSubagentStatus(cancelledEv, true)).toBe(
+        "cancelled",
+      );
+    });
+    it("cancelled event + pane dead → 'cancelled'", () => {
+      expect(deriveInteractiveSubagentStatus(cancelledEv, false)).toBe(
+        "cancelled",
+      );
+    });
+    it("no event + pane dead → 'unknown'", () => {
+      expect(deriveInteractiveSubagentStatus(null, false)).toBe("unknown");
+    });
+  });
 
   // ------------------------------------------------------------------
   // Tests for the child completion protocol (buildChildSubagentProtocol),
@@ -362,7 +427,10 @@ describe("interactive-tmux", () => {
     const FIXTURE_DIR = "/tmp/pi-subagentura-fixture";
 
     it("names all three completion signals (done / error / cancelled)", async () => {
-      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { buildChildSubagentProtocol } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
       expect(protocol).toContain("done");
       expect(protocol).toContain("error");
@@ -370,7 +438,10 @@ describe("interactive-tmux", () => {
     });
 
     it("points the child to the literal artifact paths (no shell var for write tool)", async () => {
-      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { buildChildSubagentProtocol } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
       // The rendered protocol must use the literal absolute path, not a shell var.
       // The rendered protocol uses the literal absolute path in the actionable step
@@ -385,14 +456,20 @@ describe("interactive-tmux", () => {
     });
 
     it("still shows the bash $ARTIFACT_DIR form for cli.mjs (env-var shell usage)", async () => {
-      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { buildChildSubagentProtocol } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
       // The bash examples still use $ARTIFACT_DIR because the launch script exports it.
       expect(protocol).toContain("$ARTIFACT_DIR/cli.mjs");
     });
 
     it("tells the child to keep the REPL open after done", async () => {
-      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { buildChildSubagentProtocol } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
       expect(protocol).toMatch(/REPL stays open/i);
       // The protocol explicitly warns against exiting the REPL (e.g. via /exit, Ctrl-D,
@@ -401,7 +478,10 @@ describe("interactive-tmux", () => {
     });
 
     it("tells the child to be brief (avoid verbose preambles, short summary in step 3)", async () => {
-      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { buildChildSubagentProtocol } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
       // The BE BRIEF directive lives at the top of the protocol so it gets
       // high attention. We match the literal "BE BRIEF" token so the exact
@@ -410,7 +490,10 @@ describe("interactive-tmux", () => {
     });
 
     it("embeds the literal artifact dir in the rendered prompt", async () => {
-      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const { buildChildSubagentProtocol } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const protocol = buildChildSubagentProtocol("/tmp/some-other-dir");
       expect(protocol).toContain("/tmp/some-other-dir");
       // Sanity: the fixture from a different call must not appear here.
@@ -439,11 +522,20 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const { buildChildSubagentProtocol } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const state = mod.launchInteractiveSubagent({ name: "NoPersona", task: "x", cwd: tmp });
+      const mod =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const { buildChildSubagentProtocol } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const state = mod.launchInteractiveSubagent({
+        name: "NoPersona",
+        task: "x",
+        cwd: tmp,
+      });
       const sysFile = join(state.artifactDir, "nopersona-system.md");
-
 
       expect(existsSync(sysFile)).toBe(true);
       const content = readFileSync(sysFile, "utf8");
@@ -466,7 +558,10 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const mod =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const state = mod.launchInteractiveSubagent({
         name: "WithPersona",
         task: "x",
@@ -492,7 +587,10 @@ describe("interactive-tmux", () => {
 
       installMockExec(() => MOCK_PANE_ID + "\n");
 
-      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const mod =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const tooBig = "x".repeat(64 * 1024 + 1);
       let threw = false;
       try {
@@ -529,8 +627,15 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const state = mod.launchInteractiveSubagent({ name: "Wire", task: "x", cwd: tmp });
+      const mod =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const state = mod.launchInteractiveSubagent({
+        name: "Wire",
+        task: "x",
+        cwd: tmp,
+      });
 
       const launchScript = readFileSync(state.launchScriptFile, "utf8");
       expect(launchScript).toContain("--append-system-prompt");
@@ -563,12 +668,19 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const state = mod.launchInteractiveSubagent({ name: "NoNotify", task: "x", cwd: tmp });
+      const mod =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const state = mod.launchInteractiveSubagent({
+        name: "NoNotify",
+        task: "x",
+        cwd: tmp,
+      });
 
       // Default: no notification mode requested. The poller falls back to notify.
       expect(state.notifyOnComplete).toBeUndefined();
-			expect(state.lastInjectedEventTs).toBeUndefined();
+      expect(state.lastInjectedEventTs).toBeUndefined();
     });
 
     it("propagates notifyOnComplete: 'inject' from launchInteractiveSubagent to the state", async () => {
@@ -584,7 +696,10 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const mod =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const state = mod.launchInteractiveSubagent({
         name: "InjectMode",
         task: "x",
@@ -608,7 +723,10 @@ describe("interactive-tmux", () => {
         return "";
       });
 
-      const mod = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
+      const mod =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
       const state = mod.launchInteractiveSubagent({
         name: "NotifyMode",
         task: "x",
@@ -622,36 +740,77 @@ describe("interactive-tmux", () => {
 
   describe("buildPiInteractiveCommand", () => {
     it("starts with `cd <cwd> &&` and shell-escapes the cwd", async () => {
-      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/tmp/has space" });
+      const { buildPiInteractiveCommand } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const cmd = buildPiInteractiveCommand({
+        sessionFile: "/s.jsonl",
+        name: "n",
+        promptFile: "/p.md",
+        cwd: "/tmp/has space",
+      });
       expect(cmd).toMatch(/^cd '\/tmp\/has space' &&/);
     });
 
     it("includes --session, --name, and the @<promptFile>", async () => {
-      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c" });
+      const { buildPiInteractiveCommand } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const cmd = buildPiInteractiveCommand({
+        sessionFile: "/s.jsonl",
+        name: "n",
+        promptFile: "/p.md",
+        cwd: "/c",
+      });
       expect(cmd).toContain("--session '/s.jsonl'");
       expect(cmd).toContain("--name 'n'");
       // The prompt file is invoked via "@<file>" — verify the path appears in that form.
       expect(cmd).toMatch(/'\@\/p\.md'$/);
-
     });
 
     it("omits --model when undefined", async () => {
-      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c" });
+      const { buildPiInteractiveCommand } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const cmd = buildPiInteractiveCommand({
+        sessionFile: "/s.jsonl",
+        name: "n",
+        promptFile: "/p.md",
+        cwd: "/c",
+      });
       expect(cmd).not.toContain("--model");
     });
 
     it("includes --model when set, escaped", async () => {
-      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c", model: "p/m" });
+      const { buildPiInteractiveCommand } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const cmd = buildPiInteractiveCommand({
+        sessionFile: "/s.jsonl",
+        name: "n",
+        promptFile: "/p.md",
+        cwd: "/c",
+        model: "p/m",
+      });
       expect(cmd).toContain("--model 'p/m'");
     });
 
     it("includes --append-system-prompt when systemPromptFile is set", async () => {
-      const { buildPiInteractiveCommand } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-      const cmd = buildPiInteractiveCommand({ sessionFile: "/s.jsonl", name: "n", promptFile: "/p.md", cwd: "/c", systemPromptFile: "/s.md" });
+      const { buildPiInteractiveCommand } =
+        await importFresh<typeof import("./interactive-tmux")>(
+          "./interactive-tmux",
+        );
+      const cmd = buildPiInteractiveCommand({
+        sessionFile: "/s.jsonl",
+        name: "n",
+        promptFile: "/p.md",
+        cwd: "/c",
+        systemPromptFile: "/s.md",
+      });
       expect(cmd).toContain("--append-system-prompt");
       expect(cmd).toContain("/s.md");
     });

--- a/src/multiplexer-tmux.ts
+++ b/src/multiplexer-tmux.ts
@@ -31,205 +31,259 @@ import { commandExists, shellEscape } from "./multiplexer";
  * via `display-message`. Throws if the pane is dead or the id is malformed —
  * callers that want a liveness probe should use `isPaneAlive` instead.
  */
-function getPaneLocation(paneId: string): { session: string; window: string; pane: string } {
-	const output = execFileSync(
-		"tmux",
-		["display-message", "-p", "-t", paneId, "#{session_name}\t#{window_index}\t#{pane_index}"],
-		{ encoding: "utf8", timeout: 5000 },
-	).trim();
-	const [session, window, pane] = output.split("\t");
-	return { session, window, pane };
+function getPaneLocation(paneId: string): {
+  session: string;
+  window: string;
+  pane: string;
+} {
+  const output = execFileSync(
+    "tmux",
+    [
+      "display-message",
+      "-p",
+      "-t",
+      paneId,
+      "#{session_name}\t#{window_index}\t#{pane_index}",
+    ],
+    { encoding: "utf8", timeout: 5000 },
+  ).trim();
+  const [session, window, pane] = output.split("\t");
+  return { session, window, pane };
 }
 
 /** Sanitize a free-form name into a tmux-safe segment. tmux names allow most
  * chars but reject `:`, `.`, and whitespace; we collapse everything else to
  * a single dash to keep the resulting window/session names copy-pasteable. */
 function safeSegment(value: string): string {
-	return (
-		value
-			.toLowerCase()
-			.replace(/[^a-z0-9._-]+/g, "-")
-			.replace(/-+/g, "-")
-			.replace(/^-|-$/g, "") || "subagent"
-	);
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "subagent"
+  );
 }
 
 export class TmuxMultiplexer implements Multiplexer {
-	readonly name = "tmux" as const;
+  readonly name = "tmux" as const;
 
-	/**
-	 * True iff the `tmux` binary is on PATH. Does NOT require the parent
-	 * process to be attached to a tmux server (the relaxed-spawn path in
-	 * `createPane` handles unattached parents by creating a detached session).
-	 *
-	 * The env-var heuristic (`process.env.TMUX`) lives in `getMux()`'s
-	 * auto-resolution, not here — `isAvailable` is a pure binary-availability
-	 * check so the fallback path in `getMux()` can find a backend even when
-	 * the user is running in a plain terminal.
-	 */
-	isAvailable(): boolean {
-		return commandExists("tmux");
-	}
+  /**
+   * True iff the `tmux` binary is on PATH. Does NOT require the parent
+   * process to be attached to a tmux server (the relaxed-spawn path in
+   * `createPane` handles unattached parents by creating a detached session).
+   *
+   * The env-var heuristic (`process.env.TMUX`) lives in `getMux()`'s
+   * auto-resolution, not here — `isAvailable` is a pure binary-availability
+   * check so the fallback path in `getMux()` can find a backend even when
+   * the user is running in a plain terminal.
+   */
+  isAvailable(): boolean {
+    return commandExists("tmux");
+  }
 
-	/**
-	 * Create a pane for the child process. When the parent is in tmux
-	 * (the common case), behaves as before:
-	 *   - background: true  → `new-window -d -n <name>` in the current session
-	 *   - background: false → `split-window -h` from `$TMUX_PANE` (a visible
-	 *                         side-by-side; the parent keeps focus)
-	 *
-	 * When the parent is NOT in tmux (the new relaxed-spawn path), creates a
-	 * brand-new detached session named `pi-subagent-<id>` and puts the
-	 * child in its only window. The user attaches via `tmux attach -t
-	 * pi-subagent-<id>`. This path is selected by the orchestrator
-	 * (`launchInteractiveSubagent`) — it passes a non-empty `id` to the
-	 * unique-session path. For backwards compat, callers that don't pass
-	 * an id (e.g., the pre-PR-1 `createTmuxPane(name, cwd, { background })`
-	 * shape) still get the old behavior, and the relaxed path is only used
-	 * when the parent is not in tmux AND background is true.
-	 *
-	 * Note: this method intentionally does not check `isAvailable` — the
-	 * relaxed path must work even when `process.env.TMUX` is unset, as long
-	 * as the `tmux` binary is on PATH. The orchestrator probes both.
-	 */
-	createPane(opts: {
-		name: string;
-		cwd: string;
-		background: boolean;
-		parentPane?: string;
-		windowName?: string;
-		id?: string; // sub-agent id (8 hex); used for the relaxed-path unique session name
-	}): { paneId: string; windowName?: string } {
-		if (!commandExists("tmux")) {
-			throw new Error("tmux is not available. Install tmux or set PATH to include it.");
-		}
+  /**
+   * Create a pane for the child process. When the parent is in tmux
+   * (the common case), behaves as before:
+   *   - background: true  → `new-window -d -n <name>` in the current session
+   *   - background: false → `split-window -h` from `$TMUX_PANE` (a visible
+   *                         side-by-side; the parent keeps focus)
+   *
+   * When the parent is NOT in tmux (the new relaxed-spawn path), creates a
+   * brand-new detached session named `pi-subagent-<id>` and puts the
+   * child in its only window. The user attaches via `tmux attach -t
+   * pi-subagent-<id>`. This path is selected by the orchestrator
+   * (`launchInteractiveSubagent`) — it passes a non-empty `id` to the
+   * unique-session path. For backwards compat, callers that don't pass
+   * an id (e.g., the pre-PR-1 `createTmuxPane(name, cwd, { background })`
+   * shape) still get the old behavior, and the relaxed path is only used
+   * when the parent is not in tmux AND background is true.
+   *
+   * Note: this method intentionally does not check `isAvailable` — the
+   * relaxed path must work even when `process.env.TMUX` is unset, as long
+   * as the `tmux` binary is on PATH. The orchestrator probes both.
+   */
+  createPane(opts: {
+    name: string;
+    cwd: string;
+    background: boolean;
+    parentPane?: string;
+    windowName?: string;
+    id?: string; // sub-agent id (8 hex); used for the relaxed-path unique session name
+  }): { paneId: string; windowName?: string } {
+    if (!commandExists("tmux")) {
+      throw new Error(
+        "tmux is not available. Install tmux or set PATH to include it.",
+      );
+    }
 
-		// Relaxed path: parent not in tmux. Create a brand-new detached
-		// session so the child has somewhere to live. The user attaches via
-		// `tmux attach -t <session-name>` after the spawn returns.
-		if (!process.env.TMUX) {
-			const sessionName = `pi-subagent-${opts.id ?? safeSegment(opts.name)}`;
-			const paneId = execFileSync(
-				"tmux",
-				["new-session", "-d", "-s", sessionName, "-c", opts.cwd, "-P", "-F", "#{pane_id}"],
-				{ encoding: "utf8", timeout: 10000 },
-			).trim();
-			if (!paneId.startsWith("%")) {
-				throw new Error(`Unexpected tmux pane id: ${paneId || "(empty)"}`);
-			}
-			// Rename the default window to the sub-agent's display name so the
-			// user's `tmux ls` output is recognizable.
-			const windowName = opts.windowName ?? safeSegment(opts.name);
-			try {
-				execFileSync("tmux", ["rename-window", "-t", `${sessionName}:0`, windowName], {
-					encoding: "utf8",
-					timeout: 5000,
-				});
-			} catch {
-				// Cosmetic; don't fail the spawn if rename doesn't take.
-			}
-			return { paneId, windowName };
-		}
+    // Relaxed path: parent not in tmux. Create a brand-new detached
+    // session so the child has somewhere to live. The user attaches via
+    // `tmux attach -t <session-name>` after the spawn returns.
+    if (!process.env.TMUX) {
+      const sessionName = `pi-subagent-${opts.id ?? safeSegment(opts.name)}`;
+      const paneId = execFileSync(
+        "tmux",
+        [
+          "new-session",
+          "-d",
+          "-s",
+          sessionName,
+          "-c",
+          opts.cwd,
+          "-P",
+          "-F",
+          "#{pane_id}",
+        ],
+        { encoding: "utf8", timeout: 10000 },
+      ).trim();
+      if (!paneId.startsWith("%")) {
+        throw new Error(`Unexpected tmux pane id: ${paneId || "(empty)"}`);
+      }
+      // Rename the default window to the sub-agent's display name so the
+      // user's `tmux ls` output is recognizable.
+      const windowName = opts.windowName ?? safeSegment(opts.name);
+      try {
+        execFileSync(
+          "tmux",
+          ["rename-window", "-t", `${sessionName}:0`, windowName],
+          {
+            encoding: "utf8",
+            timeout: 5000,
+          },
+        );
+      } catch {
+        // Cosmetic; don't fail the spawn if rename doesn't take.
+      }
+      return { paneId, windowName };
+    }
 
-		// Standard path: parent is in tmux.
-		let paneId: string;
-		let windowName: string | undefined;
-		if (opts.background) {
-			// Spawn in a new detached window — invisible to the user until they
-			// select it. Each background sub-agent gets its own named window
-			// so they don't clobber each other in the tmux window list.
-			windowName = opts.windowName ?? safeSegment(opts.name);
-			paneId = execFileSync(
-				"tmux",
-				["new-window", "-d", "-n", windowName, "-P", "-F", "#{pane_id}", "-c", opts.cwd],
-				{ encoding: "utf8", timeout: 10000 },
-			).trim();
-		} else {
-			// Visible horizontal split — parent pane keeps focus. Same session,
-			// immediately adjacent to the parent's pane.
-			const args = ["split-window", "-d", "-h", "-P", "-F", "#{pane_id}", "-c", opts.cwd];
-			const parent = opts.parentPane ?? process.env.TMUX_PANE;
-			if (parent) {
-				args.splice(4, 0, "-t", parent);
-			}
-			paneId = execFileSync("tmux", args, { encoding: "utf8", timeout: 10000 }).trim();
-		}
-		if (!paneId.startsWith("%")) {
-			throw new Error(`Unexpected tmux pane id: ${paneId || "(empty)"}`);
-		}
-		if (!opts.background) {
-			// Pane title is cosmetic and the new window already shows `name`.
-			try {
-				execFileSync("tmux", ["select-pane", "-t", paneId, "-T", opts.name], { encoding: "utf8" });
-			} catch {
-				// Pane title is cosmetic and can fail on older tmux versions.
-			}
-		}
-		return { paneId, windowName };
-	}
+    // Standard path: parent is in tmux.
+    let paneId: string;
+    let windowName: string | undefined;
+    if (opts.background) {
+      // Spawn in a new detached window — invisible to the user until they
+      // select it. Each background sub-agent gets its own named window
+      // so they don't clobber each other in the tmux window list.
+      windowName = opts.windowName ?? safeSegment(opts.name);
+      paneId = execFileSync(
+        "tmux",
+        [
+          "new-window",
+          "-d",
+          "-n",
+          windowName,
+          "-P",
+          "-F",
+          "#{pane_id}",
+          "-c",
+          opts.cwd,
+        ],
+        { encoding: "utf8", timeout: 10000 },
+      ).trim();
+    } else {
+      // Visible horizontal split — parent pane keeps focus. Same session,
+      // immediately adjacent to the parent's pane.
+      const args = [
+        "split-window",
+        "-d",
+        "-h",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "-c",
+        opts.cwd,
+      ];
+      const parent = opts.parentPane ?? process.env.TMUX_PANE;
+      if (parent) {
+        args.splice(4, 0, "-t", parent);
+      }
+      paneId = execFileSync("tmux", args, {
+        encoding: "utf8",
+        timeout: 10000,
+      }).trim();
+    }
+    if (!paneId.startsWith("%")) {
+      throw new Error(`Unexpected tmux pane id: ${paneId || "(empty)"}`);
+    }
+    if (!opts.background) {
+      // Pane title is cosmetic and the new window already shows `name`.
+      try {
+        execFileSync("tmux", ["select-pane", "-t", paneId, "-T", opts.name], {
+          encoding: "utf8",
+        });
+      } catch {
+        // Pane title is cosmetic and can fail on older tmux versions.
+      }
+    }
+    return { paneId, windowName };
+  }
 
-	isPaneAlive(paneId: string): boolean {
-		try {
-			execFileSync("tmux", ["display-message", "-p", "-t", paneId, "#{pane_id}"], {
-				stdio: "ignore",
-				timeout: 5000,
-			});
-			return true;
-		} catch {
-			return false;
-		}
-	}
+  isPaneAlive(paneId: string): boolean {
+    try {
+      execFileSync(
+        "tmux",
+        ["display-message", "-p", "-t", paneId, "#{pane_id}"],
+        {
+          stdio: "ignore",
+          timeout: 5000,
+        },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
-	sendKeys(paneId: string, text: string): void {
-		execFileSync("tmux", ["send-keys", "-t", paneId, "-l", text], {
-			encoding: "utf8",
-			timeout: 5000,
-		});
-	}
+  sendKeys(paneId: string, text: string): void {
+    execFileSync("tmux", ["send-keys", "-t", paneId, "-l", text], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+  }
 
-	sendEnter(paneId: string): void {
-		execFileSync("tmux", ["send-keys", "-t", paneId, "Enter"], {
-			encoding: "utf8",
-			timeout: 5000,
-		});
-	}
+  sendEnter(paneId: string): void {
+    execFileSync("tmux", ["send-keys", "-t", paneId, "Enter"], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+  }
 
-	killPane(paneId: string): void {
-		try {
-			execFileSync("tmux", ["kill-pane", "-t", paneId], {
-				stdio: "ignore",
-				timeout: 5000,
-			});
-		} catch {
-			// Best effort — pane may already be dead.
-		}
-	}
+  killPane(paneId: string): void {
+    try {
+      execFileSync("tmux", ["kill-pane", "-t", paneId], {
+        stdio: "ignore",
+        timeout: 5000,
+      });
+    } catch {
+      // Best effort — pane may already be dead.
+    }
+  }
 
-	buildAttachCommands(opts: { paneId: string; windowName?: string }): {
-		attachCommand: string;
-		focusCommand: string;
-	} {
-		if (opts.windowName) {
-			// Background mode: pane lives in a named detached window. Attach
-			// command chains `attach -t <session>` with
-			// `select-window -t <windowName>` so it works from outside the
-			// session too. Inside-tmux callers get the same effect via `\;`
-			// chaining — the attach errors with "nested sessions" but the
-			// select-window still runs.
-			const location = getPaneLocation(opts.paneId);
-			return {
-				attachCommand: `tmux attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(opts.windowName)}`,
-				focusCommand: `tmux select-window -t ${shellEscape(opts.windowName)}`,
-			};
-		}
-		// Visible split: attach by pane id inside the parent's window.
-		const location = getPaneLocation(opts.paneId);
-		const targetWindow = `${location.session}:${location.window}`;
-		return {
-			attachCommand: `tmux attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(targetWindow)} \\; select-pane -t ${shellEscape(opts.paneId)}`,
-			focusCommand: `tmux select-pane -t ${shellEscape(opts.paneId)}`,
-		};
-	}
+  buildAttachCommands(opts: { paneId: string; windowName?: string }): {
+    attachCommand: string;
+    focusCommand: string;
+  } {
+    if (opts.windowName) {
+      // Background mode: pane lives in a named detached window. Attach
+      // command chains `attach -t <session>` with
+      // `select-window -t <windowName>` so it works from outside the
+      // session too. Inside-tmux callers get the same effect via `\;`
+      // chaining — the attach errors with "nested sessions" but the
+      // select-window still runs.
+      const location = getPaneLocation(opts.paneId);
+      return {
+        attachCommand: `tmux attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(opts.windowName)}`,
+        focusCommand: `tmux select-window -t ${shellEscape(opts.windowName)}`,
+      };
+    }
+    // Visible split: attach by pane id inside the parent's window.
+    const location = getPaneLocation(opts.paneId);
+    const targetWindow = `${location.session}:${location.window}`;
+    return {
+      attachCommand: `tmux attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(targetWindow)} \\; select-pane -t ${shellEscape(opts.paneId)}`,
+      focusCommand: `tmux select-pane -t ${shellEscape(opts.paneId)}`,
+    };
+  }
 }
 
 /**
@@ -244,22 +298,22 @@ export class TmuxMultiplexer implements Multiplexer {
  * tooling that wants to read the option directly.
  */
 export function readPaneExitCode(paneId: string): number | null {
-	try {
-		const value = execFileSync(
-			"tmux",
-			["show-options", "-p", "-v", "-t", paneId, "@pi-exit-code"],
-			// stderr must be ignored: while the child is still running the
-			// option is unset and tmux would otherwise print
-			// `invalid option: @pi-exit-code` to the parent's stderr (the
-			// agent's TUI). We rely on the non-zero exit + catch below to
-			// detect "not set", not on stderr.
-			{ encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 },
-		).trim();
-		if (!value) return null;
-		const n = Number(value);
-		return Number.isFinite(n) ? n : null;
-	} catch {
-		// Option unset (still running) or pane dead.
-		return null;
-	}
+  try {
+    const value = execFileSync(
+      "tmux",
+      ["show-options", "-p", "-v", "-t", paneId, "@pi-exit-code"],
+      // stderr must be ignored: while the child is still running the
+      // option is unset and tmux would otherwise print
+      // `invalid option: @pi-exit-code` to the parent's stderr (the
+      // agent's TUI). We rely on the non-zero exit + catch below to
+      // detect "not set", not on stderr.
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 },
+    ).trim();
+    if (!value) return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    // Option unset (still running) or pane dead.
+    return null;
+  }
 }

--- a/src/multiplexer-zellij.test.ts
+++ b/src/multiplexer-zellij.test.ts
@@ -9,516 +9,529 @@ const PANES_BEFORE = JSON.stringify([{ id: 1, tab_position: 0 }]);
 
 /** JSON with an added pane after `new-tab`. */
 const PANES_AFTER = JSON.stringify([
-	{ id: 1, tab_position: 0 },
-	{ id: 2, tab_position: 1 },
+  { id: 1, tab_position: 0 },
+  { id: 2, tab_position: 1 },
 ]);
 
 function installMockExec(scenario: (file: string, args: string[]) => string) {
-	vi.resetModules();
-	vi.doMock("node:child_process", () => ({
-		execFileSync: (_file: string, args: string[]) => scenario("zellij", args as string[]),
-	}));
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) =>
+      scenario("zellij", args as string[]),
+  }));
 }
 
 describe("multiplexer-zellij", () => {
-	beforeEach(() => {
-		const g = globalThis as any;
-		g.__piSubagenturaInteractiveRegistry?.clear?.();
-	});
-
-	afterEach(() => {
-		vi.doUnmock("node:child_process");
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  isAvailable                                                        */
-	/* ------------------------------------------------------------------ */
-
-	it("isAvailable returns true when ZELLIJ env var is set and binary exists", async () => {
-		process.env.ZELLIJ = "0";
-		installMockExec((_f, args) => {
-			// command -v zellij — return empty means success
-			if (args.includes("-lc")) return "";
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(mux.isAvailable()).toBe(true);
-	});
-
-	it("isAvailable is binary-only: returns true even when ZELLIJ env var is unset", async () => {
-		// Regression for the auto-resolution bug: isAvailable must NOT require
-		// ZELLIJ === "0". The "am I inside zellij" heuristic lives in getMux();
-		// keeping it out of isAvailable lets the relaxed-spawn fallback select
-		// zellij from a plain terminal. Symmetric with TmuxMultiplexer.
-		process.env.ZELLIJ = "";
-		delete process.env.ZELLIJ_SESSION_NAME;
-		installMockExec((_f, args) => {
-			if (args.includes("-lc")) return ""; // command -v zellij succeeds
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(mux.isAvailable()).toBe(true);
-	});
-
-	it("isAvailable returns false when zellij binary is not on PATH", async () => {
-		process.env.ZELLIJ = "0";
-		installMockExec((_f, args) => {
-			if (args.includes("-lc")) throw new Error("command not found");
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(mux.isAvailable()).toBe(false);
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  createPane — background mode (new-tab)                             */
-	/* ------------------------------------------------------------------ */
-
-	it("createPane in background mode (new-tab) returns paneId and windowName", async () => {
-		process.env.ZELLIJ = "0";
-		process.env.ZELLIJ_SESSION_NAME = "main";
-		const calls: string[][] = [];
-		let listCallCount = 0;
-
-		installMockExec((_f, args) => {
-			calls.push(args);
-			if (args.includes("list-panes") && args.includes("--json")) {
-				listCallCount++;
-				return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
-			}
-			if (args.includes("new-tab")) return "";
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const result = mux.createPane({ name: "Demo", cwd: "/tmp", background: true });
-
-		expect(result.paneId).toBe("2");
-		expect(result.windowName).toBe("demo");
-		// In-session spawn: session is ZELLIJ_SESSION_NAME so later ops target it.
-		expect(result.session).toBe("main");
-
-		const usedNewTab = calls.some((a) => a.includes("new-tab"));
-		const usedNewPane = calls.some((a) => a.includes("new-pane"));
-		expect(usedNewTab).toBe(true);
-		expect(usedNewPane).toBe(false);
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  createPane — visible-split mode (new-pane)                         */
-	/* ------------------------------------------------------------------ */
-
-	it("createPane in visible-split mode (in zellij) uses new-pane and recovers the list-panes id via diff", async () => {
-		// `new-pane`'s `terminal_<n>` stdout counter is NOT the same number as the
-		// `id` field in `list-panes` (verified on zellij 0.44.3), so createPane
-		// recovers the canonical id from a before/after list-panes diff — the same
-		// number every other op (isPaneAlive/sendKeys/killPane) compares against.
-		process.env.ZELLIJ = "0";
-		process.env.ZELLIJ_SESSION_NAME = "main";
-		const calls: string[][] = [];
-		let listCallCount = 0;
-
-		installMockExec((_f, args) => {
-			calls.push(args);
-			if (args.includes("list-panes") && args.includes("--json")) {
-				listCallCount++;
-				return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
-			}
-			if (args.includes("new-pane")) return "terminal_2\n"; // distinct counter; must be ignored
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const result = mux.createPane({ name: "Demo", cwd: "/tmp", background: false });
-
-		expect(result.paneId).toBe("2"); // from list-panes diff, not new-pane stdout
-		expect(result.windowName).toBeUndefined();
-
-		const usedNewPane = calls.some((a) => a.includes("new-pane"));
-		const usedNewTab = calls.some((a) => a.includes("new-tab"));
-		expect(usedNewPane).toBe(true);
-		expect(usedNewTab).toBe(false);
-	});
-
-	it("createPane new-pane passes neither --in-pane-id nor --close-on-exit", async () => {
-		// `new-pane` has no `--in-pane-id` flag (parentPane has no mapping in
-		// zellij — it splits the focused pane). And `--close-on-exit` makes a
-		// trailing <COMMAND> mandatory, so passing it without a command makes
-		// zellij exit non-zero. Both must be absent.
-		process.env.ZELLIJ = "0";
-		process.env.ZELLIJ_SESSION_NAME = "main";
-		const calls: string[][] = [];
-		let listCallCount = 0;
-
-		installMockExec((_f, args) => {
-			calls.push(args);
-			if (args.includes("list-panes") && args.includes("--json")) {
-				listCallCount++;
-				return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
-			}
-			if (args.includes("new-pane")) return "terminal_2\n";
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		mux.createPane({ name: "Demo", cwd: "/tmp", background: false, parentPane: "1" });
-
-		const newPaneCall = calls.find((a) => a.includes("new-pane"));
-		expect(newPaneCall).toBeDefined();
-		expect(newPaneCall).not.toContain("--in-pane-id");
-		expect(newPaneCall).not.toContain("--close-on-exit");
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  createPane — relaxed path (parent not in zellij)                   */
-	/* ------------------------------------------------------------------ */
-
-	it("createPane relaxed path creates a background session and forces new-tab (no attached client → no split)", async () => {
-		// Parent not in zellij ⇒ no attached client. A visible split is invisible
-		// and isn't tracked by list-panes in a detached session, so createPane
-		// must force background (new-tab) mode even when background:false is asked
-		// — mirroring the tmux backend's relaxed path.
-		process.env.ZELLIJ = "";
-		delete process.env.ZELLIJ_SESSION_NAME;
-		const calls: string[][] = [];
-		let listCallCount = 0;
-
-		installMockExec((_f, args) => {
-			calls.push(args);
-			if (args.includes("attach") && args.includes("--create-background")) return "";
-			if (args.includes("list-panes") && args.includes("--json")) {
-				listCallCount++;
-				return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
-			}
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const result = mux.createPane({
-			name: "Demo",
-			cwd: "/tmp",
-			background: false, // asked for split, but relaxed path must override
-			id: "abc12345",
-		});
-
-		expect(result.paneId).toBe("2");
-		// The created session must be returned so the orchestrator can persist it
-		// on state.muxSession and target later ops — it is NOT held on the
-		// (resolver-shared) backend instance.
-		expect(result.session).toBe("pi-subagent-abc12345");
-		const attachCall = calls.find((a) => a.includes("attach"));
-		expect(attachCall).toBeDefined();
-		expect(attachCall).toContain("--create-background");
-		expect(attachCall).toContain("pi-subagent-abc12345");
-		// Forced background: new-tab, never new-pane.
-		expect(calls.some((a) => a.includes("new-tab"))).toBe(true);
-		expect(calls.some((a) => a.includes("new-pane"))).toBe(false);
-		// And every action after session creation must carry --session <name>.
-		const newTabCall = calls.find((a) => a.includes("new-tab"));
-		expect(newTabCall).toEqual(expect.arrayContaining(["--session", "pi-subagent-abc12345"]));
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  isPaneAlive                                                        */
-	/* ------------------------------------------------------------------ */
-
-	it("isPaneAlive returns true when pane exists in list", async () => {
-		process.env.ZELLIJ = "0";
-		installMockExec((_f, args) => {
-			if (args.includes("list-panes") && args.includes("--json")) {
-				return JSON.stringify([
-					{ id: 1 },
-					{ id: 42 },
-					{ id: 3 },
-				]);
-			}
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(mux.isPaneAlive("42")).toBe(true);
-	});
-
-	it("isPaneAlive returns false when pane does not exist in list", async () => {
-		process.env.ZELLIJ = "0";
-		installMockExec((_f, args) => {
-			if (args.includes("list-panes") && args.includes("--json")) {
-				return JSON.stringify([{ id: 1 }, { id: 2 }]);
-			}
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(mux.isPaneAlive("99")).toBe(false);
-	});
-
-	it("isPaneAlive returns false on exec error", async () => {
-		process.env.ZELLIJ = "0";
-		installMockExec(() => {
-			throw new Error("no such pane");
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(mux.isPaneAlive("42")).toBe(false);
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  sendKeys + sendEnter                                               */
-	/* ------------------------------------------------------------------ */
-
-	it("sendKeys calls write-chars with the text", async () => {
-		process.env.ZELLIJ = "0";
-		const calls: string[][] = [];
-
-		installMockExec((_f, args) => {
-			calls.push(args);
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		mux.sendKeys("42", "echo hello");
-
-		const writeCharsCall = calls.find((a) => a.includes("write-chars"));
-		expect(writeCharsCall).toBeDefined();
-		expect(writeCharsCall).toContain("--pane-id");
-		expect(writeCharsCall).toContain("42");
-		expect(writeCharsCall).toContain("echo hello");
-	});
-
-	it("sendEnter calls write with 13 (Enter key)", async () => {
-		process.env.ZELLIJ = "0";
-		const calls: string[][] = [];
-
-		installMockExec((_f, args) => {
-			calls.push(args);
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		mux.sendEnter("42");
-
-		const writeCall = calls.find((a) => a.includes("write") && !a.includes("write-chars"));
-		expect(writeCall).toBeDefined();
-		expect(writeCall).toContain("--pane-id");
-		expect(writeCall).toContain("42");
-		expect(writeCall).toContain("13");
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  killPane                                                           */
-	/* ------------------------------------------------------------------ */
-
-	it("killPane calls close-pane", async () => {
-		process.env.ZELLIJ = "0";
-		const calls: string[][] = [];
-
-		installMockExec((_f, args) => {
-			calls.push(args);
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		mux.killPane("42");
-
-		const closeCall = calls.find((a) => a.includes("close-pane"));
-		expect(closeCall).toBeDefined();
-		expect(closeCall).toContain("--pane-id");
-		expect(closeCall).toContain("42");
-	});
-
-	it("killPane does not throw on error (best-effort)", async () => {
-		process.env.ZELLIJ = "0";
-		installMockExec(() => {
-			throw new Error("pane not found");
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(() => mux.killPane("42")).not.toThrow();
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  buildAttachCommands — with windowName (tab mode)                   */
-	/* ------------------------------------------------------------------ */
-
-	it("buildAttachCommands with windowName returns tab-focused commands", async () => {
-		process.env.ZELLIJ = "0";
-		process.env.ZELLIJ_SESSION_NAME = "main";
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const cmds = mux.buildAttachCommands({ paneId: "42", windowName: "demo" });
-
-		expect(cmds.attachCommand).toBe("zellij attach 'main'");
-		expect(cmds.focusCommand).toBe("zellij action go-to-tab-name 'demo'");
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  buildAttachCommands — without windowName (pane mode)               */
-	/* ------------------------------------------------------------------ */
-
-	it("buildAttachCommands without windowName returns pane-focused commands", async () => {
-		process.env.ZELLIJ = "0";
-		process.env.ZELLIJ_SESSION_NAME = "main";
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const cmds = mux.buildAttachCommands({ paneId: "42" });
-
-		expect(cmds.attachCommand).toBe(
-			"zellij attach 'main'",
-		);
-		// The action is `focus-pane-id <id>` — there is no `focus-pane` subcommand.
-		expect(cmds.focusCommand).toBe("zellij action focus-pane-id 42");
-	});
-
-	it("buildAttachCommands normalizes a terminal_<n> paneId in the focus command", async () => {
-		process.env.ZELLIJ = "0";
-		process.env.ZELLIJ_SESSION_NAME = "main";
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const cmds = mux.buildAttachCommands({ paneId: "terminal_42" });
-		expect(cmds.focusCommand).toBe("zellij action focus-pane-id 42");
-	});
-
-	it("attachCommand for visible split does NOT use tmux \; chaining (zellij doesn't support it)", async () => {
-		process.env.ZELLIJ = "0";
-		process.env.ZELLIJ_SESSION_NAME = "main";
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const cmds = mux.buildAttachCommands({ paneId: "42" });
-
-		// Zellij does not support tmux-style \; command chaining.
-		// The attach command should be a simple `zellij attach <sess>`
-		// without chained actions.
-		expect(cmds.attachCommand).not.toContain("\\;");
-		expect(cmds.attachCommand).toBe("zellij attach 'main'");
-	});
-
-	it("buildAttachCommands uses the session passed via opts (relaxed-path session)", async () => {
-		// The relaxed-path session name is threaded in through opts.session
-		// (persisted on state.muxSession by the orchestrator), NOT stored on the
-		// shared backend instance — so concurrent spawns can't clobber it.
-		process.env.ZELLIJ = "";
-		delete process.env.ZELLIJ_SESSION_NAME;
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-
-		const cmds = mux.buildAttachCommands({
-			paneId: "42",
-			windowName: "demo",
-			session: "pi-subagent-abc123",
-		});
-		expect(cmds.attachCommand).toBe("zellij attach 'pi-subagent-abc123'");
-		expect(cmds.focusCommand).toBe("zellij action go-to-tab-name 'demo'");
-	});
-
-	/* ------------------------------------------------------------------ */
-	/*  session threading + isPaneAlive exited-guard / normalization       */
-	/* ------------------------------------------------------------------ */
-
-	it("ops target the supplied session via --session and normalize prefixed ids", async () => {
-		process.env.ZELLIJ = "0";
-		const calls: string[][] = [];
-		installMockExec((_f, args) => {
-			calls.push(args);
-			if (args.includes("list-panes")) return JSON.stringify([{ id: 42 }]);
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		const sess = "pi-subagent-xyz";
-
-		expect(mux.isPaneAlive("terminal_42", sess)).toBe(true);
-		mux.sendKeys("terminal_42", "echo hi", sess);
-		mux.sendEnter("terminal_42", sess);
-		mux.killPane("terminal_42", sess);
-
-		// Every call carries --session, and the pane id is the bare integer.
-		for (const verb of ["list-panes", "write-chars", "write", "close-pane"]) {
-			const call = calls.find((a) => a.includes(verb));
-			expect(call, verb).toEqual(expect.arrayContaining(["--session", sess]));
-		}
-		const writeChars = calls.find((a) => a.includes("write-chars"))!;
-		expect(writeChars).toEqual(expect.arrayContaining(["--pane-id", "42"]));
-		expect(writeChars).not.toContain("terminal_42");
-	});
-
-	it("isPaneAlive returns false for a pane reported as exited", async () => {
-		// `--close-on-exit` is not always set, so a finished pane can linger in
-		// list-panes with exited:true. Presence alone must not mean 'alive'.
-		process.env.ZELLIJ = "0";
-		installMockExec((_f, args) => {
-			if (args.includes("list-panes")) {
-				return JSON.stringify([{ id: 42, exited: true }]);
-			}
-			return "";
-		});
-
-		const { ZellijMultiplexer } = await importFresh<typeof import("./multiplexer-zellij")>(
-			"./multiplexer-zellij",
-		);
-		const mux = new ZellijMultiplexer();
-		expect(mux.isPaneAlive("42")).toBe(false);
-	});
+  beforeEach(() => {
+    const g = globalThis as any;
+    g.__piSubagenturaInteractiveRegistry?.clear?.();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("node:child_process");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  isAvailable                                                        */
+  /* ------------------------------------------------------------------ */
+
+  it("isAvailable returns true when ZELLIJ env var is set and binary exists", async () => {
+    process.env.ZELLIJ = "0";
+    installMockExec((_f, args) => {
+      // command -v zellij — return empty means success
+      if (args.includes("-lc")) return "";
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(mux.isAvailable()).toBe(true);
+  });
+
+  it("isAvailable is binary-only: returns true even when ZELLIJ env var is unset", async () => {
+    // Regression for the auto-resolution bug: isAvailable must NOT require
+    // ZELLIJ === "0". The "am I inside zellij" heuristic lives in getMux();
+    // keeping it out of isAvailable lets the relaxed-spawn fallback select
+    // zellij from a plain terminal. Symmetric with TmuxMultiplexer.
+    process.env.ZELLIJ = "";
+    delete process.env.ZELLIJ_SESSION_NAME;
+    installMockExec((_f, args) => {
+      if (args.includes("-lc")) return ""; // command -v zellij succeeds
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(mux.isAvailable()).toBe(true);
+  });
+
+  it("isAvailable returns false when zellij binary is not on PATH", async () => {
+    process.env.ZELLIJ = "0";
+    installMockExec((_f, args) => {
+      if (args.includes("-lc")) throw new Error("command not found");
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(mux.isAvailable()).toBe(false);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — background mode (new-tab)                             */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane in background mode (new-tab) returns paneId and windowName", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    const calls: string[][] = [];
+    let listCallCount = 0;
+
+    installMockExec((_f, args) => {
+      calls.push(args);
+      if (args.includes("list-panes") && args.includes("--json")) {
+        listCallCount++;
+        return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
+      }
+      if (args.includes("new-tab")) return "";
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const result = mux.createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: true,
+    });
+
+    expect(result.paneId).toBe("2");
+    expect(result.windowName).toBe("demo");
+    // In-session spawn: session is ZELLIJ_SESSION_NAME so later ops target it.
+    expect(result.session).toBe("main");
+
+    const usedNewTab = calls.some((a) => a.includes("new-tab"));
+    const usedNewPane = calls.some((a) => a.includes("new-pane"));
+    expect(usedNewTab).toBe(true);
+    expect(usedNewPane).toBe(false);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — visible-split mode (new-pane)                         */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane in visible-split mode (in zellij) uses new-pane and recovers the list-panes id via diff", async () => {
+    // `new-pane`'s `terminal_<n>` stdout counter is NOT the same number as the
+    // `id` field in `list-panes` (verified on zellij 0.44.3), so createPane
+    // recovers the canonical id from a before/after list-panes diff — the same
+    // number every other op (isPaneAlive/sendKeys/killPane) compares against.
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    const calls: string[][] = [];
+    let listCallCount = 0;
+
+    installMockExec((_f, args) => {
+      calls.push(args);
+      if (args.includes("list-panes") && args.includes("--json")) {
+        listCallCount++;
+        return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
+      }
+      if (args.includes("new-pane")) return "terminal_2\n"; // distinct counter; must be ignored
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const result = mux.createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: false,
+    });
+
+    expect(result.paneId).toBe("2"); // from list-panes diff, not new-pane stdout
+    expect(result.windowName).toBeUndefined();
+
+    const usedNewPane = calls.some((a) => a.includes("new-pane"));
+    const usedNewTab = calls.some((a) => a.includes("new-tab"));
+    expect(usedNewPane).toBe(true);
+    expect(usedNewTab).toBe(false);
+  });
+
+  it("createPane new-pane passes neither --in-pane-id nor --close-on-exit", async () => {
+    // `new-pane` has no `--in-pane-id` flag (parentPane has no mapping in
+    // zellij — it splits the focused pane). And `--close-on-exit` makes a
+    // trailing <COMMAND> mandatory, so passing it without a command makes
+    // zellij exit non-zero. Both must be absent.
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    const calls: string[][] = [];
+    let listCallCount = 0;
+
+    installMockExec((_f, args) => {
+      calls.push(args);
+      if (args.includes("list-panes") && args.includes("--json")) {
+        listCallCount++;
+        return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
+      }
+      if (args.includes("new-pane")) return "terminal_2\n";
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    mux.createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: false,
+      parentPane: "1",
+    });
+
+    const newPaneCall = calls.find((a) => a.includes("new-pane"));
+    expect(newPaneCall).toBeDefined();
+    expect(newPaneCall).not.toContain("--in-pane-id");
+    expect(newPaneCall).not.toContain("--close-on-exit");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — relaxed path (parent not in zellij)                   */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane relaxed path creates a background session and forces new-tab (no attached client → no split)", async () => {
+    // Parent not in zellij ⇒ no attached client. A visible split is invisible
+    // and isn't tracked by list-panes in a detached session, so createPane
+    // must force background (new-tab) mode even when background:false is asked
+    // — mirroring the tmux backend's relaxed path.
+    process.env.ZELLIJ = "";
+    delete process.env.ZELLIJ_SESSION_NAME;
+    const calls: string[][] = [];
+    let listCallCount = 0;
+
+    installMockExec((_f, args) => {
+      calls.push(args);
+      if (args.includes("attach") && args.includes("--create-background"))
+        return "";
+      if (args.includes("list-panes") && args.includes("--json")) {
+        listCallCount++;
+        return listCallCount === 1 ? PANES_BEFORE : PANES_AFTER;
+      }
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const result = mux.createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: false, // asked for split, but relaxed path must override
+      id: "abc12345",
+    });
+
+    expect(result.paneId).toBe("2");
+    // The created session must be returned so the orchestrator can persist it
+    // on state.muxSession and target later ops — it is NOT held on the
+    // (resolver-shared) backend instance.
+    expect(result.session).toBe("pi-subagent-abc12345");
+    const attachCall = calls.find((a) => a.includes("attach"));
+    expect(attachCall).toBeDefined();
+    expect(attachCall).toContain("--create-background");
+    expect(attachCall).toContain("pi-subagent-abc12345");
+    // Forced background: new-tab, never new-pane.
+    expect(calls.some((a) => a.includes("new-tab"))).toBe(true);
+    expect(calls.some((a) => a.includes("new-pane"))).toBe(false);
+    // And every action after session creation must carry --session <name>.
+    const newTabCall = calls.find((a) => a.includes("new-tab"));
+    expect(newTabCall).toEqual(
+      expect.arrayContaining(["--session", "pi-subagent-abc12345"]),
+    );
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  isPaneAlive                                                        */
+  /* ------------------------------------------------------------------ */
+
+  it("isPaneAlive returns true when pane exists in list", async () => {
+    process.env.ZELLIJ = "0";
+    installMockExec((_f, args) => {
+      if (args.includes("list-panes") && args.includes("--json")) {
+        return JSON.stringify([{ id: 1 }, { id: 42 }, { id: 3 }]);
+      }
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(mux.isPaneAlive("42")).toBe(true);
+  });
+
+  it("isPaneAlive returns false when pane does not exist in list", async () => {
+    process.env.ZELLIJ = "0";
+    installMockExec((_f, args) => {
+      if (args.includes("list-panes") && args.includes("--json")) {
+        return JSON.stringify([{ id: 1 }, { id: 2 }]);
+      }
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(mux.isPaneAlive("99")).toBe(false);
+  });
+
+  it("isPaneAlive returns false on exec error", async () => {
+    process.env.ZELLIJ = "0";
+    installMockExec(() => {
+      throw new Error("no such pane");
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(mux.isPaneAlive("42")).toBe(false);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  sendKeys + sendEnter                                               */
+  /* ------------------------------------------------------------------ */
+
+  it("sendKeys calls write-chars with the text", async () => {
+    process.env.ZELLIJ = "0";
+    const calls: string[][] = [];
+
+    installMockExec((_f, args) => {
+      calls.push(args);
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    mux.sendKeys("42", "echo hello");
+
+    const writeCharsCall = calls.find((a) => a.includes("write-chars"));
+    expect(writeCharsCall).toBeDefined();
+    expect(writeCharsCall).toContain("--pane-id");
+    expect(writeCharsCall).toContain("42");
+    expect(writeCharsCall).toContain("echo hello");
+  });
+
+  it("sendEnter calls write with 13 (Enter key)", async () => {
+    process.env.ZELLIJ = "0";
+    const calls: string[][] = [];
+
+    installMockExec((_f, args) => {
+      calls.push(args);
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    mux.sendEnter("42");
+
+    const writeCall = calls.find(
+      (a) => a.includes("write") && !a.includes("write-chars"),
+    );
+    expect(writeCall).toBeDefined();
+    expect(writeCall).toContain("--pane-id");
+    expect(writeCall).toContain("42");
+    expect(writeCall).toContain("13");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  killPane                                                           */
+  /* ------------------------------------------------------------------ */
+
+  it("killPane calls close-pane", async () => {
+    process.env.ZELLIJ = "0";
+    const calls: string[][] = [];
+
+    installMockExec((_f, args) => {
+      calls.push(args);
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    mux.killPane("42");
+
+    const closeCall = calls.find((a) => a.includes("close-pane"));
+    expect(closeCall).toBeDefined();
+    expect(closeCall).toContain("--pane-id");
+    expect(closeCall).toContain("42");
+  });
+
+  it("killPane does not throw on error (best-effort)", async () => {
+    process.env.ZELLIJ = "0";
+    installMockExec(() => {
+      throw new Error("pane not found");
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(() => mux.killPane("42")).not.toThrow();
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  buildAttachCommands — with windowName (tab mode)                   */
+  /* ------------------------------------------------------------------ */
+
+  it("buildAttachCommands with windowName returns tab-focused commands", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const cmds = mux.buildAttachCommands({ paneId: "42", windowName: "demo" });
+
+    expect(cmds.attachCommand).toBe("zellij attach 'main'");
+    expect(cmds.focusCommand).toBe("zellij action go-to-tab-name 'demo'");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  buildAttachCommands — without windowName (pane mode)               */
+  /* ------------------------------------------------------------------ */
+
+  it("buildAttachCommands without windowName returns pane-focused commands", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const cmds = mux.buildAttachCommands({ paneId: "42" });
+
+    expect(cmds.attachCommand).toBe("zellij attach 'main'");
+    // The action is `focus-pane-id <id>` — there is no `focus-pane` subcommand.
+    expect(cmds.focusCommand).toBe("zellij action focus-pane-id 42");
+  });
+
+  it("buildAttachCommands normalizes a terminal_<n> paneId in the focus command", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const cmds = mux.buildAttachCommands({ paneId: "terminal_42" });
+    expect(cmds.focusCommand).toBe("zellij action focus-pane-id 42");
+  });
+
+  it("attachCommand for visible split does NOT use tmux \; chaining (zellij doesn't support it)", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const cmds = mux.buildAttachCommands({ paneId: "42" });
+
+    // Zellij does not support tmux-style \; command chaining.
+    // The attach command should be a simple `zellij attach <sess>`
+    // without chained actions.
+    expect(cmds.attachCommand).not.toContain("\\;");
+    expect(cmds.attachCommand).toBe("zellij attach 'main'");
+  });
+
+  it("buildAttachCommands uses the session passed via opts (relaxed-path session)", async () => {
+    // The relaxed-path session name is threaded in through opts.session
+    // (persisted on state.muxSession by the orchestrator), NOT stored on the
+    // shared backend instance — so concurrent spawns can't clobber it.
+    process.env.ZELLIJ = "";
+    delete process.env.ZELLIJ_SESSION_NAME;
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+
+    const cmds = mux.buildAttachCommands({
+      paneId: "42",
+      windowName: "demo",
+      session: "pi-subagent-abc123",
+    });
+    expect(cmds.attachCommand).toBe("zellij attach 'pi-subagent-abc123'");
+    expect(cmds.focusCommand).toBe("zellij action go-to-tab-name 'demo'");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  session threading + isPaneAlive exited-guard / normalization       */
+  /* ------------------------------------------------------------------ */
+
+  it("ops target the supplied session via --session and normalize prefixed ids", async () => {
+    process.env.ZELLIJ = "0";
+    const calls: string[][] = [];
+    installMockExec((_f, args) => {
+      calls.push(args);
+      if (args.includes("list-panes")) return JSON.stringify([{ id: 42 }]);
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const sess = "pi-subagent-xyz";
+
+    expect(mux.isPaneAlive("terminal_42", sess)).toBe(true);
+    mux.sendKeys("terminal_42", "echo hi", sess);
+    mux.sendEnter("terminal_42", sess);
+    mux.killPane("terminal_42", sess);
+
+    // Every call carries --session, and the pane id is the bare integer.
+    for (const verb of ["list-panes", "write-chars", "write", "close-pane"]) {
+      const call = calls.find((a) => a.includes(verb));
+      expect(call, verb).toEqual(expect.arrayContaining(["--session", sess]));
+    }
+    const writeChars = calls.find((a) => a.includes("write-chars"))!;
+    expect(writeChars).toEqual(expect.arrayContaining(["--pane-id", "42"]));
+    expect(writeChars).not.toContain("terminal_42");
+  });
+
+  it("isPaneAlive returns false for a pane reported as exited", async () => {
+    // `--close-on-exit` is not always set, so a finished pane can linger in
+    // list-panes with exited:true. Presence alone must not mean 'alive'.
+    process.env.ZELLIJ = "0";
+    installMockExec((_f, args) => {
+      if (args.includes("list-panes")) {
+        return JSON.stringify([{ id: 42, exited: true }]);
+      }
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("./multiplexer-zellij")
+    >("./multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(mux.isPaneAlive("42")).toBe(false);
+  });
 });

--- a/src/multiplexer-zellij.ts
+++ b/src/multiplexer-zellij.ts
@@ -33,13 +33,13 @@ import { commandExists, shellEscape } from "./multiplexer";
 
 /** Sanitize a free-form name into a safe segment for zellij tab/session names. */
 function safeSegment(value: string): string {
-	return (
-		value
-			.toLowerCase()
-			.replace(/[^a-z0-9._-]+/g, "-")
-			.replace(/-+/g, "-")
-			.replace(/^-|-$/g, "") || "subagent"
-	);
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "subagent"
+  );
 }
 
 /**
@@ -49,244 +49,261 @@ function safeSegment(value: string): string {
  * round-trips through `isPaneAlive` / `sendKeys` / `killPane`.
  */
 function normalizePaneId(raw: string): string {
-	return raw.trim().replace(/^(?:terminal_|plugin_)/, "");
+  return raw.trim().replace(/^(?:terminal_|plugin_)/, "");
 }
 
 export class ZellijMultiplexer implements Multiplexer {
-	readonly name = "zellij" as const;
+  readonly name = "zellij" as const;
 
-	/**
-	 * True iff `zellij` is on PATH. Binary-only — symmetric with
-	 * `TmuxMultiplexer.isAvailable()`. The "am I inside a zellij session"
-	 * heuristic (`ZELLIJ` / `ZELLIJ_SESSION_NAME`) lives in `getMux()`'s
-	 * auto-resolution, NOT here, so the relaxed-spawn fallback in `getMux()`
-	 * can select zellij from a plain terminal (it creates a detached session
-	 * in `createPane`). Previously this also required `ZELLIJ === "0"`, which
-	 * made zellij unreachable via `preference: "auto"` outside a session.
-	 */
-	isAvailable(): boolean {
-		return commandExists("zellij");
-	}
+  /**
+   * True iff `zellij` is on PATH. Binary-only — symmetric with
+   * `TmuxMultiplexer.isAvailable()`. The "am I inside a zellij session"
+   * heuristic (`ZELLIJ` / `ZELLIJ_SESSION_NAME`) lives in `getMux()`'s
+   * auto-resolution, NOT here, so the relaxed-spawn fallback in `getMux()`
+   * can select zellij from a plain terminal (it creates a detached session
+   * in `createPane`). Previously this also required `ZELLIJ === "0"`, which
+   * made zellij unreachable via `preference: "auto"` outside a session.
+   */
+  isAvailable(): boolean {
+    return commandExists("zellij");
+  }
 
-	/**
-	 * Build the `--session <name>` argv prefix, or `[]` when no session is
-	 * known (operate on the current/attached session).
-	 */
-	private sessionFlag(session?: string): string[] {
-		return session ? ["--session", session] : [];
-	}
+  /**
+   * Build the `--session <name>` argv prefix, or `[]` when no session is
+   * known (operate on the current/attached session).
+   */
+  private sessionFlag(session?: string): string[] {
+    return session ? ["--session", session] : [];
+  }
 
-	/**
-	 * Create a pane for the child process.
-	 *
-	 * When the parent is in zellij (the common case):
-	 *   - background: true  → `new-tab -n <name>` in the current session
-	 *   - background: false → `new-pane --direction right --close-on-exit`
-	 *
-	 * When the parent is NOT in zellij (the relaxed spawn path), creates a
-	 * brand-new detached session named `pi-subagent-<id>` first, then creates
-	 * the pane/tab inside it.
-	 *
-	 * Returns the session the pane lives in so the caller can address it later.
-	 */
-	createPane(opts: {
-		name: string;
-		cwd: string;
-		background: boolean;
-		parentPane?: string;
-		windowName?: string;
-		id?: string;
-	}): { paneId: string; windowName?: string; session?: string } {
-		if (!commandExists("zellij")) {
-			throw new Error("zellij is not available. Install zellij or set PATH to include it.");
-		}
+  /**
+   * Create a pane for the child process.
+   *
+   * When the parent is in zellij (the common case):
+   *   - background: true  → `new-tab -n <name>` in the current session
+   *   - background: false → `new-pane --direction right --close-on-exit`
+   *
+   * When the parent is NOT in zellij (the relaxed spawn path), creates a
+   * brand-new detached session named `pi-subagent-<id>` first, then creates
+   * the pane/tab inside it.
+   *
+   * Returns the session the pane lives in so the caller can address it later.
+   */
+  createPane(opts: {
+    name: string;
+    cwd: string;
+    background: boolean;
+    parentPane?: string;
+    windowName?: string;
+    id?: string;
+  }): { paneId: string; windowName?: string; session?: string } {
+    if (!commandExists("zellij")) {
+      throw new Error(
+        "zellij is not available. Install zellij or set PATH to include it.",
+      );
+    }
 
-		let windowName: string | undefined;
-		const isInZellij = !!process.env.ZELLIJ;
+    let windowName: string | undefined;
+    const isInZellij = !!process.env.ZELLIJ;
 
-		let session: string;
-		if (!isInZellij) {
-			// Relaxed path: parent not in zellij. Create a background session.
-			session = `pi-subagent-${opts.id ?? safeSegment(opts.name)}`;
-			execFileSync("zellij", ["attach", "--create-background", session], {
-				encoding: "utf8",
-				timeout: 10000,
-			});
-		} else {
-			session = process.env.ZELLIJ_SESSION_NAME ?? "";
-		}
+    let session: string;
+    if (!isInZellij) {
+      // Relaxed path: parent not in zellij. Create a background session.
+      session = `pi-subagent-${opts.id ?? safeSegment(opts.name)}`;
+      execFileSync("zellij", ["attach", "--create-background", session], {
+        encoding: "utf8",
+        timeout: 10000,
+      });
+    } else {
+      session = process.env.ZELLIJ_SESSION_NAME ?? "";
+    }
 
-		const sessionFlag = this.sessionFlag(session);
+    const sessionFlag = this.sessionFlag(session);
 
-		// A visible side-by-side split only works when a client is attached to
-		// the session: in a detached session zellij doesn't materialize the new
-		// pane (it never shows up in `list-panes`). When the parent isn't in
-		// zellij we have no attached client, so force background (new-tab) mode
-		// — matching how the tmux backend treats its relaxed path. `new-tab`
-		// panes are tracked in detached sessions; `new-pane` panes are not.
-		const useBackground = opts.background || !isInZellij;
+    // A visible side-by-side split only works when a client is attached to
+    // the session: in a detached session zellij doesn't materialize the new
+    // pane (it never shows up in `list-panes`). When the parent isn't in
+    // zellij we have no attached client, so force background (new-tab) mode
+    // — matching how the tmux backend treats its relaxed path. `new-tab`
+    // panes are tracked in detached sessions; `new-pane` panes are not.
+    const useBackground = opts.background || !isInZellij;
 
-		// Snapshot panes before creating, so we can identify the new pane by
-		// diffing afterwards. Neither `new-tab` nor `new-pane` gives us an id
-		// that round-trips against `list-panes` (new-pane prints a `terminal_N`
-		// counter that is distinct from the `id` field every other op compares
-		// against), so the diff is the canonical way to recover the pane id.
-		const panesBefore = this.listPanes(session);
+    // Snapshot panes before creating, so we can identify the new pane by
+    // diffing afterwards. Neither `new-tab` nor `new-pane` gives us an id
+    // that round-trips against `list-panes` (new-pane prints a `terminal_N`
+    // counter that is distinct from the `id` field every other op compares
+    // against), so the diff is the canonical way to recover the pane id.
+    const panesBefore = this.listPanes(session);
 
-		if (useBackground) {
-			windowName = opts.windowName ?? safeSegment(opts.name);
-			execFileSync("zellij", [...sessionFlag, "action", "new-tab", "--name", windowName], {
-				encoding: "utf8",
-				timeout: 10000,
-			});
-		} else {
-			// Visible split — side-by-side with the focused pane. zellij splits
-			// relative to the currently-focused pane; there is no flag to split
-			// from a specific pane id (`new-pane` has no `--in-pane-id`), so
-			// `opts.parentPane` is intentionally ignored. No `--close-on-exit`:
-			// that flag makes a trailing `<COMMAND>` mandatory, and we want a
-			// plain shell pane that outlives the launch script (like tmux's split).
-			execFileSync("zellij", [...sessionFlag, "action", "new-pane", "--direction", "right"], {
-				encoding: "utf8",
-				timeout: 10000,
-			});
-		}
+    if (useBackground) {
+      windowName = opts.windowName ?? safeSegment(opts.name);
+      execFileSync(
+        "zellij",
+        [...sessionFlag, "action", "new-tab", "--name", windowName],
+        {
+          encoding: "utf8",
+          timeout: 10000,
+        },
+      );
+    } else {
+      // Visible split — side-by-side with the focused pane. zellij splits
+      // relative to the currently-focused pane; there is no flag to split
+      // from a specific pane id (`new-pane` has no `--in-pane-id`), so
+      // `opts.parentPane` is intentionally ignored. No `--close-on-exit`:
+      // that flag makes a trailing `<COMMAND>` mandatory, and we want a
+      // plain shell pane that outlives the launch script (like tmux's split).
+      execFileSync(
+        "zellij",
+        [...sessionFlag, "action", "new-pane", "--direction", "right"],
+        {
+          encoding: "utf8",
+          timeout: 10000,
+        },
+      );
+    }
 
-		const panesAfter = this.listPanes(session);
-		const beforeIds = new Set(panesBefore.map((p) => String(p.id)));
-		// Ignore plugin panes (the tab-bar / status-bar plugins zellij spawns) —
-		// only a real terminal pane can host the child shell.
-		const newPanes = panesAfter.filter((p) => !beforeIds.has(String(p.id)) && !p.is_plugin);
-		const chosen = newPanes[0] ?? panesAfter.find((p) => !p.is_plugin) ?? panesAfter[0];
-		const paneId = chosen ? normalizePaneId(String(chosen.id)) : "";
-		if (!paneId) {
-			throw new Error("Failed to determine pane ID after creating pane");
-		}
+    const panesAfter = this.listPanes(session);
+    const beforeIds = new Set(panesBefore.map((p) => String(p.id)));
+    // Ignore plugin panes (the tab-bar / status-bar plugins zellij spawns) —
+    // only a real terminal pane can host the child shell.
+    const newPanes = panesAfter.filter(
+      (p) => !beforeIds.has(String(p.id)) && !p.is_plugin,
+    );
+    const chosen =
+      newPanes[0] ?? panesAfter.find((p) => !p.is_plugin) ?? panesAfter[0];
+    const paneId = chosen ? normalizePaneId(String(chosen.id)) : "";
+    if (!paneId) {
+      throw new Error("Failed to determine pane ID after creating pane");
+    }
 
-		return { paneId, windowName, session: session || undefined };
-	}
+    return { paneId, windowName, session: session || undefined };
+  }
 
-	/** Run `list-panes --json` against a session, returning [] on any failure. */
-	private listPanes(
-		session?: string,
-	): Array<{ id: unknown; is_plugin?: boolean; exited?: boolean }> {
-		try {
-			const output = execFileSync(
-				"zellij",
-				[...this.sessionFlag(session), "action", "list-panes", "--json"],
-				{ encoding: "utf8", timeout: 5000 },
-			);
-			const parsed = JSON.parse(output);
-			return Array.isArray(parsed) ? parsed : [];
-		} catch {
-			return [];
-		}
-	}
+  /** Run `list-panes --json` against a session, returning [] on any failure. */
+  private listPanes(
+    session?: string,
+  ): Array<{ id: unknown; is_plugin?: boolean; exited?: boolean }> {
+    try {
+      const output = execFileSync(
+        "zellij",
+        [...this.sessionFlag(session), "action", "list-panes", "--json"],
+        { encoding: "utf8", timeout: 5000 },
+      );
+      const parsed = JSON.parse(output);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
 
-	/**
-	 * Probe whether the pane is still alive. Runs `list-panes --json` and
-	 * checks whether the pane ID appears AND has not exited. Returns false on
-	 * any error (dead pane, backend down, malformed id).
-	 */
-	isPaneAlive(paneId: string, session?: string): boolean {
-		const target = normalizePaneId(paneId);
-		return this.listPanes(session).some(
-			(p) => String(p.id) === target && p.exited !== true,
-		);
-	}
+  /**
+   * Probe whether the pane is still alive. Runs `list-panes --json` and
+   * checks whether the pane ID appears AND has not exited. Returns false on
+   * any error (dead pane, backend down, malformed id).
+   */
+  isPaneAlive(paneId: string, session?: string): boolean {
+    const target = normalizePaneId(paneId);
+    return this.listPanes(session).some(
+      (p) => String(p.id) === target && p.exited !== true,
+    );
+  }
 
-	/**
-	 * Send literal text to the pane's shell input buffer, character by
-	 * character. Does NOT submit (no Enter).
-	 */
-	sendKeys(paneId: string, text: string, session?: string): void {
-		execFileSync(
-			"zellij",
-			[
-				...this.sessionFlag(session),
-				"action",
-				"write-chars",
-				"--pane-id",
-				normalizePaneId(paneId),
-				text,
-			],
-			{ encoding: "utf8", timeout: 5000 },
-		);
-	}
+  /**
+   * Send literal text to the pane's shell input buffer, character by
+   * character. Does NOT submit (no Enter).
+   */
+  sendKeys(paneId: string, text: string, session?: string): void {
+    execFileSync(
+      "zellij",
+      [
+        ...this.sessionFlag(session),
+        "action",
+        "write-chars",
+        "--pane-id",
+        normalizePaneId(paneId),
+        text,
+      ],
+      { encoding: "utf8", timeout: 5000 },
+    );
+  }
 
-	/**
-	 * Send a single Enter / Return key to the pane (decimal 13 = Enter key).
-	 */
-	sendEnter(paneId: string, session?: string): void {
-		execFileSync(
-			"zellij",
-			[
-				...this.sessionFlag(session),
-				"action",
-				"write",
-				"--pane-id",
-				normalizePaneId(paneId),
-				"13",
-			],
-			{ encoding: "utf8", timeout: 5000 },
-		);
-	}
+  /**
+   * Send a single Enter / Return key to the pane (decimal 13 = Enter key).
+   */
+  sendEnter(paneId: string, session?: string): void {
+    execFileSync(
+      "zellij",
+      [
+        ...this.sessionFlag(session),
+        "action",
+        "write",
+        "--pane-id",
+        normalizePaneId(paneId),
+        "13",
+      ],
+      { encoding: "utf8", timeout: 5000 },
+    );
+  }
 
-	/**
-	 * Kill the pane. Best-effort — no throw on already-dead panes.
-	 */
-	killPane(paneId: string, session?: string): void {
-		try {
-			execFileSync(
-				"zellij",
-				[
-					...this.sessionFlag(session),
-					"action",
-					"close-pane",
-					"--pane-id",
-					normalizePaneId(paneId),
-				],
-				{ stdio: "ignore", timeout: 5000 },
-			);
-		} catch {
-			// Best effort — pane may already be dead.
-		}
-	}
+  /**
+   * Kill the pane. Best-effort — no throw on already-dead panes.
+   */
+  killPane(paneId: string, session?: string): void {
+    try {
+      execFileSync(
+        "zellij",
+        [
+          ...this.sessionFlag(session),
+          "action",
+          "close-pane",
+          "--pane-id",
+          normalizePaneId(paneId),
+        ],
+        { stdio: "ignore", timeout: 5000 },
+      );
+    } catch {
+      // Best effort — pane may already be dead.
+    }
+  }
 
-	/**
-	 * Build the user-facing commands to attach to (or focus) the child's pane.
-	 *
-	 * Two forms:
-	 *   - `attachCommand`: works from a plain shell — attaches to the zellij
-	 *     session.
-	 *   - `focusCommand`: works from inside the same zellij session — goes to
-	 *     the tab (background mode) or focuses the pane by id (split mode).
-	 *
-	 * Session name comes from the `session` returned by `createPane` (threaded
-	 * through by the caller), falling back to `ZELLIJ_SESSION_NAME` for an
-	 * in-session spawn.
-	 */
-	buildAttachCommands(opts: { paneId: string; windowName?: string; session?: string }): {
-		attachCommand: string;
-		focusCommand: string;
-	} {
-		const sessionName = opts.session || process.env.ZELLIJ_SESSION_NAME || "";
-		const escapedSession = shellEscape(sessionName);
+  /**
+   * Build the user-facing commands to attach to (or focus) the child's pane.
+   *
+   * Two forms:
+   *   - `attachCommand`: works from a plain shell — attaches to the zellij
+   *     session.
+   *   - `focusCommand`: works from inside the same zellij session — goes to
+   *     the tab (background mode) or focuses the pane by id (split mode).
+   *
+   * Session name comes from the `session` returned by `createPane` (threaded
+   * through by the caller), falling back to `ZELLIJ_SESSION_NAME` for an
+   * in-session spawn.
+   */
+  buildAttachCommands(opts: {
+    paneId: string;
+    windowName?: string;
+    session?: string;
+  }): {
+    attachCommand: string;
+    focusCommand: string;
+  } {
+    const sessionName = opts.session || process.env.ZELLIJ_SESSION_NAME || "";
+    const escapedSession = shellEscape(sessionName);
 
-		if (opts.windowName) {
-			// Background mode: pane lives in a named tab.
-			return {
-				attachCommand: `zellij attach ${escapedSession}`,
-				focusCommand: `zellij action go-to-tab-name ${shellEscape(opts.windowName)}`,
-			};
-		}
+    if (opts.windowName) {
+      // Background mode: pane lives in a named tab.
+      return {
+        attachCommand: `zellij attach ${escapedSession}`,
+        focusCommand: `zellij action go-to-tab-name ${shellEscape(opts.windowName)}`,
+      };
+    }
 
-		// Visible split: focus by pane id. The zellij action is `focus-pane-id`
-		// (there is no `focus-pane`), and it takes the bare pane id as a
-		// positional argument. No `\;` chaining — that's tmux-only syntax.
-		return {
-			attachCommand: `zellij attach ${escapedSession}`,
-			focusCommand: `zellij action focus-pane-id ${normalizePaneId(opts.paneId)}`,
-		};
-	}
+    // Visible split: focus by pane id. The zellij action is `focus-pane-id`
+    // (there is no `focus-pane`), and it takes the bare pane id as a
+    // positional argument. No `\;` chaining — that's tmux-only syntax.
+    return {
+      attachCommand: `zellij attach ${escapedSession}`,
+      focusCommand: `zellij action focus-pane-id ${normalizePaneId(opts.paneId)}`,
+    };
+  }
 }

--- a/src/multiplexer.test.ts
+++ b/src/multiplexer.test.ts
@@ -21,95 +21,114 @@ import { importFresh } from "./test-utils";
  * heuristic lives in `getMux()`'s auto-resolution, not in `isAvailable()`.
  */
 describe("getMux relaxed-spawn resolution", () => {
-	let originalEnv: NodeJS.ProcessEnv;
+  let originalEnv: NodeJS.ProcessEnv;
 
-	beforeEach(() => {
-		originalEnv = { ...process.env };
-		delete process.env.TMUX;
-		delete process.env.ZELLIJ;
-		delete process.env.ZELLIJ_SESSION_NAME;
-	});
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.TMUX;
+    delete process.env.ZELLIJ;
+    delete process.env.ZELLIJ_SESSION_NAME;
+  });
 
-	afterEach(() => {
-		process.env = originalEnv;
-		vi.doUnmock("node:child_process");
-	});
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.doUnmock("node:child_process");
+  });
 
-	it("getMux auto returns TmuxMultiplexer when TMUX/ZELLIJ env vars unset but tmux binary exists", async () => {
-		// Arrange: mock execFileSync so commandExists("tmux") returns true.
-		vi.doMock("node:child_process", () => ({
-			execFileSync: (_file: string, args: string[]) => {
-				const joined = args.join(" ");
-				if (joined.includes("command -v 'tmux'")) return "";
-				throw new Error("unexpected exec: " + joined);
-			},
-		} as unknown as typeof import("node:child_process")));
+  it("getMux auto returns TmuxMultiplexer when TMUX/ZELLIJ env vars unset but tmux binary exists", async () => {
+    // Arrange: mock execFileSync so commandExists("tmux") returns true.
+    vi.doMock(
+      "node:child_process",
+      () =>
+        ({
+          execFileSync: (_file: string, args: string[]) => {
+            const joined = args.join(" ");
+            if (joined.includes("command -v 'tmux'")) return "";
+            throw new Error("unexpected exec: " + joined);
+          },
+        }) as unknown as typeof import("node:child_process"),
+    );
 
-		const { getMux, __resetMuxInstances } =
-			await importFresh<typeof import("./multiplexer")>("./multiplexer");
-		__resetMuxInstances();
+    const { getMux, __resetMuxInstances } =
+      await importFresh<typeof import("./multiplexer")>("./multiplexer");
+    __resetMuxInstances();
 
-		// Act
-		const mux = getMux({ preference: "auto" });
+    // Act
+    const mux = getMux({ preference: "auto" });
 
-		// Assert
-		expect(mux).toBeDefined();
-		expect(mux.name).toBe("tmux");
-	});
+    // Assert
+    expect(mux).toBeDefined();
+    expect(mux.name).toBe("tmux");
+  });
 
-	it("getMux auto returns ZellijMultiplexer when only the zellij binary exists (relaxed-spawn fallback)", async () => {
-		// Regression for the auto-resolution asymmetry: with no env vars set and
-		// only zellij on PATH, auto must fall back to zellij (its isAvailable is
-		// now binary-only). Previously it threw because zellij.isAvailable()
-		// required ZELLIJ === "0".
-		vi.doMock("node:child_process", () => ({
-			execFileSync: (_file: string, args: string[]) => {
-				const joined = args.join(" ");
-				if (joined.includes("command -v 'zellij'")) return "";
-				if (joined.includes("command -v 'tmux'")) throw new Error("no tmux");
-				throw new Error("unexpected exec: " + joined);
-			},
-		} as unknown as typeof import("node:child_process")));
+  it("getMux auto returns ZellijMultiplexer when only the zellij binary exists (relaxed-spawn fallback)", async () => {
+    // Regression for the auto-resolution asymmetry: with no env vars set and
+    // only zellij on PATH, auto must fall back to zellij (its isAvailable is
+    // now binary-only). Previously it threw because zellij.isAvailable()
+    // required ZELLIJ === "0".
+    vi.doMock(
+      "node:child_process",
+      () =>
+        ({
+          execFileSync: (_file: string, args: string[]) => {
+            const joined = args.join(" ");
+            if (joined.includes("command -v 'zellij'")) return "";
+            if (joined.includes("command -v 'tmux'"))
+              throw new Error("no tmux");
+            throw new Error("unexpected exec: " + joined);
+          },
+        }) as unknown as typeof import("node:child_process"),
+    );
 
-		const { getMux, __resetMuxInstances } =
-			await importFresh<typeof import("./multiplexer")>("./multiplexer");
-		__resetMuxInstances();
+    const { getMux, __resetMuxInstances } =
+      await importFresh<typeof import("./multiplexer")>("./multiplexer");
+    __resetMuxInstances();
 
-		const mux = getMux({ preference: "auto" });
-		expect(mux.name).toBe("zellij");
-	});
+    const mux = getMux({ preference: "auto" });
+    expect(mux.name).toBe("zellij");
+  });
 
-	it("getMux throws NoMultiplexerAvailableError when neither binary exists", async () => {
-		// Arrange: mock execFileSync so commandExists always throws.
-		vi.doMock("node:child_process", () => ({
-			execFileSync: () => {
-				throw new Error("ENOENT");
-			},
-		} as unknown as typeof import("node:child_process")));
+  it("getMux throws NoMultiplexerAvailableError when neither binary exists", async () => {
+    // Arrange: mock execFileSync so commandExists always throws.
+    vi.doMock(
+      "node:child_process",
+      () =>
+        ({
+          execFileSync: () => {
+            throw new Error("ENOENT");
+          },
+        }) as unknown as typeof import("node:child_process"),
+    );
 
-		const { getMux, __resetMuxInstances } =
-			await importFresh<typeof import("./multiplexer")>("./multiplexer");
-		__resetMuxInstances();
+    const { getMux, __resetMuxInstances } =
+      await importFresh<typeof import("./multiplexer")>("./multiplexer");
+    __resetMuxInstances();
 
-		// Act & Assert
-		expect(() => getMux({ preference: "auto" })).toThrow("No multiplexer available");
-	});
+    // Act & Assert
+    expect(() => getMux({ preference: "auto" })).toThrow(
+      "No multiplexer available",
+    );
+  });
 
-	it("getMux explicit preference bypasses all env checks", async () => {
-		// Even with no env vars and binary unavailable, explicit preference
-		// should return the requested backend (the error comes later at
-		// createPane time, not at resolution time).
-		vi.doMock("node:child_process", () => ({
-			execFileSync: () => {
-				throw new Error("ENOENT");
-			},
-		} as unknown as typeof import("node:child_process")));
+  it("getMux explicit preference bypasses all env checks", async () => {
+    // Even with no env vars and binary unavailable, explicit preference
+    // should return the requested backend (the error comes later at
+    // createPane time, not at resolution time).
+    vi.doMock(
+      "node:child_process",
+      () =>
+        ({
+          execFileSync: () => {
+            throw new Error("ENOENT");
+          },
+        }) as unknown as typeof import("node:child_process"),
+    );
 
-		const { getMux, __resetMuxInstances } =
-			await importFresh<typeof import("./multiplexer")>("./multiplexer");
-		__resetMuxInstances();
+    const { getMux, __resetMuxInstances } =
+      await importFresh<typeof import("./multiplexer")>("./multiplexer");
+    __resetMuxInstances();
 
-		const mux = getMux({ preference: "tmux" });
-		expect(mux.name).toBe("tmux");
-	});
+    const mux = getMux({ preference: "tmux" });
+    expect(mux.name).toBe("tmux");
+  });
 });

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -37,121 +37,125 @@ export type MuxName = "tmux" | "zellij";
  * same backend that created it.
  */
 export interface Multiplexer {
-	readonly name: MuxName;
+  readonly name: MuxName;
 
-	/**
-	 * True iff this backend's binary is on PATH AND a server is currently
-	 * running that we can attach to / create panes in. Used by the resolver
-	 * and by the `subagent_interactive` tool's preflight check.
-	 *
-	 * MUST be cheap (no network, no prompt). Implementations are expected to
-	 * probe the env var + run a single `display-message` / `list-sessions`
-	 * equivalent with a short timeout.
-	 */
-	isAvailable(): boolean;
+  /**
+   * True iff this backend's binary is on PATH AND a server is currently
+   * running that we can attach to / create panes in. Used by the resolver
+   * and by the `subagent_interactive` tool's preflight check.
+   *
+   * MUST be cheap (no network, no prompt). Implementations are expected to
+   * probe the env var + run a single `display-message` / `list-sessions`
+   * equivalent with a short timeout.
+   */
+  isAvailable(): boolean;
 
-	/**
-	 * Create a new pane for the child process.
-	 *
-	 * @param opts.name          Display name for the pane (used as tmux window
-	 *                           name in background mode, or as the zellij pane
-	 *                           name). Safe-segmented by the caller.
-	 * @param opts.cwd           Working directory for the spawned shell.
-	 * @param opts.background    true = invisible (new detached window/tab);
-	 *                           false = visible side-by-side split of the
-	 *                           parent pane (parent must be attached to a mux
-	 *                           session for the split mode to work — callers
-	 *                           should fall back to background when the parent
-	 *                           is not in a session).
-	 * @param opts.parentPane    Parent pane id for split mode. Required when
-	 *                           `background === false`. Ignored otherwise.
-	 * @param opts.windowName    Optional explicit name for the detached
-	 *                           window/tab. Backends are free to ignore this
-	 *                           and generate their own (zellij requires unique
-	 *                           tab names per session).
-	 * @returns paneId           String id usable in subsequent `sendKeys` /
-	 *                           `isPaneAlive` / `killPane` calls. The string
-	 *                           format is backend-specific (tmux uses `%N`,
-	 *                           zellij uses `terminal_N` or just an integer
-	 *                           stringified).
-	 * @returns windowName       The actual window/tab name used (for
-	 *                           `attachCommand` formatting). Always defined
-	 *                           for background mode, undefined for visible
-	 *                           split mode (the pane lives in the same window
-	 *                           as the parent).
-	 */
-	createPane(opts: {
-		name: string;
-		cwd: string;
-		background: boolean;
-		parentPane?: string;
-		windowName?: string;
-		/** Unique id (8 hex) for naming the new session when parent is not in a mux. */
-		id?: string;
-	}): { paneId: string; windowName?: string; session?: string };
+  /**
+   * Create a new pane for the child process.
+   *
+   * @param opts.name          Display name for the pane (used as tmux window
+   *                           name in background mode, or as the zellij pane
+   *                           name). Safe-segmented by the caller.
+   * @param opts.cwd           Working directory for the spawned shell.
+   * @param opts.background    true = invisible (new detached window/tab);
+   *                           false = visible side-by-side split of the
+   *                           parent pane (parent must be attached to a mux
+   *                           session for the split mode to work — callers
+   *                           should fall back to background when the parent
+   *                           is not in a session).
+   * @param opts.parentPane    Parent pane id for split mode. Required when
+   *                           `background === false`. Ignored otherwise.
+   * @param opts.windowName    Optional explicit name for the detached
+   *                           window/tab. Backends are free to ignore this
+   *                           and generate their own (zellij requires unique
+   *                           tab names per session).
+   * @returns paneId           String id usable in subsequent `sendKeys` /
+   *                           `isPaneAlive` / `killPane` calls. The string
+   *                           format is backend-specific (tmux uses `%N`,
+   *                           zellij uses `terminal_N` or just an integer
+   *                           stringified).
+   * @returns windowName       The actual window/tab name used (for
+   *                           `attachCommand` formatting). Always defined
+   *                           for background mode, undefined for visible
+   *                           split mode (the pane lives in the same window
+   *                           as the parent).
+   */
+  createPane(opts: {
+    name: string;
+    cwd: string;
+    background: boolean;
+    parentPane?: string;
+    windowName?: string;
+    /** Unique id (8 hex) for naming the new session when parent is not in a mux. */
+    id?: string;
+  }): { paneId: string; windowName?: string; session?: string };
 
-	/**
-	 * Probe whether the pane is still alive (the backend still knows about
-	 * it). MUST NOT throw — return false on any failure (dead pane, backend
-	 * down, pane id malformed). Used by the artifact poller on every tick.
-	 *
-	 * @param session  The session returned by `createPane`. zellij needs it to
-	 *                 target the right server; tmux ignores it (pane ids are
-	 *                 server-global).
-	 */
-	isPaneAlive(paneId: string, session?: string): boolean;
+  /**
+   * Probe whether the pane is still alive (the backend still knows about
+   * it). MUST NOT throw — return false on any failure (dead pane, backend
+   * down, pane id malformed). Used by the artifact poller on every tick.
+   *
+   * @param session  The session returned by `createPane`. zellij needs it to
+   *                 target the right server; tmux ignores it (pane ids are
+   *                 server-global).
+   */
+  isPaneAlive(paneId: string, session?: string): boolean;
 
-	/**
-	 * Send literal text to the pane's shell input buffer, character-by-character.
-	 * Does NOT submit (no Enter). Callers that want to submit pair this with
-	 * a second call to `sendEnter`.
-	 *
-	 * The text may contain newlines (used by the launch script template);
-	 * backends are expected to deliver them verbatim.
-	 *
-	 * @param session  The session returned by `createPane` (zellij needs it;
-	 *                 tmux ignores it).
-	 */
-	sendKeys(paneId: string, text: string, session?: string): void;
+  /**
+   * Send literal text to the pane's shell input buffer, character-by-character.
+   * Does NOT submit (no Enter). Callers that want to submit pair this with
+   * a second call to `sendEnter`.
+   *
+   * The text may contain newlines (used by the launch script template);
+   * backends are expected to deliver them verbatim.
+   *
+   * @param session  The session returned by `createPane` (zellij needs it;
+   *                 tmux ignores it).
+   */
+  sendKeys(paneId: string, text: string, session?: string): void;
 
-	/**
-	 * Send a single Enter / Return key to the pane, submitting whatever is
-	 * in the input buffer. Kept separate from `sendKeys` because the encoding
-	 * differs (tmux uses a key name, zellij uses a byte value).
-	 *
-	 * @param session  The session returned by `createPane` (zellij needs it;
-	 *                 tmux ignores it).
-	 */
-	sendEnter(paneId: string, session?: string): void;
+  /**
+   * Send a single Enter / Return key to the pane, submitting whatever is
+   * in the input buffer. Kept separate from `sendKeys` because the encoding
+   * differs (tmux uses a key name, zellij uses a byte value).
+   *
+   * @param session  The session returned by `createPane` (zellij needs it;
+   *                 tmux ignores it).
+   */
+  sendEnter(paneId: string, session?: string): void;
 
-	/**
-	 * Kill the pane. MUST be best-effort: no throw on already-dead panes.
-	 * Used by the cancel path and the orphan-pane guard.
-	 *
-	 * @param session  The session returned by `createPane` (zellij needs it;
-	 *                 tmux ignores it).
-	 */
-	killPane(paneId: string, session?: string): void;
+  /**
+   * Kill the pane. MUST be best-effort: no throw on already-dead panes.
+   * Used by the cancel path and the orphan-pane guard.
+   *
+   * @param session  The session returned by `createPane` (zellij needs it;
+   *                 tmux ignores it).
+   */
+  killPane(paneId: string, session?: string): void;
 
-	/**
-	 * Build the user-facing commands to attach to (or focus) the child's pane.
-	 *
-	 * Two forms are returned because the UX differs based on whether the user
-	 * is currently inside a mux session:
-	 *   - `attachCommand` works from a plain shell (`tmux attach -t <sess>`
-	 *     or `zellij attach <sess>`). Falls back to a `switch-client` style
-	 *     command when run from inside an existing session.
-	 *   - `focusCommand` works from inside the same mux session (`select-window`
-	 *     / `go-to-tab-name`). No-op if the user is not attached.
-	 *
-	 * Both strings are intended to be copy-pasted into a terminal by the user
-	 * — they should be safe to display verbatim and survive a paste into any
-	 * shell (no quoting required by the caller).
-	 */
-	buildAttachCommands(opts: { paneId: string; windowName?: string; session?: string }): {
-		attachCommand: string;
-		focusCommand: string;
-	};
+  /**
+   * Build the user-facing commands to attach to (or focus) the child's pane.
+   *
+   * Two forms are returned because the UX differs based on whether the user
+   * is currently inside a mux session:
+   *   - `attachCommand` works from a plain shell (`tmux attach -t <sess>`
+   *     or `zellij attach <sess>`). Falls back to a `switch-client` style
+   *     command when run from inside an existing session.
+   *   - `focusCommand` works from inside the same mux session (`select-window`
+   *     / `go-to-tab-name`). No-op if the user is not attached.
+   *
+   * Both strings are intended to be copy-pasted into a terminal by the user
+   * — they should be safe to display verbatim and survive a paste into any
+   * shell (no quoting required by the caller).
+   */
+  buildAttachCommands(opts: {
+    paneId: string;
+    windowName?: string;
+    session?: string;
+  }): {
+    attachCommand: string;
+    focusCommand: string;
+  };
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -159,21 +163,21 @@ export interface Multiplexer {
  * ──────────────────────────────────────────────────────────────────────────── */
 
 export interface GetMuxOptions {
-	/**
-	 * Explicit backend choice. `'auto'` (the default) walks the env-var +
-	 * availability chain described in the file header.
-	 */
-	preference?: MuxName | "auto";
+  /**
+   * Explicit backend choice. `'auto'` (the default) walks the env-var +
+   * availability chain described in the file header.
+   */
+  preference?: MuxName | "auto";
 }
 
 export class NoMultiplexerAvailableError extends Error {
-	constructor() {
-		super(
-			"No multiplexer available. Start pi inside tmux or zellij, " +
-				"for example: tmux new -A -s pi 'pi'  —  or install one of them and ensure a server is running.",
-		);
-		this.name = "NoMultiplexerAvailableError";
-	}
+  constructor() {
+    super(
+      "No multiplexer available. Start pi inside tmux or zellij, " +
+        "for example: tmux new -A -s pi 'pi'  —  or install one of them and ensure a server is running.",
+    );
+    this.name = "NoMultiplexerAvailableError";
+  }
 }
 
 /**
@@ -185,28 +189,28 @@ export class NoMultiplexerAvailableError extends Error {
  * is cheap on the hot path because it just looks up the cached instance.
  */
 export function getMux(opts: GetMuxOptions = {}): Multiplexer {
-	const tmux = getOrCreate("tmux", () => new TmuxMultiplexer());
-	const zellij = getOrCreate("zellij", () => new ZellijMultiplexer());
+  const tmux = getOrCreate("tmux", () => new TmuxMultiplexer());
+  const zellij = getOrCreate("zellij", () => new ZellijMultiplexer());
 
-	const preference = opts.preference ?? "auto";
-	if (preference === "tmux") return tmux;
-	if (preference === "zellij") return zellij;
+  const preference = opts.preference ?? "auto";
+  if (preference === "tmux") return tmux;
+  if (preference === "zellij") return zellij;
 
-	// Auto: prefer the mux already attached to this process. We check env vars
-	// (cheap) before probing availability (one exec call each). If both env
-	// vars are set (e.g., nested sessions — exotic but possible), zellij wins
-	// (it's the more specific signal — ZELLIJ_SESSION_NAME is a single session
-	// name, TMUX can be inherited through nested tmux-in-tmux shells).
-	if (process.env.ZELLIJ_SESSION_NAME && zellij.isAvailable()) return zellij;
-	if (process.env.TMUX && tmux.isAvailable()) return tmux;
+  // Auto: prefer the mux already attached to this process. We check env vars
+  // (cheap) before probing availability (one exec call each). If both env
+  // vars are set (e.g., nested sessions — exotic but possible), zellij wins
+  // (it's the more specific signal — ZELLIJ_SESSION_NAME is a single session
+  // name, TMUX can be inherited through nested tmux-in-tmux shells).
+  if (process.env.ZELLIJ_SESSION_NAME && zellij.isAvailable()) return zellij;
+  if (process.env.TMUX && tmux.isAvailable()) return tmux;
 
-	// Neither env var matched. Fall back to whichever backend is available;
-	// tmux first to preserve existing user setups that rely on `tmux` being
-	// on PATH even when the parent isn't attached.
-	if (tmux.isAvailable()) return tmux;
-	if (zellij.isAvailable()) return zellij;
+  // Neither env var matched. Fall back to whichever backend is available;
+  // tmux first to preserve existing user setups that rely on `tmux` being
+  // on PATH even when the parent isn't attached.
+  if (tmux.isAvailable()) return tmux;
+  if (zellij.isAvailable()) return zellij;
 
-	throw new NoMultiplexerAvailableError();
+  throw new NoMultiplexerAvailableError();
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -216,29 +220,29 @@ export function getMux(opts: GetMuxOptions = {}): Multiplexer {
 const instances = new Map<MuxName, Multiplexer>();
 
 function getOrCreate(name: MuxName, factory: () => Multiplexer): Multiplexer {
-	let inst = instances.get(name);
-	if (!inst) {
-		inst = factory();
-		instances.set(name, inst);
-	}
-	return inst;
+  let inst = instances.get(name);
+  if (!inst) {
+    inst = factory();
+    instances.set(name, inst);
+  }
+  return inst;
 }
 
 /** Test seam: replace the cached tmux backend. Pass `undefined` to restore. */
 export function __setTmuxMultiplexer(impl: Multiplexer | undefined): void {
-	if (impl) instances.set("tmux", impl);
-	else instances.delete("tmux");
+  if (impl) instances.set("tmux", impl);
+  else instances.delete("tmux");
 }
 
 /** Test seam: replace the cached zellij backend. Pass `undefined` to restore. */
 export function __setZellijMultiplexer(impl: Multiplexer | undefined): void {
-	if (impl) instances.set("zellij", impl);
-	else instances.delete("zellij");
+  if (impl) instances.set("zellij", impl);
+  else instances.delete("zellij");
 }
 
 /** Test seam: clear all cached backend instances (forces re-instantiation). */
 export function __resetMuxInstances(): void {
-	instances.clear();
+  instances.clear();
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -251,18 +255,18 @@ export function __resetMuxInstances(): void {
  * against a hung PATH (e.g., NFS hang) blocking the agent's startup probe.
  */
 export function commandExists(command: string): boolean {
-	try {
-		execFileSync("/bin/sh", ["-lc", `command -v ${shellEscape(command)}`], {
-			stdio: "ignore",
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
+  try {
+    execFileSync("/bin/sh", ["-lc", `command -v ${shellEscape(command)}`], {
+      stdio: "ignore",
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** POSIX-style single-quote escape. Safe for paths, names, and command args. */
 export function shellEscape(value: string): string {
-	return `'${value.replace(/'/g, `'\\''`)}'`;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }

--- a/src/published-tarball.test.ts
+++ b/src/published-tarball.test.ts
@@ -20,7 +20,13 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -28,116 +34,133 @@ import { fileURLToPath } from "node:url";
 
 const REPO = resolve(fileURLToPath(import.meta.url), "..", "..");
 const PKG = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
-	name: string;
-	version: string;
-	files: string[];
+  name: string;
+  version: string;
+  files: string[];
 };
 
 interface PackResult {
-	tgz: string;
-	entries: string[];
-	pkgDir: string;
+  tgz: string;
+  entries: string[];
+  pkgDir: string;
 }
 
 function pack(work: string): PackResult {
-	const packed = spawnSync("npm", ["pack", "--pack-destination", work, "--silent"], {
-		cwd: REPO,
-		encoding: "utf8",
-	});
-	if (packed.status !== 0) {
-		throw new Error(`npm pack failed (exit ${packed.status}):\n${packed.stderr || packed.stdout}`);
-	}
-	const tgzName = readdirSync(work).find((f) => f.endsWith(".tgz"));
-	if (!tgzName) {
-		throw new Error(`npm pack produced no .tgz in ${work}\nstdout: ${packed.stdout}`);
-	}
-	const tgz = join(work, tgzName);
+  const packed = spawnSync(
+    "npm",
+    ["pack", "--pack-destination", work, "--silent"],
+    {
+      cwd: REPO,
+      encoding: "utf8",
+    },
+  );
+  if (packed.status !== 0) {
+    throw new Error(
+      `npm pack failed (exit ${packed.status}):\n${packed.stderr || packed.stdout}`,
+    );
+  }
+  const tgzName = readdirSync(work).find((f) => f.endsWith(".tgz"));
+  if (!tgzName) {
+    throw new Error(
+      `npm pack produced no .tgz in ${work}\nstdout: ${packed.stdout}`,
+    );
+  }
+  const tgz = join(work, tgzName);
 
-	const list = spawnSync("tar", ["-tzf", tgz], { encoding: "utf8" });
-	if (list.status !== 0) {
-		throw new Error(`tar -tzf failed (exit ${list.status}):\n${list.stderr}`);
-	}
-	const entries = list.stdout
-		.split("\n")
-		.map((s) => s.trim())
-		.filter(Boolean)
-		.map((e) => e.replace(/^package\//, ""));
+  const list = spawnSync("tar", ["-tzf", tgz], { encoding: "utf8" });
+  if (list.status !== 0) {
+    throw new Error(`tar -tzf failed (exit ${list.status}):\n${list.stderr}`);
+  }
+  const entries = list.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((e) => e.replace(/^package\//, ""));
 
-	const pkgDir = join(work, "pkg");
-	mkdirSync(pkgDir);
-	const extract = spawnSync("tar", ["-xzf", tgz, "-C", pkgDir], { encoding: "utf8" });
-	if (extract.status !== 0) {
-		throw new Error(`tar -xzf failed (exit ${extract.status}):\n${extract.stderr}`);
-	}
+  const pkgDir = join(work, "pkg");
+  mkdirSync(pkgDir);
+  const extract = spawnSync("tar", ["-xzf", tgz, "-C", pkgDir], {
+    encoding: "utf8",
+  });
+  if (extract.status !== 0) {
+    throw new Error(
+      `tar -xzf failed (exit ${extract.status}):\n${extract.stderr}`,
+    );
+  }
 
-	return { tgz, entries, pkgDir: join(pkgDir, "package") };
+  return { tgz, entries, pkgDir: join(pkgDir, "package") };
 }
 
 /** Returns the module specifier for every `from "./foo"` (or `./foo/bar`) in source. */
 function localImports(source: string): string[] {
-	const re = /from\s+["'](\.\/[^"']+)["']/g;
-	const out: string[] = [];
-	let m: RegExpExecArray | null;
-	while ((m = re.exec(source)) !== null) out.push(m[1].slice(2)); // strip "./"
-	return out;
+  const re = /from\s+["'](\.\/[^"']+)["']/g;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) out.push(m[1].slice(2)); // strip "./"
+  return out;
 }
 
 /** Local module `./foo` resolves to either `./foo.ts` or `./foo/index.ts`. */
 function resolvesInTarball(mod: string, entries: string[]): boolean {
-	return entries.includes(`src/${mod}.ts`) || entries.includes(`src/${mod}/index.ts`);
+  return (
+    entries.includes(`src/${mod}.ts`) || entries.includes(`src/${mod}/index.ts`)
+  );
 }
 
 describe("published tarball", () => {
-	const work = mkdtempSync(join(tmpdir(), "pi-subagentura-pubtest-"));
-	let entries: string[] = [];
-	let pkgDir = "";
+  const work = mkdtempSync(join(tmpdir(), "pi-subagentura-pubtest-"));
+  let entries: string[] = [];
+  let pkgDir = "";
 
-	beforeAll(() => {
-		const r = pack(work);
-		entries = r.entries;
-		pkgDir = r.pkgDir;
-	});
+  beforeAll(() => {
+    const r = pack(work);
+    entries = r.entries;
+    pkgDir = r.pkgDir;
+  });
 
-	afterAll(() => {
-		rmSync(work, { recursive: true, force: true });
-	});
+  afterAll(() => {
+    rmSync(work, { recursive: true, force: true });
+  });
 
-	it("npm pack produces a non-empty tarball", () => {
-		expect(entries.length, `tarball empty; working dir: ${work}`).toBeGreaterThan(0);
-	});
+  it("npm pack produces a non-empty tarball", () => {
+    expect(
+      entries.length,
+      `tarball empty; working dir: ${work}`,
+    ).toBeGreaterThan(0);
+  });
 
-	it("package.json `files` array matches the tarball contents", () => {
-		const missing = PKG.files.filter((f) => !entries.includes(f));
-		expect(
-			missing,
-			`tarball is missing files declared in package.json: ${missing.join(", ")}`
-		).toEqual([]);
-	});
+  it("package.json `files` array matches the tarball contents", () => {
+    const missing = PKG.files.filter((f) => !entries.includes(f));
+    expect(
+      missing,
+      `tarball is missing files declared in package.json: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
 
-	it("contains src/helpers.ts (regression test for the v2.0.0 publish bug)", () => {
-		expect(
-			entries,
-			"src/helpers.ts is missing from the tarball — this is the exact pi-subagentura@2.0.0 regression. " +
-				"Re-add it to package.json `files`."
-		).toContain("src/helpers.ts");
-	});
+  it("contains src/helpers.ts (regression test for the v2.0.0 publish bug)", () => {
+    expect(
+      entries,
+      "src/helpers.ts is missing from the tarball — this is the exact pi-subagentura@2.0.0 regression. " +
+        "Re-add it to package.json `files`.",
+    ).toContain("src/helpers.ts");
+  });
 
-	it("every local import in shipped .ts files resolves to a file in the tarball", () => {
-		const failures: string[] = [];
-		for (const entry of entries) {
-			if (!entry.endsWith(".ts")) continue;
-			const src = readFileSync(join(pkgDir, entry), "utf8");
-			for (const mod of localImports(src)) {
-				if (!resolvesInTarball(mod, entries)) {
-					failures.push(
-						`${entry} imports './${mod}' but no candidate (${mod}.ts, ${mod}/index.ts) is in the tarball`,
-					);
-				}
-			}
-		}
-		expect(
-			failures,
-			failures.length === 0 ? "" : `\n${failures.join("\n")}`,
-		).toEqual([]);
-	});
+  it("every local import in shipped .ts files resolves to a file in the tarball", () => {
+    const failures: string[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith(".ts")) continue;
+      const src = readFileSync(join(pkgDir, entry), "utf8");
+      for (const mod of localImports(src)) {
+        if (!resolvesInTarball(mod, entries)) {
+          failures.push(
+            `${entry} imports './${mod}' but no candidate (${mod}.ts, ${mod}/index.ts) is in the tarball`,
+          );
+        }
+      }
+    }
+    expect(
+      failures,
+      failures.length === 0 ? "" : `\n${failures.join("\n")}`,
+    ).toEqual([]);
+  });
 });

--- a/src/subagent-artifact-cli.test.ts
+++ b/src/subagent-artifact-cli.test.ts
@@ -1,126 +1,153 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { CLI_SOURCE, writeCliScript } from "./subagent-artifact-cli";
 
 function makeTmp(): string {
-	return mkdtempSync(join(tmpdir(), "pi-subagentura-cli-"));
+  return mkdtempSync(join(tmpdir(), "pi-subagentura-cli-"));
 }
 
-function runCli(artDir: string, args: string[], input?: string): { status: number; stdout: string; stderr: string } {
-	// Write the CLI source to the artifact dir, then invoke it.
-	const cliPath = join(artDir, "cli.mjs");
-	writeCliScript(cliPath);
-	const res = spawnSync("node", [cliPath, ...args], {
-		env: { ...process.env, ARTIFACT_DIR: artDir },
-		input,
-		encoding: "utf8",
-	});
-	return { status: res.status ?? -1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+function runCli(
+  artDir: string,
+  args: string[],
+  input?: string,
+): { status: number; stdout: string; stderr: string } {
+  // Write the CLI source to the artifact dir, then invoke it.
+  const cliPath = join(artDir, "cli.mjs");
+  writeCliScript(cliPath);
+  const res = spawnSync("node", [cliPath, ...args], {
+    env: { ...process.env, ARTIFACT_DIR: artDir },
+    input,
+    encoding: "utf8",
+  });
+  return {
+    status: res.status ?? -1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
 }
 
 describe("subagent-artifact CLI", () => {
-	let tmp: string;
+  let tmp: string;
 
-	beforeEach(() => {
-		tmp = makeTmp();
-	});
+  beforeEach(() => {
+    tmp = makeTmp();
+  });
 
-	afterEach(() => {
-		rmSync(tmp, { recursive: true, force: true });
-	});
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
 
-	describe("source", () => {
-		it("starts with a shebang", () => {
-			expect(CLI_SOURCE.startsWith("#!/usr/bin/env node")).toBe(true);
-		});
+  describe("source", () => {
+    it("starts with a shebang", () => {
+      expect(CLI_SOURCE.startsWith("#!/usr/bin/env node")).toBe(true);
+    });
 
-		it("parses as valid JavaScript (node --check)", () => {
-			// Strip the shebang (node can't parse it as a file) and write to a
-			// temp .mjs file, then `node --check` it.
-			const body = CLI_SOURCE.replace(/^#!.*\n/, "");
-			const target = join(tmp, "check.mjs");
-			writeFileSync(target, body);
-			const r = spawnSync("node", ["--check", target], { encoding: "utf8" });
-			expect({ status: r.status, stderr: r.stderr }).toEqual({ status: 0, stderr: "" });
-		});
+    it("parses as valid JavaScript (node --check)", () => {
+      // Strip the shebang (node can't parse it as a file) and write to a
+      // temp .mjs file, then `node --check` it.
+      const body = CLI_SOURCE.replace(/^#!.*\n/, "");
+      const target = join(tmp, "check.mjs");
+      writeFileSync(target, body);
+      const r = spawnSync("node", ["--check", target], { encoding: "utf8" });
+      expect({ status: r.status, stderr: r.stderr }).toEqual({
+        status: 0,
+        stderr: "",
+      });
+    });
 
-		it("the generated cli.mjs is 0o700", () => {
-			const cliPath = join(tmp, "cli.mjs");
-			writeCliScript(cliPath);
-			expect(statSync(cliPath).mode & 0o777).toBe(0o700);
-		});
-	});
+    it("the generated cli.mjs is 0o700", () => {
+      const cliPath = join(tmp, "cli.mjs");
+      writeCliScript(cliPath);
+      expect(statSync(cliPath).mode & 0o777).toBe(0o700);
+    });
+  });
 
-	describe("start", () => {
-		it("writes a started event", () => {
-			const r = runCli(tmp, ["start"]);
-			expect(r.status).toBe(0);
-			const events = readFileSync(join(tmp, "events.ndjson"), "utf8").trim().split("\n");
-			expect(events).toHaveLength(1);
-			const ev = JSON.parse(events[0]);
-			expect(ev.type).toBe("started");
-			expect(ev.status).toBe("running");
-			expect(typeof ev.ts).toBe("number");
-		});
-	});
+  describe("start", () => {
+    it("writes a started event", () => {
+      const r = runCli(tmp, ["start"]);
+      expect(r.status).toBe(0);
+      const events = readFileSync(join(tmp, "events.ndjson"), "utf8")
+        .trim()
+        .split("\n");
+      expect(events).toHaveLength(1);
+      const ev = JSON.parse(events[0]);
+      expect(ev.type).toBe("started");
+      expect(ev.status).toBe("running");
+      expect(typeof ev.ts).toBe("number");
+    });
+  });
 
-	describe("done", () => {
+  describe("done", () => {
+    it("writes a done event with exit code 0 → status done", () => {
+      runCli(tmp, ["done", "0"]);
+      const ev = JSON.parse(
+        readFileSync(join(tmp, "events.ndjson"), "utf8").trim(),
+      );
+      expect(ev.type).toBe("done");
+      expect(ev.status).toBe("done");
+      expect(ev.exitCode).toBe(0);
+    });
 
-		it("writes a done event with exit code 0 → status done", () => {
-			runCli(tmp, ["done", "0"]);
-			const ev = JSON.parse(readFileSync(join(tmp, "events.ndjson"), "utf8").trim());
-			expect(ev.type).toBe("done");
-			expect(ev.status).toBe("done");
-			expect(ev.exitCode).toBe(0);
-		});
+    it("writes a done event with non-zero exit code → status error", () => {
+      runCli(tmp, ["done", "1"]);
+      const ev = JSON.parse(
+        readFileSync(join(tmp, "events.ndjson"), "utf8").trim(),
+      );
+      expect(ev.status).toBe("error");
+      expect(ev.exitCode).toBe(1);
+    });
+  });
 
-		it("writes a done event with non-zero exit code → status error", () => {
-			runCli(tmp, ["done", "1"]);
-			const ev = JSON.parse(readFileSync(join(tmp, "events.ndjson"), "utf8").trim());
-			expect(ev.status).toBe("error");
-			expect(ev.exitCode).toBe(1);
-		});
-	});
+  describe("error", () => {
+    it("writes an error event with message", () => {
+      runCli(tmp, ["error", "boom"]);
+      const ev = JSON.parse(
+        readFileSync(join(tmp, "events.ndjson"), "utf8").trim(),
+      );
+      expect(ev.type).toBe("error");
+      expect(ev.status).toBe("error");
+      expect(ev.message).toBe("boom");
+    });
+  });
 
-	describe("error", () => {
-		it("writes an error event with message", () => {
-			runCli(tmp, ["error", "boom"]);
-			const ev = JSON.parse(readFileSync(join(tmp, "events.ndjson"), "utf8").trim());
-			expect(ev.type).toBe("error");
-			expect(ev.status).toBe("error");
-			expect(ev.message).toBe("boom");
-		});
-	});
+  describe("cancelled", () => {
+    it("writes a cancelled event", () => {
+      runCli(tmp, ["cancelled"]);
+      const ev = JSON.parse(
+        readFileSync(join(tmp, "events.ndjson"), "utf8").trim(),
+      );
+      expect(ev.type).toBe("cancelled");
+      expect(ev.status).toBe("cancelled");
+    });
+  });
 
-	describe("cancelled", () => {
-		it("writes a cancelled event", () => {
-			runCli(tmp, ["cancelled"]);
-			const ev = JSON.parse(readFileSync(join(tmp, "events.ndjson"), "utf8").trim());
-			expect(ev.type).toBe("cancelled");
-			expect(ev.status).toBe("cancelled");
-		});
-	});
+  describe("errors", () => {
+    it("fails when ARTIFACT_DIR is unset", () => {
+      // Spawn without ARTIFACT_DIR
+      const cliPath = join(tmp, "cli.mjs");
+      writeCliScript(cliPath);
+      const r = spawnSync("node", [cliPath, "start"], {
+        env: { ...process.env, ARTIFACT_DIR: "" },
+        encoding: "utf8",
+      });
+      expect(r.status).toBe(2);
+      expect(r.stderr).toContain("ARTIFACT_DIR not set");
+    });
 
-	describe("errors", () => {
-		it("fails when ARTIFACT_DIR is unset", () => {
-			// Spawn without ARTIFACT_DIR
-			const cliPath = join(tmp, "cli.mjs");
-			writeCliScript(cliPath);
-			const r = spawnSync("node", [cliPath, "start"], {
-				env: { ...process.env, ARTIFACT_DIR: "" },
-				encoding: "utf8",
-			});
-			expect(r.status).toBe(2);
-			expect(r.stderr).toContain("ARTIFACT_DIR not set");
-		});
-
-		it("fails on unknown subcommand", () => {
-			const r = runCli(tmp, ["bogus"]);
-			expect(r.status).toBe(2);
-			expect(r.stderr).toContain("Unknown command");
-		});
-	});
+    it("fails on unknown subcommand", () => {
+      const r = runCli(tmp, ["bogus"]);
+      expect(r.status).toBe(2);
+      expect(r.stderr).toContain("Unknown command");
+    });
+  });
 });

--- a/src/subagent-artifact-cli.ts
+++ b/src/subagent-artifact-cli.ts
@@ -19,7 +19,6 @@
  * Exit codes: 0 on success, 2 on usage error (missing env var / unknown cmd).
  */
 
-
 /**
  * The body of the CLI as a string, written verbatim to
  * `$ARTIFACT_DIR/cli.mjs` by `writeLaunchScript`. The string is the literal
@@ -68,11 +67,10 @@ switch (cmd) {
 }
 `;
 
-
-
 /** Test-only helper: write the CLI to a file and chmod it. */
 export function writeCliScript(targetPath: string): void {
-	const { writeFileSync, chmodSync } = require("node:fs") as typeof import("node:fs");
-	writeFileSync(targetPath, CLI_SOURCE, { mode: 0o700 });
-	chmodSync(targetPath, 0o700);
+  const { writeFileSync, chmodSync } =
+    require("node:fs") as typeof import("node:fs");
+  writeFileSync(targetPath, CLI_SOURCE, { mode: 0o700 });
+  chmodSync(targetPath, 0o700);
 }

--- a/src/subagent-auto-done.test.ts
+++ b/src/subagent-auto-done.test.ts
@@ -12,803 +12,893 @@ import type { InteractiveSubagentState } from "./interactive-tmux";
 import { importFresh } from "./test-utils";
 
 function makeTmp(): string {
-	return mkdtempSync(join(tmpdir(), "pi-subagentura-auto-done-"));
+  return mkdtempSync(join(tmpdir(), "pi-subagentura-auto-done-"));
 }
 
 interface MakeOpts {
-	sessionFile?: string;
-	outputContent?: string | null;
+  sessionFile?: string;
+  outputContent?: string | null;
 }
 
-function makeState(overrides: MakeOpts): { id: string; artifactDir: string; state: InteractiveSubagentState } {
-	const id = "id-" + Math.random().toString(36).slice(2, 8);
-	const root = makeTmp();
-	const artifactDir = join(root, id);
-	mkdirSync(artifactDir, { recursive: true });
-	const sessionFile = overrides.sessionFile ?? join(artifactDir, "session.jsonl");
-	if (overrides.outputContent !== undefined && overrides.outputContent !== null) {
-		writeFileSync(join(artifactDir, "output.md"), overrides.outputContent);
-	}
-	const state: InteractiveSubagentState = {
-		id,
-		name: "Test",
-		task: "t",
-		paneId: "%99",
-		sessionFile,
-		cwd: "/tmp",
-		startedAt: Date.now(),
-		status: "running",
-		mux: "tmux",
-		attachCommand: "tmux attach -t sess",
-		selectPaneCommand: "tmux select-pane -t '%99'",
-		launchScriptFile: "/tmp/launch.sh",
-		artifactDir,
-		// Pretend the model stopped 11s ago, past the 10s debounce.
-		lastStopReason: "stop",
-		lastStopReasonAt: Date.now() - 11_000,
-	};
-	return { id, artifactDir, state };
+function makeState(overrides: MakeOpts): {
+  id: string;
+  artifactDir: string;
+  state: InteractiveSubagentState;
+} {
+  const id = "id-" + Math.random().toString(36).slice(2, 8);
+  const root = makeTmp();
+  const artifactDir = join(root, id);
+  mkdirSync(artifactDir, { recursive: true });
+  const sessionFile =
+    overrides.sessionFile ?? join(artifactDir, "session.jsonl");
+  if (
+    overrides.outputContent !== undefined &&
+    overrides.outputContent !== null
+  ) {
+    writeFileSync(join(artifactDir, "output.md"), overrides.outputContent);
+  }
+  const state: InteractiveSubagentState = {
+    id,
+    name: "Test",
+    task: "t",
+    paneId: "%99",
+    sessionFile,
+    cwd: "/tmp",
+    startedAt: Date.now(),
+    status: "running",
+    mux: "tmux",
+    attachCommand: "tmux attach -t sess",
+    selectPaneCommand: "tmux select-pane -t '%99'",
+    launchScriptFile: "/tmp/launch.sh",
+    artifactDir,
+    // Pretend the model stopped 11s ago, past the 10s debounce.
+    lastStopReason: "stop",
+    lastStopReasonAt: Date.now() - 11_000,
+  };
+  return { id, artifactDir, state };
 }
 
 /** Variant of makeState for end-to-end tests: no pre-seeded stopReason. */
-function makeFreshState(overrides: MakeOpts): { id: string; artifactDir: string; state: InteractiveSubagentState } {
-	const seeded = makeState(overrides);
-	seeded.state.lastStopReason = undefined;
-	seeded.state.lastStopReasonAt = undefined;
-	seeded.state.lastStopText = undefined;
-	seeded.state.autoDoneForTurnAt = undefined;
-	return seeded;
+function makeFreshState(overrides: MakeOpts): {
+  id: string;
+  artifactDir: string;
+  state: InteractiveSubagentState;
+} {
+  const seeded = makeState(overrides);
+  seeded.state.lastStopReason = undefined;
+  seeded.state.lastStopReasonAt = undefined;
+  seeded.state.lastStopText = undefined;
+  seeded.state.autoDoneForTurnAt = undefined;
+  return seeded;
 }
 
-function writeAssistantTurn(file: string, ts: number, stopReason: string, text: string): void {
-	const entry = {
-		type: "message",
-		message: {
-			role: "assistant",
-			content: [{ type: "text", text }],
-			api: "openai",
-			provider: "openai",
-			model: "gpt-4",
-			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
-			stopReason,
-			timestamp: ts,
-		},
-	};
-	writeFileSync(file, JSON.stringify(entry) + "\n");
+function writeAssistantTurn(
+  file: string,
+  ts: number,
+  stopReason: string,
+  text: string,
+): void {
+  const entry = {
+    type: "message",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      api: "openai",
+      provider: "openai",
+      model: "gpt-4",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason,
+      timestamp: ts,
+    },
+  };
+  writeFileSync(file, JSON.stringify(entry) + "\n");
 }
 
 describe("auto-done fallback", () => {
-	let root: string;
-
-	beforeEach(() => {
-		// Mock child_process so isTmuxPaneAlive returns true for the synthetic %99 pane used in
-		// makeState. Without this, CI environments without a real %99 pane would make the poller
-		// mark state as "unknown" (pane dead) instead of "running"/"idle", breaking assertions that
-		// check the post-poll status. The mock is permissive: any non-pane-liveness call also
-		// returns success so the poller's "show-options" read for @pi-exit-code doesn't throw.
-		vi.resetModules();
-		vi.doMock("node:child_process", () => ({
-			execFileSync: (_file: string, args: string[]) => {
-				if (args[0] === "display-message") return Buffer.from("%99");
-				return "";
-			},
-		}));
-		root = makeTmp();
-		const g = globalThis as any;
-		g.__piSubagenturaInteractiveRegistry?.clear?.();
-		g.__piSubagenturaPiRef = undefined;
-		g.__piSubagenturaUi = undefined;
-	});
-
-	afterEach(() => {
-		rmSync(root, { recursive: true, force: true });
-	});
-
-	// ─── Core behavior ────────────────────────────────────────────────
-
-	it("synthesizes a done event when stopReason is 'stop' and output.md exists, after the debounce", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "the result" });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const sendMessage = vi.fn();
-		mod.pollArtifactChanges({ sendMessage } as any);
-
-		const art = artifactPath(dirname(artifactDir), state.id);
-		const events = readEvents(art);
-		const done = events.find((e) => e.type === "done");
-		expect(done).toBeDefined();
-	afterEach(() => {
-		rmSync(root, { recursive: true, force: true });
-		vi.doUnmock("node:child_process");
-	});
-		expect(done && done.type === "done" && done.summary).toMatch(/auto-detected/);
-		expect(sendMessage).toHaveBeenCalled();
-		expect(state.status).toBe("running"); // stays running so for-loop keeps tail-reading
-		expect(state.injected).toBe(true);
-	});
-
-	it("synthesizes an error event (not done) when stopReason is 'stop' but output.md is missing", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: null });
-		state.lastStopText = "Review complete. The findings file `/tmp/review-sec.md` contains 0 critical vulns.";
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(dirname(artifactDir), state.id);
-		const events = readEvents(art);
-		const err = events.find((e) => e.type === "error");
-		expect(err).toBeDefined();
-		const msg = err && err.type === "error" ? err.message : "";
-		expect(msg).toMatch(/without writing output\.md/);
-		expect(msg).toMatch(/review-sec\.md/); // fallback content from lastStopText
-		expect(state.status).toBe("running");
-		expect(state.exitCode).toBe(1);
-	});
+  let root: string;
+
+  beforeEach(() => {
+    // Mock child_process so isTmuxPaneAlive returns true for the synthetic %99 pane used in
+    // makeState. Without this, CI environments without a real %99 pane would make the poller
+    // mark state as "unknown" (pane dead) instead of "running"/"idle", breaking assertions that
+    // check the post-poll status. The mock is permissive: any non-pane-liveness call also
+    // returns success so the poller's "show-options" read for @pi-exit-code doesn't throw.
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("%99");
+        return "";
+      },
+    }));
+    root = makeTmp();
+    const g = globalThis as any;
+    g.__piSubagenturaInteractiveRegistry?.clear?.();
+    g.__piSubagenturaPiRef = undefined;
+    g.__piSubagenturaUi = undefined;
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // ─── Core behavior ────────────────────────────────────────────────
+
+  it("synthesizes a done event when stopReason is 'stop' and output.md exists, after the debounce", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "the result" });
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const sendMessage = vi.fn();
+    mod.pollArtifactChanges({ sendMessage } as any);
+
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    afterEach(() => {
+      rmSync(root, { recursive: true, force: true });
+      vi.doUnmock("node:child_process");
+    });
+    expect(done && done.type === "done" && done.summary).toMatch(
+      /auto-detected/,
+    );
+    expect(sendMessage).toHaveBeenCalled();
+    expect(state.status).toBe("running"); // stays running so for-loop keeps tail-reading
+    expect(state.injected).toBe(true);
+  });
+
+  it("synthesizes an error event (not done) when stopReason is 'stop' but output.md is missing", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: null });
+    state.lastStopText =
+      "Review complete. The findings file `/tmp/review-sec.md` contains 0 critical vulns.";
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    const msg = err && err.type === "error" ? err.message : "";
+    expect(msg).toMatch(/without writing output\.md/);
+    expect(msg).toMatch(/review-sec\.md/); // fallback content from lastStopText
+    expect(state.status).toBe("running");
+    expect(state.exitCode).toBe(1);
+  });
+
+  it("synthesizes an error event with a generic message when output.md is missing AND no lastStopText", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({ outputContent: null });
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(dirname(state.artifactDir), state.id);
+    const events = readEvents(art);
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    expect(err && err.type === "error" && err.message).toBe(
+      "sub-agent stopped without writing output.md",
+    );
+  });
+
+  it("does NOT synthesize for stopReason 'toolUse' (model is mid-turn, not finished)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    // Cast: the runtime value is intentionally outside the union so we can verify only
+    // the four terminal stopReasons are accepted by the typecheck.
+    state.lastStopReason = "toolUse" as unknown as "stop";
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    const synthesized = events.find(
+      (e) => e.type === "done" || e.type === "error",
+    );
+    expect(synthesized).toBeUndefined();
+    expect(state.status).toBe("running");
+  });
 
-	it("synthesizes an error event with a generic message when output.md is missing AND no lastStopText", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({ outputContent: null });
-		mod.interactiveSubagentRegistry.set(state.id, state);
+  it.each(["length", "error", "aborted"] as const)(
+    "does NOT auto-synthesize for stopReason '%s'",
+    async (reason) => {
+      const mod = await importFresh<typeof import("./subagent")>("./subagent");
+      const { state, artifactDir } = makeState({ outputContent: "result" });
+      state.lastStopReason = reason;
+      mod.interactiveSubagentRegistry.set(state.id, state);
 
-		mod.pollArtifactChanges({} as any);
+      mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(dirname(state.artifactDir), state.id);
-		const events = readEvents(art);
-		const err = events.find((e) => e.type === "error");
-		expect(err).toBeDefined();
-		expect(err && err.type === "error" && err.message).toBe("sub-agent stopped without writing output.md");
-	});
+      const art = artifactPath(dirname(artifactDir), state.id);
+      const events = readEvents(art);
+      const synthesized = events.find(
+        (e) => e.type === "done" || e.type === "error",
+      );
+      expect(synthesized).toBeUndefined();
+    },
+  );
 
-	it("does NOT synthesize for stopReason 'toolUse' (model is mid-turn, not finished)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "result" });
-		// Cast: the runtime value is intentionally outside the union so we can verify only
-		// the four terminal stopReasons are accepted by the typecheck.
-		state.lastStopReason = "toolUse" as unknown as "stop";
-		mod.interactiveSubagentRegistry.set(state.id, state);
+  it("does NOT synthesize before the debounce window elapses", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    state.lastStopReasonAt = Date.now() - 1_000; // 1s ago, well inside the 10s debounce
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-		mod.pollArtifactChanges({} as any);
+    mod.pollArtifactChanges({} as any);
 
-		const art = artifactPath(dirname(artifactDir), state.id);
-		const events = readEvents(art);
-		const synthesized = events.find((e) => e.type === "done" || e.type === "error");
-		expect(synthesized).toBeUndefined();
-		expect(state.status).toBe("running");
-	});
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    expect(
+      events.filter((e) => e.type === "done" || e.type === "error"),
+    ).toHaveLength(0);
+  });
 
-	it.each(["length", "error", "aborted"] as const)(
-		"does NOT auto-synthesize for stopReason '%s'",
-		async (reason) => {
-			const mod = await importFresh<typeof import("./subagent")>("./subagent");
-			const { state, artifactDir } = makeState({ outputContent: "result" });
-			state.lastStopReason = reason;
-			mod.interactiveSubagentRegistry.set(state.id, state);
+  it("does NOT synthesize when an explicit done event already exists in the artifact", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
 
-			mod.pollArtifactChanges({} as any);
+    const { state, artifactDir } = makeState({ outputContent: "result" });
 
-			const art = artifactPath(dirname(artifactDir), state.id);
-			const events = readEvents(art);
-			const synthesized = events.find((e) => e.type === "done" || e.type === "error");
-			expect(synthesized).toBeUndefined();
-		},
-	);
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-	it("does NOT synthesize before the debounce window elapses", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "result" });
-		state.lastStopReasonAt = Date.now() - 1_000; // 1s ago, well inside the 10s debounce
-		mod.interactiveSubagentRegistry.set(state.id, state);
+    const art = artifactPath(dirname(artifactDir), state.id);
 
-		mod.pollArtifactChanges({} as any);
+    appendEvent(art, {
+      ts: Date.now() - 100,
+      type: "done",
+      status: "done",
+      exitCode: 0,
+    });
 
-		const art = artifactPath(dirname(artifactDir), state.id);
-		const events = readEvents(art);
-		expect(events.filter((e) => e.type === "done" || e.type === "error")).toHaveLength(0);
-	});
+    mod.pollArtifactChanges({} as any);
 
-	it("does NOT synthesize when an explicit done event already exists in the artifact", async () => {
+    const events = readEvents(art);
 
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const doneEvents = events.filter((e) => e.type === "done");
 
-		const { state, artifactDir } = makeState({ outputContent: "result" });
+    expect(doneEvents).toHaveLength(1);
 
-		mod.interactiveSubagentRegistry.set(state.id, state);
+    expect(state.autoDoneForTurnAt).toBeUndefined();
+  });
 
+  // Regression: the child called `cli.mjs done` (so a `done` event is already in events.ndjson),
 
+  // but the session log contains a tool call (e.g. `write output.md` or `bash cli.mjs done 0`)
 
-		const art = artifactPath(dirname(artifactDir), state.id);
+  // that tailReadSessionLog has not yet processed. On THIS poll, tailReadSessionLog appends a
 
-		appendEvent(art, { ts: Date.now() - 100, type: "done", status: "done", exitCode: 0 });
+  // `tool_activity` row to events.ndjson AFTER the explicit done — making `lastEvent` return the
 
+  // tool_activity and the previous `lastEvent().type === "done"` guard miss. The fallback then
 
+  // synthesizes a duplicate `done` and the events loop re-delivers the explicit one, causing
 
-		mod.pollArtifactChanges({} as any);
+  // a double-notify. This was observed in production on 2026-06-15 (subagentura sessions under
 
+  // pi-agents-5c91e6). The fix scans ALL events for a terminal type, not just lastEvent.
 
+  it("regression: does NOT synthesize when an explicit done is present AND a tool_activity is appended after it in the same poll", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
 
-		const events = readEvents(art);
+    const { state, artifactDir } = makeState({ outputContent: "result" });
 
-		const doneEvents = events.filter((e) => e.type === "done");
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-		expect(doneEvents).toHaveLength(1);
+    const art = artifactPath(dirname(artifactDir), state.id);
 
-		expect(state.autoDoneForTurnAt).toBeUndefined();
+    // Explicit done from the child. ts SMALLER than the tool_activity ts we will produce next,
 
-	});
+    // so the file order is: [done@SMALL, tool_activity@MEDIUM, ...] — lastEvent is the tool_activity.
 
+    const explicitTs = Date.now() - 20_000;
 
+    appendEvent(art, {
+      ts: explicitTs,
+      type: "done",
+      status: "done",
+      exitCode: 0,
+    });
 
-	// Regression: the child called `cli.mjs done` (so a `done` event is already in events.ndjson),
+    // Session log: a `write` tool call (so tailReadSessionLog appends a tool_activity) plus an
 
-	// but the session log contains a tool call (e.g. `write output.md` or `bash cli.mjs done 0`)
+    // assistant message with stopReason "stop" (so the auto-done preconditions are met).
 
-	// that tailReadSessionLog has not yet processed. On THIS poll, tailReadSessionLog appends a
+    // The tool-call timestamp is later than the explicit done but still 11s in the past relative
 
-	// `tool_activity` row to events.ndjson AFTER the explicit done — making `lastEvent` return the
+    // to "now" so the debounce has elapsed.
 
-	// tool_activity and the previous `lastEvent().type === "done"` guard miss. The fallback then
+    const toolTs = explicitTs + 5_000; // later than the explicit done
 
-	// synthesizes a duplicate `done` and the events loop re-delivers the explicit one, causing
+    const assistantTs = toolTs + 100;
 
-	// a double-notify. This was observed in production on 2026-06-15 (subagentura sessions under
+    writeFileSync(
+      state.sessionFile,
 
-	// pi-agents-5c91e6). The fix scans ALL events for a terminal type, not just lastEvent.
+      JSON.stringify({
+        type: "message",
 
-	it("regression: does NOT synthesize when an explicit done is present AND a tool_activity is appended after it in the same poll", async () => {
+        message: {
+          role: "assistant",
 
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+          content: [
+            { type: "text", text: "result text" },
 
-		const { state, artifactDir } = makeState({ outputContent: "result" });
+            {
+              type: "toolCall",
 
-		mod.interactiveSubagentRegistry.set(state.id, state);
+              name: "write",
 
+              arguments: { path: "/tmp/result.md", content: "result" },
+            },
+          ],
 
+          api: "openai",
 
-		const art = artifactPath(dirname(artifactDir), state.id);
+          provider: "openai",
 
-		// Explicit done from the child. ts SMALLER than the tool_activity ts we will produce next,
+          model: "gpt-4",
 
-		// so the file order is: [done@SMALL, tool_activity@MEDIUM, ...] — lastEvent is the tool_activity.
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
 
-		const explicitTs = Date.now() - 20_000;
+          stopReason: "stop",
 
-		appendEvent(art, { ts: explicitTs, type: "done", status: "done", exitCode: 0 });
+          timestamp: assistantTs,
+        },
+      }) + "\n",
+    );
 
+    // makeState already set lastStopReasonAt = Date.now() - 11_000 (past debounce). After this
 
+    // poll, tailReadSessionLog will set lastStopReasonAt to assistantTs. Since assistantTs is
 
-		// Session log: a `write` tool call (so tailReadSessionLog appends a tool_activity) plus an
+    // 20s+ in the past, the debounce is comfortably satisfied. The previous lastStopReasonAt
 
-		// assistant message with stopReason "stop" (so the auto-done preconditions are met).
+    // was also past the debounce, so either way the time check would pass.
 
-		// The tool-call timestamp is later than the explicit done but still 11s in the past relative
+    const sendMessage = vi.fn();
 
-		// to "now" so the debounce has elapsed.
+    mod.pollArtifactChanges({ sendMessage } as any);
 
-		const toolTs = explicitTs + 5_000; // later than the explicit done
+    const events = readEvents(art);
 
-		const assistantTs = toolTs + 100;
+    const doneEvents = events.filter((e) => e.type === "done");
 
-		writeFileSync(
+    // Without the fix: there would be a synthesized `done` here (in addition to the explicit one).
 
-			state.sessionFile,
+    expect(doneEvents).toHaveLength(1);
 
-			JSON.stringify({
+    expect(doneEvents[0].ts).toBe(explicitTs);
 
-				type: "message",
+    expect(state.autoDoneForTurnAt).toBeUndefined();
 
-				message: {
+    // The sendMessage call (if any) must be for the original done only, never a second time
 
-					role: "assistant",
+    // for the synthesized one. We check that sendMessage was called at most once with content
 
-					content: [
+    // matching the done event — the simplest assertion is "no synthesized event was sent".
 
-						{ type: "text", text: "result text" },
+    const sendMessageCalls = sendMessage.mock.calls.filter((call) => {
+      const text = JSON.stringify(call);
 
-						{
+      return text.includes("auto-detected from session stopReason:stop");
+    });
 
-							type: "toolCall",
+    expect(sendMessageCalls).toHaveLength(0);
+  });
 
-							name: "write",
+  it("does NOT synthesize twice (idempotent across repeated polls)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-							arguments: { path: "/tmp/result.md", content: "result" },
+    mod.pollArtifactChanges({} as any);
+    mod.pollArtifactChanges({} as any);
+    mod.pollArtifactChanges({} as any);
 
-						},
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    const doneEvents = events.filter((e) => e.type === "done");
+    expect(doneEvents).toHaveLength(1);
+  });
 
-					],
+  it("suppresses duplicate notification if an explicit done arrives after the auto-synthesis", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-					api: "openai",
+    const sendMessage = vi.fn();
+    mod.pollArtifactChanges({ sendMessage } as any);
+    const callsAfterAuto = sendMessage.mock.calls.length;
+    expect(callsAfterAuto).toBeGreaterThan(0);
 
-					provider: "openai",
+    const art = artifactPath(dirname(artifactDir), state.id);
+    appendEvent(art, {
+      ts: Date.now(),
+      type: "done",
+      status: "done",
+      exitCode: 0,
+    });
 
-					model: "gpt-4",
+    sendMessage.mockClear();
+    mod.pollArtifactChanges({ sendMessage } as any);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
 
-					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+  it("a new user message in the session log resets the auto-done guard for the next turn", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-					stopReason: "stop",
+    mod.pollArtifactChanges({} as any);
+    expect(state.autoDoneForTurnAt).toBeDefined();
 
-					timestamp: assistantTs,
+    const userMsg = {
+      type: "message",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "thanks, also do X" }],
+        timestamp: Date.now(),
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
 
-				},
+    mod.pollArtifactChanges({} as any);
+    expect(state.autoDoneForTurnAt).toBeUndefined();
+  });
 
-			}) + "\n",
+  it("a new user message in the session log revives status from 'exited' to 'running' (auto-done case)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-		);
+    mod.pollArtifactChanges({} as any);
+    // Simulate the post-synthesized-error state: the poller's main loop sets status to "exited"
+    // once the synthesized error event lands in the artifact. The user has now sent a follow-up;
+    // we want to verify the user-role revival clears "exited" too.
+    state.status = "exited";
 
+    const userMsg = {
+      type: "message",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "thanks, also do X" }],
+        timestamp: Date.now(),
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
 
+    mod.pollArtifactChanges({} as any);
+    // Status revived so the next auto-done / done-event opportunity can fire for the new turn.
+    expect(state.status).toBe("running");
+  });
 
-		// makeState already set lastStopReasonAt = Date.now() - 11_000 (past debounce). After this
+  it("a new user message in the session log revives status from 'idle' to 'running' (follow-up case)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-		// poll, tailReadSessionLog will set lastStopReasonAt to assistantTs. Since assistantTs is
+    // Simulate the post-turn state that follow-up work produces: the child called `cli.mjs done`
+    // (so a `done` event is in the artifact and the poller would naturally transition to "idle" via
+    // deriveInteractiveSubagentStatus), and the parent has just sent a follow-up keystroke into
+    // the REPL. The user-role entry in the session log must revive status so the next
+    // auto-done / done-event opportunity fires for the new turn.
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+    state.status = "idle";
+    mod.pollArtifactChanges({} as any);
+    expect(state.status).toBe("idle");
 
-		// 20s+ in the past, the debounce is comfortably satisfied. The previous lastStopReasonAt
+    const userMsg = {
+      type: "message",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "follow-up after turn 1" }],
+        timestamp: Date.now(),
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
 
-		// was also past the debounce, so either way the time check would pass.
+    mod.pollArtifactChanges({} as any);
+    expect(state.status).toBe("running");
+  });
 
-		const sendMessage = vi.fn();
+  it("captures stopReason and lastStopText from real session JSONL tail-read", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
 
-		mod.pollArtifactChanges({ sendMessage } as any);
+    state.lastStopReason = undefined;
+    state.lastStopReasonAt = undefined;
+    state.lastStopText = undefined;
 
+    const ts = Date.now() - 11_000;
+    writeAssistantTurn(
+      state.sessionFile,
+      ts,
+      "stop",
+      "Done. Wrote the result.",
+    );
 
+    mod.pollArtifactChanges({} as any);
 
-		const events = readEvents(art);
+    expect(state.lastStopReason).toBe("stop");
+    expect(state.lastStopReasonAt).toBe(ts);
+    expect(state.lastStopText).toBe("Done. Wrote the result.");
+  });
 
-		const doneEvents = events.filter((e) => e.type === "done");
-
-		// Without the fix: there would be a synthesized `done` here (in addition to the explicit one).
-
-		expect(doneEvents).toHaveLength(1);
-
-		expect(doneEvents[0].ts).toBe(explicitTs);
-
-		expect(state.autoDoneForTurnAt).toBeUndefined();
-
-		// The sendMessage call (if any) must be for the original done only, never a second time
-
-		// for the synthesized one. We check that sendMessage was called at most once with content
-
-		// matching the done event — the simplest assertion is "no synthesized event was sent".
-
-		const sendMessageCalls = sendMessage.mock.calls.filter((call) => {
-
-			const text = JSON.stringify(call);
-
-			return text.includes("auto-detected from session stopReason:stop");
-
-		});
-
-		expect(sendMessageCalls).toHaveLength(0);
-
-	});
-
-
-	it("does NOT synthesize twice (idempotent across repeated polls)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "result" });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		mod.pollArtifactChanges({} as any);
-		mod.pollArtifactChanges({} as any);
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(dirname(artifactDir), state.id);
-		const events = readEvents(art);
-		const doneEvents = events.filter((e) => e.type === "done");
-		expect(doneEvents).toHaveLength(1);
-	});
-
-	it("suppresses duplicate notification if an explicit done arrives after the auto-synthesis", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "result" });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const sendMessage = vi.fn();
-		mod.pollArtifactChanges({ sendMessage } as any);
-		const callsAfterAuto = sendMessage.mock.calls.length;
-		expect(callsAfterAuto).toBeGreaterThan(0);
-
-		const art = artifactPath(dirname(artifactDir), state.id);
-		appendEvent(art, { ts: Date.now(), type: "done", status: "done", exitCode: 0 });
-
-		sendMessage.mockClear();
-		mod.pollArtifactChanges({ sendMessage } as any);
-		expect(sendMessage).not.toHaveBeenCalled();
-	});
-
-	it("a new user message in the session log resets the auto-done guard for the next turn", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "result" });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		mod.pollArtifactChanges({} as any);
-		expect(state.autoDoneForTurnAt).toBeDefined();
-
-		const userMsg = {
-			type: "message",
-			message: {
-				role: "user",
-				content: [{ type: "text", text: "thanks, also do X" }],
-				timestamp: Date.now(),
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-		expect(state.autoDoneForTurnAt).toBeUndefined();
-	});
-
-	it("a new user message in the session log revives status from 'exited' to 'running' (auto-done case)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "result" });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		mod.pollArtifactChanges({} as any);
-		// Simulate the post-synthesized-error state: the poller's main loop sets status to "exited"
-		// once the synthesized error event lands in the artifact. The user has now sent a follow-up;
-		// we want to verify the user-role revival clears "exited" too.
-		state.status = "exited";
-
-		const userMsg = {
-			type: "message",
-			message: {
-				role: "user",
-				content: [{ type: "text", text: "thanks, also do X" }],
-				timestamp: Date.now(),
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-		// Status revived so the next auto-done / done-event opportunity can fire for the new turn.
-		expect(state.status).toBe("running");
-	});
-
-	it("a new user message in the session log revives status from 'idle' to 'running' (follow-up case)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({ outputContent: "result" });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		// Simulate the post-turn state that follow-up work produces: the child called `cli.mjs done`
-		// (so a `done` event is in the artifact and the poller would naturally transition to "idle" via
-		// deriveInteractiveSubagentStatus), and the parent has just sent a follow-up keystroke into
-		// the REPL. The user-role entry in the session log must revive status so the next
-		// auto-done / done-event opportunity fires for the new turn.
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		appendEvent(art, { ts: 1, type: "started", status: "running" });
-		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
-		state.status = "idle";
-		mod.pollArtifactChanges({} as any);
-		expect(state.status).toBe("idle");
-
-		const userMsg = {
-			type: "message",
-			message: {
-				role: "user",
-				content: [{ type: "text", text: "follow-up after turn 1" }],
-				timestamp: Date.now(),
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-		expect(state.status).toBe("running");
-	});
-
-	it("captures stopReason and lastStopText from real session JSONL tail-read", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		state.lastStopReason = undefined;
-		state.lastStopReasonAt = undefined;
-		state.lastStopText = undefined;
-
-		const ts = Date.now() - 11_000;
-		writeAssistantTurn(state.sessionFile, ts, "stop", "Done. Wrote the result.");
-
-		mod.pollArtifactChanges({} as any);
-
-		expect(state.lastStopReason).toBe("stop");
-		expect(state.lastStopReasonAt).toBe(ts);
-		expect(state.lastStopText).toBe("Done. Wrote the result.");
-	});
-
-	it("does NOT capture lastStopText for non-'stop' stopReasons", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		state.lastStopReason = undefined;
-		state.lastStopText = undefined;
-
-		const ts = Date.now() - 11_000;
-		writeAssistantTurn(state.sessionFile, ts, "length", "I hit the token limit.");
-
-		mod.pollArtifactChanges({} as any);
-
-		expect(state.lastStopReason).toBe("length");
-		expect(state.lastStopText).toBeUndefined();
-	});
-
-	it("a user message in the session log clears the per-turn stop-capture (lastStopReason, lastStopReasonAt, lastStopText)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		// Simulate a prior turn that captured stop-capture state.
-		state.lastStopReason = "stop";
-		state.lastStopReasonAt = Date.now() - 60_000;
-		state.lastStopText = "STALE_TEXT_FROM_PRIOR_TURN";
-
-		// A user follow-up arrives.
-		const userTs = Date.now() - 30_000;
-		writeFileSync(
-			state.sessionFile,
-			JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "text", text: "do more" }], timestamp: userTs } }) + "\n",
-			{ flag: "a" },
-		);
-
-		mod.pollArtifactChanges({} as any);
-
-		// All three per-turn fields must be cleared, matching the reset of
-		// autoDoneForTurnAt on the same code path.
-		const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
-		expect(after.lastStopReason).toBeUndefined();
-		expect(after.lastStopReasonAt).toBeUndefined();
-		expect(after.lastStopText).toBeUndefined();
-	});
-
-	it("appends a '… (truncated)' marker to the synthesized error when lastStopText exceeds the slice length", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const longText = "X".repeat(1000); // >500 char slice threshold
-		const ts = Date.now() - 11_000;
-		writeAssistantTurn(state.sessionFile, ts, "stop", longText);
-
-		mod.pollArtifactChanges({} as any);
-
-		const events = readEvents(artifactPath(dirname(state.artifactDir), state.id));
-		const err = events.find((e) => e.type === "error");
-		expect(err).toBeDefined();
-		const msg = err && err.type === "error" ? err.message : "";
-		expect(msg).toMatch(/… \(truncated\)/);
-		expect(msg).toContain("X".repeat(500));
-		expect(msg).not.toContain("X".repeat(501)); // slice is exact
-	});
-
-	it("does NOT append a '… (truncated)' marker when lastStopText fits within the slice length", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const shortText = "short text that fits in the slice"; // well under 500
-		const ts = Date.now() - 11_000;
-		writeAssistantTurn(state.sessionFile, ts, "stop", shortText);
-
-		mod.pollArtifactChanges({} as any);
-
-		const events = readEvents(artifactPath(dirname(state.artifactDir), state.id));
-		const err = events.find((e) => e.type === "error");
-		const msg = err && err.type === "error" ? err.message : "";
-		expect(msg).not.toMatch(/… \(truncated\)/);
-		expect(msg).toContain(shortText);
-	});
-
-	it("auto-fallback does NOT mark state.injected when notifyOnComplete is 'inject' (so the regular inject path can fire next poll)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({ outputContent: "final result" });
-		state.notifyOnComplete = "inject";
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const ts = Date.now() - 11_000;
-		writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
-
-		mod.pollArtifactChanges({} as any);
-
-		// W1 fix: in inject mode, leave state.injected unset so the regular
-		// inject path at lines 547-585 picks up the synthesized `done` event
-		// on the next poll. With the old behavior (state.injected = true
-		// unconditionally), inject mode would silently degrade to pointer-only.
-		const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
-		expect(after.injected).not.toBe(true);
-	});
-
-	it("auto-fallback DOES mark state.injected when notifyOnComplete is 'notify' (no inject path to defer to)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({ outputContent: "final result" });
-		state.notifyOnComplete = "notify";
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const ts = Date.now() - 11_000;
-		writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
-
-		mod.pollArtifactChanges({} as any);
-
-		// For non-inject modes, the inject path at lines 547-585 will never
-		// fire (gated on notifyOnComplete === "inject"). Marking injected
-		// here is a no-op-defensive; what matters is no regression.
-		const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
-		expect(after.injected).toBe(true);
-	});
-
-	// ─── End-to-end: real session JSONL is the only input ────────────
-	// Mirrors the production failure mode seen in 4 silent sub-agents in
-	// ~/.pi/agent/sessions/subagentura. The only input to the poller is a
-	// session JSONL containing a final assistant turn with stopReason:"stop"
-	// — no pre-seeded state, no events.ndjson activity, no `cli.mjs done`.
-	// After AUTO_DONE_DEBOUNCE_MS the parent must synthesize a recovery event.
-
-	it("end-to-end (with output): silent sub-agent whose model wrote output.md but never called `cli.mjs done` → auto-done", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeFreshState({ outputContent: "the review findings" });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const stopTs = Date.now() - 11_000;
-		writeFileSync(
-			state.sessionFile,
-			JSON.stringify({
-				type: "message",
-				message: {
-					role: "assistant",
-					content: [{ type: "text", text: "Review complete." }],
-					api: "openai",
-					provider: "openai",
-					model: "gpt-4",
-					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
-					stopReason: "stop",
-					timestamp: stopTs,
-				},
-			}) + "\n",
-		);
-
-		const sendMessage = vi.fn();
-		mod.pollArtifactChanges({ sendMessage } as any);
-
-		expect(state.lastStopReason).toBe("stop");
-		expect(state.lastStopReasonAt).toBe(stopTs);
-		const art = artifactPath(dirname(artifactDir), state.id);
-		const events = readEvents(art);
-		const done = events.find((e) => e.type === "done");
-		expect(done).toBeDefined();
-		expect(done && done.type === "done" && done.exitCode).toBe(0);
-		expect(sendMessage).toHaveBeenCalled();
-	});
-
-	it("end-to-end (no output): silent sub-agent whose model wrote to /tmp not output.md → auto-error with lastStopText fallback", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeFreshState({ outputContent: null });
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const stopTs = Date.now() - 11_000;
-		const summary = "Review complete. The findings file `/tmp/review-sec.md` contains 0 critical vulnerabilities.";
-		writeFileSync(
-			state.sessionFile,
-			JSON.stringify({
-				type: "message",
-				message: {
-					role: "assistant",
-					content: [{ type: "text", text: summary }],
-					api: "openai",
-					provider: "openai",
-					model: "gpt-4",
-					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
-					stopReason: "stop",
-					timestamp: stopTs,
-				},
-			}) + "\n",
-		);
-
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(dirname(artifactDir), state.id);
-		const events = readEvents(art);
-		const err = events.find((e) => e.type === "error");
-		expect(err).toBeDefined();
-		const msg = err && err.type === "error" ? err.message : "";
-		expect(msg).toMatch(/without writing output\.md/);
-		expect(msg).toMatch(/review-sec\.md/);
-	});
-
-	// ─── Regression guard: replay the real `notdone.jsonl` session ────
-	// The model produced a 10K-char audit at t=183s, then sat in the REPL for
-	// 4.5 minutes until the parent prompted it with "u didnt make the done".
-	// With the fix, auto-done would have fired at t=193s — 4.5 minutes BEFORE
-	// the user had to notice and prompt. Skips if the production session is
-	// not present (e.g. CI without the local session dir).
-	//
-	// SAFETY: the production session JSONL is read-only input; the replay
-	// runs against a tmp artifactDir. The production dir is never written to.
-	it("regression: notdone.jsonl would have auto-recovered the 10K audit at t=193s", async () => {
-		const fs = await import("node:fs");
-		const sourceSession = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/2026-06-11T19-25-31-403Z-fb57cd05.jsonl";
-		if (!fs.existsSync(sourceSession)) {
-			console.warn("skip: real notdone.jsonl not present at", sourceSession);
-			return;
-		}
-
-		const lines = fs.readFileSync(sourceSession, "utf8").trim().split("\n").map((l) => JSON.parse(l));
-		let firstStop: { timestamp: number } | null = null;
-		let firstStopText = "";
-		for (const e of lines) {
-			if (e.type !== "message") continue;
-			const m = e.message;
-			if (!m || m.role !== "assistant" || m.stopReason !== "stop") continue;
-			firstStop = m;
-			for (const b of (m.content || [])) {
-				if (b.type === "text" && typeof b.text === "string") {
-					firstStopText = b.text;
-					break;
-				}
-			}
-			break;
-		}
-		expect(firstStop).not.toBeNull();
-		// Non-null assertion: expect().not.toBeNull() narrows at runtime but not in tsc's strict null checks.
-		const firstStopNonNull = firstStop as { timestamp: number };
-		expect(firstStop).not.toBeNull();
-		expect(firstStopText.length).toBeGreaterThan(5000);
-
-		// Replay into a tmp dir, NOT the production artifact dir. The
-		// poller computes the artifact via
-		//   artifactPath(dirname(state.artifactDir), basename(state.artifactDir))
-		// so point state.artifactDir at a fresh tmp leaf and let
-		// ensureArtifactDir() create it on first appendEvent.
-		const replayRoot = makeTmp();
-		const replayId = "notdone-replay";
-		const replayArtifactDir = join(replayRoot, replayId);
-		const replaySession = join(replayRoot, "session.jsonl");
-		fs.writeFileSync(
-			replaySession,
-			JSON.stringify({
-				type: "message",
-				message: {
-					role: "assistant",
-					content: [{ type: "text", text: firstStopText }],
-					stopReason: "stop",
-					timestamp: firstStopNonNull.timestamp,
-				},
-			}) + "\n",
-		);
-
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		mod.interactiveSubagentRegistry.set(replayId, {
-			id: replayId,
-			name: "notdone.jsonl Replay",
-			task: "(replay)",
-			paneId: "%1",
-			sessionFile: replaySession,
-			cwd: "/tmp",
-			startedAt: firstStopNonNull.timestamp - 60_000,
-			status: "running",
-			mux: "tmux",
-			attachCommand: "n/a",
-			selectPaneCommand: "n/a",
-			launchScriptFile: "n/a",
-			artifactDir: replayArtifactDir,
-		});
-
-		mod.pollArtifactChanges({} as any);
-
-		// The poller wrote a synthesized event into the tmp artifact dir.
-		const eventsFile = join(replayArtifactDir, "events.ndjson");
-		expect(fs.existsSync(eventsFile)).toBe(true);
-		const events = fs.readFileSync(eventsFile, "utf8").trim().split("\n").map((l) => JSON.parse(l));
-		const err = events.find((e) => e.type === "error");
-		expect(err, "expected synthesized error event").toBeDefined();
-		const msg = err && err.type === "error" ? err.message : "";
-		expect(msg).toMatch(/without writing output\.md/);
-		expect(msg).toMatch(/Test Quality Audit Report/);
-
-		// Defensive: confirm we did NOT touch the production dir. If
-		// events.ndjson exists there, its mtime must predate this test run.
-		const productionArtifactDir = "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/artifacts/fb57cd05";
-		const productionEvents = join(productionArtifactDir, "events.ndjson");
-		if (fs.existsSync(productionEvents)) {
-			const stat = fs.statSync(productionEvents);
-			expect(stat.mtimeMs).toBeLessThan(Date.now() - 1000);
-		}
-	});
+  it("does NOT capture lastStopText for non-'stop' stopReasons", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    state.lastStopReason = undefined;
+    state.lastStopText = undefined;
+
+    const ts = Date.now() - 11_000;
+    writeAssistantTurn(
+      state.sessionFile,
+      ts,
+      "length",
+      "I hit the token limit.",
+    );
+
+    mod.pollArtifactChanges({} as any);
+
+    expect(state.lastStopReason).toBe("length");
+    expect(state.lastStopText).toBeUndefined();
+  });
+
+  it("a user message in the session log clears the per-turn stop-capture (lastStopReason, lastStopReasonAt, lastStopText)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    // Simulate a prior turn that captured stop-capture state.
+    state.lastStopReason = "stop";
+    state.lastStopReasonAt = Date.now() - 60_000;
+    state.lastStopText = "STALE_TEXT_FROM_PRIOR_TURN";
+
+    // A user follow-up arrives.
+    const userTs = Date.now() - 30_000;
+    writeFileSync(
+      state.sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "do more" }],
+          timestamp: userTs,
+        },
+      }) + "\n",
+      { flag: "a" },
+    );
+
+    mod.pollArtifactChanges({} as any);
+
+    // All three per-turn fields must be cleared, matching the reset of
+    // autoDoneForTurnAt on the same code path.
+    const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
+    expect(after.lastStopReason).toBeUndefined();
+    expect(after.lastStopReasonAt).toBeUndefined();
+    expect(after.lastStopText).toBeUndefined();
+  });
+
+  it("appends a '… (truncated)' marker to the synthesized error when lastStopText exceeds the slice length", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const longText = "X".repeat(1000); // >500 char slice threshold
+    const ts = Date.now() - 11_000;
+    writeAssistantTurn(state.sessionFile, ts, "stop", longText);
+
+    mod.pollArtifactChanges({} as any);
+
+    const events = readEvents(
+      artifactPath(dirname(state.artifactDir), state.id),
+    );
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    const msg = err && err.type === "error" ? err.message : "";
+    expect(msg).toMatch(/… \(truncated\)/);
+    expect(msg).toContain("X".repeat(500));
+    expect(msg).not.toContain("X".repeat(501)); // slice is exact
+  });
+
+  it("does NOT append a '… (truncated)' marker when lastStopText fits within the slice length", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const shortText = "short text that fits in the slice"; // well under 500
+    const ts = Date.now() - 11_000;
+    writeAssistantTurn(state.sessionFile, ts, "stop", shortText);
+
+    mod.pollArtifactChanges({} as any);
+
+    const events = readEvents(
+      artifactPath(dirname(state.artifactDir), state.id),
+    );
+    const err = events.find((e) => e.type === "error");
+    const msg = err && err.type === "error" ? err.message : "";
+    expect(msg).not.toMatch(/… \(truncated\)/);
+    expect(msg).toContain(shortText);
+  });
+
+  it("auto-fallback does NOT mark state.injected when notifyOnComplete is 'inject' (so the regular inject path can fire next poll)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({ outputContent: "final result" });
+    state.notifyOnComplete = "inject";
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const ts = Date.now() - 11_000;
+    writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
+
+    mod.pollArtifactChanges({} as any);
+
+    // W1 fix: in inject mode, leave state.injected unset so the regular
+    // inject path at lines 547-585 picks up the synthesized `done` event
+    // on the next poll. With the old behavior (state.injected = true
+    // unconditionally), inject mode would silently degrade to pointer-only.
+    const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
+    expect(after.injected).not.toBe(true);
+  });
+
+  it("auto-fallback DOES mark state.injected when notifyOnComplete is 'notify' (no inject path to defer to)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({ outputContent: "final result" });
+    state.notifyOnComplete = "notify";
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const ts = Date.now() - 11_000;
+    writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
+
+    mod.pollArtifactChanges({} as any);
+
+    // For non-inject modes, the inject path at lines 547-585 will never
+    // fire (gated on notifyOnComplete === "inject"). Marking injected
+    // here is a no-op-defensive; what matters is no regression.
+    const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
+    expect(after.injected).toBe(true);
+  });
+
+  // ─── End-to-end: real session JSONL is the only input ────────────
+  // Mirrors the production failure mode seen in 4 silent sub-agents in
+  // ~/.pi/agent/sessions/subagentura. The only input to the poller is a
+  // session JSONL containing a final assistant turn with stopReason:"stop"
+  // — no pre-seeded state, no events.ndjson activity, no `cli.mjs done`.
+  // After AUTO_DONE_DEBOUNCE_MS the parent must synthesize a recovery event.
+
+  it("end-to-end (with output): silent sub-agent whose model wrote output.md but never called `cli.mjs done` → auto-done", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeFreshState({
+      outputContent: "the review findings",
+    });
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const stopTs = Date.now() - 11_000;
+    writeFileSync(
+      state.sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Review complete." }],
+          api: "openai",
+          provider: "openai",
+          model: "gpt-4",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          stopReason: "stop",
+          timestamp: stopTs,
+        },
+      }) + "\n",
+    );
+
+    const sendMessage = vi.fn();
+    mod.pollArtifactChanges({ sendMessage } as any);
+
+    expect(state.lastStopReason).toBe("stop");
+    expect(state.lastStopReasonAt).toBe(stopTs);
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    expect(done && done.type === "done" && done.exitCode).toBe(0);
+    expect(sendMessage).toHaveBeenCalled();
+  });
+
+  it("end-to-end (no output): silent sub-agent whose model wrote to /tmp not output.md → auto-error with lastStopText fallback", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeFreshState({ outputContent: null });
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const stopTs = Date.now() - 11_000;
+    const summary =
+      "Review complete. The findings file `/tmp/review-sec.md` contains 0 critical vulnerabilities.";
+    writeFileSync(
+      state.sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: summary }],
+          api: "openai",
+          provider: "openai",
+          model: "gpt-4",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          stopReason: "stop",
+          timestamp: stopTs,
+        },
+      }) + "\n",
+    );
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    const msg = err && err.type === "error" ? err.message : "";
+    expect(msg).toMatch(/without writing output\.md/);
+    expect(msg).toMatch(/review-sec\.md/);
+  });
+
+  // ─── Regression guard: replay the real `notdone.jsonl` session ────
+  // The model produced a 10K-char audit at t=183s, then sat in the REPL for
+  // 4.5 minutes until the parent prompted it with "u didnt make the done".
+  // With the fix, auto-done would have fired at t=193s — 4.5 minutes BEFORE
+  // the user had to notice and prompt. Skips if the production session is
+  // not present (e.g. CI without the local session dir).
+  //
+  // SAFETY: the production session JSONL is read-only input; the replay
+  // runs against a tmp artifactDir. The production dir is never written to.
+  it("regression: notdone.jsonl would have auto-recovered the 10K audit at t=193s", async () => {
+    const fs = await import("node:fs");
+    const sourceSession =
+      "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/2026-06-11T19-25-31-403Z-fb57cd05.jsonl";
+    if (!fs.existsSync(sourceSession)) {
+      console.warn("skip: real notdone.jsonl not present at", sourceSession);
+      return;
+    }
+
+    const lines = fs
+      .readFileSync(sourceSession, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    let firstStop: { timestamp: number } | null = null;
+    let firstStopText = "";
+    for (const e of lines) {
+      if (e.type !== "message") continue;
+      const m = e.message;
+      if (!m || m.role !== "assistant" || m.stopReason !== "stop") continue;
+      firstStop = m;
+      for (const b of m.content || []) {
+        if (b.type === "text" && typeof b.text === "string") {
+          firstStopText = b.text;
+          break;
+        }
+      }
+      break;
+    }
+    expect(firstStop).not.toBeNull();
+    // Non-null assertion: expect().not.toBeNull() narrows at runtime but not in tsc's strict null checks.
+    const firstStopNonNull = firstStop as { timestamp: number };
+    expect(firstStop).not.toBeNull();
+    expect(firstStopText.length).toBeGreaterThan(5000);
+
+    // Replay into a tmp dir, NOT the production artifact dir. The
+    // poller computes the artifact via
+    //   artifactPath(dirname(state.artifactDir), basename(state.artifactDir))
+    // so point state.artifactDir at a fresh tmp leaf and let
+    // ensureArtifactDir() create it on first appendEvent.
+    const replayRoot = makeTmp();
+    const replayId = "notdone-replay";
+    const replayArtifactDir = join(replayRoot, replayId);
+    const replaySession = join(replayRoot, "session.jsonl");
+    fs.writeFileSync(
+      replaySession,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: firstStopText }],
+          stopReason: "stop",
+          timestamp: firstStopNonNull.timestamp,
+        },
+      }) + "\n",
+    );
+
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    mod.interactiveSubagentRegistry.set(replayId, {
+      id: replayId,
+      name: "notdone.jsonl Replay",
+      task: "(replay)",
+      paneId: "%1",
+      sessionFile: replaySession,
+      cwd: "/tmp",
+      startedAt: firstStopNonNull.timestamp - 60_000,
+      status: "running",
+      mux: "tmux",
+      attachCommand: "n/a",
+      selectPaneCommand: "n/a",
+      launchScriptFile: "n/a",
+      artifactDir: replayArtifactDir,
+    });
+
+    mod.pollArtifactChanges({} as any);
+
+    // The poller wrote a synthesized event into the tmp artifact dir.
+    const eventsFile = join(replayArtifactDir, "events.ndjson");
+    expect(fs.existsSync(eventsFile)).toBe(true);
+    const events = fs
+      .readFileSync(eventsFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    const err = events.find((e) => e.type === "error");
+    expect(err, "expected synthesized error event").toBeDefined();
+    const msg = err && err.type === "error" ? err.message : "";
+    expect(msg).toMatch(/without writing output\.md/);
+    expect(msg).toMatch(/Test Quality Audit Report/);
+
+    // Defensive: confirm we did NOT touch the production dir. If
+    // events.ndjson exists there, its mtime must predate this test run.
+    const productionArtifactDir =
+      "/Users/applesucks/.pi/agent/sessions/subagentura/pi-agents-workflow-impl-ef3eab/artifacts/fb57cd05";
+    const productionEvents = join(productionArtifactDir, "events.ndjson");
+    if (fs.existsSync(productionEvents)) {
+      const stat = fs.statSync(productionEvents);
+      expect(stat.mtimeMs).toBeLessThan(Date.now() - 1000);
+    }
+  });
 });

--- a/src/subagent-extension.test.ts
+++ b/src/subagent-extension.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import registerExtension from "./subagent";
 
 describe("extension registration", () => {
-describe("extension registration", () => {
-  it("registers all tools without throwing", () => {
-    const api = {
-      registerTool: vi.fn(),
-      registerMessageRenderer: vi.fn(),
-      on: vi.fn(),
-    };
+  describe("extension registration", () => {
+    it("registers all tools without throwing", () => {
+      const api = {
+        registerTool: vi.fn(),
+        registerMessageRenderer: vi.fn(),
+        on: vi.fn(),
+      };
 
-    expect(() => registerExtension(api as any)).not.toThrow();
-    expect(api.registerTool).toHaveBeenCalledTimes(13);
+      expect(() => registerExtension(api as any)).not.toThrow();
+      expect(api.registerTool).toHaveBeenCalledTimes(13);
+    });
   });
-});
 });

--- a/src/subagent-find-artifact.test.ts
+++ b/src/subagent-find-artifact.test.ts
@@ -22,96 +22,119 @@ import { join } from "node:path";
 import { importFresh } from "./test-utils";
 
 describe("findArtifactById (path-traversal guard)", () => {
-	let tmp: string;
-	let legitDir: string;
+  let tmp: string;
+  let legitDir: string;
 
-	beforeEach(() => {
-		tmp = mkdtempSync(join(tmpdir(), "pi-subagentura-findartifact-"));
-		// The production layout is <root>/<cwdLabel>/artifacts/<id>.
-		// Create one such directory to use for the well-formed id test.
-		legitDir = join(tmp, "cwdLabel1", "artifacts", "deadbeef");
-		mkdirSync(legitDir, { recursive: true });
-		// POSITIVE CONTROLS — these dirs are what the malicious ids would
-		// resolve to via path.join. The pre-fix vulnerable code would find
-		// them via statSync and return a non-null artifact; the regex fix
-		// is what makes these return null.
-		mkdirSync(join(tmp, "etc"), { recursive: true });
-		mkdirSync(join(tmp, "legit-id"), { recursive: true });
-		// stubEnv so vi.resetModules() inside importFresh() doesn't lose the value.
-		vi.stubEnv("PI_CODING_AGENT_SESSION_DIR", tmp);
-	});
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "pi-subagentura-findartifact-"));
+    // The production layout is <root>/<cwdLabel>/artifacts/<id>.
+    // Create one such directory to use for the well-formed id test.
+    legitDir = join(tmp, "cwdLabel1", "artifacts", "deadbeef");
+    mkdirSync(legitDir, { recursive: true });
+    // POSITIVE CONTROLS — these dirs are what the malicious ids would
+    // resolve to via path.join. The pre-fix vulnerable code would find
+    // them via statSync and return a non-null artifact; the regex fix
+    // is what makes these return null.
+    mkdirSync(join(tmp, "etc"), { recursive: true });
+    mkdirSync(join(tmp, "legit-id"), { recursive: true });
+    // stubEnv so vi.resetModules() inside importFresh() doesn't lose the value.
+    vi.stubEnv("PI_CODING_AGENT_SESSION_DIR", tmp);
+  });
 
-	afterEach(() => {
-		rmSync(tmp, { recursive: true, force: true });
-		vi.unstubAllEnvs();
-	});
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
 
-	it("returns null for ids with path-traversal sequences", async () => {
-		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
-		// Each of these would have resolved outside the artifact root before the fix.
-		// With the positive controls in beforeEach, the parent dir /etc and
-		// the sibling /legit-id exist on disk — so the pre-fix code would
-		// find them and return a non-null artifact. Only the regex fix makes
-		// these return null.
-		for (const bad of ["../../../etc", "..", "../../legit-id", "/etc/passwd", "..\\..\\windows"]) {
-			expect(findArtifactById(bad), `id=${JSON.stringify(bad)} should return null`).toBeNull();
-		}
-	});
+  it("returns null for ids with path-traversal sequences", async () => {
+    const { findArtifactById } =
+      await importFresh<typeof import("./subagent")>("./subagent");
+    // Each of these would have resolved outside the artifact root before the fix.
+    // With the positive controls in beforeEach, the parent dir /etc and
+    // the sibling /legit-id exist on disk — so the pre-fix code would
+    // find them and return a non-null artifact. Only the regex fix makes
+    // these return null.
+    for (const bad of [
+      "../../../etc",
+      "..",
+      "../../legit-id",
+      "/etc/passwd",
+      "..\\..\\windows",
+    ]) {
+      expect(
+        findArtifactById(bad),
+        `id=${JSON.stringify(bad)} should return null`,
+      ).toBeNull();
+    }
+  });
 
-	it("returns null for ids that do not match the 8-hex-char shape", async () => {
-		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
-		// Either too short, too long, contains non-hex / non-ASCII / control
-		// chars, or uppercase hex (the regex is anchored to [a-f0-9], not
-		// case-insensitive — uppercase would survive any "looks like hex"
-		// heuristic but must not match).
-		for (const bad of [
-			"",
-			"abc",
-			"zzzzzzzz",
-			"1234567",
-			"123456789",
-			"abc1234 ",
-			"abc-1234",
-			"DEADBEEF", // uppercase hex — must not match [a-f0-9]
-			"абвгдежз", // Cyrillic unicode, 8 chars by codepoint count
-			"\0\0\0\0\0\0\0\0", // 8 NUL bytes
-			"a".repeat(1000), // absurdly long
-		]) {
-			expect(findArtifactById(bad), `id=${JSON.stringify(bad)} should return null`).toBeNull();
-		}
-	});
+  it("returns null for ids that do not match the 8-hex-char shape", async () => {
+    const { findArtifactById } =
+      await importFresh<typeof import("./subagent")>("./subagent");
+    // Either too short, too long, contains non-hex / non-ASCII / control
+    // chars, or uppercase hex (the regex is anchored to [a-f0-9], not
+    // case-insensitive — uppercase would survive any "looks like hex"
+    // heuristic but must not match).
+    for (const bad of [
+      "",
+      "abc",
+      "zzzzzzzz",
+      "1234567",
+      "123456789",
+      "abc1234 ",
+      "abc-1234",
+      "DEADBEEF", // uppercase hex — must not match [a-f0-9]
+      "абвгдежз", // Cyrillic unicode, 8 chars by codepoint count
+      "\0\0\0\0\0\0\0\0", // 8 NUL bytes
+      "a".repeat(1000), // absurdly long
+    ]) {
+      expect(
+        findArtifactById(bad),
+        `id=${JSON.stringify(bad)} should return null`,
+      ).toBeNull();
+    }
+  });
 
-	it("returns the artifact for a well-formed id when present on disk", async () => {
-		// Sanity-check the fixture: the directory we created should be a directory.
-		expect(statSync(legitDir).isDirectory()).toBe(true);
-		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
-		const art = findArtifactById("deadbeef");
-		expect(art, "well-formed id with matching dir on disk should be found").not.toBeNull();
-		expect(art!.id).toBe("deadbeef");
-	});
+  it("returns the artifact for a well-formed id when present on disk", async () => {
+    // Sanity-check the fixture: the directory we created should be a directory.
+    expect(statSync(legitDir).isDirectory()).toBe(true);
+    const { findArtifactById } =
+      await importFresh<typeof import("./subagent")>("./subagent");
+    const art = findArtifactById("deadbeef");
+    expect(
+      art,
+      "well-formed id with matching dir on disk should be found",
+    ).not.toBeNull();
+    expect(art!.id).toBe("deadbeef");
+  });
 
-	it("returns null for a well-formed id that does not exist on disk", async () => {
-		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
-		expect(findArtifactById("feedface")).toBeNull();
-	});
+  it("returns null for a well-formed id that does not exist on disk", async () => {
+    const { findArtifactById } =
+      await importFresh<typeof import("./subagent")>("./subagent");
+    expect(findArtifactById("feedface")).toBeNull();
+  });
 
-	it("blocks symlink escapes (realpath-aware containment check)", async () => {
-		// Replace the legit deadbeef directory with a symlink that points
-		// OUTSIDE the artifact root. The id "deadbeef" is well-formed and
-		// statSync-follows-symlinks would see a directory at the candidate
-		// path — only the realpath check inside findArtifactById can stop
-		// this primitive. The target has to escape the root, not just the
-		// cwdLabel1/artifacts subdir, so we point it at the real /etc dir.
-		rmSync(legitDir, { recursive: true, force: true });
-		// /etc is a directory on every unix-like system. The artifact root
-		// is mkdtemp'd under tmpdir(), so /etc is definitely outside it.
-		if (process.platform === "win32") return; // findArtifactById has no Windows consumers
-		symlinkSync("/etc", legitDir);
-		// Sanity: statSync follows the symlink, so the candidate IS a directory.
-		expect(statSync(legitDir).isDirectory()).toBe(true);
+  it("blocks symlink escapes (realpath-aware containment check)", async () => {
+    // Replace the legit deadbeef directory with a symlink that points
+    // OUTSIDE the artifact root. The id "deadbeef" is well-formed and
+    // statSync-follows-symlinks would see a directory at the candidate
+    // path — only the realpath check inside findArtifactById can stop
+    // this primitive. The target has to escape the root, not just the
+    // cwdLabel1/artifacts subdir, so we point it at the real /etc dir.
+    rmSync(legitDir, { recursive: true, force: true });
+    // /etc is a directory on every unix-like system. The artifact root
+    // is mkdtemp'd under tmpdir(), so /etc is definitely outside it.
+    if (process.platform === "win32") return; // findArtifactById has no Windows consumers
+    symlinkSync("/etc", legitDir);
+    // Sanity: statSync follows the symlink, so the candidate IS a directory.
+    expect(statSync(legitDir).isDirectory()).toBe(true);
 
-		const { findArtifactById } = await importFresh<typeof import("./subagent")>("./subagent");
-		const art = findArtifactById("deadbeef");
-		expect(art, "symlink escaping the artifact root must be rejected").toBeNull();
-	});
+    const { findArtifactById } =
+      await importFresh<typeof import("./subagent")>("./subagent");
+    const art = findArtifactById("deadbeef");
+    expect(
+      art,
+      "symlink escaping the artifact root must be rejected",
+    ).toBeNull();
+  });
 });

--- a/src/subagent-interactive-default.test.ts
+++ b/src/subagent-interactive-default.test.ts
@@ -9,133 +9,146 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockLaunchInteractiveSubagent } = vi.hoisted(() => ({
-	mockLaunchInteractiveSubagent: vi.fn(),
+  mockLaunchInteractiveSubagent: vi.fn(),
 }));
 
 vi.mock("./interactive-tmux", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("./interactive-tmux")>();
-	return {
-		...actual,
-		launchInteractiveSubagent: mockLaunchInteractiveSubagent,
-	};
+  const actual = await importOriginal<typeof import("./interactive-tmux")>();
+  return {
+    ...actual,
+    launchInteractiveSubagent: mockLaunchInteractiveSubagent,
+  };
 });
 
 import registerExtension from "./subagent";
 
 /** Minimal ctx for the tool's execute signature. */
 function mockCtx() {
-	return {
-		cwd: "/tmp",
-		ui: { setStatus: vi.fn() },
-		sessionManager: { getBranch: vi.fn().mockReturnValue([]) },
-	};
+  return {
+    cwd: "/tmp",
+    ui: { setStatus: vi.fn() },
+    sessionManager: { getBranch: vi.fn().mockReturnValue([]) },
+  };
 }
 
 /** Find the subagent_interactive tool def from the registered API. */
-function getInteractiveToolDef(api: { registerTool: ReturnType<typeof vi.fn> }) {
-	return api.registerTool.mock.calls.find(([t]: any[]) => t.name === "subagent_interactive")?.[0];
+function getInteractiveToolDef(api: {
+  registerTool: ReturnType<typeof vi.fn>;
+}) {
+  return api.registerTool.mock.calls.find(
+    ([t]: any[]) => t.name === "subagent_interactive",
+  )?.[0];
 }
 
 describe("subagent_interactive notifyOnComplete default", () => {
-	let api: ReturnType<typeof setupExtension>;
+  let api: ReturnType<typeof setupExtension>;
 
-	function setupExtension() {
-		const _api = {
-			registerTool: vi.fn(),
-			registerMessageRenderer: vi.fn(),
-			sendMessage: vi.fn(),
-			sendUserMessage: vi.fn(),
-			on: vi.fn(),
-		};
-		registerExtension(_api as any);
-		return _api;
-	}
+  function setupExtension() {
+    const _api = {
+      registerTool: vi.fn(),
+      registerMessageRenderer: vi.fn(),
+      sendMessage: vi.fn(),
+      sendUserMessage: vi.fn(),
+      on: vi.fn(),
+    };
+    registerExtension(_api as any);
+    return _api;
+  }
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-		api = setupExtension() as any;
-		mockLaunchInteractiveSubagent.mockReset();
-		// Return a minimal valid InteractiveSubagentState.
-		mockLaunchInteractiveSubagent.mockReturnValue({
-			id: "abc12345",
-			name: "Test",
-			task: "t",
-			paneId: "%99",
-			sessionFile: "/tmp/sess.jsonl",
-			cwd: "/tmp",
-			startedAt: Date.now(),
-			status: "running",
-			mux: "tmux",
-			attachCommand: "tmux attach -t s",
-			selectPaneCommand: "tmux select-pane -t '%99'",
-			launchScriptFile: "/tmp/launch.sh",
-			artifactDir: "/tmp/artifacts/abc12345",
-		});
-	});
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api = setupExtension() as any;
+    mockLaunchInteractiveSubagent.mockReset();
+    // Return a minimal valid InteractiveSubagentState.
+    mockLaunchInteractiveSubagent.mockReturnValue({
+      id: "abc12345",
+      name: "Test",
+      task: "t",
+      paneId: "%99",
+      sessionFile: "/tmp/sess.jsonl",
+      cwd: "/tmp",
+      startedAt: Date.now(),
+      status: "running",
+      mux: "tmux",
+      attachCommand: "tmux attach -t s",
+      selectPaneCommand: "tmux select-pane -t '%99'",
+      launchScriptFile: "/tmp/launch.sh",
+      artifactDir: "/tmp/artifacts/abc12345",
+    });
+  });
 
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
 
-	it("defaults to 'inject' when notifyOnComplete is omitted (parent LLM is woken up by default)", async () => {
-		const toolDef = getInteractiveToolDef(api);
-		expect(toolDef).toBeDefined();
+  it("defaults to 'inject' when notifyOnComplete is omitted (parent LLM is woken up by default)", async () => {
+    const toolDef = getInteractiveToolDef(api);
+    expect(toolDef).toBeDefined();
 
-		await toolDef.execute("call-1", { task: "research X" }, undefined, undefined, mockCtx());
+    await toolDef.execute(
+      "call-1",
+      { task: "research X" },
+      undefined,
+      undefined,
+      mockCtx(),
+    );
 
-		// The helper was called exactly once.
-		expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
-		// And the default was 'inject' — not 'notify'.
-		const callArgs = mockLaunchInteractiveSubagent.mock.calls[0][0];
-		expect(callArgs.notifyOnComplete).toBe("inject");
-	});
+    // The helper was called exactly once.
+    expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
+    // And the default was 'inject' — not 'notify'.
+    const callArgs = mockLaunchInteractiveSubagent.mock.calls[0][0];
+    expect(callArgs.notifyOnComplete).toBe("inject");
+  });
 
-	it("forwards 'notify' when explicitly passed (opt out of LLM wake-up)", async () => {
-		const toolDef = getInteractiveToolDef(api);
+  it("forwards 'notify' when explicitly passed (opt out of LLM wake-up)", async () => {
+    const toolDef = getInteractiveToolDef(api);
 
-		await toolDef.execute(
-			"call-2",
-			{ task: "research X", notifyOnComplete: "notify" },
-			undefined,
-			undefined,
-			mockCtx(),
-		);
+    await toolDef.execute(
+      "call-2",
+      { task: "research X", notifyOnComplete: "notify" },
+      undefined,
+      undefined,
+      mockCtx(),
+    );
 
-		expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
-		expect(mockLaunchInteractiveSubagent.mock.calls[0][0].notifyOnComplete).toBe("notify");
-	});
+    expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
+    expect(
+      mockLaunchInteractiveSubagent.mock.calls[0][0].notifyOnComplete,
+    ).toBe("notify");
+  });
 
-	it("forwards 'inject' when explicitly passed (matches the default behavior, but explicit)", async () => {
-		const toolDef = getInteractiveToolDef(api);
+  it("forwards 'inject' when explicitly passed (matches the default behavior, but explicit)", async () => {
+    const toolDef = getInteractiveToolDef(api);
 
-		await toolDef.execute(
-			"call-3",
-			{ task: "research X", notifyOnComplete: "inject" },
-			undefined,
-			undefined,
-			mockCtx(),
-		);
+    await toolDef.execute(
+      "call-3",
+      { task: "research X", notifyOnComplete: "inject" },
+      undefined,
+      undefined,
+      mockCtx(),
+    );
 
-		expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
-		expect(mockLaunchInteractiveSubagent.mock.calls[0][0].notifyOnComplete).toBe("inject");
-	});
+    expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(1);
+    expect(
+      mockLaunchInteractiveSubagent.mock.calls[0][0].notifyOnComplete,
+    ).toBe("inject");
+  });
 
-	it("exposes notifyOnComplete in the schema with the new default documented", () => {
-		const toolDef = getInteractiveToolDef(api);
-		expect(toolDef).toBeDefined();
-		const params = toolDef.parameters;
-		// TypeBox runtime shape: properties.notifyOnComplete exists
-		const properties = (params as any).properties;
-		expect(properties).toBeDefined();
-		expect(properties.notifyOnComplete).toBeDefined();
-		// Description must document 'inject' as the default and 'notify' as a valid
-		// alternative. We don't assert literal phrasing — just that 'inject' is the
-		// documented default — so wording tweaks don't break the test.
-		const desc = properties.notifyOnComplete.description ?? "";
-		// 'inject' is documented as the default.
-		expect(desc).toMatch(/inject.*default|default.*inject/i);
-		// 'notify' is documented as a valid choice (just not the default).
-		expect(desc).toContain('"notify"');
-	});
+  it("exposes notifyOnComplete in the schema with the new default documented", () => {
+    const toolDef = getInteractiveToolDef(api);
+    expect(toolDef).toBeDefined();
+    const params = toolDef.parameters;
+    // TypeBox runtime shape: properties.notifyOnComplete exists
+    const properties = (params as any).properties;
+    expect(properties).toBeDefined();
+    expect(properties.notifyOnComplete).toBeDefined();
+    // Description must document 'inject' as the default and 'notify' as a valid
+    // alternative. We don't assert literal phrasing — just that 'inject' is the
+    // documented default — so wording tweaks don't break the test.
+    const desc = properties.notifyOnComplete.description ?? "";
+    // 'inject' is documented as the default.
+    expect(desc).toMatch(/inject.*default|default.*inject/i);
+    // 'notify' is documented as a valid choice (just not the default).
+    expect(desc).toContain('"notify"');
+  });
 });
-

--- a/src/subagent-notify.test.ts
+++ b/src/subagent-notify.test.ts
@@ -586,11 +586,7 @@ describe("notifyOnComplete", () => {
       const jobId = "status-override-model";
       const control = createJobControl();
       mockStartSubagentJob.mockImplementationOnce(() =>
-        mockJobResult(
-          jobId,
-          control.jobPromise,
-          "override/provider-model",
-        ),
+        mockJobResult(jobId, control.jobPromise, "override/provider-model"),
       );
 
       await isolatedToolDef.execute(
@@ -1050,7 +1046,9 @@ describe("read_subagent_artifact (invalid id)", () => {
       on: vi.fn(),
     };
     registerExtension(_api as any);
-    return _api.registerTool.mock.calls.find(([t]: any[]) => t.name === "read_subagent_artifact")?.[0];
+    return _api.registerTool.mock.calls.find(
+      ([t]: any[]) => t.name === "read_subagent_artifact",
+    )?.[0];
   }
 
   beforeEach(() => {
@@ -1066,7 +1064,13 @@ describe("read_subagent_artifact (invalid id)", () => {
     const toolDef = setupReadArtifactTool();
     expect(toolDef).toBeDefined();
 
-    const result = await toolDef.execute("call-malformed", { id: "not-a-hex-id" }, undefined, undefined, {} as any);
+    const result = await toolDef.execute(
+      "call-malformed",
+      { id: "not-a-hex-id" },
+      undefined,
+      undefined,
+      {} as any,
+    );
 
     expect(result.isError).toBe(true);
     expect(result.details.status).toBe("invalid_id");
@@ -1114,7 +1118,9 @@ describe("read_subagent_artifact (output reporting)", () => {
       on: vi.fn(),
     };
     (mod as any).default(_api as any);
-    return _api.registerTool.mock.calls.find(([t]: any[]) => t.name === "read_subagent_artifact")?.[0];
+    return _api.registerTool.mock.calls.find(
+      ([t]: any[]) => t.name === "read_subagent_artifact",
+    )?.[0];
   }
 
   beforeEach(() => {
@@ -1136,9 +1142,17 @@ describe("read_subagent_artifact (output reporting)", () => {
       const readTool = makeReadTool(mod);
       expect(readTool).toBeDefined();
 
-      const result = await readTool.execute("call-1", { id }, undefined, undefined, {} as any);
+      const result = await readTool.execute(
+        "call-1",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
       const text = result.content[0].text;
-      expect(text).toContain("Output: (sub-agent exited without writing output.md");
+      expect(text).toContain(
+        "Output: (sub-agent exited without writing output.md",
+      );
       expect(text).toContain("last event: done @ 2");
       expect(text).not.toContain("not written yet");
       expect(result.details.output).toBeNull();
@@ -1161,7 +1175,7 @@ describe("read_subagent_artifact (output reporting)", () => {
         cwd: "/tmp",
         startedAt: 1,
         status: "running",
-      mux: "tmux",
+        mux: "tmux",
         attachCommand: "tmux attach",
         selectPaneCommand: "tmux select-pane",
         launchScriptFile: "/tmp/launch.sh",
@@ -1169,13 +1183,25 @@ describe("read_subagent_artifact (output reporting)", () => {
       };
       const art = artifactPath(parent, id);
       appendEvent(art, { ts: 1, type: "started", status: "running" });
-      appendEvent(art, { ts: 2, type: "tool_activity", status: "running", tool: "bash", summary: "ls" });
+      appendEvent(art, {
+        ts: 2,
+        type: "tool_activity",
+        status: "running",
+        tool: "bash",
+        summary: "ls",
+      });
 
       const mod = await importFresh<typeof import("./subagent")>("./subagent");
       mod.interactiveSubagentRegistry.set(id, state);
 
       const readTool = makeReadTool(mod);
-      const result = await readTool.execute("call-2", { id }, undefined, undefined, {} as any);
+      const result = await readTool.execute(
+        "call-2",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
       const text = result.content[0].text;
       expect(text).toContain("Output: (2 events");
       expect(text).toContain("last: tool_activity @ 2");
@@ -1196,7 +1222,13 @@ describe("read_subagent_artifact (output reporting)", () => {
       mod.interactiveSubagentRegistry.set(id, state);
 
       const readTool = makeReadTool(mod);
-      const result = await readTool.execute("call-3", { id }, undefined, undefined, {} as any);
+      const result = await readTool.execute(
+        "call-3",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
       const text = result.content[0].text;
       expect(text).toContain("Output: (empty — 0 chars)");
       expect(result.details.output).toBe("");
@@ -1216,7 +1248,13 @@ describe("read_subagent_artifact (output reporting)", () => {
       mod.interactiveSubagentRegistry.set(id, state);
 
       const readTool = makeReadTool(mod);
-      const result = await readTool.execute("call-4", { id }, undefined, undefined, {} as any);
+      const result = await readTool.execute(
+        "call-4",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
       const text = result.content[0].text;
       expect(text).toContain("Output: 13 chars");
       expect(result.details.output).toBe("Hello, world!");

--- a/src/subagent-send-message.test.ts
+++ b/src/subagent-send-message.test.ts
@@ -13,209 +13,246 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockSendCommandToPane, mockGet } = vi.hoisted(() => ({
-	mockSendCommandToPane: vi.fn(),
-	mockGet: vi.fn(),
+  mockSendCommandToPane: vi.fn(),
+  mockGet: vi.fn(),
 }));
 
 // Mock interactive-tmux so we get a stub registry + controllable send-keys helper.
 vi.mock("./interactive-tmux", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("./interactive-tmux")>();
-	return {
-		...actual,
-		sendCommandToPane: mockSendCommandToPane,
-		interactiveSubagentRegistry: {
-			get: mockGet,
-		} as any,
-	};
+  const actual = await importOriginal<typeof import("./interactive-tmux")>();
+  return {
+    ...actual,
+    sendCommandToPane: mockSendCommandToPane,
+    interactiveSubagentRegistry: {
+      get: mockGet,
+    } as any,
+  };
 });
 
 import registerExtension from "./subagent";
 
 function setupExtension() {
-	const api = {
-		registerTool: vi.fn(),
-		registerMessageRenderer: vi.fn(),
-		sendMessage: vi.fn(),
-		sendUserMessage: vi.fn(),
-		on: vi.fn(),
-	};
-	registerExtension(api as any);
-	return api;
+  const api = {
+    registerTool: vi.fn(),
+    registerMessageRenderer: vi.fn(),
+    sendMessage: vi.fn(),
+    sendUserMessage: vi.fn(),
+    on: vi.fn(),
+  };
+  registerExtension(api as any);
+  return api;
 }
 
-function getToolDef(api: { registerTool: ReturnType<typeof vi.fn> }, name: string) {
-	return api.registerTool.mock.calls.find(([t]: any[]) => t.name === name)?.[0];
+function getToolDef(
+  api: { registerTool: ReturnType<typeof vi.fn> },
+  name: string,
+) {
+  return api.registerTool.mock.calls.find(([t]: any[]) => t.name === name)?.[0];
 }
 
 function runningState(overrides: Record<string, any> = {}) {
-	return {
-		id: "abc12345",
-		name: "Test",
-		paneId: "%99",
-		status: "running",
-		...overrides,
-	};
+  return {
+    id: "abc12345",
+    name: "Test",
+    paneId: "%99",
+    status: "running",
+    ...overrides,
+  };
 }
 
 describe("send_interactive_subagent_message", () => {
-	let api: ReturnType<typeof setupExtension>;
+  let api: ReturnType<typeof setupExtension>;
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-		api = setupExtension() as any;
-	});
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api = setupExtension() as any;
+  });
 
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
 
-	it("is registered with the expected name", () => {
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		expect(toolDef).toBeDefined();
-	});
+  it("is registered with the expected name", () => {
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    expect(toolDef).toBeDefined();
+  });
 
-	it("sends the message to the pane and returns success details", async () => {
-		mockGet.mockReturnValue(runningState());
-		mockSendCommandToPane.mockReturnValue(undefined);
+  it("sends the message to the pane and returns success details", async () => {
+    mockGet.mockReturnValue(runningState());
+    mockSendCommandToPane.mockReturnValue(undefined);
 
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const result = await toolDef.execute("call-1", {
-			id: "abc12345",
-			message: "now do step 2",
-		});
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const result = await toolDef.execute("call-1", {
+      id: "abc12345",
+      message: "now do step 2",
+    });
 
-		expect(mockGet).toHaveBeenCalledWith("abc12345");
-		expect(mockSendCommandToPane).toHaveBeenCalledWith(expect.objectContaining({ paneId: "%99" }), "now do step 2");
-		expect(result.isError).toBeFalsy();
-		expect(result.details).toMatchObject({
-			id: "abc12345",
-			paneId: "%99",
-			messageLength: "now do step 2".length,
-			status: "sent",
-		});
-		expect(result.content[0].text).toContain("Sent follow-up to interactive sub-agent abc12345");
-		expect(result.content[0].text).toContain("pane %99");
-	});
+    expect(mockGet).toHaveBeenCalledWith("abc12345");
+    expect(mockSendCommandToPane).toHaveBeenCalledWith(
+      expect.objectContaining({ paneId: "%99" }),
+      "now do step 2",
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.details).toMatchObject({
+      id: "abc12345",
+      paneId: "%99",
+      messageLength: "now do step 2".length,
+      status: "sent",
+    });
+    expect(result.content[0].text).toContain(
+      "Sent follow-up to interactive sub-agent abc12345",
+    );
+    expect(result.content[0].text).toContain("pane %99");
+  });
 
-	it("accepts 'idle' sub-agents (the follow-up case — child between turns, REPL open)", async () => {
-		// 'idle' is the whole point of the follow-up flow: the child finished a turn, REPL is still
-		// open, status='idle' (not 'exited'). The tool must accept sends in this state.
-		mockGet.mockReturnValue(runningState({ status: "idle" }));
-		mockSendCommandToPane.mockReturnValue(undefined);
+  it("accepts 'idle' sub-agents (the follow-up case — child between turns, REPL open)", async () => {
+    // 'idle' is the whole point of the follow-up flow: the child finished a turn, REPL is still
+    // open, status='idle' (not 'exited'). The tool must accept sends in this state.
+    mockGet.mockReturnValue(runningState({ status: "idle" }));
+    mockSendCommandToPane.mockReturnValue(undefined);
 
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const result = await toolDef.execute("call-1b", {
-			id: "abc12345",
-			message: "follow-up after turn 1",
-		});
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const result = await toolDef.execute("call-1b", {
+      id: "abc12345",
+      message: "follow-up after turn 1",
+    });
 
-		expect(mockSendCommandToPane).toHaveBeenCalledWith(expect.objectContaining({ paneId: "%99" }), "follow-up after turn 1");
-		expect(result.isError).toBeFalsy();
-		expect(result.details.status).toBe("sent");
-	});
+    expect(mockSendCommandToPane).toHaveBeenCalledWith(
+      expect.objectContaining({ paneId: "%99" }),
+      "follow-up after turn 1",
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.details.status).toBe("sent");
+  });
 
+  it("rejects malformed ids with a precise error", async () => {
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const result = await toolDef.execute("call-2", {
+      id: "not-hex",
+      message: "hi",
+    });
 
-	it("rejects malformed ids with a precise error", async () => {
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const result = await toolDef.execute("call-2", { id: "not-hex", message: "hi" });
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockSendCommandToPane).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.details.status).toBe("invalid_id");
+    expect(result.content[0].text).toMatch(/Invalid sub-agent id/);
+  });
 
-		expect(mockGet).not.toHaveBeenCalled();
-		expect(mockSendCommandToPane).not.toHaveBeenCalled();
-		expect(result.isError).toBe(true);
-		expect(result.details.status).toBe("invalid_id");
-		expect(result.content[0].text).toMatch(/Invalid sub-agent id/);
-	});
+  it.each(["", "   ", "\n\n", "\t  \n"])(
+    "rejects empty / whitespace-only message: %j",
+    async (message) => {
+      // An empty Enter in the child REPL would submit a blank prompt and confuse the child;
+      // reject it before any registry / tmux work happens.
+      const toolDef = getToolDef(api, "send_interactive_subagent_message");
+      const result = await toolDef.execute("call-empty", {
+        id: "abc12345",
+        message,
+      });
 
-	it.each(["", "   ", "\n\n", "\t  \n"])("rejects empty / whitespace-only message: %j", async (message) => {
-		// An empty Enter in the child REPL would submit a blank prompt and confuse the child;
-		// reject it before any registry / tmux work happens.
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const result = await toolDef.execute("call-empty", { id: "abc12345", message });
+      expect(mockGet).not.toHaveBeenCalled();
+      expect(mockSendCommandToPane).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.details.status).toBe("empty_message");
+      expect(result.details.messageLength).toBe(0);
+      expect(result.content[0].text).toMatch(/empty/i);
+    },
+  );
 
-		expect(mockGet).not.toHaveBeenCalled();
-		expect(mockSendCommandToPane).not.toHaveBeenCalled();
-		expect(result.isError).toBe(true);
-		expect(result.details.status).toBe("empty_message");
-		expect(result.details.messageLength).toBe(0);
-		expect(result.content[0].text).toMatch(/empty/i);
-	});
+  it("rejects a message larger than 64 KiB", async () => {
+    // Symmetric with MAX_PERSONA_BYTES in interactive-tmux.ts. 64 KiB UTF-8 is well above any
+    // realistic follow-up prompt; larger values risk blowing the child REPL history.
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const message = "x".repeat(64 * 1024 + 1);
+    const result = await toolDef.execute("call-huge", {
+      id: "abc12345",
+      message,
+    });
 
-	it("rejects a message larger than 64 KiB", async () => {
-		// Symmetric with MAX_PERSONA_BYTES in interactive-tmux.ts. 64 KiB UTF-8 is well above any
-		// realistic follow-up prompt; larger values risk blowing the child REPL history.
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const message = "x".repeat(64 * 1024 + 1);
-		const result = await toolDef.execute("call-huge", { id: "abc12345", message });
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockSendCommandToPane).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.details).toMatchObject({
+      id: "abc12345",
+      status: "message_too_large",
+      messageLength: 64 * 1024 + 1,
+      maxBytes: 64 * 1024,
+    });
+    expect(result.content[0].text).toMatch(/too large/);
+    expect(result.content[0].text).toMatch(/65536/);
+  });
 
-		expect(mockGet).not.toHaveBeenCalled();
-		expect(mockSendCommandToPane).not.toHaveBeenCalled();
-		expect(result.isError).toBe(true);
-		expect(result.details).toMatchObject({
-			id: "abc12345",
-			status: "message_too_large",
-			messageLength: 64 * 1024 + 1,
-			maxBytes: 64 * 1024,
-		});
-		expect(result.content[0].text).toMatch(/too large/);
-		expect(result.content[0].text).toMatch(/65536/);
-	});
+  it("accepts a message exactly at the 64 KiB boundary", async () => {
+    // Boundary check: 64 KiB is allowed, 64 KiB + 1 is not.
+    mockGet.mockReturnValue(runningState());
+    mockSendCommandToPane.mockReturnValue(undefined);
 
-	it("accepts a message exactly at the 64 KiB boundary", async () => {
-		// Boundary check: 64 KiB is allowed, 64 KiB + 1 is not.
-		mockGet.mockReturnValue(runningState());
-		mockSendCommandToPane.mockReturnValue(undefined);
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const message = "x".repeat(64 * 1024);
+    const result = await toolDef.execute("call-boundary", {
+      id: "abc12345",
+      message,
+    });
 
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const message = "x".repeat(64 * 1024);
-		const result = await toolDef.execute("call-boundary", { id: "abc12345", message });
+    expect(mockSendCommandToPane).toHaveBeenCalledWith(
+      expect.objectContaining({ paneId: "%99" }),
+      message,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.details.status).toBe("sent");
+    expect(result.details.messageLength).toBe(64 * 1024);
+  });
+  it("rejects unknown sub-agent ids", async () => {
+    mockGet.mockReturnValue(undefined);
 
-		expect(mockSendCommandToPane).toHaveBeenCalledWith(expect.objectContaining({ paneId: "%99" }), message);
-		expect(result.isError).toBeFalsy();
-		expect(result.details.status).toBe("sent");
-		expect(result.details.messageLength).toBe(64 * 1024);
-	});
-	it("rejects unknown sub-agent ids", async () => {
-		mockGet.mockReturnValue(undefined);
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const result = await toolDef.execute("call-3", {
+      id: "deadbeef",
+      message: "hi",
+    });
 
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const result = await toolDef.execute("call-3", { id: "deadbeef", message: "hi" });
+    expect(mockSendCommandToPane).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.details.status).toBe("not_found");
+  });
 
-		expect(mockSendCommandToPane).not.toHaveBeenCalled();
-		expect(result.isError).toBe(true);
-		expect(result.details.status).toBe("not_found");
-	});
+  it.each(["cancelled", "exited", "unknown"] as const)(
+    "refuses to send when the sub-agent status is %s",
+    async (status) => {
+      mockGet.mockReturnValue(runningState({ status }));
 
-	it.each(["cancelled", "exited", "unknown"] as const)(
-		"refuses to send when the sub-agent status is %s",
-		async (status) => {
-			mockGet.mockReturnValue(runningState({ status }));
+      const toolDef = getToolDef(api, "send_interactive_subagent_message");
+      const result = await toolDef.execute("call-4", {
+        id: "abc12345",
+        message: "hi",
+      });
 
-			const toolDef = getToolDef(api, "send_interactive_subagent_message");
-			const result = await toolDef.execute("call-4", { id: "abc12345", message: "hi" });
+      expect(mockSendCommandToPane).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.details.status).toBe(status);
+      expect(result.content[0].text).toContain(`is ${status}`);
+    },
+  );
 
-			expect(mockSendCommandToPane).not.toHaveBeenCalled();
-			expect(result.isError).toBe(true);
-			expect(result.details.status).toBe(status);
-			expect(result.content[0].text).toContain(`is ${status}`);
-		},
-	);
+  it("returns a structured error when tmux send-keys throws (pane gone between check and send)", async () => {
+    mockGet.mockReturnValue(runningState());
+    mockSendCommandToPane.mockImplementation(() => {
+      throw new Error("can't find pane: %99");
+    });
 
-	it("returns a structured error when tmux send-keys throws (pane gone between check and send)", async () => {
-		mockGet.mockReturnValue(runningState());
-		mockSendCommandToPane.mockImplementation(() => {
-			throw new Error("can't find pane: %99");
-		});
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const result = await toolDef.execute("call-5", {
+      id: "abc12345",
+      message: "hi",
+    });
 
-		const toolDef = getToolDef(api, "send_interactive_subagent_message");
-		const result = await toolDef.execute("call-5", { id: "abc12345", message: "hi" });
-
-		expect(result.isError).toBe(true);
-		expect(result.details).toMatchObject({
-			id: "abc12345",
-			paneId: "%99",
-			status: "send_failed",
-		});
-		expect(result.content[0].text).toContain("Failed to send message");
-		expect(result.content[0].text).toContain("can't find pane: %99");
-	});
+    expect(result.isError).toBe(true);
+    expect(result.details).toMatchObject({
+      id: "abc12345",
+      paneId: "%99",
+      status: "send_failed",
+    });
+    expect(result.content[0].text).toContain("Failed to send message");
+    expect(result.content[0].text).toContain("can't find pane: %99");
+  });
 });

--- a/src/subagent-session-log.test.ts
+++ b/src/subagent-session-log.test.ts
@@ -11,7 +11,14 @@
  * at it, then call `pollArtifactChanges` and assert the appended events.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendEvent, artifactPath, readEvents } from "./artifact";
@@ -19,662 +26,858 @@ import type { InteractiveSubagentState } from "./interactive-tmux";
 import { importFresh } from "./test-utils";
 
 function makeTmp(): string {
-	return mkdtempSync(join(tmpdir(), "pi-subagentura-session-log-"));
+  return mkdtempSync(join(tmpdir(), "pi-subagentura-session-log-"));
 }
 
-function makeState(overrides: {
-	sessionFile?: string;
-}): { id: string; artifactDir: string; state: InteractiveSubagentState } {
-	const id = "id-" + Math.random().toString(36).slice(2, 8);
-	const root = makeTmp();
-	const artifactDir = join(root, id);
-	mkdirSync(artifactDir, { recursive: true });
-	const state: InteractiveSubagentState = {
-		id,
-		name: "Test",
-		task: "t",
-		paneId: "%99",
-		sessionFile: overrides.sessionFile ?? join(artifactDir, "session.jsonl"),
-		cwd: "/tmp",
-		startedAt: Date.now(),
-		status: "running",
-		mux: "tmux",
-		attachCommand: "tmux attach -t sess",
-		selectPaneCommand: "tmux select-pane -t '%99'",
-		launchScriptFile: "/tmp/launch.sh",
-		artifactDir,
-	};
-	return { id, artifactDir, state };
+function makeState(overrides: { sessionFile?: string }): {
+  id: string;
+  artifactDir: string;
+  state: InteractiveSubagentState;
+} {
+  const id = "id-" + Math.random().toString(36).slice(2, 8);
+  const root = makeTmp();
+  const artifactDir = join(root, id);
+  mkdirSync(artifactDir, { recursive: true });
+  const state: InteractiveSubagentState = {
+    id,
+    name: "Test",
+    task: "t",
+    paneId: "%99",
+    sessionFile: overrides.sessionFile ?? join(artifactDir, "session.jsonl"),
+    cwd: "/tmp",
+    startedAt: Date.now(),
+    status: "running",
+    mux: "tmux",
+    attachCommand: "tmux attach -t sess",
+    selectPaneCommand: "tmux select-pane -t '%99'",
+    launchScriptFile: "/tmp/launch.sh",
+    artifactDir,
+  };
+  return { id, artifactDir, state };
 }
-
-
 
 describe("session-log tail-read", () => {
-	let root: string;
-
-	beforeEach(() => {
-		root = makeTmp();
-		const g = globalThis as any;
-		g.__piSubagenturaInteractiveRegistry?.clear?.();
-		g.__piSubagenturaPiRef = undefined;
-		g.__piSubagenturaUi = undefined;
-		// Force `isTmuxPaneAlive` to return true so the poller's status-decision does not flip our
-		// sub-agent to "unknown" (which would skip it on subsequent polls). The test does not have a
-		// live tmux server, and host tmux behaviour varies — some versions exit 0 for unknown panes,
-		// some exit 1, and on a machine without tmux at all `execFileSync` throws. Mocking here keeps the
-		// suite hermetic and matches the pattern in subagent-poll.test.ts.
-		vi.doMock("node:child_process", () => ({
-			execFileSync: (_file: string, args: string[]) => {
-				if (args[0] === "display-message") return Buffer.from("#99");
-				return "";
-			},
-		}));
-	});
-
-	afterEach(() => {
-		rmSync(root, { recursive: true, force: true });
-	});
-
-	it("appends a tool_activity event for a bash tool call", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		// Write a fake session log with one assistant message containing a toolCall.
-		const sessionFile = state.sessionFile;
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [
-					{ type: "text", text: "I'll search the codebase." },
-					{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "rg TODO src/" } },
-				],
-				api: "openai",
-				provider: "openai",
-				model: "gpt-4",
-				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
-				stopReason: "toolUse",
-				timestamp: 1700000000000,
-			},
-		};
-		writeFileSync(sessionFile, JSON.stringify(entry) + "\n");
-
-		const sendMessage = vi.fn();
-		mod.pollArtifactChanges({ sendMessage } as any);
-
-		// Should not have notified the LLM (tool_activity is silent).
-		expect(sendMessage).not.toHaveBeenCalled();
-
-		// Should have appended a tool_activity event to events.ndjson.
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		expect(events).toHaveLength(1);
-		const event = events[0];
-		expect(event.type).toBe("tool_activity");
-		if (event.type === "tool_activity") {
-			expect(event.tool).toBe("bash");
-			expect(event.summary).toBe("rg TODO src/");
-		}
-		expect(event.status).toBe("running");
-		// Cursor advanced.
-		expect(state.lastDeliveredSessionByte).toBeGreaterThan(0);
-	});
-
-	it("appends tool_activity for write, edit, read with file paths", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [
-					{ type: "toolCall", id: "t1", name: "write", arguments: { path: "/tmp/review-1.md", content: "..." } },
-					{ type: "toolCall", id: "t2", name: "edit", arguments: { path: "/src/foo.ts", oldText: "a", newText: "b" } },
-					{ type: "toolCall", id: "t3", name: "read", arguments: { path: "/src/bar.ts" } },
-				],
-				timestamp: 1700000000000,
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		const tools = events.filter((e) => e.type === "tool_activity");
-		expect(tools).toHaveLength(3);
-		expect(tools[0]).toMatchObject({ tool: "write", summary: "/tmp/review-1.md" });
-		expect(tools[1]).toMatchObject({ tool: "edit", summary: "/src/foo.ts" });
-		expect(tools[2]).toMatchObject({ tool: "read", summary: "/src/bar.ts" });
-	});
-
-	it("skips tools with no summary (grep, find, ls, custom)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [
-					{ type: "toolCall", id: "t1", name: "grep", arguments: { pattern: "TODO", path: "/src" } },
-					{ type: "toolCall", id: "t2", name: "find", arguments: { pattern: "*.ts" } },
-					{ type: "toolCall", id: "t3", name: "ls", arguments: { path: "/src" } },
-				],
-				timestamp: 1700000000000,
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(0);
-	});
-
-	it("truncates long bash commands to 80 chars", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const longCmd = "echo " + "x".repeat(200);
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: longCmd } }],
-				timestamp: 1700000000000,
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		const activity = events.find((e) => e.type === "tool_activity");
-		expect(activity?.summary).toBeDefined();
-		expect(activity!.summary!.length).toBeLessThanOrEqual(80);
-		expect(activity!.summary!.endsWith("…")).toBe(true);
-	});
-
-	it("cursor advances — second poll with no new lines does not duplicate", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "echo hi" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-		const after1 = state.lastDeliveredSessionByte;
-		expect(after1).toBeGreaterThan(0);
-
-		mod.pollArtifactChanges({} as any);
-		expect(state.lastDeliveredSessionByte).toBe(after1); // unchanged
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(1);
-	});
-
-	it("picks up new lines written between polls", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const e1 = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "echo 1" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		const e2 = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t2", name: "write", arguments: { path: "/tmp/foo.md" } }],
-				timestamp: 1700000001000,
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(e1) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-
-		// Append second line.
-		const { appendFileSync } = await import("node:fs");
-		appendFileSync(state.sessionFile, JSON.stringify(e2) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		const activity = events.filter((e) => e.type === "tool_activity");
-		expect(activity).toHaveLength(2);
-		expect(activity[0].tool).toBe("bash");
-		expect(activity[1].tool).toBe("write");
-	});
-
-	it("tolerates a partial trailing line without crashing", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "echo hi" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		// Write a complete line + a truncated second line.
-		const complete = JSON.stringify(entry) + "\n";
-		const partial = '{ "type": "mess';
-		writeFileSync(state.sessionFile, complete + partial);
-
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		// Only the complete line was processed.
-
-		expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(1);
-		// Cursor advances to the end of the read window (the partial bytes are now buffered inside the
-		// ndjson parser). Re-reading them next tick would re-feed the parser and double-emit, so the new
-		// design lets the cursor sweep past the partial and relies on the parser to track line state.
-		expect(state.lastDeliveredSessionByte).toBe(Buffer.byteLength(complete + partial, "utf8"));
-	});
-
-
-	it("re-reads a partial line once it is completed on a later poll", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "write", arguments: { path: "/tmp/x" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		const complete = JSON.stringify(entry) + "\n";
-		const partial = '{ "type": "mess';
-		writeFileSync(state.sessionFile, complete + partial);
-		// First poll: ndjson parser buffers the partial internally. The cursor sweeps to the end of
-		// the read window so the next tick only reads NEW bytes (not the buffered partial).
-		mod.pollArtifactChanges({} as any);
-		expect(state.lastDeliveredSessionByte).toBe(Buffer.byteLength(complete + partial, "utf8"));
-
-		// Second poll: child finishes writing the partial. We need to APPEND to
-		// the file (not rewrite) so the byte offset after the partial is
-		// unchanged.
-		const appended = "age\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"toolCall\",\"id\":\"t2\",\"name\":\"bash\",\"arguments\":{\"command\":\"ls\"}}]}}\n";
-		appendFileSync(state.sessionFile, appended);
-
-		mod.pollArtifactChanges({} as any);
-		expect(state.lastDeliveredSessionByte).toBe(
-			Buffer.byteLength(complete + partial, "utf8") + Buffer.byteLength(appended, "utf8"),
-		);
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const events = readEvents(art);
-		// Now BOTH tool_activity events should be present.
-		expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(2);
-	});
-
-
-	it("does nothing when the session file does not exist yet", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({
-			sessionFile: "/tmp/does-not-exist-" + Math.random() + ".jsonl",
-		});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		expect(() => mod.pollArtifactChanges({} as any)).not.toThrow();
-		expect(state.lastDeliveredSessionByte).toBeUndefined();
-	});
-
-	it("updates state.lastToolSummary and lastActivityAt for the widget", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "rg TODO src/" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-
-		expect(state.lastToolName).toBe("bash");
-		expect(state.lastToolSummary).toBe("rg TODO src/");
-		expect(state.lastActivityAt).toBe(1700000000000);
-	});
-
-	it("paints the TUI widget when ui ref is set", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "rg TODO src/" } }],
-				timestamp: Date.now(),
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
-
-		const setStatus = vi.fn();
-		const setWidget = vi.fn();
-		(globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
-
-		mod.pollArtifactChanges({} as any);
-
-		// Footer status shows count.
-		expect(setStatus).toHaveBeenCalledWith("subagentura-running", "⚡ 1 sub-agent running");
-		// Widget shows the activity row.
-		expect(setWidget).toHaveBeenCalledTimes(1);
-		const [key, lines, opts] = setWidget.mock.calls[0];
-		expect(key).toBe("subagentura-activity");
-		expect(opts).toEqual({ placement: "belowEditor" });
-		expect(lines[0]).toContain("Test:");
-		expect(lines[0]).toContain("rg TODO src/");
-	});
-
-	it("clears the widget and footer when no sub-agents are running", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		// Empty registry.
-		const setStatus = vi.fn();
-		const setWidget = vi.fn();
-		(globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
-
-		mod.pollArtifactChanges({} as any);
-
-		expect(setStatus).toHaveBeenCalledWith("subagentura-running", undefined);
-		expect(setWidget).toHaveBeenCalledWith("subagentura-activity", undefined, { placement: "belowEditor" });
-	});
-
-	it("inlines the error message in the LLM notification but uses pointers on success", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
-		appendEvent(art, {
-			ts: 2,
-			type: "error",
-			status: "error",
-			message: "bash exited with code 1: rg foo missing",
-		});
-
-		const sendMessage = vi.fn();
-		mod.pollArtifactChanges({ sendMessage } as any);
-
-		expect(sendMessage).toHaveBeenCalledTimes(2);
-
-		// done: pointer only, no body.
-		const doneCall = sendMessage.mock.calls[0][0];
-		expect(doneCall.content).toContain("done");
-		expect(doneCall.content).toContain("Output:");
-		expect(doneCall.content).toContain("Activity log:");
-		expect(doneCall.content).not.toContain("exited with code");
-
-		// error: inline message + pointers.
-		const errCall = sendMessage.mock.calls[1][0];
-		expect(errCall.content).toContain("error");
-		expect(errCall.content).toContain("bash exited with code 1");
-		expect(errCall.content).toContain("Output:");
-		expect(errCall.content).toContain("Activity log:");
-	});
-
-	it("truncates the inline error message to 500 chars", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const longMsg = "x".repeat(2000);
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		appendEvent(art, { ts: 1, type: "error", status: "error", message: longMsg });
-
-		const sendMessage = vi.fn();
-		mod.pollArtifactChanges({ sendMessage } as any);
-
-		const content = sendMessage.mock.calls[0][0].content as string;
-		// The "x".repeat(2000) portion must be capped.
-		const match = content.match(/x+/);
-		expect(match).not.toBeNull();
-		expect(match![0].length).toBeLessThanOrEqual(500);
-		expect(match![0].length).toBeLessThanOrEqual(500);
-	});
-
-	it("resets the cursor when the session log is truncated below it", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-		// write 1KB of content, poll to advance cursor
-		writeFileSync(state.sessionFile, "x".repeat(1024) + "\n");
-		mod.pollArtifactChanges({} as any);
-		expect(state.lastDeliveredSessionByte).toBe(1025);
-		// truncate to 0, then write new content
-		writeFileSync(state.sessionFile, "new\n");
-		mod.pollArtifactChanges({} as any);
-		// cursor should have been reset, so it now points past the new content
-		expect(state.lastDeliveredSessionByte).toBe(4);
-	});
-	it("resets the cursor when the session log is truncated below it", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-		// write 1KB of content, poll to advance cursor
-		writeFileSync(state.sessionFile, "x".repeat(1024) + "\n");
-		mod.pollArtifactChanges({} as any);
-		expect(state.lastDeliveredSessionByte).toBe(1025);
-		// truncate to 0, then write new content
-		writeFileSync(state.sessionFile, "new\n");
-		mod.pollArtifactChanges({} as any);
-		// cursor should have been reset, so it now points past the new content
-		expect(state.lastDeliveredSessionByte).toBe(4);
-	});
-	// ── New tests for the ndjson refactor ──────────────────────────────────────────────────
-	// The 4 cases below cover the bug class that triggered the refactor: hand-rolled partial-line
-	// + cursor logic could pin a poller on a single line larger than the 1 MiB cap. The new design uses
-	// the `ndjson` library which buffers partial lines internally across polls.
-
-	it("processes a single JSONL line larger than 1 MiB (the original cap)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		// Build a single 1.5 MiB JSONL line. The old 1 MiB cap would have pinned the poller on this line forever.
-		const bigPayload = "x".repeat(1.5 * 1024 * 1024);
-		const entry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t-big", name: "bash", arguments: { command: "echo BIG" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		// Splice the big payload into the JSONL line as a string field so the line itself is huge.
-		// We keep the toolCall so we can assert on the emitted event after the ndjson parser swallows it.
-		const line = JSON.stringify({ ...entry, _big: bigPayload });
-		writeFileSync(state.sessionFile, line + "\n");
-
-		// First poll: ndjson reads up to 1 MiB (the defensive cap), buffers the rest internally.
-		mod.pollArtifactChanges({} as any);
-		const afterFirst = state.lastDeliveredSessionByte ?? 0;
-		expect(afterFirst).toBe(1 * 1024 * 1024); // defensive cap was hit
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		// The complete line has not arrived yet, so no events should be emitted.
-		expect(readEvents(art).filter((e) => e.type === "tool_activity")).toHaveLength(0);
-
-		// Second poll: cursor at 1 MiB, file has another ~0.5 MiB left. The ndjson parser combines the
-		// buffered partial with the new bytes and emits the completed line. The cursor advances to the end
-		// of the file. The OLD code would have re-read the same 1 MiB over and over and never advanced.
-		mod.pollArtifactChanges({} as any);
-		expect(state.lastDeliveredSessionByte).toBeGreaterThan(afterFirst);
-		const activityAfterSecond = readEvents(art).filter((e) => e.type === "tool_activity");
-		expect(activityAfterSecond).toHaveLength(1);
-		expect(activityAfterSecond[0]).toMatchObject({ tool: "bash", summary: "echo BIG" });
-
-		// Append a small next line and poll to confirm the parser keeps processing after the big one.
-		const nextEntry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t-next", name: "read", arguments: { path: "/tmp/x" } }],
-				timestamp: 1700000001000,
-			},
-		};
-		appendFileSync(state.sessionFile, JSON.stringify(nextEntry) + "\n");
-		mod.pollArtifactChanges({} as any);
-		const activity = readEvents(art).filter((e) => e.type === "tool_activity");
-		expect(activity).toHaveLength(2);
-		expect(activity[1]).toMatchObject({ tool: "read", summary: "/tmp/x" });
-	});
-
-	it("resets the cursor and parser on file truncation", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-
-		// Build a 1 KB initial log, write to the file, poll once.
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-		const initialEntry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "echo before" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		writeFileSync(state.sessionFile, "x".repeat(1024) + "\n" + JSON.stringify(initialEntry) + "\n");
-		mod.pollArtifactChanges({} as any);
-		const cursorBeforeTruncation = state.lastDeliveredSessionByte;
-		expect(cursorBeforeTruncation).toBeGreaterThan(1024);
-
-		// Truncate the file to 0 bytes (size < cursor triggers the reset path).
-		truncateSync(state.sessionFile, 0);
-
-		// Write fresh content and poll again. The new design resets cursor to 0 and the parser, then re-reads.
-		const newEntry = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t2", name: "write", arguments: { path: "/tmp/after-truncation" } }],
-				timestamp: 1700000002000,
-			},
-		};
-		writeFileSync(state.sessionFile, JSON.stringify(newEntry) + "\n");
-		mod.pollArtifactChanges({} as any);
-
-		// Cursor was reset to 0, then advanced to the end of the new content.
-		const newSize = Buffer.byteLength(JSON.stringify(newEntry) + "\n", "utf8");
-		expect(state.lastDeliveredSessionByte).toBe(newSize);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const activity = readEvents(art).filter((e) => e.type === "tool_activity");
-		// The new content's tool_call must be processed. The old content might be re-emitted too (best-effort),
-		// so we just assert the new one is present.
-		expect(activity.some((e) => e.tool === "write" && e.summary === "/tmp/after-truncation")).toBe(true);
-	});
-
-	it("skips a malformed line and continues processing subsequent valid lines", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { state, artifactDir } = makeState({});
-		mod.interactiveSubagentRegistry.set(state.id, state);
-
-		const entry1 = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t1", name: "bash", arguments: { command: "echo first" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		const entry2 = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "t2", name: "write", arguments: { path: "/tmp/after-bad" } }],
-				timestamp: 1700000001000,
-			},
-		};
-		const malformed = "{this is not valid json";
-		writeFileSync(state.sessionFile, JSON.stringify(entry1) + "\n" + malformed + "\n" + JSON.stringify(entry2) + "\n");
-		mod.pollArtifactChanges({} as any);
-
-		const art = artifactPath(join(artifactDir, ".."), state.id);
-		const activity = readEvents(art).filter((e) => e.type === "tool_activity");
-		// Both valid lines must be processed; the malformed one is silently dropped.
-		expect(activity).toHaveLength(2);
-		expect(activity[0]).toMatchObject({ tool: "bash", summary: "echo first" });
-		expect(activity[1]).toMatchObject({ tool: "write", summary: "/tmp/after-bad" });
-	});
-
-	it("keeps parser state per sub-agent (two parallel sub-agents see only their own events)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const a = makeState({});
-		const b = makeState({});
-		mod.interactiveSubagentRegistry.set(a.state.id, a.state);
-		mod.interactiveSubagentRegistry.set(b.state.id, b.state);
-
-		const entryA = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "ta", name: "bash", arguments: { command: "echo A" } }],
-				timestamp: 1700000000000,
-			},
-		};
-		const entryB = {
-			type: "message",
-			message: {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "tb", name: "write", arguments: { path: "/tmp/B" } }],
-				timestamp: 1700000001000,
-			},
-		};
-		writeFileSync(a.state.sessionFile, JSON.stringify(entryA) + "\n");
-		writeFileSync(b.state.sessionFile, JSON.stringify(entryB) + "\n");
-
-		mod.pollArtifactChanges({} as any);
-
-		const artA = artifactPath(join(a.artifactDir, ".."), a.state.id);
-		const artB = artifactPath(join(b.artifactDir, ".."), b.state.id);
-		const eventsA = readEvents(artA).filter((e) => e.type === "tool_activity");
-		const eventsB = readEvents(artB).filter((e) => e.type === "tool_activity");
-
-		// Each sub-agent's artifact only contains its own tool_call — no cross-contamination.
-		expect(eventsA).toHaveLength(1);
-		expect(eventsA[0]).toMatchObject({ tool: "bash", summary: "echo A" });
-		expect(eventsB).toHaveLength(1);
-		expect(eventsB[0]).toMatchObject({ tool: "write", summary: "/tmp/B" });
-	});
+  let root: string;
+
+  beforeEach(() => {
+    root = makeTmp();
+    const g = globalThis as any;
+    g.__piSubagenturaInteractiveRegistry?.clear?.();
+    g.__piSubagenturaPiRef = undefined;
+    g.__piSubagenturaUi = undefined;
+    // Force `isTmuxPaneAlive` to return true so the poller's status-decision does not flip our
+    // sub-agent to "unknown" (which would skip it on subsequent polls). The test does not have a
+    // live tmux server, and host tmux behaviour varies — some versions exit 0 for unknown panes,
+    // some exit 1, and on a machine without tmux at all `execFileSync` throws. Mocking here keeps the
+    // suite hermetic and matches the pattern in subagent-poll.test.ts.
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("#99");
+        return "";
+      },
+    }));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("appends a tool_activity event for a bash tool call", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    // Write a fake session log with one assistant message containing a toolCall.
+    const sessionFile = state.sessionFile;
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll search the codebase." },
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "rg TODO src/" },
+          },
+        ],
+        api: "openai",
+        provider: "openai",
+        model: "gpt-4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "toolUse",
+        timestamp: 1700000000000,
+      },
+    };
+    writeFileSync(sessionFile, JSON.stringify(entry) + "\n");
+
+    const sendMessage = vi.fn();
+    mod.pollArtifactChanges({ sendMessage } as any);
+
+    // Should not have notified the LLM (tool_activity is silent).
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    // Should have appended a tool_activity event to events.ndjson.
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.type).toBe("tool_activity");
+    if (event.type === "tool_activity") {
+      expect(event.tool).toBe("bash");
+      expect(event.summary).toBe("rg TODO src/");
+    }
+    expect(event.status).toBe("running");
+    // Cursor advanced.
+    expect(state.lastDeliveredSessionByte).toBeGreaterThan(0);
+  });
+
+  it("appends tool_activity for write, edit, read with file paths", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "write",
+            arguments: { path: "/tmp/review-1.md", content: "..." },
+          },
+          {
+            type: "toolCall",
+            id: "t2",
+            name: "edit",
+            arguments: { path: "/src/foo.ts", oldText: "a", newText: "b" },
+          },
+          {
+            type: "toolCall",
+            id: "t3",
+            name: "read",
+            arguments: { path: "/src/bar.ts" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    const tools = events.filter((e) => e.type === "tool_activity");
+    expect(tools).toHaveLength(3);
+    expect(tools[0]).toMatchObject({
+      tool: "write",
+      summary: "/tmp/review-1.md",
+    });
+    expect(tools[1]).toMatchObject({ tool: "edit", summary: "/src/foo.ts" });
+    expect(tools[2]).toMatchObject({ tool: "read", summary: "/src/bar.ts" });
+  });
+
+  it("skips tools with no summary (grep, find, ls, custom)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "grep",
+            arguments: { pattern: "TODO", path: "/src" },
+          },
+          {
+            type: "toolCall",
+            id: "t2",
+            name: "find",
+            arguments: { pattern: "*.ts" },
+          },
+          {
+            type: "toolCall",
+            id: "t3",
+            name: "ls",
+            arguments: { path: "/src" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(0);
+  });
+
+  it("truncates long bash commands to 80 chars", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const longCmd = "echo " + "x".repeat(200);
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: longCmd },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    const activity = events.find((e) => e.type === "tool_activity");
+    expect(activity?.summary).toBeDefined();
+    expect(activity!.summary!.length).toBeLessThanOrEqual(80);
+    expect(activity!.summary!.endsWith("…")).toBe(true);
+  });
+
+  it("cursor advances — second poll with no new lines does not duplicate", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "echo hi" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+    const after1 = state.lastDeliveredSessionByte;
+    expect(after1).toBeGreaterThan(0);
+
+    mod.pollArtifactChanges({} as any);
+    expect(state.lastDeliveredSessionByte).toBe(after1); // unchanged
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(1);
+  });
+
+  it("picks up new lines written between polls", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const e1 = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "echo 1" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    const e2 = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t2",
+            name: "write",
+            arguments: { path: "/tmp/foo.md" },
+          },
+        ],
+        timestamp: 1700000001000,
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(e1) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+
+    // Append second line.
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(state.sessionFile, JSON.stringify(e2) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    const activity = events.filter((e) => e.type === "tool_activity");
+    expect(activity).toHaveLength(2);
+    expect(activity[0].tool).toBe("bash");
+    expect(activity[1].tool).toBe("write");
+  });
+
+  it("tolerates a partial trailing line without crashing", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "echo hi" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    // Write a complete line + a truncated second line.
+    const complete = JSON.stringify(entry) + "\n";
+    const partial = '{ "type": "mess';
+    writeFileSync(state.sessionFile, complete + partial);
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    // Only the complete line was processed.
+
+    expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(1);
+    // Cursor advances to the end of the read window (the partial bytes are now buffered inside the
+    // ndjson parser). Re-reading them next tick would re-feed the parser and double-emit, so the new
+    // design lets the cursor sweep past the partial and relies on the parser to track line state.
+    expect(state.lastDeliveredSessionByte).toBe(
+      Buffer.byteLength(complete + partial, "utf8"),
+    );
+  });
+
+  it("re-reads a partial line once it is completed on a later poll", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "write",
+            arguments: { path: "/tmp/x" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    const complete = JSON.stringify(entry) + "\n";
+    const partial = '{ "type": "mess';
+    writeFileSync(state.sessionFile, complete + partial);
+    // First poll: ndjson parser buffers the partial internally. The cursor sweeps to the end of
+    // the read window so the next tick only reads NEW bytes (not the buffered partial).
+    mod.pollArtifactChanges({} as any);
+    expect(state.lastDeliveredSessionByte).toBe(
+      Buffer.byteLength(complete + partial, "utf8"),
+    );
+
+    // Second poll: child finishes writing the partial. We need to APPEND to
+    // the file (not rewrite) so the byte offset after the partial is
+    // unchanged.
+    const appended =
+      'age","message":{"role":"assistant","content":[{"type":"toolCall","id":"t2","name":"bash","arguments":{"command":"ls"}}]}}\n';
+    appendFileSync(state.sessionFile, appended);
+
+    mod.pollArtifactChanges({} as any);
+    expect(state.lastDeliveredSessionByte).toBe(
+      Buffer.byteLength(complete + partial, "utf8") +
+        Buffer.byteLength(appended, "utf8"),
+    );
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const events = readEvents(art);
+    // Now BOTH tool_activity events should be present.
+    expect(events.filter((e) => e.type === "tool_activity")).toHaveLength(2);
+  });
+
+  it("does nothing when the session file does not exist yet", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({
+      sessionFile: "/tmp/does-not-exist-" + Math.random() + ".jsonl",
+    });
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    expect(() => mod.pollArtifactChanges({} as any)).not.toThrow();
+    expect(state.lastDeliveredSessionByte).toBeUndefined();
+  });
+
+  it("updates state.lastToolSummary and lastActivityAt for the widget", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "rg TODO src/" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+
+    expect(state.lastToolName).toBe("bash");
+    expect(state.lastToolSummary).toBe("rg TODO src/");
+    expect(state.lastActivityAt).toBe(1700000000000);
+  });
+
+  it("paints the TUI widget when ui ref is set", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "rg TODO src/" },
+          },
+        ],
+        timestamp: Date.now(),
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
+
+    const setStatus = vi.fn();
+    const setWidget = vi.fn();
+    (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
+
+    mod.pollArtifactChanges({} as any);
+
+    // Footer status shows count.
+    expect(setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent running",
+    );
+    // Widget shows the activity row.
+    expect(setWidget).toHaveBeenCalledTimes(1);
+    const [key, lines, opts] = setWidget.mock.calls[0];
+    expect(key).toBe("subagentura-activity");
+    expect(opts).toEqual({ placement: "belowEditor" });
+    expect(lines[0]).toContain("Test:");
+    expect(lines[0]).toContain("rg TODO src/");
+  });
+
+  it("clears the widget and footer when no sub-agents are running", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    // Empty registry.
+    const setStatus = vi.fn();
+    const setWidget = vi.fn();
+    (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
+
+    mod.pollArtifactChanges({} as any);
+
+    expect(setStatus).toHaveBeenCalledWith("subagentura-running", undefined);
+    expect(setWidget).toHaveBeenCalledWith("subagentura-activity", undefined, {
+      placement: "belowEditor",
+    });
+  });
+
+  it("inlines the error message in the LLM notification but uses pointers on success", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
+    appendEvent(art, {
+      ts: 2,
+      type: "error",
+      status: "error",
+      message: "bash exited with code 1: rg foo missing",
+    });
+
+    const sendMessage = vi.fn();
+    mod.pollArtifactChanges({ sendMessage } as any);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+
+    // done: pointer only, no body.
+    const doneCall = sendMessage.mock.calls[0][0];
+    expect(doneCall.content).toContain("done");
+    expect(doneCall.content).toContain("Output:");
+    expect(doneCall.content).toContain("Activity log:");
+    expect(doneCall.content).not.toContain("exited with code");
+
+    // error: inline message + pointers.
+    const errCall = sendMessage.mock.calls[1][0];
+    expect(errCall.content).toContain("error");
+    expect(errCall.content).toContain("bash exited with code 1");
+    expect(errCall.content).toContain("Output:");
+    expect(errCall.content).toContain("Activity log:");
+  });
+
+  it("truncates the inline error message to 500 chars", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const longMsg = "x".repeat(2000);
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    appendEvent(art, {
+      ts: 1,
+      type: "error",
+      status: "error",
+      message: longMsg,
+    });
+
+    const sendMessage = vi.fn();
+    mod.pollArtifactChanges({ sendMessage } as any);
+
+    const content = sendMessage.mock.calls[0][0].content as string;
+    // The "x".repeat(2000) portion must be capped.
+    const match = content.match(/x+/);
+    expect(match).not.toBeNull();
+    expect(match![0].length).toBeLessThanOrEqual(500);
+    expect(match![0].length).toBeLessThanOrEqual(500);
+  });
+
+  it("resets the cursor when the session log is truncated below it", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    // write 1KB of content, poll to advance cursor
+    writeFileSync(state.sessionFile, "x".repeat(1024) + "\n");
+    mod.pollArtifactChanges({} as any);
+    expect(state.lastDeliveredSessionByte).toBe(1025);
+    // truncate to 0, then write new content
+    writeFileSync(state.sessionFile, "new\n");
+    mod.pollArtifactChanges({} as any);
+    // cursor should have been reset, so it now points past the new content
+    expect(state.lastDeliveredSessionByte).toBe(4);
+  });
+  it("resets the cursor when the session log is truncated below it", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    // write 1KB of content, poll to advance cursor
+    writeFileSync(state.sessionFile, "x".repeat(1024) + "\n");
+    mod.pollArtifactChanges({} as any);
+    expect(state.lastDeliveredSessionByte).toBe(1025);
+    // truncate to 0, then write new content
+    writeFileSync(state.sessionFile, "new\n");
+    mod.pollArtifactChanges({} as any);
+    // cursor should have been reset, so it now points past the new content
+    expect(state.lastDeliveredSessionByte).toBe(4);
+  });
+  // ── New tests for the ndjson refactor ──────────────────────────────────────────────────
+  // The 4 cases below cover the bug class that triggered the refactor: hand-rolled partial-line
+  // + cursor logic could pin a poller on a single line larger than the 1 MiB cap. The new design uses
+  // the `ndjson` library which buffers partial lines internally across polls.
+
+  it("processes a single JSONL line larger than 1 MiB (the original cap)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    // Build a single 1.5 MiB JSONL line. The old 1 MiB cap would have pinned the poller on this line forever.
+    const bigPayload = "x".repeat(1.5 * 1024 * 1024);
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t-big",
+            name: "bash",
+            arguments: { command: "echo BIG" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    // Splice the big payload into the JSONL line as a string field so the line itself is huge.
+    // We keep the toolCall so we can assert on the emitted event after the ndjson parser swallows it.
+    const line = JSON.stringify({ ...entry, _big: bigPayload });
+    writeFileSync(state.sessionFile, line + "\n");
+
+    // First poll: ndjson reads up to 1 MiB (the defensive cap), buffers the rest internally.
+    mod.pollArtifactChanges({} as any);
+    const afterFirst = state.lastDeliveredSessionByte ?? 0;
+    expect(afterFirst).toBe(1 * 1024 * 1024); // defensive cap was hit
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    // The complete line has not arrived yet, so no events should be emitted.
+    expect(
+      readEvents(art).filter((e) => e.type === "tool_activity"),
+    ).toHaveLength(0);
+
+    // Second poll: cursor at 1 MiB, file has another ~0.5 MiB left. The ndjson parser combines the
+    // buffered partial with the new bytes and emits the completed line. The cursor advances to the end
+    // of the file. The OLD code would have re-read the same 1 MiB over and over and never advanced.
+    mod.pollArtifactChanges({} as any);
+    expect(state.lastDeliveredSessionByte).toBeGreaterThan(afterFirst);
+    const activityAfterSecond = readEvents(art).filter(
+      (e) => e.type === "tool_activity",
+    );
+    expect(activityAfterSecond).toHaveLength(1);
+    expect(activityAfterSecond[0]).toMatchObject({
+      tool: "bash",
+      summary: "echo BIG",
+    });
+
+    // Append a small next line and poll to confirm the parser keeps processing after the big one.
+    const nextEntry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t-next",
+            name: "read",
+            arguments: { path: "/tmp/x" },
+          },
+        ],
+        timestamp: 1700000001000,
+      },
+    };
+    appendFileSync(state.sessionFile, JSON.stringify(nextEntry) + "\n");
+    mod.pollArtifactChanges({} as any);
+    const activity = readEvents(art).filter((e) => e.type === "tool_activity");
+    expect(activity).toHaveLength(2);
+    expect(activity[1]).toMatchObject({ tool: "read", summary: "/tmp/x" });
+  });
+
+  it("resets the cursor and parser on file truncation", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+
+    // Build a 1 KB initial log, write to the file, poll once.
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    const initialEntry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "echo before" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    writeFileSync(
+      state.sessionFile,
+      "x".repeat(1024) + "\n" + JSON.stringify(initialEntry) + "\n",
+    );
+    mod.pollArtifactChanges({} as any);
+    const cursorBeforeTruncation = state.lastDeliveredSessionByte;
+    expect(cursorBeforeTruncation).toBeGreaterThan(1024);
+
+    // Truncate the file to 0 bytes (size < cursor triggers the reset path).
+    truncateSync(state.sessionFile, 0);
+
+    // Write fresh content and poll again. The new design resets cursor to 0 and the parser, then re-reads.
+    const newEntry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t2",
+            name: "write",
+            arguments: { path: "/tmp/after-truncation" },
+          },
+        ],
+        timestamp: 1700000002000,
+      },
+    };
+    writeFileSync(state.sessionFile, JSON.stringify(newEntry) + "\n");
+    mod.pollArtifactChanges({} as any);
+
+    // Cursor was reset to 0, then advanced to the end of the new content.
+    const newSize = Buffer.byteLength(JSON.stringify(newEntry) + "\n", "utf8");
+    expect(state.lastDeliveredSessionByte).toBe(newSize);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const activity = readEvents(art).filter((e) => e.type === "tool_activity");
+    // The new content's tool_call must be processed. The old content might be re-emitted too (best-effort),
+    // so we just assert the new one is present.
+    expect(
+      activity.some(
+        (e) => e.tool === "write" && e.summary === "/tmp/after-truncation",
+      ),
+    ).toBe(true);
+  });
+
+  it("skips a malformed line and continues processing subsequent valid lines", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState({});
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const entry1 = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t1",
+            name: "bash",
+            arguments: { command: "echo first" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    const entry2 = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "t2",
+            name: "write",
+            arguments: { path: "/tmp/after-bad" },
+          },
+        ],
+        timestamp: 1700000001000,
+      },
+    };
+    const malformed = "{this is not valid json";
+    writeFileSync(
+      state.sessionFile,
+      JSON.stringify(entry1) +
+        "\n" +
+        malformed +
+        "\n" +
+        JSON.stringify(entry2) +
+        "\n",
+    );
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    const activity = readEvents(art).filter((e) => e.type === "tool_activity");
+    // Both valid lines must be processed; the malformed one is silently dropped.
+    expect(activity).toHaveLength(2);
+    expect(activity[0]).toMatchObject({ tool: "bash", summary: "echo first" });
+    expect(activity[1]).toMatchObject({
+      tool: "write",
+      summary: "/tmp/after-bad",
+    });
+  });
+
+  it("keeps parser state per sub-agent (two parallel sub-agents see only their own events)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const a = makeState({});
+    const b = makeState({});
+    mod.interactiveSubagentRegistry.set(a.state.id, a.state);
+    mod.interactiveSubagentRegistry.set(b.state.id, b.state);
+
+    const entryA = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "ta",
+            name: "bash",
+            arguments: { command: "echo A" },
+          },
+        ],
+        timestamp: 1700000000000,
+      },
+    };
+    const entryB = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "tb",
+            name: "write",
+            arguments: { path: "/tmp/B" },
+          },
+        ],
+        timestamp: 1700000001000,
+      },
+    };
+    writeFileSync(a.state.sessionFile, JSON.stringify(entryA) + "\n");
+    writeFileSync(b.state.sessionFile, JSON.stringify(entryB) + "\n");
+
+    mod.pollArtifactChanges({} as any);
+
+    const artA = artifactPath(join(a.artifactDir, ".."), a.state.id);
+    const artB = artifactPath(join(b.artifactDir, ".."), b.state.id);
+    const eventsA = readEvents(artA).filter((e) => e.type === "tool_activity");
+    const eventsB = readEvents(artB).filter((e) => e.type === "tool_activity");
+
+    // Each sub-agent's artifact only contains its own tool_call — no cross-contamination.
+    expect(eventsA).toHaveLength(1);
+    expect(eventsA[0]).toMatchObject({ tool: "bash", summary: "echo A" });
+    expect(eventsB).toHaveLength(1);
+    expect(eventsB[0]).toMatchObject({ tool: "write", summary: "/tmp/B" });
+  });
 });

--- a/src/subagent-stale-ctx.test.ts
+++ b/src/subagent-stale-ctx.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Regression test for the interactive-subagent poller stale-ctx crash.
+ *
+ * Background: `pollArtifactChanges` runs from a setInterval, capturing the
+ * ExtensionAPI at registration time. When the parent session is reloaded
+ * (model change, /reload, /ralplan, etc.), that captured ctx becomes stale
+ * and the loader's `assertActive` check throws on sendUserMessage. Without
+ * a try/catch, the uncaught exception bubbles out of the setInterval callback
+ * and crashes the entire pi process.
+ *
+ * Fix verified here:
+ *   1. The sendUserMessage call site has a try/catch (finally still runs
+ *      decrementInjectCount).
+ *   2. The whole `pollArtifactChanges` body is wrapped in a top-level
+ *      try/catch so any future bad tick cannot take down the process.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendEvent, artifactPath, writeOutput } from "./artifact";
+import { importFresh } from "./test-utils";
+
+function makeTmp(): string {
+  return mkdtempSync(join(tmpdir(), "pi-subagentura-stale-ctx-"));
+}
+
+function makeState(): {
+  id: string;
+  artifactDir: string;
+  state: import("./interactive-tmux").InteractiveSubagentState;
+} {
+  const id = "id-" + Math.random().toString(36).slice(2, 8);
+  const artifactDir = join(makeTmp(), id);
+  const state: import("./interactive-tmux").InteractiveSubagentState = {
+    id,
+    name: "Test",
+    task: "t",
+    paneId: "%99",
+    sessionFile: "/tmp/sess.jsonl",
+    cwd: "/tmp",
+    startedAt: Date.now(),
+    mux: "tmux",
+    status: "running",
+    attachCommand: "tmux attach -t sess",
+    selectPaneCommand: "tmux select-pane -t '%99'",
+    launchScriptFile: "/tmp/launch.sh",
+    artifactDir,
+  };
+  return { id, artifactDir, state };
+}
+
+describe("pollArtifactChanges stale-ctx defenses", () => {
+  beforeEach(() => {
+    const g = globalThis as any;
+    g.__piSubagenturaInteractiveRegistry?.clear?.();
+    g.__piSubagenturaPiRef = undefined;
+    g.__piSubagenturaInjectCount = 0;
+    // The poller calls isPaneAlive → child_process.execFileSync. Default the
+    // tmux mock so the pane is reported alive and the status-update branch
+    // doesn't trip on a missing tmux.
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("#99");
+        return "";
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("node:child_process");
+    const g = globalThis as any;
+    g.__piSubagenturaPiRef = undefined;
+    g.__piSubagenturaInjectCount = 0;
+  });
+
+  it("swallows sendUserMessage throwing 'This extension ctx is stale ...' (stale pi after session reload)", async () => {
+    // The exact assertion error message produced by the loader's assertActive.
+    // If the loader ever changes the wording this test should be updated to
+    // match — the regression we care about is the try/catch, not the message.
+    const staleErr = new Error(
+      "This extension ctx is stale after session replacement or reload.",
+    );
+
+    // The interactiveSubagentRegistry prefers __piSubagenturaPiRef over its
+    // own arg, so we stub the global to make sure the poller uses our broken
+    // pi. (Mirrors the real prod path where the captured `pi` closure goes
+    // stale after a session reload — the global ref is also stale, but the
+    // belt-and-suspenders pattern is: any pi, however stale, must not crash.)
+    const brokenPi = {
+      sendMessage: vi.fn(),
+      sendUserMessage: vi.fn(() => {
+        throw staleErr;
+      }),
+    };
+    (globalThis as any).__piSubagenturaPiRef = brokenPi;
+
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState();
+    state.notifyOnComplete = "inject";
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+    writeOutput(art, "the answer");
+
+    // The call must NOT throw — that's the entire point of the fix.
+    expect(() => mod.pollArtifactChanges(brokenPi as any)).not.toThrow();
+
+    // sendUserMessage was attempted and threw.
+    expect(brokenPi.sendUserMessage).toHaveBeenCalledTimes(1);
+
+    // The `finally` block MUST have run: decrementInjectCount took the count
+    // back to 0 (we started at 0, increment pushed it to 1, finally dropped
+    // it back). If the `finally` had been swallowed by a missing catch, the
+    // count would stay at 1 and the inject cap would fill up over time.
+    expect(mod.getInjectCount()).toBe(0);
+  });
+
+  it("top-level try/catch absorbs unexpected throws from anywhere in the poller", async () => {
+    // A more adversarial stub: sendMessage (used by the pointer notification
+    // path) throws a generic Error at the very start of the for-loop body.
+    // Without the top-level try/catch, this would propagate out of the
+    // setInterval callback and crash the parent pi process.
+    const boom = new Error("kaboom");
+    const brokenPi = {
+      sendMessage: vi.fn(() => {
+        throw boom;
+      }),
+      sendUserMessage: vi.fn(),
+    };
+    (globalThis as any).__piSubagenturaPiRef = brokenPi;
+
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { state, artifactDir } = makeState();
+    // Default notify mode — the pointer path runs, the inject path doesn't.
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+
+    // The call must NOT throw.
+    expect(() => mod.pollArtifactChanges(brokenPi as any)).not.toThrow();
+
+    // sendMessage was attempted (we know it threw).
+    expect(brokenPi.sendMessage).toHaveBeenCalled();
+  });
+});

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -526,173 +526,191 @@ function shouldNotify(event: SubagentEvent): boolean {
  * then advance the cursor. This naturally handles restart / backlog cases.
  */
 export function pollArtifactChanges(pi: ExtensionAPI): void {
-  const g2 = typeof global !== "undefined" ? global : globalThis;
-  const interactivePi =
-    (g2.__piSubagenturaPiRef as ExtensionAPI | undefined) ?? pi;
-  if (!interactivePi) return;
+  // Top-level defensive try/catch: the poller runs from a setInterval, so any uncaught throw here
+  // would crash the parent pi process. Better to swallow and let the next tick (with a refreshed
+  // pi ctx) try again. The loader's assertActive stale-ctx check (thrown by sendUserMessage and a
+  // few other call sites below) is the most likely culprit after a session reload/replace.
+  try {
+    const g2 = typeof global !== "undefined" ? global : globalThis;
+    const interactivePi =
+      (g2.__piSubagenturaPiRef as ExtensionAPI | undefined) ?? pi;
+    if (!interactivePi) return;
 
-  let runningCount = 0;
-  const widgetRows: string[] = [];
-  const ui = g2.__piSubagenturaUi as ExtensionUIContext | undefined;
+    let runningCount = 0;
+    const widgetRows: string[] = [];
+    const ui = g2.__piSubagenturaUi as ExtensionUIContext | undefined;
 
-  for (const state of interactiveSubagentRegistry.values()) {
-    // Skip strictly-terminal states. "exited" is INTENTIONALLY not in this list: the user-role
-    // revival at processSessionLogEntry can revive an "exited" sub-agent back to "running" if a
-    // follow-up user message lands in the session log (auto-done case). To make that reachable,
-    // the poll loop must keep tail-reading the session log for "exited" sub-agents too. The
-    // status-update block below may re-mark the state as "exited" (based on a stale synthesized
-    // error event in the artifact) but the revival, running later in the same poll via
-    // tailReadSessionLog, will reset it to "running" within this same tick.
-    if (state.status === "cancelled" || state.status === "unknown") continue;
+    for (const state of interactiveSubagentRegistry.values()) {
+      // Skip strictly-terminal states. "exited" is INTENTIONALLY not in this list: the user-role
+      // revival at processSessionLogEntry can revive an "exited" sub-agent back to "running" if a
+      // follow-up user message lands in the session log (auto-done case). To make that reachable,
+      // the poll loop must keep tail-reading the session log for "exited" sub-agents too. The
+      // status-update block below may re-mark the state as "exited" (based on a stale synthesized
+      // error event in the artifact) but the revival, running later in the same poll via
+      // tailReadSessionLog, will reset it to "running" within this same tick.
+      if (state.status === "cancelled" || state.status === "unknown") continue;
 
-    const art = artifactPath(
-      dirname(state.artifactDir),
-      basename(state.artifactDir),
-    );
-    const last = lastEvent(art);
+      const art = artifactPath(
+        dirname(state.artifactDir),
+        basename(state.artifactDir),
+      );
+      const last = lastEvent(art);
 
-    // Refresh status from the artifact + pane liveness. `done` + pane alive → "idle" (not exited),
-    // which is what allows follow-ups: a second `done` after the follow-up turn will be picked up
-    // here and the inject path below will fire again.
-    const next = deriveInteractiveSubagentStatus(last, isPaneAlive(state));
-    if (next !== state.status) {
-      state.status = next;
-      if (
-        next === "exited" &&
-        last &&
-        last.type === "done" &&
-        last.exitCode !== undefined
-      ) {
-        state.exitCode = last.exitCode;
-      }
-    }
-
-    // Tail-read the child's session log and synthesize tool_activity events.
-    // TUI-widget only — the LLM never sees them.
-    tailReadSessionLog(state, art);
-
-    // Auto-done fallback: synthesize a completion event when the model ended its turn with
-    // stopReason:"stop" but never called `cli.mjs done`. Runs BEFORE reading events so the synthesized
-    // event is part of the same poll's read-back. Sets lastDeliveredEventTs and the autoDoneForTurnAt
-    // guard so the events loop below will not re-notify.
-    maybeAutoDone(state, art, interactivePi, Date.now());
-
-    // Read events newer than the last delivered. `lastDeliveredEventTs` starts at 0,
-    // so on the first poll we deliver the whole log. Subsequent polls advance the cursor.
-    const cursor = state.lastDeliveredEventTs ?? 0;
-    const events = readEvents(art, cursor + 1);
-
-    if (events.length > 0) {
-      let maxTs = cursor;
-      for (const ev of events) {
-        if (ev.ts > maxTs) maxTs = ev.ts;
-        if (!shouldNotify(ev)) continue;
-        // If auto-done already fired for this turn, skip any later explicit `done` events:
-        // they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
+      // Refresh status from the artifact + pane liveness. `done` + pane alive → "idle" (not exited),
+      // which is what allows follow-ups: a second `done` after the follow-up turn will be picked up
+      // here and the inject path below will fire again.
+      const next = deriveInteractiveSubagentStatus(last, isPaneAlive(state));
+      if (next !== state.status) {
+        state.status = next;
         if (
-          state.autoDoneForTurnAt !== undefined &&
-          ev.ts >= state.autoDoneForTurnAt &&
-          ev.type === "done"
-        )
-          continue;
-        deliverArtifactNotification(interactivePi, state, ev);
-      }
-      state.lastDeliveredEventTs = maxTs;
-    }
-
-    // Per-turn snapshot: on a NEW `done` event, copy the latest output.md into output-N.md so turn
-    // history survives the child overwriting output.md each turn. Runs in every notifyOnComplete mode,
-    // so it needs its own cursor (`lastSnapshotEventTs`) — see the field doc for why reusing
-    // `lastInjectedEventTs` would corrupt history in the default `notify` mode.
-    if (last && last.type === "done" && state.lastSnapshotEventTs !== last.ts) {
-      const allEvents = readEvents(art);
-      const turnNumber = allEvents.filter((e) => e.type === "done").length;
-      snapshotOutput(art, turnNumber);
-      state.lastSnapshotEventTs = last.ts;
-    }
-
-    // Inject-mode delivery: on a NEW `done` event, push output.md into the parent LLM's next turn.
-    // Per-turn (not per-sub-agent) — `lastInjectedEventTs` is compared against the current `done`'s `ts`
-    // so each follow-up turn re-injects. Mirrors deliverNotification's MAX_INJECT cap.
-    if (
-      last &&
-      last.type === "done" &&
-      state.notifyOnComplete === "inject" &&
-      state.lastInjectedEventTs !== last.ts
-    ) {
-      const output = readOutput(art);
-      if (output !== null) {
-        if (getInjectCount() >= MAX_INJECT) {
-          // Degrade silently: pointer notification was already delivered above,
-          // so the user still sees a hint. We just don't inject.
-          try {
-            interactivePi.sendMessage!(
-              {
-                customType: "subagent-notify",
-                content: `Inject cap exceeded for interactive sub-agent ${state.id} — degraded to notify.`,
-                display: true,
-                details: { subagentId: state.id, mode: "notify" },
-              },
-              { deliverAs: "followUp" },
-            );
-          } catch {
-            /* pi stale */
-          }
-        } else {
-          incrementInjectCount();
-          try {
-            (interactivePi as any).sendUserMessage?.(
-              output || "(sub-agent produced no output)",
-              { deliverAs: "followUp" },
-            );
-          } finally {
-            decrementInjectCount();
-          }
+          next === "exited" &&
+          last &&
+          last.type === "done" &&
+          last.exitCode !== undefined
+        ) {
+          state.exitCode = last.exitCode;
         }
       }
-      // Record the ts of the done we just (attempted to) inject for. The next `done` from a follow-up
-      // turn has a fresh ts, so the comparison re-fires.
-      state.lastInjectedEventTs = last.ts;
+
+      // Tail-read the child's session log and synthesize tool_activity events.
+      // TUI-widget only — the LLM never sees them.
+      tailReadSessionLog(state, art);
+
+      // Auto-done fallback: synthesize a completion event when the model ended its turn with
+      // stopReason:"stop" but never called `cli.mjs done`. Runs BEFORE reading events so the synthesized
+      // event is part of the same poll's read-back. Sets lastDeliveredEventTs and the autoDoneForTurnAt
+      // guard so the events loop below will not re-notify.
+      maybeAutoDone(state, art, interactivePi, Date.now());
+
+      // Read events newer than the last delivered. `lastDeliveredEventTs` starts at 0,
+      // so on the first poll we deliver the whole log. Subsequent polls advance the cursor.
+      const cursor = state.lastDeliveredEventTs ?? 0;
+      const events = readEvents(art, cursor + 1);
+
+      if (events.length > 0) {
+        let maxTs = cursor;
+        for (const ev of events) {
+          if (ev.ts > maxTs) maxTs = ev.ts;
+          if (!shouldNotify(ev)) continue;
+          // If auto-done already fired for this turn, skip any later explicit `done` events:
+          // they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
+          if (
+            state.autoDoneForTurnAt !== undefined &&
+            ev.ts >= state.autoDoneForTurnAt &&
+            ev.type === "done"
+          )
+            continue;
+          deliverArtifactNotification(interactivePi, state, ev);
+        }
+        state.lastDeliveredEventTs = maxTs;
+      }
+
+      // Per-turn snapshot: on a NEW `done` event, copy the latest output.md into output-N.md so turn
+      // history survives the child overwriting output.md each turn. Runs in every notifyOnComplete mode,
+      // so it needs its own cursor (`lastSnapshotEventTs`) — see the field doc for why reusing
+      // `lastInjectedEventTs` would corrupt history in the default `notify` mode.
+      if (
+        last &&
+        last.type === "done" &&
+        state.lastSnapshotEventTs !== last.ts
+      ) {
+        const allEvents = readEvents(art);
+        const turnNumber = allEvents.filter((e) => e.type === "done").length;
+        snapshotOutput(art, turnNumber);
+        state.lastSnapshotEventTs = last.ts;
+      }
+
+      // Inject-mode delivery: on a NEW `done` event, push output.md into the parent LLM's next turn.
+      // Per-turn (not per-sub-agent) — `lastInjectedEventTs` is compared against the current `done`'s `ts`
+      // so each follow-up turn re-injects. Mirrors deliverNotification's MAX_INJECT cap.
+      if (
+        last &&
+        last.type === "done" &&
+        state.notifyOnComplete === "inject" &&
+        state.lastInjectedEventTs !== last.ts
+      ) {
+        const output = readOutput(art);
+        if (output !== null) {
+          if (getInjectCount() >= MAX_INJECT) {
+            // Degrade silently: pointer notification was already delivered above,
+            // so the user still sees a hint. We just don't inject.
+            try {
+              interactivePi.sendMessage!(
+                {
+                  customType: "subagent-notify",
+                  content: `Inject cap exceeded for interactive sub-agent ${state.id} — degraded to notify.`,
+                  display: true,
+                  details: { subagentId: state.id, mode: "notify" },
+                },
+                { deliverAs: "followUp" },
+              );
+            } catch {
+              /* pi stale */
+            }
+          } else {
+            incrementInjectCount();
+            try {
+              (interactivePi as any).sendUserMessage?.(
+                output || "(sub-agent produced no output)",
+                { deliverAs: "followUp" },
+              );
+            } catch {
+              /* pi stale — next poll tick will re-attempt with a refreshed ctx */
+            } finally {
+              decrementInjectCount();
+            }
+          }
+        }
+        // Record the ts of the done we just (attempted to) inject for. The next `done` from a follow-up
+        // turn has a fresh ts, so the comparison re-fires.
+        state.lastInjectedEventTs = last.ts;
+      }
+
+      // Only count sub-agents that are actively processing a turn as "running".
+
+      // "exited" is terminal (pane dead) — the sub-agent is done; hide it from the
+
+      // running count and widget even though the for-loop keeps tail-reading its
+
+      // session log (for the user-role revival case in processSessionLogEntry).
+
+      // "idle" is between turns (REPL open, pane alive) — still a live sub-agent
+
+      // awaiting follow-up, so it stays in the count.
+
+      if (state.status === "running" || state.status === "idle") {
+        runningCount++;
+
+        widgetRows.push(formatActivityRow(state));
+      }
     }
 
-    // Only count sub-agents that are actively processing a turn as "running".
-
-    // "exited" is terminal (pane dead) — the sub-agent is done; hide it from the
-
-    // running count and widget even though the for-loop keeps tail-reading its
-
-    // session log (for the user-role revival case in processSessionLogEntry).
-
-    // "idle" is between turns (REPL open, pane alive) — still a live sub-agent
-
-    // awaiting follow-up, so it stays in the count.
-
-    if (state.status === "running" || state.status === "idle") {
-      runningCount++;
-
-      widgetRows.push(formatActivityRow(state));
+    // Paint footer + widget. Both are TUI-only — never reach the LLM.
+    if (ui) {
+      try {
+        ui.setStatus(
+          FOOTER_KEY,
+          runningCount > 0
+            ? `⚡ ${runningCount} sub-agent${runningCount > 1 ? "s" : ""} running`
+            : undefined,
+        );
+      } catch {
+        /* ui stale */
+      }
+      try {
+        ui.setWidget(
+          WIDGET_KEY,
+          widgetRows.length > 0 ? widgetRows : undefined,
+          {
+            placement: "belowEditor",
+          },
+        );
+      } catch {
+        /* ui stale */
+      }
     }
-  }
-
-  // Paint footer + widget. Both are TUI-only — never reach the LLM.
-  if (ui) {
-    try {
-      ui.setStatus(
-        FOOTER_KEY,
-        runningCount > 0
-          ? `⚡ ${runningCount} sub-agent${runningCount > 1 ? "s" : ""} running`
-          : undefined,
-      );
-    } catch {
-      /* ui stale */
-    }
-    try {
-      ui.setWidget(WIDGET_KEY, widgetRows.length > 0 ? widgetRows : undefined, {
-        placement: "belowEditor",
-      });
-    } catch {
-      /* ui stale */
-    }
+  } catch {
+    /* defensive: never let one bad poll tick crash the parent process */
   }
 }
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -6,6 +6,6 @@ import { vi } from "vitest";
  * or that need to re-evaluate module-level state.
  */
 export async function importFresh<T = unknown>(specifier: string): Promise<T> {
-    vi.resetModules();
-    return import(specifier) as Promise<T>;
+  vi.resetModules();
+  return import(specifier) as Promise<T>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["node"],
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Fixes a crash where the interactive-subagent poller takes down the parent `pi` process when the session is reloaded (model change, `/reload`, `/ralplan`).

**Stack trace:**
```
Error: This extension ctx is stale after session replacement or reload.
  at pollArtifactChanges (.../src/subagent.ts:1161:353)
  at Timeout._onTimeout (.../src/subagent.ts:1302:85)
```

## Root cause

`pollArtifactChanges` runs from `setInterval` and captures `pi` at registration time. When the parent session is reloaded, that `pi` becomes stale. The `sendUserMessage` call in the inject-mode path (around master line 644) had a `try { ... } finally { ... }` block but no `catch` — so when the loader's `assertActive` threw, the exception propagated out of the `setInterval` callback and crashed the process.

A sibling `sendMessage` call site ~10 lines above already had `catch { /* pi stale */ }` — proving the author knew about stale ctx but missed this one.

## Repro (fixed)

Spawn 2 interactive sub-agents with `notifyOnComplete: "inject"` while the parent session reloads (e.g., model change). The next 5s poll tick crashed `pi` with an uncaught exception in the `setInterval` callback.

## Changes

- **`src/subagent.ts`** — two additions to `pollArtifactChanges`:
  1. Wrap the `sendUserMessage` call site in `try { ... } catch { /* pi stale */ } finally { decrementInjectCount() }` so the stale-ctx throw is swallowed and the inject cap is properly released.
  2. Wrap the **entire body** of `pollArtifactChanges` in a top-level `try { ... } catch { /* defensive */ }` so any future bug in the poller cannot take down the parent process. The poller runs from `setInterval` — an uncaught throw there is a process-killer.

- **`src/subagent-stale-ctx.test.ts`** (new) — regression test:
  - Test 1 stubs `sendUserMessage` with the exact `assertActive` error string, calls `pollArtifactChanges`, asserts no throw, and asserts the `finally` block ran (inject count returns to 0).
  - Test 2 stubs `sendMessage` to throw a generic Error, asserts the top-level try/catch absorbs it.

## Test

- Reverts the fix locally and runs the new test → fails on test 1 (proving it's a real regression test).
- With the fix applied → all 300 tests pass (298 existing + 2 new).

## Verification

- `npm run typecheck` → exit 0
- `npm test` → 300/300 pass
- `npm run format:check` → exit 0
- `npm run pack:check` → exit 0

## Note

This branch also includes a `chore:` commit (`39d467d`) that fixes pre-existing prettier format drift across 25 files. `npm run format:check` was failing on master before this PR — that cleanup unblocks the local verification loop in CONTRIBUTING.md. The fix commit is `1b3c780` on top.
