### PR TITLE
feat: rehydrate interactive sub-agents on parent reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ The runtime validation in the workflow tool (`validateSchema`, `extractJson`) is
 ### The `workflow` tool's determinism story is more limited than the docs imply
 
 `runInNewContext` is not an escape-proof jail. The `Date.now()` / `Math.random()` / argless `new Date()` guards throw when called directly, but a script that goes out of its way to be non-deterministic can reach the real ones via `eval()` / `new Function()`. The script author is the trusted main agent, so this is acceptable — but the docs and source comments must keep saying so, because the day someone un-trusts the author, the only thing standing between them and a non-deterministic workflow is a one-line `codeGeneration: { strings: false }` we have not added yet.
+
 ### Rehydrate state file (`<cwd>/.pi/subagentura-state-<sessionId>.json`)
 
 The interactive sub-agent registry is persisted to a per-(cwd, sessionId) state file on
@@ -80,6 +81,7 @@ rehydrate function reads the file and reconstructs `InteractiveSubagentState` en
 reset runtime cursors (replay-all semantics).
 
 **Crash-safe ordering at both write sites:**
+
 - **Spawn** — write the state file BEFORE `interactiveSubagentRegistry.set`.
   A crash between the two is recoverable on next reload.
   A crash before the write leaves no zombie.
@@ -88,6 +90,7 @@ reset runtime cursors (replay-all semantics).
   than drops the event.
 
 **Clean-slate on session_shutdown:**
+
 - `reason="new"` or `reason="quit"` — deletes the state file so the next
   session starts fresh.
 - `reason="reload"` or `reason="resume"` — KEEPS the file so the next
@@ -101,6 +104,7 @@ re-inject the existing result into the new parent session on its first tick.
 Future follow-up `done` events (higher ts) still inject normally.
 
 **Edge cases:**
+
 - If `parentSessionId` is omitted (e.g. programmatic spawns from tests),
   the file is not written; no rehydrate happens on reload.
 - If the state file is missing on `session_start`, rehydrate is a silent no-op.
@@ -135,7 +139,7 @@ Future follow-up `done` events (higher ts) still inject normally.
 
 ## File map at a glance
 
-```
+````
 src/
   subagent.ts                      # MAIN — tools, poller, auto-done fallback, rehydrate ~3k LOC
   helpers.ts                       # startSubagentJob, resolveModel
@@ -158,3 +162,4 @@ docs/                              # Managed by the separate pi-docs package; do
 - The existing tests in the same directory are the best documentation of intended behavior.
 - `src/subagent-auto-done.test.ts`, `src/subagent-notify.test.ts`, and `src/subagent-rehydrate.test.ts` together define the artifact-protocol contract — if you're not sure what `events.ndjson` is supposed to contain, those tests are the spec.
 - The release flow is in `CONTRIBUTING.md`. The dev loop (typecheck + test + format) is above. If a step seems to be missing from this file, it probably is — add it.
+````

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,13 +89,16 @@ reset runtime cursors (replay-all semantics).
   `removeInteractiveState` (disk). A crash between them re-delivers rather
   than drops the event.
 
-**Rehydrate only on reload/resume:**
+**Rehydrate on startup, reload, and resume:**
 
-The `session_start` handler checks `event.reason` and only rehydrates when the
-reason is `"reload"` or `"resume"`. On fresh starts (`"startup"`, `"new"`, `"fork"`),
-the state file is ignored — previous session's subagents should not pollute the new
-session's view. The state file is deleted on `session_shutdown(reason="new")` to give
-the next session a clean slate.
+The `session_start` handler checks `event.reason` and rehydrates when the
+reason is `"startup"`, `"reload"`, or `"resume"`. This means subagents that
+survived a Ctrl+D (quit) will reappear in the registry on the next pi launch.
+On explicit fresh starts (`"new"`, `"fork"`) the state file is ignored — previous
+session's subagents should not pollute the new session's view. The state file is
+deleted on `session_shutdown(reason="new")` to give the next session a clean slate.
+On `session_shutdown(reason="quit")` the panes and state file are preserved so the
+subagents survive a restart.
 
 **Inject-mode flood fix at rehydrate:**
 When `notifyOnComplete="inject"` and the artifact already has a terminal event,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,9 @@ The runtime validation in the workflow tool (`validateSchema`, `extractJson`) is
 
 `runInNewContext` is not an escape-proof jail. The `Date.now()` / `Math.random()` / argless `new Date()` guards throw when called directly, but a script that goes out of its way to be non-deterministic can reach the real ones via `eval()` / `new Function()`. The script author is the trusted main agent, so this is acceptable — but the docs and source comments must keep saying so, because the day someone un-trusts the author, the only thing standing between them and a non-deterministic workflow is a one-line `codeGeneration: { strings: false }` we have not added yet.
 
-### Rehydrate state file (`<cwd>/.pi/subagentura-state-<sessionId>.json`)
+### Rehydrate state file (`<cwd>/.pi/subagentura-state.json`)
 
-The interactive sub-agent registry is persisted to a per-(cwd, sessionId) state file on
+The interactive sub-agent registry is persisted to a per-(cwd) state file on
 `launchInteractiveSubagent`. The file stores the minimum fields needed to rehydrate
 (`paneId`, `mux`, `artifactDir`, `sessionFile`, `notifyOnComplete`). On `session_start` the
 rehydrate function reads the file and reconstructs `InteractiveSubagentState` entries with
@@ -89,13 +89,13 @@ reset runtime cursors (replay-all semantics).
   `removeInteractiveState` (disk). A crash between them re-delivers rather
   than drops the event.
 
-**Clean-slate on session_shutdown:**
+**Rehydrate only on reload/resume:**
 
-- `reason="new"` or `reason="quit"` — deletes the state file so the next
-  session starts fresh.
-- `reason="reload"` or `reason="resume"` — KEEPS the file so the next
-  session_start can rehydrate from it. Orphan panes are still killed by the
-  `cancelInteractiveSubagentByState` loop; only the bookkeeping is preserved.
+The `session_start` handler checks `event.reason` and only rehydrates when the
+reason is `"reload"` or `"resume"`. On fresh starts (`"startup"`, `"new"`, `"fork"`),
+the state file is ignored — previous session's subagents should not pollute the new
+session's view. The state file is deleted on `session_shutdown(reason="new")` to give
+the next session a clean slate.
 
 **Inject-mode flood fix at rehydrate:**
 When `notifyOnComplete="inject"` and the artifact already has a terminal event,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ A public [Pi](https://pi.dev) extension that adds in-process and attachable sub-
 - **Pi extension** — single entry point: `./src/subagent.ts` (declared in `package.json#pi.extensions`).
 - **TypeScript, ESM, strict mode**, `target: ESNext`, Node ≥ 18.
 - **Runtime deps** are minimal: `ndjson`, `is-path-inside`. Pi SDKs are peer dependencies.
-- **Tests** are `vitest` and live next to source as `*.test.ts` (17 test files, ~6500 lines of test code).
+- **Tests** are `vitest` and live next to source as `*.test.ts` (20 test files, ~7000 lines of test code).
 - **CI** is a single GitHub Actions workflow: typecheck → tests → published-tarball smoke → pack dry-run.
 
 ## Build / test / verify
@@ -17,7 +17,7 @@ Always run all of these before committing:
 
 ```bash
 npm run typecheck   # tsc --noEmit, catches TDZ / no-use-before-define
-npm test            # vitest run, 288+ tests
+npm test            # vitest run, 344+ tests
 npm run format:check  # prettier --check .
 npm run pack:check  # npm pack --dry-run, mirrors the publish step
 ```
@@ -39,7 +39,7 @@ The pre-push hook (`simple-git-hooks` → `lint-staged` → `prettier --check`) 
 
 ## Code conventions
 
-- **Follow existing project style.** This codebase uses tabs, double quotes, semicolons, trailing commas, and ~100-char lines (matches prettier defaults). Don't reformat unrelated code.
+- **Follow existing project style.** This codebase uses 2-space indents, double quotes, semicolons, trailing commas, and ~80-char lines (matches prettier defaults with `{}` config). Don't reformat unrelated code.
 - **Functions under ~50 lines** is the soft guideline; the per-tool block in `subagent.ts` and the per-test `it()` blocks run longer when they need to.
 - **Comments only for non-obvious logic** — protocol invariants, the "why" of a guard, the "what this is NOT" of a deliberate limitation. No restating the code.
 - **Declare all variables BEFORE conditional blocks that may return early.** `const`/`let` are hoisted into the TDZ; `if (cond) { return ... }` references before declaration throw at runtime. TypeScript's `no-use-before-define` (strict mode) catches this.
@@ -71,6 +71,44 @@ The runtime validation in the workflow tool (`validateSchema`, `extractJson`) is
 ### The `workflow` tool's determinism story is more limited than the docs imply
 
 `runInNewContext` is not an escape-proof jail. The `Date.now()` / `Math.random()` / argless `new Date()` guards throw when called directly, but a script that goes out of its way to be non-deterministic can reach the real ones via `eval()` / `new Function()`. The script author is the trusted main agent, so this is acceptable — but the docs and source comments must keep saying so, because the day someone un-trusts the author, the only thing standing between them and a non-deterministic workflow is a one-line `codeGeneration: { strings: false }` we have not added yet.
+### Rehydrate state file (`<cwd>/.pi/subagentura-state-<sessionId>.json`)
+
+The interactive sub-agent registry is persisted to a per-(cwd, sessionId) state file on
+`launchInteractiveSubagent`. The file stores the minimum fields needed to rehydrate
+(`paneId`, `mux`, `artifactDir`, `sessionFile`, `notifyOnComplete`). On `session_start` the
+rehydrate function reads the file and reconstructs `InteractiveSubagentState` entries with
+reset runtime cursors (replay-all semantics).
+
+**Crash-safe ordering at both write sites:**
+- **Spawn** — write the state file BEFORE `interactiveSubagentRegistry.set`.
+  A crash between the two is recoverable on next reload.
+  A crash before the write leaves no zombie.
+- **Poll cleanup** — advance `lastDeliveredEventTs` (in-memory) BEFORE
+  `removeInteractiveState` (disk). A crash between them re-delivers rather
+  than drops the event.
+
+**Clean-slate on session_shutdown:**
+- `reason="new"` or `reason="quit"` — deletes the state file so the next
+  session starts fresh.
+- `reason="reload"` or `reason="resume"` — KEEPS the file so the next
+  session_start can rehydrate from it. Orphan panes are still killed by the
+  `cancelInteractiveSubagentByState` loop; only the bookkeeping is preserved.
+
+**Inject-mode flood fix at rehydrate:**
+When `notifyOnComplete="inject"` and the artifact already has a terminal event,
+`lastInjectedEventTs` is set to the latest event's ts so the poller does NOT
+re-inject the existing result into the new parent session on its first tick.
+Future follow-up `done` events (higher ts) still inject normally.
+
+**Edge cases:**
+- If `parentSessionId` is omitted (e.g. programmatic spawns from tests),
+  the file is not written; no rehydrate happens on reload.
+- If the state file is missing on `session_start`, rehydrate is a silent no-op.
+- If a rehydrated entry's pane is dead, `deriveInteractiveSubagentStatus`
+  sets `status="exited"` or `status="unknown"`; registry entry is retained
+  so `list_subagent_artifacts` can still surface it before the next cleanup.
+- The schema is versioned (`schemaVersion: 1`) so future migrations can
+  coexist with older state files on upgrades.
 
 ## Git
 
@@ -99,24 +137,24 @@ The runtime validation in the workflow tool (`validateSchema`, `extractJson`) is
 
 ```
 src/
-  subagent.ts                      # MAIN — tools, poller, auto-done fallback
+  subagent.ts                      # MAIN — tools, poller, auto-done fallback, rehydrate ~3k LOC
   helpers.ts                       # startSubagentJob, resolveModel
-  artifact.ts                      # events.ndjson + output.md protocol
+  artifact.ts                      # events.ndjson + output.md protocol + persisted state helpers
   interactive-tmux.ts              # tmux/zellij pane management
   multiplexer{,-tmux,-zellij}.ts   # mux backend abstraction
   subagent-artifact-cli.ts         # the cli.mjs wrapper
   workflow.ts                      # (feat/workflow-tool) workflow tool
   ndjson.d.ts                      # ambient types for the `ndjson` dep
 
-  *.test.ts                        # 17 test files, ~6.5k lines
+  *.test.ts                        # 20 test files, ~7k lines
   test-utils.ts                    # importFresh helper for module-reset tests
 .github/
   workflows/                       # CI (ci.yml) and publish (publish.yml)
-docs/                              # Managed by the separate pi-docs package; do not edit
-```
+docs/                              # Managed by the separate pi-docs package; do not edit```
+
 
 ## When in doubt
 
 - The existing tests in the same directory are the best documentation of intended behavior.
-- `src/subagent-auto-done.test.ts` and `src/subagent-notify.test.ts` together define the artifact-protocol contract — if you're not sure what `events.ndjson` is supposed to contain, those tests are the spec.
+- `src/subagent-auto-done.test.ts`, `src/subagent-notify.test.ts`, and `src/subagent-rehydrate.test.ts` together define the artifact-protocol contract — if you're not sure what `events.ndjson` is supposed to contain, those tests are the spec.
 - The release flow is in `CONTRIBUTING.md`. The dev loop (typecheck + test + format) is above. If a step seems to be missing from this file, it probably is — add it.

--- a/README.md
+++ b/README.md
@@ -175,17 +175,17 @@ The state file and subagent panes are preserved across these actions:
 | ------------------------------------------------- | ----------- | ---------- | ---------------------------------------- |
 | **Ctrl+D (quit) → restart with `--session`/`-r`** | Kept        | Preserved  | ✅ Same session, parentSessionId matches |
 | **Ctrl+D → fresh `pi` (no session)**              | Kept        | Preserved  | ❌ Different session, no match           |
-| **`:reload`**                                     | Kept        | Preserved  | ✅ Same session                          |
-| **`:resume`** (switch to another session)         | Kept        | Preserved  | ✅ If parentSessionId matches            |
-| **`:new`**                                        | **Deleted** | **Killed** | ❌ Clean slate                           |
-| **`:fork`**                                       | **Deleted** | **Killed** | ❌ Clean slate                           |
+| **`/reload`**                                     | Kept        | Preserved  | ✅ Same session                          |
+| **`/resume`** (switch to another session)         | Kept        | Preserved  | ✅ If parentSessionId matches            |
+| **`/new`**                                        | **Deleted** | **Killed** | ❌ Clean slate                           |
+| **`/fork`**                                       | **Deleted** | **Killed** | ❌ Clean slate                           |
 
-> **Note:** `:new` deletes the state file. If you do `:new` and then `:resume`
+> **Note:** `/new` deletes the state file. If you do `/new` and then `/resume`
 > back to the session where subagents were spawned, they **will not reappear**
-> — the state file was already deleted. Only `:reload` or a restart with the
+> — the state file was already deleted. Only `/reload` or a restart with the
 > same session (`--session`/`-r`) preserves the registry.
 
-On `:reload` and `:resume`, the `session_start` handler rehydrates
+On `/reload` and `/resume`, the `session_start` handler rehydrates
 the in-memory registry, filtering by `parentSessionId` so only subagents
 that were created in the current session are restored.
 Runtime cursors are reset so the poller replays any backlog.

--- a/README.md
+++ b/README.md
@@ -166,15 +166,31 @@ Parameters:
 
 The sub-agent's work is **always** written to the artifact dir as `events.ndjson` (lifecycle log) and `output.md` (clean prose the child writes). The pane is for live monitoring; the artifact is the source of truth. The artifact survives parent restarts — sub-agents that finish while you're away are picked up on the next poll.
 
-The interactive sub-agent **registry state** also survives parent reloads. When spawned,
-a per-(cwd, sessionId) state file is written to `<cwd>/.pi/subagentura-state-<sessionId>.json`.
-On `:reload` or `:resume`, the `session_start` handler reads this file and rehydrates
-the in-memory registry with the minimum fields needed to address each pane
-(`paneId`, `mux`, `artifactDir`, `sessionFile`). Runtime cursors are reset so the
-poller replays any backlog that accumulated during downtime.
+The interactive sub-agent **registry state** survives parent reloads and restarts. When spawned,
+a per-(cwd) state file is written to `<cwd>/.pi/subagentura-state.json`.
 
-On `:new` or `:quit`, the state file is deleted, giving the next session a clean slate.
-See the [state file gotcha](AGENTS.md#rehydrate-state-file-cwdpisubagentura-state-sessionidjson)
+The state file and subagent panes are preserved across these actions:
+
+| Action                                            | State file  | Panes      | Rehydrated next start?                   |
+| ------------------------------------------------- | ----------- | ---------- | ---------------------------------------- |
+| **Ctrl+D (quit) → restart with `--session`/`-r`** | Kept        | Preserved  | ✅ Same session, parentSessionId matches |
+| **Ctrl+D → fresh `pi` (no session)**              | Kept        | Preserved  | ❌ Different session, no match           |
+| **`:reload`**                                     | Kept        | Preserved  | ✅ Same session                          |
+| **`:resume`** (switch to another session)         | Kept        | Preserved  | ✅ If parentSessionId matches            |
+| **`:new`**                                        | **Deleted** | **Killed** | ❌ Clean slate                           |
+| **`:fork`**                                       | **Deleted** | **Killed** | ❌ Clean slate                           |
+
+> **Note:** `:new` deletes the state file. If you do `:new` and then `:resume`
+> back to the session where subagents were spawned, they **will not reappear**
+> — the state file was already deleted. Only `:reload` or a restart with the
+> same session (`--session`/`-r`) preserves the registry.
+
+On `:reload` and `:resume`, the `session_start` handler rehydrates
+the in-memory registry, filtering by `parentSessionId` so only subagents
+that were created in the current session are restored.
+Runtime cursors are reset so the poller replays any backlog.
+
+See the [state file gotcha](AGENTS.md#rehydrate-state-file-cwdpisubagentura-state-json)
 in AGENTS.md for the crash-safety ordering and inject-mode flood fix.
 
 #### Sub-agent completion protocol

--- a/README.md
+++ b/README.md
@@ -164,7 +164,18 @@ Parameters:
 - `background` — spawn in a detached named window/tab (invisible) instead of a visible horizontal split. Default `true` — your mux layout is undisturbed and you can attach later with the returned `focus` command. Pass `background: false` for a side-by-side split you can watch in real time.
 - `notifyOnComplete` — `"inject"` (default) or `"notify"`; controls how the parent LLM is woken up on completion. See [Completion notifications: notify vs inject](#completion-notifications-notify-vs-inject) below.
 
-The sub-agent's work is **always** written to the artifact dir as `events.ndjson` (lifecycle log) and `output.md` (clean prose the child writes). The pane is for live monitoring; the artifact is the source of truth. The artifact survives parent restarts, so sub-agents that finish while you're away are picked up on the next poll.
+The sub-agent's work is **always** written to the artifact dir as `events.ndjson` (lifecycle log) and `output.md` (clean prose the child writes). The pane is for live monitoring; the artifact is the source of truth. The artifact survives parent restarts — sub-agents that finish while you're away are picked up on the next poll.
+
+The interactive sub-agent **registry state** also survives parent reloads. When spawned,
+a per-(cwd, sessionId) state file is written to `<cwd>/.pi/subagentura-state-<sessionId>.json`.
+On `:reload` or `:resume`, the `session_start` handler reads this file and rehydrates
+the in-memory registry with the minimum fields needed to address each pane
+(`paneId`, `mux`, `artifactDir`, `sessionFile`). Runtime cursors are reset so the
+poller replays any backlog that accumulated during downtime.
+
+On `:new` or `:quit`, the state file is deleted, giving the next session a clean slate.
+See the [state file gotcha](AGENTS.md#rehydrate-state-file-cwdpisubagentura-state-sessionidjson)
+in AGENTS.md for the crash-safety ordering and inject-mode flood fix.
 
 #### Sub-agent completion protocol
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,506 @@
+# Plan — Rehydrate interactive sub-agents on parent reload
+
+Branch: `fix/interactive-reload-visibility`
+Cwd: `/Users/applesucks/dev/pi-workflow-v2-worktrees/interactive-reload-visibility`
+Locked: 2026-06-19
+
+---
+
+## Context
+
+Interactive sub-agents run as separate `pi --session ...` processes in tmux/zellij panes. Each writes lifecycle events to `events.ndjson` and output to `output.md` in an artifact dir. The artifact protocol already survives parent restarts by design (`src/artifact.ts:1-17` file header).
+
+What breaks across a parent `:reload` / extension restart / parent crash:
+
+- The in-memory `interactiveSubagentRegistry` Map is wiped by `interactiveSubagentRegistry.clear()` at `src/subagent.ts:2522` during `session_shutdown`.
+- The 5s artifact poller is stopped by `clearInterval` at `src/subagent.ts:2498-2503`.
+- The pane stays alive in tmux/zellij, the artifact stays on disk, but the parent has no in-memory state to address the pane.
+- Tools that hit the registry (`get_interactive_subagent_status`, `send_interactive_subagent_message`, `cancel_interactive_subagent`, `list_subagent_artifacts`) return `not_found` for what is effectively a live orphan.
+
+After this PR, `:reload` (and any other session lifecycle event) re-attaches the parent's view of every still-live sub-agent, and completion events that fired during downtime are replayed by the existing poller.
+
+---
+
+## Locked design
+
+### File layout
+
+Per `(cwd, sessionId)` pair:
+
+```
+<cwd>/.pi/subagentura-state-<sessionId>.json
+```
+
+- `cwd` is the value of `ctx.cwd` (or `state.cwd` for spawn-time writes).
+- `sessionId` comes from `ctx.sessionManager.getSessionId()` — see `ReadonlySessionManager` at `@earendil-works/pi-coding-agent/dist/core/session-manager.d.ts:136`, getter at `:188`.
+- The directory `.pi/` is created on first write (`mkdirSync(dirname, { recursive: true, mode: 0o700 })`).
+- File mode `0o600`. Atomic via `writeFileSync(tmp); renameSync(tmp, target)`.
+
+### Schema (v1)
+
+```ts
+export interface InteractiveSubagentPersistedState {
+  schemaVersion: 1;
+  parent: string; // sessionId — redundant with filename; kept for verification/debug
+  states: {
+    [id: string]: {
+      id: string; // 8 hex chars, randomBytes(4).toString("hex")
+      paneId: string;
+      windowName?: string;
+      mux: "tmux" | "zellij";
+      muxSession?: string; // undefined for tmux; required for zellij
+      artifactDir: string;
+      sessionFile: string;
+      notifyOnComplete?: "notify" | "inject";
+    };
+  };
+}
+```
+
+Eight fields per entry. The minimum to call `sendCommandToPane` (`src/interactive-tmux.ts:533-537`), `isPaneAlive` (`:525-527`), `cancelInteractiveSubagent` (`:557-580`), and to drive the poller's `tailReadSessionLog` (`:714-773`).
+
+### Lifecycle
+
+| Event                                                       | File action                                                                       |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Spawn (`launchInteractiveSubagent`)                         | Write entry before `interactiveSubagentRegistry.set`                              |
+| Poller delivers terminal event (`done`/`error`/`cancelled`) | Rewrite file with entry removed, after cursor advance                             |
+| `:reload` (`session_shutdown` reason=`"reload"`)            | No file action — keep file, re-read on next `session_start`                       |
+| `:new` (`session_shutdown` reason=`"new"`)                  | Delete file (clean slate)                                                         |
+| `quit` (`session_shutdown` reason=`"quit"`)                 | Delete file (cleanup; pi is exiting)                                              |
+| `session_start` (any reason)                                | Read file, rehydrate states into registry                                         |
+| Rehydrate sees dead pane + last event is terminal           | Mark `exited`/`cancelled` per `deriveInteractiveSubagentStatus(lastEvent, false)` |
+
+### Cursor reset on rehydrate
+
+Runtime cursors are reset to their defaults on rehydrate (replay-all from the new process's view):
+
+- `lastDeliveredEventTs = 0`
+- `lastDeliveredSessionByte = 0`
+- `lastInjectedEventTs = undefined`
+- `lastSnapshotEventTs = undefined`
+- `injected = undefined`
+- `autoDoneForTurnAt = undefined`
+- `lastStopReason`, `lastStopReasonAt`, `lastStopText`, `lastToolSummary`, `lastToolName`, `lastActivityAt` — all reset
+
+Safe because: (a) cleanup-on-terminal removes entries from the file before re-load, so terminal events from prior sessions can't be replayed into the wrong one; (b) the cursor advances before the file rewrite in the poller, so a crash between them re-delivers rather than drops.
+
+---
+
+## Gotchas (from `AGENTS.md`)
+
+Read these in full before touching the relevant file.
+
+- **Auto-done guard is `readEvents(art).some(ev => isTerminal(ev))`, NOT `lastEvent(art)`** (`src/subagent.ts:895-901`, AGENTS.md:56). Don't simplify to `lastEvent`.
+- **`lastDeliveredEventTs` is the only poller cursor** (AGENTS.md:60). Always go through it. The new cleanup-on-terminal must NOT skip cursor advance.
+- **Don't declare variables after early-return branches** (AGENTS.md project instructions). TDZ will crash at runtime.
+- **`findArtifactById` security precedent at `src/subagent.ts:1073-1122`**: 5-layer defense (id regex, realpath root, readdir, statSync, realpath + isPathInside). Replicate for any new on-disk scanner (the rehydrate code doesn't scan — it reads one known path — so this only matters if you also touch `findArtifactById`).
+- **`writeLaunchScript` exits 0o700**, atomic via `*.tmp + rename`. Match this pattern for `state.json`.
+- **`session_shutdown` (`:2493`) currently only cancels `state.status === "running"`** at `:2510`. Don't fix this in this PR — out of scope; tracked as a follow-up. The rehydrate path makes the `idle` leak non-fatal.
+
+---
+
+## Work item breakdown
+
+Three WIs, sequential commits on `fix/interactive-reload-visibility`. Each WI is self-contained: a sub-agent working on it needs only this `plan.md` plus the files it lists. Recommend dispatching in order, but WI-2 and WI-3 don't conflict on files (both add to `src/subagent.ts`, but to different ranges — re-read after WI-1 lands).
+
+### Commit order
+
+1. **WI-1** — helpers in `src/artifact.ts`
+2. **WI-2** — spawn + terminal cleanup integration
+3. **WI-3** — rehydrate on `session_start` + clean-slate unlink in `session_shutdown`
+
+---
+
+## WI-1 — Persist helpers in `src/artifact.ts`
+
+**Goal**: Pure file-IO helpers, no pi runtime dependencies. Trivially testable.
+
+**Files**: `src/artifact.ts`, `src/artifact.test.ts` (extend)
+
+### Functions to add
+
+In `src/artifact.ts`, after `listArtifacts` (`:204`):
+
+```ts
+import { mkdirSync } from "node:fs";
+import type { MuxName } from "./multiplexer";
+
+export interface InteractiveSubagentPersistedStateV1 {
+  id: string;
+  paneId: string;
+  windowName?: string;
+  mux: MuxName;
+  muxSession?: string;
+  artifactDir: string;
+  sessionFile: string;
+  notifyOnComplete?: "notify" | "inject";
+}
+
+export interface InteractiveSubagentStateFile {
+  schemaVersion: 1;
+  parent: string;
+  states: { [id: string]: InteractiveSubagentPersistedStateV1 };
+}
+
+/** File path for a (cwd, sessionId) pair. Project-local. */
+export function stateFilePath(cwd: string, sessionId: string): string {
+  return join(cwd, ".pi", `subagentura-state-${sessionId}.json`);
+}
+
+/** Read the state file for (cwd, sessionId). Returns null on missing/malformed. */
+export function loadInteractiveStates(
+  cwd: string,
+  sessionId: string,
+): InteractiveSubagentStateFile | null;
+
+/** Atomically write the state file for (cwd, sessionId). Creates .pi/ if needed. */
+export function saveInteractiveStates(
+  cwd: string,
+  sessionId: string,
+  payload: InteractiveSubagentStateFile,
+): void;
+
+/** Convenience: load + add entry + save. Idempotent on id (overwrites). */
+export function appendInteractiveState(
+  cwd: string,
+  sessionId: string,
+  entry: InteractiveSubagentPersistedStateV1,
+): void;
+
+/** Convenience: load + remove entry by id + save (no-op if absent). */
+export function removeInteractiveState(
+  cwd: string,
+  sessionId: string,
+  id: string,
+): void;
+```
+
+### Behavior
+
+- `loadInteractiveStates`: returns null on missing file, malformed JSON, or `schemaVersion !== 1`. Returns `{ schemaVersion: 1, parent: sessionId, states: {} }` if the file exists but has no `states` key. Never throws — caught errors return null.
+- `saveInteractiveStates`: mkdir `.pi/` with mode `0o700`, write `*.tmp` with mode `0o600`, `renameSync` to final path. Validate `payload.schemaVersion === 1`; throw on mismatch.
+- `appendInteractiveState`: load, set `payload.states[entry.id] = entry`, save. If load returns null, write a fresh payload.
+- `removeInteractiveState`: load, delete `payload.states[id]`, save. If load returns null, no-op.
+
+### Test names (extend `src/artifact.test.ts`)
+
+- `stateFilePath returns <cwd>/.pi/subagentura-state-<sessionId>.json`
+- `saveInteractiveStates + loadInteractiveStates round-trips a state file`
+- `loadInteractiveStates returns null when the file is missing`
+- `loadInteractiveStates returns null when the JSON is malformed`
+- `loadInteractiveStates returns null when schemaVersion is not 1`
+- `saveInteractiveStates creates the .pi/ directory if missing (mode 0o700)`
+- `saveInteractiveStates writes atomically (no torn writes)`
+- `saveInteractiveStates rejects schemaVersion !== 1`
+- `appendInteractiveState adds a new entry to an existing file`
+- `appendInteractiveState creates a fresh file if none exists`
+- `appendInteractiveState overwrites an entry with the same id`
+- `removeInteractiveState drops the entry by id`
+- `removeInteractiveState is a no-op when the entry is absent`
+- `removeInteractiveState on a missing file does not throw`
+- `saveInteractiveStates then loadInteractiveStates returns the same payload`
+- `the saved file mode is 0o600` (cross-platform mode bits)
+
+### Acceptance criteria
+
+- All tests above pass.
+- `npm run typecheck` clean.
+- `npm run format:check` clean.
+- No new imports of pi runtime modules in `artifact.ts` (helpers are pure).
+
+---
+
+## WI-2 — Spawn + terminal cleanup integration
+
+**Goal**: Wire the helpers from WI-1 into the spawn path (write) and the poller's terminal-delivery path (remove).
+
+**Files**: `src/interactive-tmux.ts`, `src/subagent.ts`, `src/subagent-launch-script.test.ts` (extend), `src/subagent-poll.test.ts` (extend)
+
+### Changes to `src/interactive-tmux.ts`
+
+In `launchInteractiveSubagent` at `:486-506`, add a `parentSessionId` parameter and call `appendInteractiveState` before `interactiveSubagentRegistry.set`:
+
+```ts
+export function launchInteractiveSubagent(params: {
+  name: string;
+  task: string;
+  persona?: string;
+  model?: string;
+  cwd: string;
+  contextText?: string | null;
+  background?: boolean;
+  notifyOnComplete?: "notify" | "inject";
+  muxPreference?: "auto" | "tmux" | "zellij";
+  /** Session id of the parent pi process — used for persistence. */
+  parentSessionId: string;
+}): InteractiveSubagentState {
+  // ... existing code up through the state object construction at :486 ...
+
+  const state: InteractiveSubagentState = {
+    /* ... existing ... */
+  };
+
+  // NEW: persist before in-memory. Crash between these two lines is safe —
+  // rehydrate on next reload will read the file and rebuild the state.
+  try {
+    appendInteractiveState(params.cwd, params.parentSessionId, {
+      id: state.id,
+      paneId: state.paneId,
+      windowName: state.windowName,
+      mux: state.mux,
+      muxSession: state.muxSession,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+      notifyOnComplete: state.notifyOnComplete,
+    });
+  } catch {
+    /* best effort — disk full / permission denied / etc. */
+  }
+
+  interactiveSubagentRegistry.set(id, state);
+  return state;
+}
+```
+
+### Changes to `src/subagent.ts`
+
+Two changes.
+
+**(a)** The `subagent_interactive` tool handler at `:1964-2027` — pass `parentSessionId` to `launchInteractiveSubagent`. The `ctx` object has `ctx.sessionManager.getSessionId()`:
+
+```ts
+const state = launchInteractiveSubagent({
+  // ... existing params ...
+  parentSessionId: ctx.sessionManager.getSessionId(), // NEW
+});
+```
+
+**(b)** `pollArtifactChanges` at `:555-569` — after `state.lastDeliveredEventTs = maxTs`, if any delivered event was terminal, call `removeInteractiveState`:
+
+```ts
+if (events.length > 0) {
+  let maxTs = cursor;
+  let deliveredTerminal = false;
+  for (const ev of events) {
+    if (ev.ts > maxTs) maxTs = ev.ts;
+    if (!shouldNotify(ev)) continue;
+    if (ev.type === "done" || ev.type === "error" || ev.type === "cancelled") {
+      deliveredTerminal = true;
+    }
+    if (
+      state.autoDoneForTurnAt !== undefined &&
+      ev.ts >= state.autoDoneForTurnAt &&
+      ev.type === "done"
+    )
+      continue;
+    deliverArtifactNotification(interactivePi, state, ev);
+  }
+  state.lastDeliveredEventTs = maxTs;
+  // NEW: cleanup on terminal. Cursor advance first, file rewrite second.
+  if (deliveredTerminal) {
+    try {
+      removeInteractiveState(state.cwd, state.parentSessionId, state.id);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+```
+
+`state.cwd` and `state.parentSessionId` are new fields on `InteractiveSubagentState` — see (c).
+
+**(c)** Add `cwd` and `parentSessionId` to `InteractiveSubagentState` at `src/interactive-tmux.ts:107-220`:
+
+```ts
+export interface InteractiveSubagentState {
+  // ... existing fields ...
+  /** Parent pi session id. Used as the per-session key for persistence. */
+  parentSessionId: string;
+  /** cwd is already in the state (`:131`); keep using that. */
+}
+```
+
+### Test names
+
+**Extend `src/subagent-launch-script.test.ts`:**
+
+- `launchInteractiveSubagent writes state.json next to cli.mjs in the artifact dir on spawn`
+- `launchInteractiveSubagent with parentSessionId persists paneId, windowName, muxSession`
+- `launchInteractiveSubagent with background: true records the correct windowName`
+- `launchInteractiveSubagent with background: false records windowName = undefined`
+- `launchInteractiveSubagent with mux: "zellij" records muxSession`
+
+**Extend `src/subagent-poll.test.ts`:**
+
+- `after poller delivers a done event, the artifact's state.json entry is removed`
+- `after poller delivers an error event, the artifact's state.json entry is removed`
+- `after poller delivers a cancelled event, the artifact's state.json entry is removed`
+- `poller does NOT remove the state.json entry on tool_activity (only terminals)`
+- `poller advances lastDeliveredEventTs before removing the entry (crash-safe ordering)`
+- `if removeInteractiveState throws (e.g. disk full), the poller continues without throwing`
+
+### Acceptance criteria
+
+- All tests pass.
+- `npm run typecheck` clean.
+- `npm run format:check` clean.
+- New `state.cwd` and `state.parentSessionId` fields are populated in every test fixture that constructs an `InteractiveSubagentState`.
+
+---
+
+## WI-3 — Rehydrate on `session_start` + clean-slate on `/new`
+
+**Goal**: Read the persisted state file on every `session_start` and repopulate the registry. Delete the file on `session_shutdown(reason="new"|"quit")`.
+
+**Files**: `src/subagent.ts`, new `src/subagent-rehydrate.test.ts`
+
+### Changes to `src/subagent.ts`
+
+**(a)** Extend the `session_start` handler at `:1184-1186`:
+
+```ts
+pi.on("session_start", (_event, ctx) => {
+  g2.__piSubagenturaUi = ctx.ui;
+  // NEW: rehydrate orphan interactive sub-agents from the state file.
+  try {
+    rehydrateInteractiveSubagents(ctx.cwd, ctx.sessionManager.getSessionId());
+  } catch {
+    /* best effort */
+  }
+});
+```
+
+**(b)** Add the `rehydrateInteractiveSubagents` function near `findArtifactById` (`:1073`):
+
+```ts
+/**
+ * Read the state file for (cwd, sessionId), and for each entry reconstruct
+ * an InteractiveSubagentState, set its status via deriveInteractiveSubagentStatus,
+ * register it, and reset its runtime cursors. Idempotent.
+ *
+ * Pane-rediscovery: if `isPaneAlive(state)` returns false but the persisted
+ * paneId was from a detached/relaxed spawn (windowName implies pi-subagent-<id>
+ * session), re-run the discovery via the mux backend. If rediscovery fails,
+ * mark status from the artifact's lastEvent via the existing fallback chain.
+ */
+export function rehydrateInteractiveSubagents(
+  cwd: string,
+  sessionId: string,
+): {
+  total: number;
+  alive: number;
+  terminal: number;
+};
+```
+
+The function should:
+
+1. Call `loadInteractiveStates(cwd, sessionId)` — if null, return `{ total: 0, alive: 0, terminal: 0 }`.
+2. For each `entry` in `payload.states.values()`:
+   - Build `InteractiveSubagentState` from persisted fields plus:
+     - `name`, `task`, `cwd`, `model`, `startedAt`, `attachCommand`, `selectPaneCommand`, `launchScriptFile` — set to placeholders or recover from launch script if needed. For v1, placeholders are fine; document that the formatInteractiveState display will be approximate.
+     - `status` = `deriveInteractiveSubagentStatus(lastEvent(art), isPaneAlive(rehydratedState))` — see `src/interactive-tmux.ts:589-599`.
+     - `lastDeliveredEventTs = 0`, `lastDeliveredSessionByte = 0`, all `lastX` reset (see "Cursor reset on rehydrate" above).
+   - If id already in `interactiveSubagentRegistry`, skip (idempotent).
+   - Else `interactiveSubagentRegistry.set(id, state)`.
+3. Return counts.
+
+**(c)** Extend the `session_shutdown` handler at `:2493-2539` to clean-slate on `/new` and `quit`:
+
+```ts
+(pi as any).on?.("session_shutdown", (event, ctx) => {
+  // ... existing cleanup (clearInterval, cancelInteractiveSubagent, registry.clear, jobRegistry.clear) ...
+
+  // NEW: clean-slate on /new and quit. Delete the state file so rehydrate on
+  // next session_start (if any) doesn't see stale entries. On :reload, keep
+  // the file so rehydrate restores them.
+  if ((event.reason === "new" || event.reason === "quit") && ctx?.cwd) {
+    try {
+      const fs = require("node:fs");
+      const path = require("node:path");
+      fs.unlinkSync(
+        path.join(
+          ctx.cwd,
+          ".pi",
+          `subagentura-state-${ctx.sessionManager.getSessionId()}.json`,
+        ),
+      );
+    } catch {
+      /* best effort — file may not exist */
+    }
+  }
+});
+```
+
+Use `require` here because the handler is hot-path-adjacent and already in a try/catch. Or refactor to use top-of-file imports — match the existing style. The choice is yours; just be consistent with the rest of the handler.
+
+### Pane id rediscovery (for detached spawns)
+
+When `isPaneAlive(state)` returns false but the persisted state was from a relaxed spawn (the `windowName` field is the human label, not the session name), we can't recover the paneId from the persisted data alone. Recovery:
+
+1. Try `mux.listPanes({ session: "pi-subagent-<id>" })` if the backend supports it. (May need to add a method to the `Multiplexer` interface at `src/multiplexer.ts:39-155` — coordinate with whoever owns the mux layer.)
+2. If that fails, fall back to marking `exited` per the artifact's `lastEvent`.
+
+For v1, **skip the rediscovery step**. If `isPaneAlive` returns false, just mark `exited`. Document this as a known limitation — most users won't hit it because the detached session name `pi-subagent-<id>` is stable across tmux server bounces only if the user hasn't killed the server. When they do, the sub-agent is gone anyway.
+
+### Test names (new file `src/subagent-rehydrate.test.ts`)
+
+- `rehydrateInteractiveSubagents reads the file for (cwd, sessionId) and populates the registry`
+- `rehydrateInteractiveSubagents is a no-op when the file is missing`
+- `rehydrateInteractiveSubagents is a no-op when the file is malformed`
+- `rehydrateInteractiveSubagents skips ids already in the registry (idempotent)`
+- `rehydrateInteractiveSubagents does not throw when ctx.cwd is unreachable`
+- `rehydrateInteractiveSubagents resets lastDeliveredEventTs to 0 and lastDeliveredSessionByte to 0`
+- `rehydrateInteractiveSubagents resets lastInjectedEventTs, lastSnapshotEventTs, autoDoneForTurnAt to undefined`
+- `rehydrateInteractiveSubagents sets status from deriveInteractiveSubagentStatus when the pane is alive`
+- `rehydrateInteractiveSubagents marks exited/cancelled per lastEvent when the pane is dead`
+- `rehydrateInteractiveSubagents returns { total, alive, terminal } counts correctly`
+- `after rehydrate, the next poll tick replays events newer than the reset cursor`
+- `after rehydrate of a live pane with no events yet, status is "running"`
+
+**Extend `src/subagent-shutdown.test.ts`** (parallel the existing tests at `:146-180`):
+
+- `session_shutdown with reason="new" deletes the state file for the current session`
+- `session_shutdown with reason="quit" deletes the state file for the current session`
+- `session_shutdown with reason="reload" KEEPS the state file (rehydrate depends on it)`
+- `session_shutdown with reason="resume" KEEPS the state file`
+- `session_shutdown with reason="fork" KEEPS the state file`
+
+### Acceptance criteria
+
+- All tests pass.
+- `npm run typecheck` clean.
+- `npm run format:check` clean.
+- After all three WIs land: smoke test per `smoke-interactive.mjs` — spawn in tmux, `:reload`, verify the status footer returns and a follow-up message lands in the child pane.
+
+---
+
+## Coordination notes
+
+- **Order**: WI-1 → WI-2 → WI-3. WI-2 and WI-3 both modify `src/subagent.ts`; merge sequentially, don't parallelize the edits.
+- **Field additions**: WI-2 introduces `parentSessionId` on `InteractiveSubagentState`. Every test fixture in `src/subagent-find-artifact.test.ts`, `src/subagent-shutdown.test.ts`, `src/subagent-poll.test.ts`, `src/subagent-launch-script.test.ts` may need a `parentSessionId: "test-session"` field added — a sub-agent should grep for `InteractiveSubagentState` literals and update them.
+- **Imports**: `src/artifact.ts` should not import `MuxName` from `./multiplexer` in a circular way. Check the import direction first.
+- **Test fixture hygiene**: All test fixtures that construct an `InteractiveSubagentState` literal will need `parentSessionId` after WI-2 lands. Run `npm run typecheck` after WI-2 lands and fix any literal that fails.
+- **Smoke test**: After WI-3 lands, run `npm run smoke:interactive` (or whatever the project uses — see `smoke-interactive.mjs`).
+
+## Verification after each WI
+
+```bash
+npm run typecheck
+npm test
+npm run format:check
+```
+
+All three must pass. If `npm run format:check` fails, run `npx prettier --write <files>` and re-stage.
+
+---
+
+## Open follow-ups (out of scope for this PR)
+
+Documented but not implemented:
+
+- **`idle` orphan leak in `session_shutdown`** (`src/subagent.ts:2510`). Trivial fix: extend the guard to `running || idle`. After this PR lands, the leak is non-fatal because rehydrate recovers, but it's still a cleanup gap.
+- **`findArtifactById` default-root mismatch** with `defaultSessionRoot` (`src/interactive-tmux.ts:260-264` vs `src/subagent.ts:1082`). The two compute the same root with slightly different code paths; consolidate before adding a third consumer.
+- **Pane-id rediscovery for detached spawns after mux server bounce.** Listed above; punted to v2.
+- **`list_subagent_artifacts` disk scan** for past-session orphans. Separate fix; the description at `src/subagent.ts:2315` currently advertises more than the impl delivers.

--- a/src/artifact.test.ts
+++ b/src/artifact.test.ts
@@ -12,28 +12,27 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-	appendEvent,
-	appendInteractiveState,
-	artifactPath,
-	deleteInteractiveStatesFile,
-	ensureArtifactDir,
-	lastEvent,
-	listArtifacts,
-	listOutputTurns,
-	loadInteractiveStates,
-	outputPathForTurn,
-	readEvents,
-	readOutput,
-	readOutputForTurn,
-	removeInteractiveState,
-	saveInteractiveStates,
-	snapshotOutput,
-	stateFilePath,
-	writeOutput,
-	type InteractiveSubagentPersistedStateV1,
-	type SubagentEvent,
+  appendEvent,
+  appendInteractiveState,
+  artifactPath,
+  deleteInteractiveStatesFile,
+  ensureArtifactDir,
+  lastEvent,
+  listArtifacts,
+  listOutputTurns,
+  loadInteractiveStates,
+  outputPathForTurn,
+  readEvents,
+  readOutput,
+  readOutputForTurn,
+  removeInteractiveState,
+  saveInteractiveStates,
+  snapshotOutput,
+  stateFilePath,
+  writeOutput,
+  type InteractiveSubagentPersistedStateV1,
+  type SubagentEvent,
 } from "./artifact";
-
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-artifact-"));
@@ -288,285 +287,230 @@ describe("artifact", () => {
       const art = artifactPath(root, "snap6-nonexistent");
       expect(listOutputTurns(art)).toEqual([]);
     });
+  });
+
+  it("listOutputTurns returns [] when the artifact dir doesn't exist", () => {
+    const art = artifactPath(root, "snap6-nonexistent");
+    expect(listOutputTurns(art)).toEqual([]);
+  });
 });
-
-
-		it("listOutputTurns returns [] when the artifact dir doesn't exist", () => {
-			const art = artifactPath(root, "snap6-nonexistent");
-			expect(listOutputTurns(art)).toEqual([]);
-		});
-	});
-
 
 describe("persisted interactive state helpers", () => {
+  let root: string;
 
-	let root: string;
+  beforeEach(() => {
+    root = makeTmp();
+  });
 
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
 
+  const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
 
-	beforeEach(() => {
+  const SAMPLE: InteractiveSubagentPersistedStateV1 = {
+    id: "abc12345",
 
-		root = makeTmp();
+    paneId: "%42",
 
-	});
+    windowName: "demo",
 
+    mux: "tmux",
 
+    artifactDir: "/tmp/artifacts/abc12345",
 
-	afterEach(() => {
+    sessionFile: "/tmp/session.jsonl",
 
-		rmSync(root, { recursive: true, force: true });
+    notifyOnComplete: "inject",
+  };
 
-	});
+  it("stateFilePath returns <cwd>/.pi/subagentura-state-<sessionId>.json", () => {
+    expect(stateFilePath(root, SESSION)).toBe(
+      join(root, ".pi", `subagentura-state-${SESSION}.json`),
+    );
+  });
 
+  it("saveInteractiveStates + loadInteractiveStates round-trips a state file", () => {
+    saveInteractiveStates(root, SESSION, {
+      schemaVersion: 1,
+      parent: SESSION,
+      states: { abc12345: SAMPLE },
+    });
 
+    const loaded = loadInteractiveStates(root, SESSION);
 
-	const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
+    expect(loaded).toEqual({
+      schemaVersion: 1,
+      parent: SESSION,
+      states: { abc12345: SAMPLE },
+    });
+  });
 
-	const SAMPLE: InteractiveSubagentPersistedStateV1 = {
+  it("loadInteractiveStates returns null when the file is missing", () => {
+    expect(loadInteractiveStates(root, SESSION)).toBeNull();
+  });
 
-		id: "abc12345",
+  it("loadInteractiveStates returns null when the JSON is malformed", () => {
+    const file = stateFilePath(root, SESSION);
 
-		paneId: "%42",
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
 
-		windowName: "demo",
+    writeFileSync(file, "not-json{", { mode: 0o600 });
 
-		mux: "tmux",
+    expect(loadInteractiveStates(root, SESSION)).toBeNull();
+  });
 
-		artifactDir: "/tmp/artifacts/abc12345",
+  it("loadInteractiveStates returns null when schemaVersion is not 1", () => {
+    const file = stateFilePath(root, SESSION);
 
-		sessionFile: "/tmp/session.jsonl",
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
 
-		notifyOnComplete: "inject",
+    writeFileSync(
+      file,
+      JSON.stringify({ schemaVersion: 99, parent: SESSION, states: {} }),
+      { mode: 0o600 },
+    );
 
-	};
+    expect(loadInteractiveStates(root, SESSION)).toBeNull();
+  });
 
+  it("loadInteractiveStates returns empty states when the file exists but has no states key", () => {
+    const file = stateFilePath(root, SESSION);
 
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
 
-	it("stateFilePath returns <cwd>/.pi/subagentura-state-<sessionId>.json", () => {
+    writeFileSync(file, JSON.stringify({ schemaVersion: 1, parent: SESSION }), {
+      mode: 0o600,
+    });
 
-		expect(stateFilePath(root, SESSION)).toBe(join(root, ".pi", `subagentura-state-${SESSION}.json`));
+    const loaded = loadInteractiveStates(root, SESSION);
 
-	});
+    expect(loaded).toEqual({ schemaVersion: 1, parent: SESSION, states: {} });
+  });
 
+  it("saveInteractiveStates creates the .pi/ directory if missing (mode 0o700)", () => {
+    expect(existsSync(join(root, ".pi"))).toBe(false);
 
+    saveInteractiveStates(root, SESSION, {
+      schemaVersion: 1,
+      parent: SESSION,
+      states: {},
+    });
 
-	it("saveInteractiveStates + loadInteractiveStates round-trips a state file", () => {
+    expect(existsSync(join(root, ".pi"))).toBe(true);
 
-		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: { abc12345: SAMPLE } });
+    if (process.platform !== "win32") {
+      expect(statSync(join(root, ".pi")).mode & 0o777).toBe(0o700);
+    }
+  });
 
-		const loaded = loadInteractiveStates(root, SESSION);
+  it("saveInteractiveStates writes atomically (no torn writes)", () => {
+    saveInteractiveStates(root, SESSION, {
+      schemaVersion: 1,
+      parent: SESSION,
+      states: { abc12345: SAMPLE },
+    });
 
-		expect(loaded).toEqual({ schemaVersion: 1, parent: SESSION, states: { abc12345: SAMPLE } });
+    expect(existsSync(stateFilePath(root, SESSION) + ".tmp")).toBe(false);
 
-	});
+    expect(existsSync(stateFilePath(root, SESSION))).toBe(true);
+  });
 
+  it("saveInteractiveStates rejects schemaVersion !== 1", () => {
+    expect(() =>
+      saveInteractiveStates(root, SESSION, {
+        schemaVersion: 2 as any,
+        parent: SESSION,
+        states: {},
+      }),
+    ).toThrow(/unsupported schemaVersion/);
+  });
 
+  it("appendInteractiveState adds a new entry to an existing file", () => {
+    saveInteractiveStates(root, SESSION, {
+      schemaVersion: 1,
+      parent: SESSION,
+      states: {},
+    });
 
-	it("loadInteractiveStates returns null when the file is missing", () => {
+    appendInteractiveState(root, SESSION, SAMPLE);
 
-		expect(loadInteractiveStates(root, SESSION)).toBeNull();
+    expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(
+      SAMPLE,
+    );
+  });
 
-	});
+  it("appendInteractiveState creates a fresh file if none exists", () => {
+    expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
 
+    appendInteractiveState(root, SESSION, SAMPLE);
 
+    const loaded = loadInteractiveStates(root, SESSION);
 
-	it("loadInteractiveStates returns null when the JSON is malformed", () => {
+    expect(loaded?.parent).toBe(SESSION);
 
-		const file = stateFilePath(root, SESSION);
+    expect(loaded?.states["abc12345"]).toEqual(SAMPLE);
+  });
 
-		mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+  it("appendInteractiveState overwrites an entry with the same id", () => {
+    appendInteractiveState(root, SESSION, SAMPLE);
 
-		writeFileSync(file, "not-json{", { mode: 0o600 });
+    const updated = { ...SAMPLE, paneId: "%99" };
 
-		expect(loadInteractiveStates(root, SESSION)).toBeNull();
+    appendInteractiveState(root, SESSION, updated);
 
-	});
+    expect(
+      loadInteractiveStates(root, SESSION)?.states["abc12345"]?.paneId,
+    ).toBe("%99");
+  });
 
+  it("removeInteractiveState drops the entry by id", () => {
+    appendInteractiveState(root, SESSION, SAMPLE);
 
+    appendInteractiveState(root, SESSION, { ...SAMPLE, id: "def67890" });
 
-	it("loadInteractiveStates returns null when schemaVersion is not 1", () => {
+    removeInteractiveState(root, SESSION, "abc12345");
 
-		const file = stateFilePath(root, SESSION);
+    const loaded = loadInteractiveStates(root, SESSION);
 
-		mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+    expect(loaded?.states["abc12345"]).toBeUndefined();
 
-		writeFileSync(file, JSON.stringify({ schemaVersion: 99, parent: SESSION, states: {} }), { mode: 0o600 });
+    expect(loaded?.states["def67890"]).toBeDefined();
+  });
 
-		expect(loadInteractiveStates(root, SESSION)).toBeNull();
+  it("removeInteractiveState is a no-op when the entry is absent", () => {
+    appendInteractiveState(root, SESSION, SAMPLE);
 
-	});
+    removeInteractiveState(root, SESSION, "nonexistent");
 
+    expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(
+      SAMPLE,
+    );
+  });
 
+  it("removeInteractiveState on a missing file does not throw", () => {
+    expect(() =>
+      removeInteractiveState(root, SESSION, "abc12345"),
+    ).not.toThrow();
+  });
 
-	it("loadInteractiveStates returns empty states when the file exists but has no states key", () => {
+  it("the saved file mode is 0o600 (best-effort on POSIX)", () => {
+    appendInteractiveState(root, SESSION, SAMPLE);
 
-		const file = stateFilePath(root, SESSION);
+    if (process.platform !== "win32") {
+      expect(statSync(stateFilePath(root, SESSION)).mode & 0o777).toBe(0o600);
+    }
+  });
 
-		mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+  it("deleteInteractiveStatesFile removes the file", () => {
+    appendInteractiveState(root, SESSION, SAMPLE);
 
-		writeFileSync(file, JSON.stringify({ schemaVersion: 1, parent: SESSION }), { mode: 0o600 });
+    deleteInteractiveStatesFile(root, SESSION);
 
-		const loaded = loadInteractiveStates(root, SESSION);
+    expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
+  });
 
-		expect(loaded).toEqual({ schemaVersion: 1, parent: SESSION, states: {} });
-
-	});
-
-
-
-	it("saveInteractiveStates creates the .pi/ directory if missing (mode 0o700)", () => {
-
-		expect(existsSync(join(root, ".pi"))).toBe(false);
-
-		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: {} });
-
-		expect(existsSync(join(root, ".pi"))).toBe(true);
-
-		if (process.platform !== "win32") {
-
-			expect(statSync(join(root, ".pi")).mode & 0o777).toBe(0o700);
-
-		}
-
-	});
-
-
-
-	it("saveInteractiveStates writes atomically (no torn writes)", () => {
-
-		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: { abc12345: SAMPLE } });
-
-		expect(existsSync(stateFilePath(root, SESSION) + ".tmp")).toBe(false);
-
-		expect(existsSync(stateFilePath(root, SESSION))).toBe(true);
-
-	});
-
-
-
-	it("saveInteractiveStates rejects schemaVersion !== 1", () => {
-
-		expect(() =>
-
-			saveInteractiveStates(root, SESSION, { schemaVersion: 2 as any, parent: SESSION, states: {} }),
-
-		).toThrow(/unsupported schemaVersion/);
-
-	});
-
-
-
-	it("appendInteractiveState adds a new entry to an existing file", () => {
-
-		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: {} });
-
-		appendInteractiveState(root, SESSION, SAMPLE);
-
-		expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(SAMPLE);
-
-	});
-
-
-
-	it("appendInteractiveState creates a fresh file if none exists", () => {
-
-		expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
-
-		appendInteractiveState(root, SESSION, SAMPLE);
-
-		const loaded = loadInteractiveStates(root, SESSION);
-
-		expect(loaded?.parent).toBe(SESSION);
-
-		expect(loaded?.states["abc12345"]).toEqual(SAMPLE);
-
-	});
-
-
-
-	it("appendInteractiveState overwrites an entry with the same id", () => {
-
-		appendInteractiveState(root, SESSION, SAMPLE);
-
-		const updated = { ...SAMPLE, paneId: "%99" };
-
-		appendInteractiveState(root, SESSION, updated);
-
-		expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]?.paneId).toBe("%99");
-
-	});
-
-
-
-	it("removeInteractiveState drops the entry by id", () => {
-
-		appendInteractiveState(root, SESSION, SAMPLE);
-
-		appendInteractiveState(root, SESSION, { ...SAMPLE, id: "def67890" });
-
-		removeInteractiveState(root, SESSION, "abc12345");
-
-		const loaded = loadInteractiveStates(root, SESSION);
-
-		expect(loaded?.states["abc12345"]).toBeUndefined();
-
-		expect(loaded?.states["def67890"]).toBeDefined();
-
-	});
-
-
-
-	it("removeInteractiveState is a no-op when the entry is absent", () => {
-
-		appendInteractiveState(root, SESSION, SAMPLE);
-
-		removeInteractiveState(root, SESSION, "nonexistent");
-
-		expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(SAMPLE);
-
-	});
-
-
-
-	it("removeInteractiveState on a missing file does not throw", () => {
-
-		expect(() => removeInteractiveState(root, SESSION, "abc12345")).not.toThrow();
-
-	});
-
-
-
-	it("the saved file mode is 0o600 (best-effort on POSIX)", () => {
-
-		appendInteractiveState(root, SESSION, SAMPLE);
-
-		if (process.platform !== "win32") {
-
-			expect(statSync(stateFilePath(root, SESSION)).mode & 0o777).toBe(0o600);
-
-		}
-
-	});
-
-
-
-	it("deleteInteractiveStatesFile removes the file", () => {
-
-		appendInteractiveState(root, SESSION, SAMPLE);
-
-		deleteInteractiveStatesFile(root, SESSION);
-
-		expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
-
-	});
-
-
-
-	it("deleteInteractiveStatesFile is a no-op when the file is absent", () => {
-
-		expect(() => deleteInteractiveStatesFile(root, SESSION)).not.toThrow();
-
-	});
-
+  it("deleteInteractiveStatesFile is a no-op when the file is absent", () => {
+    expect(() => deleteInteractiveStatesFile(root, SESSION)).not.toThrow();
+  });
 });
-

--- a/src/artifact.test.ts
+++ b/src/artifact.test.ts
@@ -12,20 +12,28 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  appendEvent,
-  artifactPath,
-  ensureArtifactDir,
-  lastEvent,
-  listArtifacts,
-  listOutputTurns,
-  outputPathForTurn,
-  readEvents,
-  readOutput,
-  readOutputForTurn,
-  snapshotOutput,
-  writeOutput,
-  type SubagentEvent,
+	appendEvent,
+	appendInteractiveState,
+	artifactPath,
+	deleteInteractiveStatesFile,
+	ensureArtifactDir,
+	lastEvent,
+	listArtifacts,
+	listOutputTurns,
+	loadInteractiveStates,
+	outputPathForTurn,
+	readEvents,
+	readOutput,
+	readOutputForTurn,
+	removeInteractiveState,
+	saveInteractiveStates,
+	snapshotOutput,
+	stateFilePath,
+	writeOutput,
+	type InteractiveSubagentPersistedStateV1,
+	type SubagentEvent,
 } from "./artifact";
+
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-artifact-"));
@@ -280,5 +288,285 @@ describe("artifact", () => {
       const art = artifactPath(root, "snap6-nonexistent");
       expect(listOutputTurns(art)).toEqual([]);
     });
-  });
 });
+
+
+		it("listOutputTurns returns [] when the artifact dir doesn't exist", () => {
+			const art = artifactPath(root, "snap6-nonexistent");
+			expect(listOutputTurns(art)).toEqual([]);
+		});
+	});
+
+
+describe("persisted interactive state helpers", () => {
+
+	let root: string;
+
+
+
+	beforeEach(() => {
+
+		root = makeTmp();
+
+	});
+
+
+
+	afterEach(() => {
+
+		rmSync(root, { recursive: true, force: true });
+
+	});
+
+
+
+	const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
+
+	const SAMPLE: InteractiveSubagentPersistedStateV1 = {
+
+		id: "abc12345",
+
+		paneId: "%42",
+
+		windowName: "demo",
+
+		mux: "tmux",
+
+		artifactDir: "/tmp/artifacts/abc12345",
+
+		sessionFile: "/tmp/session.jsonl",
+
+		notifyOnComplete: "inject",
+
+	};
+
+
+
+	it("stateFilePath returns <cwd>/.pi/subagentura-state-<sessionId>.json", () => {
+
+		expect(stateFilePath(root, SESSION)).toBe(join(root, ".pi", `subagentura-state-${SESSION}.json`));
+
+	});
+
+
+
+	it("saveInteractiveStates + loadInteractiveStates round-trips a state file", () => {
+
+		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: { abc12345: SAMPLE } });
+
+		const loaded = loadInteractiveStates(root, SESSION);
+
+		expect(loaded).toEqual({ schemaVersion: 1, parent: SESSION, states: { abc12345: SAMPLE } });
+
+	});
+
+
+
+	it("loadInteractiveStates returns null when the file is missing", () => {
+
+		expect(loadInteractiveStates(root, SESSION)).toBeNull();
+
+	});
+
+
+
+	it("loadInteractiveStates returns null when the JSON is malformed", () => {
+
+		const file = stateFilePath(root, SESSION);
+
+		mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+
+		writeFileSync(file, "not-json{", { mode: 0o600 });
+
+		expect(loadInteractiveStates(root, SESSION)).toBeNull();
+
+	});
+
+
+
+	it("loadInteractiveStates returns null when schemaVersion is not 1", () => {
+
+		const file = stateFilePath(root, SESSION);
+
+		mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+
+		writeFileSync(file, JSON.stringify({ schemaVersion: 99, parent: SESSION, states: {} }), { mode: 0o600 });
+
+		expect(loadInteractiveStates(root, SESSION)).toBeNull();
+
+	});
+
+
+
+	it("loadInteractiveStates returns empty states when the file exists but has no states key", () => {
+
+		const file = stateFilePath(root, SESSION);
+
+		mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+
+		writeFileSync(file, JSON.stringify({ schemaVersion: 1, parent: SESSION }), { mode: 0o600 });
+
+		const loaded = loadInteractiveStates(root, SESSION);
+
+		expect(loaded).toEqual({ schemaVersion: 1, parent: SESSION, states: {} });
+
+	});
+
+
+
+	it("saveInteractiveStates creates the .pi/ directory if missing (mode 0o700)", () => {
+
+		expect(existsSync(join(root, ".pi"))).toBe(false);
+
+		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: {} });
+
+		expect(existsSync(join(root, ".pi"))).toBe(true);
+
+		if (process.platform !== "win32") {
+
+			expect(statSync(join(root, ".pi")).mode & 0o777).toBe(0o700);
+
+		}
+
+	});
+
+
+
+	it("saveInteractiveStates writes atomically (no torn writes)", () => {
+
+		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: { abc12345: SAMPLE } });
+
+		expect(existsSync(stateFilePath(root, SESSION) + ".tmp")).toBe(false);
+
+		expect(existsSync(stateFilePath(root, SESSION))).toBe(true);
+
+	});
+
+
+
+	it("saveInteractiveStates rejects schemaVersion !== 1", () => {
+
+		expect(() =>
+
+			saveInteractiveStates(root, SESSION, { schemaVersion: 2 as any, parent: SESSION, states: {} }),
+
+		).toThrow(/unsupported schemaVersion/);
+
+	});
+
+
+
+	it("appendInteractiveState adds a new entry to an existing file", () => {
+
+		saveInteractiveStates(root, SESSION, { schemaVersion: 1, parent: SESSION, states: {} });
+
+		appendInteractiveState(root, SESSION, SAMPLE);
+
+		expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(SAMPLE);
+
+	});
+
+
+
+	it("appendInteractiveState creates a fresh file if none exists", () => {
+
+		expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
+
+		appendInteractiveState(root, SESSION, SAMPLE);
+
+		const loaded = loadInteractiveStates(root, SESSION);
+
+		expect(loaded?.parent).toBe(SESSION);
+
+		expect(loaded?.states["abc12345"]).toEqual(SAMPLE);
+
+	});
+
+
+
+	it("appendInteractiveState overwrites an entry with the same id", () => {
+
+		appendInteractiveState(root, SESSION, SAMPLE);
+
+		const updated = { ...SAMPLE, paneId: "%99" };
+
+		appendInteractiveState(root, SESSION, updated);
+
+		expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]?.paneId).toBe("%99");
+
+	});
+
+
+
+	it("removeInteractiveState drops the entry by id", () => {
+
+		appendInteractiveState(root, SESSION, SAMPLE);
+
+		appendInteractiveState(root, SESSION, { ...SAMPLE, id: "def67890" });
+
+		removeInteractiveState(root, SESSION, "abc12345");
+
+		const loaded = loadInteractiveStates(root, SESSION);
+
+		expect(loaded?.states["abc12345"]).toBeUndefined();
+
+		expect(loaded?.states["def67890"]).toBeDefined();
+
+	});
+
+
+
+	it("removeInteractiveState is a no-op when the entry is absent", () => {
+
+		appendInteractiveState(root, SESSION, SAMPLE);
+
+		removeInteractiveState(root, SESSION, "nonexistent");
+
+		expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(SAMPLE);
+
+	});
+
+
+
+	it("removeInteractiveState on a missing file does not throw", () => {
+
+		expect(() => removeInteractiveState(root, SESSION, "abc12345")).not.toThrow();
+
+	});
+
+
+
+	it("the saved file mode is 0o600 (best-effort on POSIX)", () => {
+
+		appendInteractiveState(root, SESSION, SAMPLE);
+
+		if (process.platform !== "win32") {
+
+			expect(statSync(stateFilePath(root, SESSION)).mode & 0o777).toBe(0o600);
+
+		}
+
+	});
+
+
+
+	it("deleteInteractiveStatesFile removes the file", () => {
+
+		appendInteractiveState(root, SESSION, SAMPLE);
+
+		deleteInteractiveStatesFile(root, SESSION);
+
+		expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
+
+	});
+
+
+
+	it("deleteInteractiveStatesFile is a no-op when the file is absent", () => {
+
+		expect(() => deleteInteractiveStatesFile(root, SESSION)).not.toThrow();
+
+	});
+
+});
+

--- a/src/artifact.test.ts
+++ b/src/artifact.test.ts
@@ -306,8 +306,6 @@ describe("persisted interactive state helpers", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
-
   const SAMPLE: InteractiveSubagentPersistedStateV1 = {
     id: "abc12345",
 
@@ -324,76 +322,76 @@ describe("persisted interactive state helpers", () => {
     notifyOnComplete: "inject",
   };
 
-  it("stateFilePath returns <cwd>/.pi/subagentura-state-<sessionId>.json", () => {
-    expect(stateFilePath(root, SESSION)).toBe(
-      join(root, ".pi", `subagentura-state-${SESSION}.json`),
+  it("stateFilePath returns <cwd>/.pi/subagentura-state.json", () => {
+    expect(stateFilePath(root)).toBe(
+      join(root, ".pi", "subagentura-state.json"),
     );
   });
 
   it("saveInteractiveStates + loadInteractiveStates round-trips a state file", () => {
-    saveInteractiveStates(root, SESSION, {
+    saveInteractiveStates(root, {
       schemaVersion: 1,
-      parent: SESSION,
+      parent: "pi",
       states: { abc12345: SAMPLE },
     });
 
-    const loaded = loadInteractiveStates(root, SESSION);
+    const loaded = loadInteractiveStates(root);
 
     expect(loaded).toEqual({
       schemaVersion: 1,
-      parent: SESSION,
+      parent: "pi",
       states: { abc12345: SAMPLE },
     });
   });
 
   it("loadInteractiveStates returns null when the file is missing", () => {
-    expect(loadInteractiveStates(root, SESSION)).toBeNull();
+    expect(loadInteractiveStates(root)).toBeNull();
   });
 
   it("loadInteractiveStates returns null when the JSON is malformed", () => {
-    const file = stateFilePath(root, SESSION);
+    const file = stateFilePath(root);
 
     mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
 
     writeFileSync(file, "not-json{", { mode: 0o600 });
 
-    expect(loadInteractiveStates(root, SESSION)).toBeNull();
+    expect(loadInteractiveStates(root)).toBeNull();
   });
 
   it("loadInteractiveStates returns null when schemaVersion is not 1", () => {
-    const file = stateFilePath(root, SESSION);
+    const file = stateFilePath(root);
 
     mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
 
     writeFileSync(
       file,
-      JSON.stringify({ schemaVersion: 99, parent: SESSION, states: {} }),
+      JSON.stringify({ schemaVersion: 99, parent: "pi", states: {} }),
       { mode: 0o600 },
     );
 
-    expect(loadInteractiveStates(root, SESSION)).toBeNull();
+    expect(loadInteractiveStates(root)).toBeNull();
   });
 
   it("loadInteractiveStates returns empty states when the file exists but has no states key", () => {
-    const file = stateFilePath(root, SESSION);
+    const file = stateFilePath(root);
 
     mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
 
-    writeFileSync(file, JSON.stringify({ schemaVersion: 1, parent: SESSION }), {
+    writeFileSync(file, JSON.stringify({ schemaVersion: 1, parent: "pi" }), {
       mode: 0o600,
     });
 
-    const loaded = loadInteractiveStates(root, SESSION);
+    const loaded = loadInteractiveStates(root);
 
-    expect(loaded).toEqual({ schemaVersion: 1, parent: SESSION, states: {} });
+    expect(loaded).toEqual({ schemaVersion: 1, parent: "pi", states: {} });
   });
 
   it("saveInteractiveStates creates the .pi/ directory if missing (mode 0o700)", () => {
     expect(existsSync(join(root, ".pi"))).toBe(false);
 
-    saveInteractiveStates(root, SESSION, {
+    saveInteractiveStates(root, {
       schemaVersion: 1,
-      parent: SESSION,
+      parent: "pi",
       states: {},
     });
 
@@ -405,73 +403,69 @@ describe("persisted interactive state helpers", () => {
   });
 
   it("saveInteractiveStates writes atomically (no torn writes)", () => {
-    saveInteractiveStates(root, SESSION, {
+    saveInteractiveStates(root, {
       schemaVersion: 1,
-      parent: SESSION,
+      parent: "pi",
       states: { abc12345: SAMPLE },
     });
 
-    expect(existsSync(stateFilePath(root, SESSION) + ".tmp")).toBe(false);
+    expect(existsSync(stateFilePath(root) + ".tmp")).toBe(false);
 
-    expect(existsSync(stateFilePath(root, SESSION))).toBe(true);
+    expect(existsSync(stateFilePath(root))).toBe(true);
   });
 
   it("saveInteractiveStates rejects schemaVersion !== 1", () => {
     expect(() =>
-      saveInteractiveStates(root, SESSION, {
+      saveInteractiveStates(root, {
         schemaVersion: 2 as any,
-        parent: SESSION,
+        parent: "pi",
         states: {},
       }),
     ).toThrow(/unsupported schemaVersion/);
   });
 
   it("appendInteractiveState adds a new entry to an existing file", () => {
-    saveInteractiveStates(root, SESSION, {
+    saveInteractiveStates(root, {
       schemaVersion: 1,
-      parent: SESSION,
+      parent: "pi",
       states: {},
     });
 
-    appendInteractiveState(root, SESSION, SAMPLE);
+    appendInteractiveState(root, SAMPLE);
 
-    expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(
-      SAMPLE,
-    );
+    expect(loadInteractiveStates(root)?.states["abc12345"]).toEqual(SAMPLE);
   });
 
   it("appendInteractiveState creates a fresh file if none exists", () => {
-    expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
+    expect(existsSync(stateFilePath(root))).toBe(false);
 
-    appendInteractiveState(root, SESSION, SAMPLE);
+    appendInteractiveState(root, SAMPLE);
 
-    const loaded = loadInteractiveStates(root, SESSION);
+    const loaded = loadInteractiveStates(root);
 
-    expect(loaded?.parent).toBe(SESSION);
+    expect(loaded?.parent).toBe("pi");
 
     expect(loaded?.states["abc12345"]).toEqual(SAMPLE);
   });
 
   it("appendInteractiveState overwrites an entry with the same id", () => {
-    appendInteractiveState(root, SESSION, SAMPLE);
+    appendInteractiveState(root, SAMPLE);
 
     const updated = { ...SAMPLE, paneId: "%99" };
 
-    appendInteractiveState(root, SESSION, updated);
+    appendInteractiveState(root, updated);
 
-    expect(
-      loadInteractiveStates(root, SESSION)?.states["abc12345"]?.paneId,
-    ).toBe("%99");
+    expect(loadInteractiveStates(root)?.states["abc12345"]?.paneId).toBe("%99");
   });
 
   it("removeInteractiveState drops the entry by id", () => {
-    appendInteractiveState(root, SESSION, SAMPLE);
+    appendInteractiveState(root, SAMPLE);
 
-    appendInteractiveState(root, SESSION, { ...SAMPLE, id: "def67890" });
+    appendInteractiveState(root, { ...SAMPLE, id: "def67890" });
 
-    removeInteractiveState(root, SESSION, "abc12345");
+    removeInteractiveState(root, "abc12345");
 
-    const loaded = loadInteractiveStates(root, SESSION);
+    const loaded = loadInteractiveStates(root);
 
     expect(loaded?.states["abc12345"]).toBeUndefined();
 
@@ -479,38 +473,34 @@ describe("persisted interactive state helpers", () => {
   });
 
   it("removeInteractiveState is a no-op when the entry is absent", () => {
-    appendInteractiveState(root, SESSION, SAMPLE);
+    appendInteractiveState(root, SAMPLE);
 
-    removeInteractiveState(root, SESSION, "nonexistent");
+    removeInteractiveState(root, "nonexistent");
 
-    expect(loadInteractiveStates(root, SESSION)?.states["abc12345"]).toEqual(
-      SAMPLE,
-    );
+    expect(loadInteractiveStates(root)?.states["abc12345"]).toEqual(SAMPLE);
   });
 
   it("removeInteractiveState on a missing file does not throw", () => {
-    expect(() =>
-      removeInteractiveState(root, SESSION, "abc12345"),
-    ).not.toThrow();
+    expect(() => removeInteractiveState(root, "abc12345")).not.toThrow();
   });
 
   it("the saved file mode is 0o600 (best-effort on POSIX)", () => {
-    appendInteractiveState(root, SESSION, SAMPLE);
+    appendInteractiveState(root, SAMPLE);
 
     if (process.platform !== "win32") {
-      expect(statSync(stateFilePath(root, SESSION)).mode & 0o777).toBe(0o600);
+      expect(statSync(stateFilePath(root)).mode & 0o777).toBe(0o600);
     }
   });
 
   it("deleteInteractiveStatesFile removes the file", () => {
-    appendInteractiveState(root, SESSION, SAMPLE);
+    appendInteractiveState(root, SAMPLE);
 
-    deleteInteractiveStatesFile(root, SESSION);
+    deleteInteractiveStatesFile(root);
 
-    expect(existsSync(stateFilePath(root, SESSION))).toBe(false);
+    expect(existsSync(stateFilePath(root))).toBe(false);
   });
 
   it("deleteInteractiveStatesFile is a no-op when the file is absent", () => {
-    expect(() => deleteInteractiveStatesFile(root, SESSION)).not.toThrow();
+    expect(() => deleteInteractiveStatesFile(root)).not.toThrow();
   });
 });

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -275,6 +275,9 @@ export interface InteractiveSubagentPersistedStateV1 {
   sessionFile: string;
 
   notifyOnComplete?: "notify" | "inject";
+
+  /** Parent pi session id; only rehydrated when the current session matches. */
+  parentSessionId?: string;
 }
 
 export interface InteractiveSubagentStateFile {

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -17,17 +17,19 @@
  */
 
 import {
-  appendFileSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  renameSync,
-  statSync,
-  writeFileSync,
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import ndjson from "ndjson";
+import type { MuxName } from "./multiplexer";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -241,3 +243,258 @@ export function lastEvent(art: SubagentArtifact): SubagentEvent | null {
   const events = readEvents(art);
   return events.length > 0 ? events[events.length - 1] : null;
 }
+
+
+
+
+// ── Persisted interactive state (project-local, per parent session) ───────────
+
+
+
+/**
+
+ * Per-entry shape. The minimum to drive sendCommandToPane (src/interactive-tmux.ts:533),
+
+ * isPaneAlive (:525), cancelInteractiveSubagent (:557), and the poller's tailReadSessionLog
+
+ * (:714). Fields like task/model/startedAt are intentionally not persisted — they're
+
+ * recoverable from the launch script + prompt file on demand, or not needed for live ops.
+
+ */
+
+export interface InteractiveSubagentPersistedStateV1 {
+
+	id: string;
+
+	paneId: string;
+
+	windowName?: string;
+
+	mux: MuxName;
+
+	muxSession?: string;
+
+	artifactDir: string;
+
+	sessionFile: string;
+
+	notifyOnComplete?: "notify" | "inject";
+
+}
+
+
+
+export interface InteractiveSubagentStateFile {
+
+	schemaVersion: 1;
+
+	/** Parent pi session id; redundant with the filename but kept for verification/debugging. */
+
+	parent: string;
+
+	states: { [id: string]: InteractiveSubagentPersistedStateV1 };
+
+}
+
+
+
+/** File path for a (cwd, sessionId) pair. Project-local under .pi/. */
+
+export function stateFilePath(cwd: string, sessionId: string): string {
+
+	return join(cwd, ".pi", `subagentura-state-${sessionId}.json`);
+
+}
+
+
+
+/**
+
+ * Read the state file for (cwd, sessionId). Returns null on missing file, malformed
+
+ * JSON, or schemaVersion mismatch. Never throws — defensive readers for untrusted input
+
+ * (the file could be hand-edited or partial from a crash mid-rename).
+
+ */
+
+export function loadInteractiveStates(
+
+	cwd: string,
+
+	sessionId: string,
+
+): InteractiveSubagentStateFile | null {
+
+	const file = stateFilePath(cwd, sessionId);
+
+	let content: string;
+
+	try {
+
+		content = readFileSync(file, "utf8");
+
+	} catch {
+
+		return null;
+
+	}
+
+	let parsed: unknown;
+
+	try {
+
+		parsed = JSON.parse(content);
+
+	} catch {
+
+		return null;
+
+	}
+
+	if (!parsed || typeof parsed !== "object") return null;
+
+	const obj = parsed as Record<string, unknown>;
+
+	if (obj.schemaVersion !== 1) return null;
+
+	if (!obj.states || typeof obj.states !== "object") {
+
+		return { schemaVersion: 1, parent: String(obj.parent ?? sessionId), states: {} };
+
+	}
+
+	return {
+
+		schemaVersion: 1,
+
+		parent: String(obj.parent ?? sessionId),
+
+		states: obj.states as { [id: string]: InteractiveSubagentPersistedStateV1 },
+
+	};
+
+}
+
+
+
+/**
+
+ * Atomically write the state file for (cwd, sessionId). Creates .pi/ if needed.
+
+ * Mode 0o700 on .pi/, mode 0o600 on the file. Atomic via *.tmp + rename.
+
+ */
+
+export function saveInteractiveStates(
+
+	cwd: string,
+
+	sessionId: string,
+
+	payload: InteractiveSubagentStateFile,
+
+): void {
+
+	if (payload.schemaVersion !== 1) {
+
+		throw new Error(`unsupported schemaVersion: ${payload.schemaVersion}`);
+
+	}
+
+	const file = stateFilePath(cwd, sessionId);
+
+	mkdirSync(join(cwd, ".pi"), { recursive: true, mode: 0o700 });
+
+	const tmp = file + ".tmp";
+
+	writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 });
+
+	renameSync(tmp, file);
+
+}
+
+
+
+/**
+
+ * Convenience: load (or create fresh) + add/overwrite entry by id + save.
+
+ * Called from hot paths (spawn) where a write failure must not break the parent.
+
+ */
+
+export function appendInteractiveState(
+
+	cwd: string,
+
+	sessionId: string,
+
+	entry: InteractiveSubagentPersistedStateV1,
+
+): void {
+
+	const current = loadInteractiveStates(cwd, sessionId) ?? {
+
+		schemaVersion: 1,
+
+		parent: sessionId,
+
+		states: {},
+
+	};
+
+	current.states[entry.id] = entry;
+
+	saveInteractiveStates(cwd, sessionId, current);
+
+}
+
+
+
+/**
+
+ * Convenience: load + drop entry by id + save. No-op if absent or file missing.
+
+ */
+
+export function removeInteractiveState(cwd: string, sessionId: string, id: string): void {
+
+	const current = loadInteractiveStates(cwd, sessionId);
+
+	if (!current) return;
+
+	if (!(id in current.states)) return;
+
+	delete current.states[id];
+
+	saveInteractiveStates(cwd, sessionId, current);
+
+}
+
+
+
+/**
+
+ * Delete the state file outright. Used on session_shutdown(reason="new"|"quit") to
+
+ * give the next session a clean slate. No-op if the file doesn't exist.
+
+ */
+
+export function deleteInteractiveStatesFile(cwd: string, sessionId: string): void {
+
+	try {
+
+		unlinkSync(stateFilePath(cwd, sessionId));
+
+	} catch {
+
+		/* best effort — file may not exist */
+
+	}
+
+}
+
+

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -17,15 +17,15 @@
  */
 
 import {
-	appendFileSync,
-	existsSync,
-	mkdirSync,
-	readdirSync,
-	readFileSync,
-	renameSync,
-	statSync,
-	unlinkSync,
-	writeFileSync,
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import ndjson from "ndjson";
@@ -244,12 +244,7 @@ export function lastEvent(art: SubagentArtifact): SubagentEvent | null {
   return events.length > 0 ? events[events.length - 1] : null;
 }
 
-
-
-
 // ── Persisted interactive state (project-local, per parent session) ───────────
-
-
 
 /**
 
@@ -264,50 +259,38 @@ export function lastEvent(art: SubagentArtifact): SubagentEvent | null {
  */
 
 export interface InteractiveSubagentPersistedStateV1 {
+  id: string;
 
-	id: string;
+  paneId: string;
 
-	paneId: string;
+  windowName?: string;
 
-	windowName?: string;
+  mux: MuxName;
 
-	mux: MuxName;
+  muxSession?: string;
 
-	muxSession?: string;
+  artifactDir: string;
 
-	artifactDir: string;
+  sessionFile: string;
 
-	sessionFile: string;
-
-	notifyOnComplete?: "notify" | "inject";
-
+  notifyOnComplete?: "notify" | "inject";
 }
-
-
 
 export interface InteractiveSubagentStateFile {
+  schemaVersion: 1;
 
-	schemaVersion: 1;
+  /** Parent pi session id; redundant with the filename but kept for verification/debugging. */
 
-	/** Parent pi session id; redundant with the filename but kept for verification/debugging. */
+  parent: string;
 
-	parent: string;
-
-	states: { [id: string]: InteractiveSubagentPersistedStateV1 };
-
+  states: { [id: string]: InteractiveSubagentPersistedStateV1 };
 }
-
-
 
 /** File path for a (cwd, sessionId) pair. Project-local under .pi/. */
 
 export function stateFilePath(cwd: string, sessionId: string): string {
-
-	return join(cwd, ".pi", `subagentura-state-${sessionId}.json`);
-
+  return join(cwd, ".pi", `subagentura-state-${sessionId}.json`);
 }
-
-
 
 /**
 
@@ -320,64 +303,50 @@ export function stateFilePath(cwd: string, sessionId: string): string {
  */
 
 export function loadInteractiveStates(
+  cwd: string,
 
-	cwd: string,
-
-	sessionId: string,
-
+  sessionId: string,
 ): InteractiveSubagentStateFile | null {
+  const file = stateFilePath(cwd, sessionId);
 
-	const file = stateFilePath(cwd, sessionId);
+  let content: string;
 
-	let content: string;
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
 
-	try {
+  let parsed: unknown;
 
-		content = readFileSync(file, "utf8");
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
 
-	} catch {
+  if (!parsed || typeof parsed !== "object") return null;
 
-		return null;
+  const obj = parsed as Record<string, unknown>;
 
-	}
+  if (obj.schemaVersion !== 1) return null;
 
-	let parsed: unknown;
+  if (!obj.states || typeof obj.states !== "object") {
+    return {
+      schemaVersion: 1,
+      parent: String(obj.parent ?? sessionId),
+      states: {},
+    };
+  }
 
-	try {
+  return {
+    schemaVersion: 1,
 
-		parsed = JSON.parse(content);
+    parent: String(obj.parent ?? sessionId),
 
-	} catch {
-
-		return null;
-
-	}
-
-	if (!parsed || typeof parsed !== "object") return null;
-
-	const obj = parsed as Record<string, unknown>;
-
-	if (obj.schemaVersion !== 1) return null;
-
-	if (!obj.states || typeof obj.states !== "object") {
-
-		return { schemaVersion: 1, parent: String(obj.parent ?? sessionId), states: {} };
-
-	}
-
-	return {
-
-		schemaVersion: 1,
-
-		parent: String(obj.parent ?? sessionId),
-
-		states: obj.states as { [id: string]: InteractiveSubagentPersistedStateV1 },
-
-	};
-
+    states: obj.states as { [id: string]: InteractiveSubagentPersistedStateV1 },
+  };
 }
-
-
 
 /**
 
@@ -388,34 +357,26 @@ export function loadInteractiveStates(
  */
 
 export function saveInteractiveStates(
+  cwd: string,
 
-	cwd: string,
+  sessionId: string,
 
-	sessionId: string,
-
-	payload: InteractiveSubagentStateFile,
-
+  payload: InteractiveSubagentStateFile,
 ): void {
+  if (payload.schemaVersion !== 1) {
+    throw new Error(`unsupported schemaVersion: ${payload.schemaVersion}`);
+  }
 
-	if (payload.schemaVersion !== 1) {
+  const file = stateFilePath(cwd, sessionId);
 
-		throw new Error(`unsupported schemaVersion: ${payload.schemaVersion}`);
+  mkdirSync(join(cwd, ".pi"), { recursive: true, mode: 0o700 });
 
-	}
+  const tmp = file + ".tmp";
 
-	const file = stateFilePath(cwd, sessionId);
+  writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 });
 
-	mkdirSync(join(cwd, ".pi"), { recursive: true, mode: 0o700 });
-
-	const tmp = file + ".tmp";
-
-	writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 });
-
-	renameSync(tmp, file);
-
+  renameSync(tmp, file);
 }
-
-
 
 /**
 
@@ -426,32 +387,24 @@ export function saveInteractiveStates(
  */
 
 export function appendInteractiveState(
+  cwd: string,
 
-	cwd: string,
+  sessionId: string,
 
-	sessionId: string,
-
-	entry: InteractiveSubagentPersistedStateV1,
-
+  entry: InteractiveSubagentPersistedStateV1,
 ): void {
+  const current = loadInteractiveStates(cwd, sessionId) ?? {
+    schemaVersion: 1,
 
-	const current = loadInteractiveStates(cwd, sessionId) ?? {
+    parent: sessionId,
 
-		schemaVersion: 1,
+    states: {},
+  };
 
-		parent: sessionId,
+  current.states[entry.id] = entry;
 
-		states: {},
-
-	};
-
-	current.states[entry.id] = entry;
-
-	saveInteractiveStates(cwd, sessionId, current);
-
+  saveInteractiveStates(cwd, sessionId, current);
 }
-
-
 
 /**
 
@@ -459,21 +412,21 @@ export function appendInteractiveState(
 
  */
 
-export function removeInteractiveState(cwd: string, sessionId: string, id: string): void {
+export function removeInteractiveState(
+  cwd: string,
+  sessionId: string,
+  id: string,
+): void {
+  const current = loadInteractiveStates(cwd, sessionId);
 
-	const current = loadInteractiveStates(cwd, sessionId);
+  if (!current) return;
 
-	if (!current) return;
+  if (!(id in current.states)) return;
 
-	if (!(id in current.states)) return;
+  delete current.states[id];
 
-	delete current.states[id];
-
-	saveInteractiveStates(cwd, sessionId, current);
-
+  saveInteractiveStates(cwd, sessionId, current);
 }
-
-
 
 /**
 
@@ -483,18 +436,13 @@ export function removeInteractiveState(cwd: string, sessionId: string, id: strin
 
  */
 
-export function deleteInteractiveStatesFile(cwd: string, sessionId: string): void {
-
-	try {
-
-		unlinkSync(stateFilePath(cwd, sessionId));
-
-	} catch {
-
-		/* best effort — file may not exist */
-
-	}
-
+export function deleteInteractiveStatesFile(
+  cwd: string,
+  sessionId: string,
+): void {
+  try {
+    unlinkSync(stateFilePath(cwd, sessionId));
+  } catch {
+    /* best effort — file may not exist */
+  }
 }
-
-

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -29,6 +29,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import ndjson from "ndjson";
+import { debugLog } from "./helpers";
 import type { MuxName } from "./multiplexer";
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -377,13 +378,14 @@ export function saveInteractiveStates(
 
   renameSync(tmp, file);
 }
-
+// SAFETY: load-modify-write is not atomic across concurrent callers.
+// Safe today only because a pi session is single-event-loop and never
+// calls this re-entrantly. Do NOT call from parallel async paths without
+// adding a write lock.
 /**
-
  * Convenience: load (or create fresh) + add/overwrite entry by id + save.
-
+ *
  * Called from hot paths (spawn) where a write failure must not break the parent.
-
  */
 
 export function appendInteractiveState(
@@ -406,10 +408,12 @@ export function appendInteractiveState(
   saveInteractiveStates(cwd, sessionId, current);
 }
 
+// SAFETY: load-modify-write is not atomic across concurrent callers.
+// Safe today only because a pi session is single-event-loop and never
+// calls this re-entrantly. Do NOT call from parallel async paths without
+// adding a write lock.
 /**
-
  * Convenience: load + drop entry by id + save. No-op if absent or file missing.
-
  */
 
 export function removeInteractiveState(

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -287,28 +287,21 @@ export interface InteractiveSubagentStateFile {
   states: { [id: string]: InteractiveSubagentPersistedStateV1 };
 }
 
-/** File path for a (cwd, sessionId) pair. Project-local under .pi/. */
+/** File path for the project-local state file under .pi/. */
 
-export function stateFilePath(cwd: string, sessionId: string): string {
-  return join(cwd, ".pi", `subagentura-state-${sessionId}.json`);
+export function stateFilePath(cwd: string): string {
+  return join(cwd, ".pi", "subagentura-state.json");
 }
-
 /**
-
- * Read the state file for (cwd, sessionId). Returns null on missing file, malformed
-
+ * Read the state file. Returns null on missing file, malformed
  * JSON, or schemaVersion mismatch. Never throws — defensive readers for untrusted input
-
  * (the file could be hand-edited or partial from a crash mid-rename).
-
  */
 
 export function loadInteractiveStates(
   cwd: string,
-
-  sessionId: string,
 ): InteractiveSubagentStateFile | null {
-  const file = stateFilePath(cwd, sessionId);
+  const file = stateFilePath(cwd);
 
   let content: string;
 
@@ -340,7 +333,7 @@ export function loadInteractiveStates(
   if (!obj.states || typeof obj.states !== "object") {
     return {
       schemaVersion: 1,
-      parent: String(obj.parent ?? sessionId),
+      parent: String(obj.parent ?? "pi"),
       states: {},
     };
   }
@@ -348,32 +341,24 @@ export function loadInteractiveStates(
   return {
     schemaVersion: 1,
 
-    parent: String(obj.parent ?? sessionId),
+    parent: String(obj.parent ?? "pi"),
 
     states: obj.states as { [id: string]: InteractiveSubagentPersistedStateV1 },
   };
 }
-
 /**
-
- * Atomically write the state file for (cwd, sessionId). Creates .pi/ if needed.
-
+ * Atomically write the state file. Creates .pi/ if needed.
  * Mode 0o700 on .pi/, mode 0o600 on the file. Atomic via *.tmp + rename.
-
  */
-
 export function saveInteractiveStates(
   cwd: string,
-
-  sessionId: string,
-
   payload: InteractiveSubagentStateFile,
 ): void {
   if (payload.schemaVersion !== 1) {
     throw new Error(`unsupported schemaVersion: ${payload.schemaVersion}`);
   }
 
-  const file = stateFilePath(cwd, sessionId);
+  const file = stateFilePath(cwd);
 
   mkdirSync(join(cwd, ".pi"), { recursive: true, mode: 0o700 });
 
@@ -389,28 +374,23 @@ export function saveInteractiveStates(
 // adding a write lock.
 /**
  * Convenience: load (or create fresh) + add/overwrite entry by id + save.
- *
  * Called from hot paths (spawn) where a write failure must not break the parent.
  */
-
 export function appendInteractiveState(
   cwd: string,
-
-  sessionId: string,
-
   entry: InteractiveSubagentPersistedStateV1,
 ): void {
-  const current = loadInteractiveStates(cwd, sessionId) ?? {
+  const current = loadInteractiveStates(cwd) ?? {
     schemaVersion: 1,
 
-    parent: sessionId,
+    parent: "pi",
 
     states: {},
   };
 
   current.states[entry.id] = entry;
 
-  saveInteractiveStates(cwd, sessionId, current);
+  saveInteractiveStates(cwd, current);
 }
 
 // SAFETY: load-modify-write is not atomic across concurrent callers.
@@ -420,13 +400,8 @@ export function appendInteractiveState(
 /**
  * Convenience: load + drop entry by id + save. No-op if absent or file missing.
  */
-
-export function removeInteractiveState(
-  cwd: string,
-  sessionId: string,
-  id: string,
-): void {
-  const current = loadInteractiveStates(cwd, sessionId);
+export function removeInteractiveState(cwd: string, id: string): void {
+  const current = loadInteractiveStates(cwd);
 
   if (!current) return;
 
@@ -434,23 +409,15 @@ export function removeInteractiveState(
 
   delete current.states[id];
 
-  saveInteractiveStates(cwd, sessionId, current);
+  saveInteractiveStates(cwd, current);
 }
-
 /**
-
- * Delete the state file outright. Used on session_shutdown(reason="new"|"quit") to
-
+ * Delete the state file outright. Used on session_shutdown(reason="new") to
  * give the next session a clean slate. No-op if the file doesn't exist.
-
  */
-
-export function deleteInteractiveStatesFile(
-  cwd: string,
-  sessionId: string,
-): void {
+export function deleteInteractiveStatesFile(cwd: string): void {
   try {
-    unlinkSync(stateFilePath(cwd, sessionId));
+    unlinkSync(stateFilePath(cwd));
   } catch {
     /* best effort — file may not exist */
   }

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -330,7 +330,12 @@ export function loadInteractiveStates(
 
   const obj = parsed as Record<string, unknown>;
 
-  if (obj.schemaVersion !== 1) return null;
+  if (obj.schemaVersion !== 1) {
+    debugLog("warn", "state-file-unknown-schema", {
+      schemaVersion: obj.schemaVersion as number,
+    });
+    return null;
+  }
 
   if (!obj.states || typeof obj.states !== "object") {
     return {

--- a/src/interactive-tmux.test.ts
+++ b/src/interactive-tmux.test.ts
@@ -22,6 +22,11 @@ function installMockExec(scenario: (file: string, args: string[]) => string) {
     execFileSync: (_file: string, args: string[]) =>
       scenario("tmux", args as string[]),
   }));
+  // Ensure getMux selects tmux, not zellij. The mock only handles tmux
+  // commands; if ZELLIJ_SESSION_NAME is set from the outer environment,
+  // getMux would pick zellij and the mock would not intercept its calls.
+  delete process.env.ZELLIJ;
+  delete process.env.ZELLIJ_SESSION_NAME;
 }
 
 function makeArgs() {

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -28,14 +28,19 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { CLI_SOURCE } from "./subagent-artifact-cli";
-import { appendInteractiveState, artifactPath, lastEvent, type SubagentArtifact, type SubagentEvent } from "./artifact";
 import {
-	getMux,
-	NoMultiplexerAvailableError,
-	type MuxName,
-	type Multiplexer,
+  appendInteractiveState,
+  artifactPath,
+  lastEvent,
+  type SubagentArtifact,
+  type SubagentEvent,
+} from "./artifact";
+import {
+  getMux,
+  NoMultiplexerAvailableError,
+  type MuxName,
+  type Multiplexer,
 } from "./multiplexer";
-
 
 // Re-export the tmux-specific `readPaneExitCode` for the test suite. The
 // launch script's EXIT trap still writes the @pi-exit-code pane option
@@ -232,7 +237,6 @@ export interface InteractiveSubagentState {
   injected?: boolean;
 }
 
-
 declare global {
   var __piSubagenturaInteractiveRegistry:
     | Map<string, InteractiveSubagentState>
@@ -424,33 +428,29 @@ export function writeLaunchScript(
 }
 
 export function launchInteractiveSubagent(params: {
-	name: string;
-	task: string;
-	persona?: string;
-	model?: string;
-	cwd: string;
-	contextText?: string | null;
-	/** Spawn in a detached named window (invisible) instead of a visible split. */
-	background?: boolean;
-	/**
-	 * Notification delivery mode requested by the spawner. "notify" (default)
-	 * emits a UI hint on completion. "inject" also injects output.md as a user
-	 * message so the parent LLM processes it in its next turn.
-	 */
-	notifyOnComplete?: "notify" | "inject";
-	/** Mux preference — passed to getMux(). "auto" (default) = env-var heuristic. */
-	muxPreference?: "auto" | "tmux" | "zellij";
-	/**
-	 * Parent pi session id. Used as the per-session key for the on-disk state file
-	 * so a parent reload can rehydrate the sub-agent. If omitted, persistence is
-	 * skipped (used by tests that don't care about reload).
-	 */
-	parentSessionId?: string;
+  name: string;
+  task: string;
+  persona?: string;
+  model?: string;
+  cwd: string;
+  contextText?: string | null;
+  /** Spawn in a detached named window (invisible) instead of a visible split. */
+  background?: boolean;
+  /**
+   * Notification delivery mode requested by the spawner. "notify" (default)
+   * emits a UI hint on completion. "inject" also injects output.md as a user
+   * message so the parent LLM processes it in its next turn.
+   */
+  notifyOnComplete?: "notify" | "inject";
+  /** Mux preference — passed to getMux(). "auto" (default) = env-var heuristic. */
+  muxPreference?: "auto" | "tmux" | "zellij";
+  /**
+   * Parent pi session id. Used as the per-session key for the on-disk state file
+   * so a parent reload can rehydrate the sub-agent. If omitted, persistence is
+   * skipped (used by tests that don't care about reload).
+   */
+  parentSessionId?: string;
 }): InteractiveSubagentState {
-
-
-
-
   const id = randomBytes(4).toString("hex");
   const cwd = resolve(params.cwd);
   const background = params.background !== false; // default true (hidden)
@@ -462,7 +462,6 @@ export function launchInteractiveSubagent(params: {
 
   mkdirSync(paths.artifactDir, { recursive: true });
   writeFileSync(paths.promptFile, prompt, { encoding: "utf8", mode: 0o600 });
-
 
   // Cap the persona to prevent a misbehaving parent from shipping a huge
   // system prompt to the model on every turn. 64 KiB is well above what any
@@ -593,8 +592,6 @@ export function launchInteractiveSubagent(params: {
   return state;
 }
 
-
-
 /**
  * Resolve the multiplexer that created a given sub-agent state. Uses
  * `state.mux` to dispatch to the right backend via `getMux({ preference:
@@ -617,8 +614,10 @@ export function isPaneAlive(state: InteractiveSubagentState): boolean {
  * Send a command (text + Enter) to a pane, using the mux that created it.
  * Mux-agnostic — replaces `sendCommandToTmuxPane(paneId, command)`.
  */
-export function sendCommandToPane(state: InteractiveSubagentState, command: string): void {
-
+export function sendCommandToPane(
+  state: InteractiveSubagentState,
+  command: string,
+): void {
   const mux = getMuxForState(state);
   mux.sendKeys(state.paneId, command, state.muxSession);
   mux.sendEnter(state.paneId, state.muxSession);

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -28,25 +28,21 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { CLI_SOURCE } from "./subagent-artifact-cli";
+import { appendInteractiveState, artifactPath, lastEvent, type SubagentArtifact, type SubagentEvent } from "./artifact";
 import {
-  artifactPath,
-  lastEvent,
-  type SubagentArtifact,
-  type SubagentEvent,
-} from "./artifact";
-import {
-  getMux,
-  NoMultiplexerAvailableError,
-  type MuxName,
-  type Multiplexer,
+	getMux,
+	NoMultiplexerAvailableError,
+	type MuxName,
+	type Multiplexer,
 } from "./multiplexer";
-import { TmuxMultiplexer } from "./multiplexer-tmux";
+
 
 // Re-export the tmux-specific `readPaneExitCode` for the test suite. The
 // launch script's EXIT trap still writes the @pi-exit-code pane option
 // (it's a no-op on non-tmux systems thanks to `2>/dev/null || true`); this
 // helper is the only place that reads it back. The artifact's `done`
 // event is the source of truth in production.
+import { TmuxMultiplexer } from "./multiplexer-tmux";
 export { readPaneExitCode } from "./multiplexer-tmux";
 
 /**
@@ -140,6 +136,13 @@ export interface InteractiveSubagentState {
   muxSession?: string;
   sessionFile: string;
   cwd: string;
+  /**
+   * Parent pi session id. Used as the per-session key for the on-disk state file
+   * (see src/artifact.ts: stateFilePath). Required for terminal-event cleanup to
+   * remove the entry from the file; rehydrate rebuilds it from the file on
+   * session_start. Optional for tests that don't care about reload semantics.
+   */
+  parentSessionId?: string;
   model?: string;
   startedAt: number;
   /**
@@ -228,6 +231,7 @@ export interface InteractiveSubagentState {
    */
   injected?: boolean;
 }
+
 
 declare global {
   var __piSubagenturaInteractiveRegistry:
@@ -420,23 +424,33 @@ export function writeLaunchScript(
 }
 
 export function launchInteractiveSubagent(params: {
-  name: string;
-  task: string;
-  persona?: string;
-  model?: string;
-  cwd: string;
-  contextText?: string | null;
-  /** Spawn in a detached named window (invisible) instead of a visible split. */
-  background?: boolean;
-  /**
-   * Notification delivery mode requested by the spawner. "notify" (default)
-   * emits a UI hint on completion. "inject" also injects output.md as a user
-   * message so the parent LLM processes it in its next turn.
-   */
-  notifyOnComplete?: "notify" | "inject";
-  /** Mux preference — passed to getMux(). "auto" (default) = env-var heuristic. */
-  muxPreference?: "auto" | "tmux" | "zellij";
+	name: string;
+	task: string;
+	persona?: string;
+	model?: string;
+	cwd: string;
+	contextText?: string | null;
+	/** Spawn in a detached named window (invisible) instead of a visible split. */
+	background?: boolean;
+	/**
+	 * Notification delivery mode requested by the spawner. "notify" (default)
+	 * emits a UI hint on completion. "inject" also injects output.md as a user
+	 * message so the parent LLM processes it in its next turn.
+	 */
+	notifyOnComplete?: "notify" | "inject";
+	/** Mux preference — passed to getMux(). "auto" (default) = env-var heuristic. */
+	muxPreference?: "auto" | "tmux" | "zellij";
+	/**
+	 * Parent pi session id. Used as the per-session key for the on-disk state file
+	 * so a parent reload can rehydrate the sub-agent. If omitted, persistence is
+	 * skipped (used by tests that don't care about reload).
+	 */
+	parentSessionId?: string;
 }): InteractiveSubagentState {
+
+
+
+
   const id = randomBytes(4).toString("hex");
   const cwd = resolve(params.cwd);
   const background = params.background !== false; // default true (hidden)
@@ -448,6 +462,7 @@ export function launchInteractiveSubagent(params: {
 
   mkdirSync(paths.artifactDir, { recursive: true });
   writeFileSync(paths.promptFile, prompt, { encoding: "utf8", mode: 0o600 });
+
 
   // Cap the persona to prevent a misbehaving parent from shipping a huge
   // system prompt to the model on every turn. 64 KiB is well above what any
@@ -551,11 +566,34 @@ export function launchInteractiveSubagent(params: {
     launchScriptFile: paths.launchScriptFile,
     artifactDir: paths.artifactDir,
     notifyOnComplete: params.notifyOnComplete,
+    parentSessionId: params.parentSessionId,
   };
+  // Persist to the project-local state file BEFORE registering in-memory. Order
+  // matters: a crash between this write and interactiveSubagentRegistry.set is
+  // safe — the next session_start's rehydrate reads the file and rebuilds the
+  // state. A crash before this write leaves no zombie.
+  if (params.parentSessionId) {
+    try {
+      appendInteractiveState(params.cwd, params.parentSessionId, {
+        id,
+        paneId,
+        windowName,
+        mux: mux.name,
+        muxSession,
+        artifactDir: paths.artifactDir,
+        sessionFile: paths.sessionFile,
+        notifyOnComplete: params.notifyOnComplete,
+      });
+    } catch {
+      /* best effort — disk full, permission denied, etc. In-memory still works. */
+    }
+  }
 
   interactiveSubagentRegistry.set(id, state);
   return state;
 }
+
+
 
 /**
  * Resolve the multiplexer that created a given sub-agent state. Uses
@@ -579,10 +617,8 @@ export function isPaneAlive(state: InteractiveSubagentState): boolean {
  * Send a command (text + Enter) to a pane, using the mux that created it.
  * Mux-agnostic — replaces `sendCommandToTmuxPane(paneId, command)`.
  */
-export function sendCommandToPane(
-  state: InteractiveSubagentState,
-  command: string,
-): void {
+export function sendCommandToPane(state: InteractiveSubagentState, command: string): void {
+
   const mux = getMuxForState(state);
   mux.sendKeys(state.paneId, command, state.muxSession);
   mux.sendEnter(state.paneId, state.muxSession);

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -535,6 +535,7 @@ export function launchInteractiveSubagent(params: {
         artifactDir: paths.artifactDir,
         sessionFile: paths.sessionFile,
         notifyOnComplete: params.notifyOnComplete,
+        parentSessionId: params.parentSessionId,
       });
       persistedState = true;
     } catch {

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -690,6 +690,12 @@ export function cancelInteractiveSubagent(
   if (mux.isPaneAlive(state.paneId, state.muxSession)) {
     mux.killPane(state.paneId, state.muxSession);
   }
+  // 4. Clean up the persisted state entry so it doesn't litter the state file.
+  try {
+    removeInteractiveState(state.cwd, state.id);
+  } catch {
+    /* best-effort */
+  }
   return state;
 }
 
@@ -734,6 +740,12 @@ export function cancelInteractiveSubagentByState(
     } catch {
       /* best-effort */
     }
+  }
+  // 3. Clean up the persisted state entry so it doesn't litter the state file.
+  try {
+    removeInteractiveState(state.cwd, state.id);
+  } catch {
+    /* best-effort — stale entry is harmless, just clutter */
   }
   // Does NOT update state.status — see JSDoc point 2.
 }

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -25,15 +25,15 @@
 
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { CLI_SOURCE } from "./subagent-artifact-cli";
 import {
   appendInteractiveState,
   artifactPath,
   lastEvent,
-  type SubagentArtifact,
   type SubagentEvent,
+  removeInteractiveState,
 } from "./artifact";
 import {
   getMux,
@@ -521,6 +521,26 @@ export function launchInteractiveSubagent(params: {
     windowName: safeSegment(params.name),
     id,
   });
+  let persistedState = false;
+  // Persist as soon as the pane is addressable. A crash after this point is
+  // recoverable on reload. The catch path below removes it on launch failure.
+  if (params.parentSessionId) {
+    try {
+      appendInteractiveState(params.cwd, {
+        id,
+        paneId,
+        windowName,
+        mux: mux.name,
+        muxSession,
+        artifactDir: paths.artifactDir,
+        sessionFile: paths.sessionFile,
+        notifyOnComplete: params.notifyOnComplete,
+      });
+      persistedState = true;
+    } catch {
+      /* best effort — disk full, permission denied, etc. In-memory still works. */
+    }
+  }
   try {
     const command = buildPiInteractiveCommand({
       sessionFile: paths.sessionFile,
@@ -537,7 +557,14 @@ export function launchInteractiveSubagent(params: {
   } catch (err) {
     // Orphan-pane guard. If writeLaunchScript or sendKeys throws after
     // the pane was created, kill the pane before rethrowing so we don't
-    // leak it into the user's mux server.
+    // leak it into the user's mux server. Also clean up persisted state.
+    if (persistedState && params.parentSessionId) {
+      try {
+        removeInteractiveState(params.cwd, id);
+      } catch {
+        /* best effort — the pane kill below is the important cleanup */
+      }
+    }
     mux.killPane(paneId, muxSession);
     throw err;
   }
@@ -567,27 +594,6 @@ export function launchInteractiveSubagent(params: {
     notifyOnComplete: params.notifyOnComplete,
     parentSessionId: params.parentSessionId,
   };
-  // Persist to the project-local state file BEFORE registering in-memory. Order
-  // matters: a crash between this write and interactiveSubagentRegistry.set is
-  // safe — the next session_start's rehydrate reads the file and rebuilds the
-  // state. A crash before this write leaves no zombie.
-  if (params.parentSessionId) {
-    try {
-      appendInteractiveState(params.cwd, params.parentSessionId, {
-        id,
-        paneId,
-        windowName,
-        mux: mux.name,
-        muxSession,
-        artifactDir: paths.artifactDir,
-        sessionFile: paths.sessionFile,
-        notifyOnComplete: params.notifyOnComplete,
-      });
-    } catch {
-      /* best effort — disk full, permission denied, etc. In-memory still works. */
-    }
-  }
-
   interactiveSubagentRegistry.set(id, state);
   return state;
 }
@@ -623,6 +629,24 @@ export function sendCommandToPane(
   mux.sendEnter(state.paneId, state.muxSession);
 }
 
+/** Rebuild attach/focus commands for a persisted or rehydrated state. */
+export function buildAttachCommandsForState(
+  state: Pick<
+    InteractiveSubagentState,
+    "paneId" | "windowName" | "mux" | "muxSession"
+  >,
+): { attachCommand: string; focusCommand: string } {
+  return getMuxForState(state as InteractiveSubagentState).buildAttachCommands({
+    paneId: state.paneId,
+    windowName: state.windowName,
+    session: state.muxSession,
+  });
+}
+
+/**
+ * Probe a tmux pane. Kept as a thin helper for the existing call sites in
+ * subagent.ts; PR #2 will route through `state.mux` so this becomes mux-agnostic.
+ */
 /**
  * Probe a tmux pane. Kept as a thin helper for the existing call sites in
  * subagent.ts; PR #2 will route through `state.mux` so this becomes mux-agnostic.

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -450,9 +450,15 @@ export function launchInteractiveSubagent(params: {
    * skipped (used by tests that don't care about reload).
    */
   parentSessionId?: string;
+  /**
+   * The parent session's working directory, used for the state file location.
+   * If omitted, falls back to `cwd` (backward-compatible for tests).
+   */
+  parentCwd?: string;
 }): InteractiveSubagentState {
   const id = randomBytes(4).toString("hex");
   const cwd = resolve(params.cwd);
+  const stateCwd = params.parentCwd ? resolve(params.parentCwd) : cwd;
   const background = params.background !== false; // default true (hidden)
   const paths = createInteractiveSubagentPaths({ id, name: params.name, cwd });
   const prompt = buildInteractivePrompt({
@@ -526,7 +532,7 @@ export function launchInteractiveSubagent(params: {
   // recoverable on reload. The catch path below removes it on launch failure.
   if (params.parentSessionId) {
     try {
-      appendInteractiveState(params.cwd, {
+      appendInteractiveState(stateCwd, {
         id,
         paneId,
         windowName,
@@ -561,7 +567,7 @@ export function launchInteractiveSubagent(params: {
     // leak it into the user's mux server. Also clean up persisted state.
     if (persistedState && params.parentSessionId) {
       try {
-        removeInteractiveState(params.cwd, id);
+        removeInteractiveState(stateCwd, id);
       } catch {
         /* best effort — the pane kill below is the important cleanup */
       }
@@ -584,7 +590,7 @@ export function launchInteractiveSubagent(params: {
     mux: mux.name,
     muxSession,
     sessionFile: paths.sessionFile,
-    cwd,
+    cwd: stateCwd,
     model: params.model,
     startedAt: Date.now(),
     status: "running",

--- a/src/multiplexer-zellij.ts
+++ b/src/multiplexer-zellij.ts
@@ -137,6 +137,27 @@ export class ZellijMultiplexer implements Multiplexer {
 
     if (useBackground) {
       windowName = opts.windowName ?? safeSegment(opts.name);
+      // Save the current active tab position before creating the new tab,
+      // so we can switch back afterwards. zellij's new-tab always focuses
+      // the new tab; we want to leave focus on the parent's tab (matching
+      // tmux's -d flag behavior for detached windows).
+      let previousTabPosition: number | undefined;
+      if (isInZellij) {
+        try {
+          const currentTabInfo = execFileSync(
+            "zellij",
+            [...sessionFlag, "action", "current-tab-info"],
+            { encoding: "utf8", timeout: 3000 },
+          );
+          const positionMatch = currentTabInfo.match(/^position:\s*(\d+)/m);
+          if (positionMatch) {
+            previousTabPosition = parseInt(positionMatch[1], 10);
+          }
+        } catch {
+          // Best effort — if we can't get the current tab, we'll still
+          // create the new tab, just won't restore focus.
+        }
+      }
       execFileSync(
         "zellij",
         [...sessionFlag, "action", "new-tab", "--name", windowName],
@@ -145,6 +166,23 @@ export class ZellijMultiplexer implements Multiplexer {
           timeout: 10000,
         },
       );
+      // Restore focus to the previous tab if we saved its position.
+      if (previousTabPosition !== undefined) {
+        try {
+          execFileSync(
+            "zellij",
+            [
+              ...sessionFlag,
+              "action",
+              "go-to-tab",
+              String(previousTabPosition),
+            ],
+            { encoding: "utf8", timeout: 3000 },
+          );
+        } catch {
+          // Best effort — cosmetic only.
+        }
+      }
     } else {
       // Visible split — side-by-side with the focused pane. zellij splits
       // relative to the currently-focused pane; there is no flag to split

--- a/src/subagent-interactive-default.test.ts
+++ b/src/subagent-interactive-default.test.ts
@@ -24,17 +24,15 @@ import registerExtension from "./subagent";
 
 /** Minimal ctx for the tool's execute signature. */
 function mockCtx() {
-	return {
-		cwd: "/tmp",
-		ui: { setStatus: vi.fn() },
-		sessionManager: {
-			getBranch: vi.fn().mockReturnValue([]),
-			getSessionId: vi.fn().mockReturnValue("test-session-id"),
-		},
-	};
-
+  return {
+    cwd: "/tmp",
+    ui: { setStatus: vi.fn() },
+    sessionManager: {
+      getBranch: vi.fn().mockReturnValue([]),
+      getSessionId: vi.fn().mockReturnValue("test-session-id"),
+    },
+  };
 }
-
 
 /** Find the subagent_interactive tool def from the registered API. */
 function getInteractiveToolDef(api: {

--- a/src/subagent-interactive-default.test.ts
+++ b/src/subagent-interactive-default.test.ts
@@ -24,12 +24,17 @@ import registerExtension from "./subagent";
 
 /** Minimal ctx for the tool's execute signature. */
 function mockCtx() {
-  return {
-    cwd: "/tmp",
-    ui: { setStatus: vi.fn() },
-    sessionManager: { getBranch: vi.fn().mockReturnValue([]) },
-  };
+	return {
+		cwd: "/tmp",
+		ui: { setStatus: vi.fn() },
+		sessionManager: {
+			getBranch: vi.fn().mockReturnValue([]),
+			getSessionId: vi.fn().mockReturnValue("test-session-id"),
+		},
+	};
+
 }
+
 
 /** Find the subagent_interactive tool def from the registered API. */
 function getInteractiveToolDef(api: {

--- a/src/subagent-launch-script.test.ts
+++ b/src/subagent-launch-script.test.ts
@@ -216,10 +216,10 @@ describe("spawn-time state persistence", () => {
       name: "Demo",
       task: "t",
       cwd,
-      parentSessionId: SESSION,
+      parentSessionId: "pi",
     });
-    expect(existsSync(stateFilePath(cwd, SESSION))).toBe(true);
-    const loaded = loadInteractiveStates(cwd, SESSION);
+    expect(existsSync(stateFilePath(cwd))).toBe(true);
+    const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[state.id]?.paneId).toBe(state.paneId);
     expect(loaded?.states[state.id]?.mux).toBe(state.mux);
   });
@@ -230,7 +230,7 @@ describe("spawn-time state persistence", () => {
         "./interactive-tmux",
       );
     launchInteractiveSubagent({ name: "Demo", task: "t", cwd });
-    expect(existsSync(stateFilePath(cwd, SESSION))).toBe(false);
+    expect(existsSync(stateFilePath(cwd))).toBe(false);
   });
 
   it("the persisted entry records windowName, mux, and artifactDir", async () => {
@@ -242,9 +242,9 @@ describe("spawn-time state persistence", () => {
       name: "Demo",
       task: "t",
       cwd,
-      parentSessionId: SESSION,
+      parentSessionId: "pi",
     });
-    const loaded = loadInteractiveStates(cwd, SESSION);
+    const loaded = loadInteractiveStates(cwd);
     const entry = loaded?.states[state.id];
     expect(entry?.windowName).toBe(state.windowName);
     expect(entry?.mux).toBe(state.mux);
@@ -261,9 +261,9 @@ describe("spawn-time state persistence", () => {
       name: "Demo",
       task: "t",
       cwd,
-      parentSessionId: SESSION,
+      parentSessionId: "pi",
     });
-    expect(state.parentSessionId).toBe(SESSION);
+    expect(state.parentSessionId).toBe("pi");
     expect(state.cwd).toBe(cwd);
   });
 });

--- a/src/subagent-launch-script.test.ts
+++ b/src/subagent-launch-script.test.ts
@@ -200,6 +200,11 @@ describe("spawn-time state persistence", () => {
     process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
     process.env.TMUX_PANE = "%1";
     process.env.HOME = process.env.HOME ?? "/tmp";
+    // Ensure getMux selects tmux, not zellij. The test mock only handles
+    // tmux commands; if ZELLIJ_SESSION_NAME is set from the outer environment,
+    // getMux would pick zellij and the mock would not intercept its calls.
+    delete process.env.ZELLIJ;
+    delete process.env.ZELLIJ_SESSION_NAME;
   });
 
   afterEach(() => {

--- a/src/subagent-launch-script.test.ts
+++ b/src/subagent-launch-script.test.ts
@@ -12,19 +12,22 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	chmodSync,
-	existsSync,
-	mkdirSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
-import { launchInteractiveSubagent, writeLaunchScript } from "./interactive-tmux";
+import {
+  launchInteractiveSubagent,
+  writeLaunchScript,
+} from "./interactive-tmux";
 import { stateFilePath, loadInteractiveStates } from "./artifact";
 import { importFresh } from "./test-utils";
 
@@ -161,91 +164,106 @@ describe("launch script EXIT trap (idempotency)", () => {
   });
 });
 
-
 // ── Mock tmux exec so launchInteractiveSubagent doesn't create real tmux
 // windows during the test run. The existing launch script tests above run
 // real bash + the wrapper and don't need a tmux mock; the spawn-persistence
 // tests below drive launchInteractiveSubagent directly and would otherwise
 // leave orphan tmux windows behind (test pollution).
 function installTmuxMock() {
-	vi.resetModules();
-	vi.doMock("node:child_process", () => ({
-		execFileSync: (_file: string, args: string[]) => {
-			// new-window / new-session / split-window return a pane id; everything
-			// else is a no-op (display-message would otherwise throw).
-			if (args[0] === "new-window" || args[0] === "split-window" || args[0] === "new-session") {
-				return "%99\n";
-			}
-			if (args[0] === "display-message") {
-				return "sess\t1\t0\n";
-			}
-			return "";
-		},
-	}));
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      // new-window / new-session / split-window return a pane id; everything
+      // else is a no-op (display-message would otherwise throw).
+      if (
+        args[0] === "new-window" ||
+        args[0] === "split-window" ||
+        args[0] === "new-session"
+      ) {
+        return "%99\n";
+      }
+      if (args[0] === "display-message") {
+        return "sess\t1\t0\n";
+      }
+      return "";
+    },
+  }));
 }
 
 describe("spawn-time state persistence", () => {
-	let cwd: string;
-	const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
+  let cwd: string;
+  const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
 
-	beforeEach(() => {
-		installTmuxMock();
-		cwd = mkdtempSync(join(tmpdir(), "pi-subagentura-spawn-persist-"));
-		process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
-		process.env.TMUX_PANE = "%1";
-		process.env.HOME = process.env.HOME ?? "/tmp";
-	});
+  beforeEach(() => {
+    installTmuxMock();
+    cwd = mkdtempSync(join(tmpdir(), "pi-subagentura-spawn-persist-"));
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%1";
+    process.env.HOME = process.env.HOME ?? "/tmp";
+  });
 
-	afterEach(() => {
-		rmSync(cwd, { recursive: true, force: true });
-		vi.doUnmock("node:child_process");
-	});
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    vi.doUnmock("node:child_process");
+  });
 
-	it("launchInteractiveSubagent with parentSessionId writes the state file", async () => {
-		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-		const state = launchInteractiveSubagent({
-			name: "Demo",
-			task: "t",
-			cwd,
-			parentSessionId: SESSION,
-		});
-		expect(existsSync(stateFilePath(cwd, SESSION))).toBe(true);
-		const loaded = loadInteractiveStates(cwd, SESSION);
-		expect(loaded?.states[state.id]?.paneId).toBe(state.paneId);
-		expect(loaded?.states[state.id]?.mux).toBe(state.mux);
-	});
+  it("launchInteractiveSubagent with parentSessionId writes the state file", async () => {
+    const { launchInteractiveSubagent } =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
+    const state = launchInteractiveSubagent({
+      name: "Demo",
+      task: "t",
+      cwd,
+      parentSessionId: SESSION,
+    });
+    expect(existsSync(stateFilePath(cwd, SESSION))).toBe(true);
+    const loaded = loadInteractiveStates(cwd, SESSION);
+    expect(loaded?.states[state.id]?.paneId).toBe(state.paneId);
+    expect(loaded?.states[state.id]?.mux).toBe(state.mux);
+  });
 
-	it("launchInteractiveSubagent without parentSessionId does NOT write the state file", async () => {
-		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-		launchInteractiveSubagent({ name: "Demo", task: "t", cwd });
-		expect(existsSync(stateFilePath(cwd, SESSION))).toBe(false);
-	});
+  it("launchInteractiveSubagent without parentSessionId does NOT write the state file", async () => {
+    const { launchInteractiveSubagent } =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
+    launchInteractiveSubagent({ name: "Demo", task: "t", cwd });
+    expect(existsSync(stateFilePath(cwd, SESSION))).toBe(false);
+  });
 
-	it("the persisted entry records windowName, mux, and artifactDir", async () => {
-		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-		const state = launchInteractiveSubagent({
-			name: "Demo",
-			task: "t",
-			cwd,
-			parentSessionId: SESSION,
-		});
-		const loaded = loadInteractiveStates(cwd, SESSION);
-		const entry = loaded?.states[state.id];
-		expect(entry?.windowName).toBe(state.windowName);
-		expect(entry?.mux).toBe(state.mux);
-		expect(entry?.artifactDir).toBe(state.artifactDir);
-		expect(entry?.sessionFile).toBe(state.sessionFile);
-	});
+  it("the persisted entry records windowName, mux, and artifactDir", async () => {
+    const { launchInteractiveSubagent } =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
+    const state = launchInteractiveSubagent({
+      name: "Demo",
+      task: "t",
+      cwd,
+      parentSessionId: SESSION,
+    });
+    const loaded = loadInteractiveStates(cwd, SESSION);
+    const entry = loaded?.states[state.id];
+    expect(entry?.windowName).toBe(state.windowName);
+    expect(entry?.mux).toBe(state.mux);
+    expect(entry?.artifactDir).toBe(state.artifactDir);
+    expect(entry?.sessionFile).toBe(state.sessionFile);
+  });
 
-	it("the state has parentSessionId populated for terminal cleanup", async () => {
-		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
-		const state = launchInteractiveSubagent({
-			name: "Demo",
-			task: "t",
-			cwd,
-			parentSessionId: SESSION,
-		});
-		expect(state.parentSessionId).toBe(SESSION);
-		expect(state.cwd).toBe(cwd);
-	});
+  it("the state has parentSessionId populated for terminal cleanup", async () => {
+    const { launchInteractiveSubagent } =
+      await importFresh<typeof import("./interactive-tmux")>(
+        "./interactive-tmux",
+      );
+    const state = launchInteractiveSubagent({
+      name: "Demo",
+      task: "t",
+      cwd,
+      parentSessionId: SESSION,
+    });
+    expect(state.parentSessionId).toBe(SESSION);
+    expect(state.cwd).toBe(cwd);
+  });
 });

--- a/src/subagent-launch-script.test.ts
+++ b/src/subagent-launch-script.test.ts
@@ -10,7 +10,7 @@
  *
  * See: AGENTS.md "cli.mjs done is the contract for interactive sub-agents"
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	chmodSync,
 	existsSync,
@@ -26,6 +26,7 @@ import { spawnSync } from "node:child_process";
 
 import { launchInteractiveSubagent, writeLaunchScript } from "./interactive-tmux";
 import { stateFilePath, loadInteractiveStates } from "./artifact";
+import { importFresh } from "./test-utils";
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-launch-"));
@@ -161,20 +162,47 @@ describe("launch script EXIT trap (idempotency)", () => {
 });
 
 
+// ── Mock tmux exec so launchInteractiveSubagent doesn't create real tmux
+// windows during the test run. The existing launch script tests above run
+// real bash + the wrapper and don't need a tmux mock; the spawn-persistence
+// tests below drive launchInteractiveSubagent directly and would otherwise
+// leave orphan tmux windows behind (test pollution).
+function installTmuxMock() {
+	vi.resetModules();
+	vi.doMock("node:child_process", () => ({
+		execFileSync: (_file: string, args: string[]) => {
+			// new-window / new-session / split-window return a pane id; everything
+			// else is a no-op (display-message would otherwise throw).
+			if (args[0] === "new-window" || args[0] === "split-window" || args[0] === "new-session") {
+				return "%99\n";
+			}
+			if (args[0] === "display-message") {
+				return "sess\t1\t0\n";
+			}
+			return "";
+		},
+	}));
+}
 
 describe("spawn-time state persistence", () => {
 	let cwd: string;
 	const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
 
 	beforeEach(() => {
+		installTmuxMock();
 		cwd = mkdtempSync(join(tmpdir(), "pi-subagentura-spawn-persist-"));
+		process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+		process.env.TMUX_PANE = "%1";
+		process.env.HOME = process.env.HOME ?? "/tmp";
 	});
 
 	afterEach(() => {
 		rmSync(cwd, { recursive: true, force: true });
+		vi.doUnmock("node:child_process");
 	});
 
-	it("launchInteractiveSubagent with parentSessionId writes the state file", () => {
+	it("launchInteractiveSubagent with parentSessionId writes the state file", async () => {
+		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
 		const state = launchInteractiveSubagent({
 			name: "Demo",
 			task: "t",
@@ -187,12 +215,14 @@ describe("spawn-time state persistence", () => {
 		expect(loaded?.states[state.id]?.mux).toBe(state.mux);
 	});
 
-	it("launchInteractiveSubagent without parentSessionId does NOT write the state file", () => {
+	it("launchInteractiveSubagent without parentSessionId does NOT write the state file", async () => {
+		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
 		launchInteractiveSubagent({ name: "Demo", task: "t", cwd });
 		expect(existsSync(stateFilePath(cwd, SESSION))).toBe(false);
 	});
 
-	it("the persisted entry records windowName, mux, and artifactDir", () => {
+	it("the persisted entry records windowName, mux, and artifactDir", async () => {
+		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
 		const state = launchInteractiveSubagent({
 			name: "Demo",
 			task: "t",
@@ -207,7 +237,8 @@ describe("spawn-time state persistence", () => {
 		expect(entry?.sessionFile).toBe(state.sessionFile);
 	});
 
-	it("the state has parentSessionId populated for terminal cleanup", () => {
+	it("the state has parentSessionId populated for terminal cleanup", async () => {
+		const { launchInteractiveSubagent } = await importFresh<typeof import("./interactive-tmux")>("./interactive-tmux");
 		const state = launchInteractiveSubagent({
 			name: "Demo",
 			task: "t",
@@ -218,4 +249,3 @@ describe("spawn-time state persistence", () => {
 		expect(state.cwd).toBe(cwd);
 	});
 });
-

--- a/src/subagent-launch-script.test.ts
+++ b/src/subagent-launch-script.test.ts
@@ -12,18 +12,20 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { writeLaunchScript } from "./interactive-tmux";
+
+import { launchInteractiveSubagent, writeLaunchScript } from "./interactive-tmux";
+import { stateFilePath, loadInteractiveStates } from "./artifact";
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-launch-"));
@@ -157,3 +159,63 @@ describe("launch script EXIT trap (idempotency)", () => {
     expect(countEvents(artDir, "cancelled")).toHaveLength(0);
   });
 });
+
+
+
+describe("spawn-time state persistence", () => {
+	let cwd: string;
+	const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
+
+	beforeEach(() => {
+		cwd = mkdtempSync(join(tmpdir(), "pi-subagentura-spawn-persist-"));
+	});
+
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+	});
+
+	it("launchInteractiveSubagent with parentSessionId writes the state file", () => {
+		const state = launchInteractiveSubagent({
+			name: "Demo",
+			task: "t",
+			cwd,
+			parentSessionId: SESSION,
+		});
+		expect(existsSync(stateFilePath(cwd, SESSION))).toBe(true);
+		const loaded = loadInteractiveStates(cwd, SESSION);
+		expect(loaded?.states[state.id]?.paneId).toBe(state.paneId);
+		expect(loaded?.states[state.id]?.mux).toBe(state.mux);
+	});
+
+	it("launchInteractiveSubagent without parentSessionId does NOT write the state file", () => {
+		launchInteractiveSubagent({ name: "Demo", task: "t", cwd });
+		expect(existsSync(stateFilePath(cwd, SESSION))).toBe(false);
+	});
+
+	it("the persisted entry records windowName, mux, and artifactDir", () => {
+		const state = launchInteractiveSubagent({
+			name: "Demo",
+			task: "t",
+			cwd,
+			parentSessionId: SESSION,
+		});
+		const loaded = loadInteractiveStates(cwd, SESSION);
+		const entry = loaded?.states[state.id];
+		expect(entry?.windowName).toBe(state.windowName);
+		expect(entry?.mux).toBe(state.mux);
+		expect(entry?.artifactDir).toBe(state.artifactDir);
+		expect(entry?.sessionFile).toBe(state.sessionFile);
+	});
+
+	it("the state has parentSessionId populated for terminal cleanup", () => {
+		const state = launchInteractiveSubagent({
+			name: "Demo",
+			task: "t",
+			cwd,
+			parentSessionId: SESSION,
+		});
+		expect(state.parentSessionId).toBe(SESSION);
+		expect(state.cwd).toBe(cwd);
+	});
+});
+

--- a/src/subagent-poll.test.ts
+++ b/src/subagent-poll.test.ts
@@ -4,7 +4,7 @@
  * events directly to the artifact dir to drive the poller.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -12,7 +12,6 @@ import {
   appendInteractiveState,
   artifactPath,
   loadInteractiveStates,
-  removeInteractiveState,
   writeOutput,
 } from "./artifact";
 import { importFresh } from "./test-utils";
@@ -784,9 +783,9 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
       selectPaneCommand: "tmux select-pane -t '%99'",
       launchScriptFile: "/tmp/launch.sh",
       artifactDir: join(cwd, id),
-      parentSessionId: SESSION,
+      parentSessionId: "pi",
     };
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id,
       paneId: state.paneId,
       windowName: state.windowName,
@@ -797,7 +796,13 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     return { id, cwd, state };
   }
 
-  it("removes the state.json entry after delivering a done event", async () => {
+  it("removes the state.json entry after delivering a done event when the pane is dead", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => {
+        throw new Error("can't find pane: %99");
+      },
+    }));
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const { cwd, id, state } = makePersistedState();
     mod.interactiveSubagentRegistry.set(id, state);
@@ -807,10 +812,31 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
 
     mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-    const loaded = loadInteractiveStates(cwd, SESSION);
+    const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeUndefined();
   });
 
+  it("keeps the state.json entry after delivering a done event when the pane is alive", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("#99");
+        return "";
+      },
+    }));
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+
+    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+    const loaded = loadInteractiveStates(cwd);
+    expect(loaded?.states[id]).toBeDefined();
+    expect(state.status).toBe("idle");
+  });
   it("removes the state.json entry after delivering an error event", async () => {
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const { cwd, id, state } = makePersistedState();
@@ -825,7 +851,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
 
     mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-    const loaded = loadInteractiveStates(cwd, SESSION);
+    const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeUndefined();
   });
 
@@ -838,8 +864,31 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
 
     mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-    const loaded = loadInteractiveStates(cwd, SESSION);
+    const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeUndefined();
+  });
+
+  it("keeps the state.json entry and cursor when notification delivery fails", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, {
+      ts: 1,
+      type: "error",
+      status: "error",
+      message: "boom",
+    });
+
+    mod.pollArtifactChanges({
+      sendMessage: vi.fn(() => {
+        throw new Error("stale pi");
+      }),
+    } as any);
+
+    const loaded = loadInteractiveStates(cwd);
+    expect(loaded?.states[id]).toBeDefined();
+    expect(state.lastDeliveredEventTs ?? 0).toBe(0);
   });
 
   it("does NOT remove the state.json entry on tool_activity events (only terminals)", async () => {
@@ -857,7 +906,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
 
     mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-    const loaded = loadInteractiveStates(cwd, SESSION);
+    const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeDefined();
   });
 

--- a/src/subagent-poll.test.ts
+++ b/src/subagent-poll.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { appendEvent, artifactPath, writeOutput } from "./artifact";
+import { appendEvent, appendInteractiveState, artifactPath, loadInteractiveStates, removeInteractiveState, writeOutput } from "./artifact";
 import { importFresh } from "./test-utils";
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
@@ -745,4 +745,143 @@ describe("pollArtifactChanges", () => {
       delete (globalThis as any).__piSubagenturaUi;
     });
   });
+});
+
+
+
+
+describe("pollArtifactChanges — terminal cleanup of state.json", () => {
+	const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
+
+	beforeEach(() => {
+		const g = globalThis as any;
+		g.__piSubagenturaInteractiveRegistry?.clear?.();
+		g.__piSubagenturaPiRef = undefined;
+	});
+
+	function makePersistedState(): {
+		id: string;
+		cwd: string;
+		state: import("./interactive-tmux").InteractiveSubagentState;
+	} {
+		const cwd = makeTmp();
+		const id = "id-" + Math.random().toString(36).slice(2, 8);
+		const state: import("./interactive-tmux").InteractiveSubagentState = {
+			id,
+			name: "Test",
+			task: "t",
+			paneId: "%99",
+			sessionFile: "/tmp/sess.jsonl",
+			cwd,
+			startedAt: Date.now(),
+			mux: "tmux",
+			status: "running",
+			attachCommand: "tmux attach -t sess",
+			selectPaneCommand: "tmux select-pane -t '%99'",
+			launchScriptFile: "/tmp/launch.sh",
+			artifactDir: join(cwd, id),
+			parentSessionId: SESSION,
+		};
+		appendInteractiveState(cwd, SESSION, {
+			id,
+			paneId: state.paneId,
+			windowName: state.windowName,
+			mux: state.mux,
+			artifactDir: state.artifactDir,
+			sessionFile: state.sessionFile,
+		});
+		return { id, cwd, state };
+	}
+
+	it("removes the state.json entry after delivering a done event", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { cwd, id, state } = makePersistedState();
+		mod.interactiveSubagentRegistry.set(id, state);
+		const art = artifactPath(join(state.artifactDir, ".."), id);
+		appendEvent(art, { ts: 1, type: "started", status: "running" });
+		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+
+		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+		const loaded = loadInteractiveStates(cwd, SESSION);
+		expect(loaded?.states[id]).toBeUndefined();
+	});
+
+	it("removes the state.json entry after delivering an error event", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { cwd, id, state } = makePersistedState();
+		mod.interactiveSubagentRegistry.set(id, state);
+		const art = artifactPath(join(state.artifactDir, ".."), id);
+		appendEvent(art, { ts: 1, type: "error", status: "error", message: "boom" });
+
+		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+		const loaded = loadInteractiveStates(cwd, SESSION);
+		expect(loaded?.states[id]).toBeUndefined();
+	});
+
+	it("removes the state.json entry after delivering a cancelled event", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { cwd, id, state } = makePersistedState();
+		mod.interactiveSubagentRegistry.set(id, state);
+		const art = artifactPath(join(state.artifactDir, ".."), id);
+		appendEvent(art, { ts: 1, type: "cancelled", status: "cancelled" });
+
+		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+		const loaded = loadInteractiveStates(cwd, SESSION);
+		expect(loaded?.states[id]).toBeUndefined();
+	});
+
+	it("does NOT remove the state.json entry on tool_activity events (only terminals)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { cwd, id, state } = makePersistedState();
+		mod.interactiveSubagentRegistry.set(id, state);
+		const art = artifactPath(join(state.artifactDir, ".."), id);
+		appendEvent(art, { ts: 1, type: "tool_activity", status: "running", tool: "bash", summary: "ls" });
+
+		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+		const loaded = loadInteractiveStates(cwd, SESSION);
+		expect(loaded?.states[id]).toBeDefined();
+	});
+
+	it("does NOT throw if state has no parentSessionId (no-op guard)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const id = "id-" + Math.random().toString(36).slice(2, 8);
+		const state: import("./interactive-tmux").InteractiveSubagentState = {
+			id,
+			name: "Test",
+			task: "t",
+			paneId: "%99",
+			sessionFile: "/tmp/sess.jsonl",
+			cwd: "/tmp",
+			startedAt: Date.now(),
+			mux: "tmux",
+			status: "running",
+			attachCommand: "",
+			selectPaneCommand: "",
+			launchScriptFile: "/tmp/launch.sh",
+			artifactDir: "/tmp/art-" + id,
+		};
+		mod.interactiveSubagentRegistry.set(id, state);
+		const art = artifactPath("/tmp", id);
+		appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
+
+		expect(() => mod.pollArtifactChanges({ sendMessage: vi.fn() } as any)).not.toThrow();
+	});
+
+	it("advances lastDeliveredEventTs before removing the state entry (crash-safe ordering)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const { id, state } = makePersistedState();
+		mod.interactiveSubagentRegistry.set(id, state);
+		const art = artifactPath(join(state.artifactDir, ".."), id);
+		appendEvent(art, { ts: 1, type: "started", status: "running" });
+		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+
+		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+		expect(state.lastDeliveredEventTs).toBe(2);
+	});
+
 });

--- a/src/subagent-poll.test.ts
+++ b/src/subagent-poll.test.ts
@@ -7,7 +7,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { appendEvent, appendInteractiveState, artifactPath, loadInteractiveStates, removeInteractiveState, writeOutput } from "./artifact";
+import {
+  appendEvent,
+  appendInteractiveState,
+  artifactPath,
+  loadInteractiveStates,
+  removeInteractiveState,
+  writeOutput,
+} from "./artifact";
 import { importFresh } from "./test-utils";
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
@@ -747,141 +754,150 @@ describe("pollArtifactChanges", () => {
   });
 });
 
-
-
-
 describe("pollArtifactChanges — terminal cleanup of state.json", () => {
-	const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
+  const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
 
-	beforeEach(() => {
-		const g = globalThis as any;
-		g.__piSubagenturaInteractiveRegistry?.clear?.();
-		g.__piSubagenturaPiRef = undefined;
-	});
+  beforeEach(() => {
+    const g = globalThis as any;
+    g.__piSubagenturaInteractiveRegistry?.clear?.();
+    g.__piSubagenturaPiRef = undefined;
+  });
 
-	function makePersistedState(): {
-		id: string;
-		cwd: string;
-		state: import("./interactive-tmux").InteractiveSubagentState;
-	} {
-		const cwd = makeTmp();
-		const id = "id-" + Math.random().toString(36).slice(2, 8);
-		const state: import("./interactive-tmux").InteractiveSubagentState = {
-			id,
-			name: "Test",
-			task: "t",
-			paneId: "%99",
-			sessionFile: "/tmp/sess.jsonl",
-			cwd,
-			startedAt: Date.now(),
-			mux: "tmux",
-			status: "running",
-			attachCommand: "tmux attach -t sess",
-			selectPaneCommand: "tmux select-pane -t '%99'",
-			launchScriptFile: "/tmp/launch.sh",
-			artifactDir: join(cwd, id),
-			parentSessionId: SESSION,
-		};
-		appendInteractiveState(cwd, SESSION, {
-			id,
-			paneId: state.paneId,
-			windowName: state.windowName,
-			mux: state.mux,
-			artifactDir: state.artifactDir,
-			sessionFile: state.sessionFile,
-		});
-		return { id, cwd, state };
-	}
+  function makePersistedState(): {
+    id: string;
+    cwd: string;
+    state: import("./interactive-tmux").InteractiveSubagentState;
+  } {
+    const cwd = makeTmp();
+    const id = "id-" + Math.random().toString(36).slice(2, 8);
+    const state: import("./interactive-tmux").InteractiveSubagentState = {
+      id,
+      name: "Test",
+      task: "t",
+      paneId: "%99",
+      sessionFile: "/tmp/sess.jsonl",
+      cwd,
+      startedAt: Date.now(),
+      mux: "tmux",
+      status: "running",
+      attachCommand: "tmux attach -t sess",
+      selectPaneCommand: "tmux select-pane -t '%99'",
+      launchScriptFile: "/tmp/launch.sh",
+      artifactDir: join(cwd, id),
+      parentSessionId: SESSION,
+    };
+    appendInteractiveState(cwd, SESSION, {
+      id,
+      paneId: state.paneId,
+      windowName: state.windowName,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+    });
+    return { id, cwd, state };
+  }
 
-	it("removes the state.json entry after delivering a done event", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { cwd, id, state } = makePersistedState();
-		mod.interactiveSubagentRegistry.set(id, state);
-		const art = artifactPath(join(state.artifactDir, ".."), id);
-		appendEvent(art, { ts: 1, type: "started", status: "running" });
-		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+  it("removes the state.json entry after delivering a done event", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-		const loaded = loadInteractiveStates(cwd, SESSION);
-		expect(loaded?.states[id]).toBeUndefined();
-	});
+    const loaded = loadInteractiveStates(cwd, SESSION);
+    expect(loaded?.states[id]).toBeUndefined();
+  });
 
-	it("removes the state.json entry after delivering an error event", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { cwd, id, state } = makePersistedState();
-		mod.interactiveSubagentRegistry.set(id, state);
-		const art = artifactPath(join(state.artifactDir, ".."), id);
-		appendEvent(art, { ts: 1, type: "error", status: "error", message: "boom" });
+  it("removes the state.json entry after delivering an error event", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, {
+      ts: 1,
+      type: "error",
+      status: "error",
+      message: "boom",
+    });
 
-		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-		const loaded = loadInteractiveStates(cwd, SESSION);
-		expect(loaded?.states[id]).toBeUndefined();
-	});
+    const loaded = loadInteractiveStates(cwd, SESSION);
+    expect(loaded?.states[id]).toBeUndefined();
+  });
 
-	it("removes the state.json entry after delivering a cancelled event", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { cwd, id, state } = makePersistedState();
-		mod.interactiveSubagentRegistry.set(id, state);
-		const art = artifactPath(join(state.artifactDir, ".."), id);
-		appendEvent(art, { ts: 1, type: "cancelled", status: "cancelled" });
+  it("removes the state.json entry after delivering a cancelled event", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, { ts: 1, type: "cancelled", status: "cancelled" });
 
-		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-		const loaded = loadInteractiveStates(cwd, SESSION);
-		expect(loaded?.states[id]).toBeUndefined();
-	});
+    const loaded = loadInteractiveStates(cwd, SESSION);
+    expect(loaded?.states[id]).toBeUndefined();
+  });
 
-	it("does NOT remove the state.json entry on tool_activity events (only terminals)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { cwd, id, state } = makePersistedState();
-		mod.interactiveSubagentRegistry.set(id, state);
-		const art = artifactPath(join(state.artifactDir, ".."), id);
-		appendEvent(art, { ts: 1, type: "tool_activity", status: "running", tool: "bash", summary: "ls" });
+  it("does NOT remove the state.json entry on tool_activity events (only terminals)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, {
+      ts: 1,
+      type: "tool_activity",
+      status: "running",
+      tool: "bash",
+      summary: "ls",
+    });
 
-		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-		const loaded = loadInteractiveStates(cwd, SESSION);
-		expect(loaded?.states[id]).toBeDefined();
-	});
+    const loaded = loadInteractiveStates(cwd, SESSION);
+    expect(loaded?.states[id]).toBeDefined();
+  });
 
-	it("does NOT throw if state has no parentSessionId (no-op guard)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const id = "id-" + Math.random().toString(36).slice(2, 8);
-		const state: import("./interactive-tmux").InteractiveSubagentState = {
-			id,
-			name: "Test",
-			task: "t",
-			paneId: "%99",
-			sessionFile: "/tmp/sess.jsonl",
-			cwd: "/tmp",
-			startedAt: Date.now(),
-			mux: "tmux",
-			status: "running",
-			attachCommand: "",
-			selectPaneCommand: "",
-			launchScriptFile: "/tmp/launch.sh",
-			artifactDir: "/tmp/art-" + id,
-		};
-		mod.interactiveSubagentRegistry.set(id, state);
-		const art = artifactPath("/tmp", id);
-		appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
+  it("does NOT throw if state has no parentSessionId (no-op guard)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const id = "id-" + Math.random().toString(36).slice(2, 8);
+    const state: import("./interactive-tmux").InteractiveSubagentState = {
+      id,
+      name: "Test",
+      task: "t",
+      paneId: "%99",
+      sessionFile: "/tmp/sess.jsonl",
+      cwd: "/tmp",
+      startedAt: Date.now(),
+      mux: "tmux",
+      status: "running",
+      attachCommand: "",
+      selectPaneCommand: "",
+      launchScriptFile: "/tmp/launch.sh",
+      artifactDir: "/tmp/art-" + id,
+    };
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath("/tmp", id);
+    appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
 
-		expect(() => mod.pollArtifactChanges({ sendMessage: vi.fn() } as any)).not.toThrow();
-	});
+    expect(() =>
+      mod.pollArtifactChanges({ sendMessage: vi.fn() } as any),
+    ).not.toThrow();
+  });
 
-	it("advances lastDeliveredEventTs before removing the state entry (crash-safe ordering)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const { id, state } = makePersistedState();
-		mod.interactiveSubagentRegistry.set(id, state);
-		const art = artifactPath(join(state.artifactDir, ".."), id);
-		appendEvent(art, { ts: 1, type: "started", status: "running" });
-		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+  it("advances lastDeliveredEventTs before removing the state entry (crash-safe ordering)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const { id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-		mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
-		expect(state.lastDeliveredEventTs).toBe(2);
-	});
-
+    expect(state.lastDeliveredEventTs).toBe(2);
+  });
 });

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -222,13 +222,12 @@ describe("rehydrateInteractiveSubagents", () => {
     ).not.toThrow();
   });
 
-  it("inject-mode orphans do NOT re-inject their existing terminal event on the first poll after rehydrate", async () => {
-    // Regression for the inject-flood bug: if the persisted entry had
-    // notifyOnComplete="inject" and the artifact has a done event, the
-    // rehydrated state must set lastInjectedEventTs so the inject path
-    // (subagent.ts:609) skips the existing done event. Without this fix
-    // every parent reload would flood the new parent LLM with user
-    // messages for orphans from the previous session.
+  it("inject-mode orphans DO re-inject their existing terminal event on the first poll after rehydrate", async () => {
+    // Behavior change: we no longer suppress re-injection here. The inject-mode path
+    // fires on every NEW `done` event. On rehydrate, lastInjectedEventTs starts as
+    // undefined, so the first poll will re-inject the latest terminal event. This means
+    // exactly one extra inject per sub-agent on parent reload, which is acceptable —
+    // it's better than silently dropping a result that completed during the reload downtime.
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const id = "inject-orphan";
     const artDir = join(cwd, id);
@@ -249,9 +248,8 @@ describe("rehydrateInteractiveSubagents", () => {
 
     const rehydrated = interactiveSubagentRegistry.get(id);
     expect(rehydrated).toBeDefined();
-    // The cursor must equal the latest event's ts so the inject path's
-    // `state.lastInjectedEventTs !== last.ts` check evaluates to false.
-    expect(rehydrated?.lastInjectedEventTs).toBe(2);
+    // lastInjectedEventTs should remain undefined — we no longer suppress re-injection.
+    expect(rehydrated?.lastInjectedEventTs).toBeUndefined();
   });
 
   it("notify-mode orphans leave lastInjectedEventTs undefined (inject path is irrelevant)", async () => {

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -395,7 +395,7 @@ describe("rehydrateInteractiveSubagents", () => {
       expect(interactiveSubagentRegistry.size).toBe(0);
     });
 
-    it("session_start does NOT rehydrate on startup (fresh session)", async () => {
+    it("session_start DOES rehydrate on startup (survived a quit)", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
       appendInteractiveState(cwd, {
         id: "from-previous-session",
@@ -408,8 +408,11 @@ describe("rehydrateInteractiveSubagents", () => {
       const { startHandler } = await setupExtension();
       startHandler!({ type: "session_start", reason: "startup" }, { cwd });
 
-      // Registry should be empty - fresh sessions don't rehydrate old subagents
-      expect(interactiveSubagentRegistry.size).toBe(0);
+      // Registry should have the rehydrated entry - startup after quit preserves subagents
+      expect(interactiveSubagentRegistry.size).toBe(1);
+      expect(interactiveSubagentRegistry.has("from-previous-session")).toBe(
+        true,
+      );
     });
 
     it("session_start does NOT rehydrate on new (explicit new session)", async () => {

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -7,9 +7,9 @@
  * session_shutdown(reason="new"|"quit") gives /new a fresh start.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
 import {
   appendEvent,
   appendInteractiveState,
@@ -242,6 +242,60 @@ describe("rehydrateInteractiveSubagents", () => {
     mod.rehydrateInteractiveSubagents(cwd, SESSION);
     const rehydrated = interactiveSubagentRegistry.get(id);
     expect(rehydrated?.lastInjectedEventTs).toBeUndefined();
+  });
+
+  it("recovers name from prompt file and startedAt from first event", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const id = "recover-me";
+    const artDir = join(cwd, id);
+    mkdirSync(artDir, { recursive: true });
+
+    // Create a prompt file: the label before "-prompt.md" becomes the name
+    writeFileSync(join(artDir, "my-agent-prompt.md"), "task content", {
+      mode: 0o600,
+    });
+
+    // Persist state entry (name not in persisted state — recovered from prompt file)
+    appendInteractiveState(cwd, SESSION, {
+      id,
+      paneId: "%99",
+      mux: "tmux",
+      artifactDir: artDir,
+      sessionFile: "/tmp/sess.jsonl",
+    });
+
+    // Write events: first event's ts becomes startedAt
+    const art = artifactPath(cwd, id);
+    appendEvent(art, { ts: 1000, type: "started", status: "running" });
+    appendEvent(art, { ts: 2000, type: "done", status: "done", exitCode: 0 });
+
+    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+
+    const rehydrated = interactiveSubagentRegistry.get(id);
+    expect(rehydrated).toBeDefined();
+    expect(rehydrated?.name).toBe("my-agent"); // from prompt file label
+    expect(rehydrated?.startedAt).toBe(1000); // from first event's ts
+  });
+
+  it("falls back to id for name and 0 for startedAt when artifacts are missing", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const id = "fallback-id";
+
+    // Persist state with no artifact files (dir won't exist)
+    appendInteractiveState(cwd, SESSION, {
+      id,
+      paneId: "%99",
+      mux: "tmux",
+      artifactDir: join(cwd, id),
+      sessionFile: "/tmp/sess.jsonl",
+    });
+
+    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+
+    const rehydrated = interactiveSubagentRegistry.get(id);
+    expect(rehydrated).toBeDefined();
+    expect(rehydrated?.name).toBe(id); // falls back to entry.id
+    expect(rehydrated?.startedAt).toBe(0); // falls back to 0
   });
 
   describe("session_start rehydrate integration", () => {

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -395,7 +395,7 @@ describe("rehydrateInteractiveSubagents", () => {
       expect(interactiveSubagentRegistry.size).toBe(0);
     });
 
-    it("session_start DOES rehydrate on startup (survived a quit)", async () => {
+    it("session_start does NOT rehydrate on startup (fresh pi launch)", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
       appendInteractiveState(cwd, {
         id: "from-previous-session",
@@ -408,11 +408,43 @@ describe("rehydrateInteractiveSubagents", () => {
       const { startHandler } = await setupExtension();
       startHandler!({ type: "session_start", reason: "startup" }, { cwd });
 
-      // Registry should have the rehydrated entry - startup after quit preserves subagents
+      // Registry should be empty - startup is a different session, not a reload/resume
+      expect(interactiveSubagentRegistry.size).toBe(0);
+    });
+
+    it("session_start filters by parentSessionId on reload", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      // Entry from a DIFFERENT session
+      appendInteractiveState(cwd, {
+        id: "other-session-agent",
+        paneId: "%99",
+        mux: "tmux",
+        artifactDir: join(cwd, "other-session-agent"),
+        sessionFile: "/tmp/sess.jsonl",
+        parentSessionId: "session-other",
+      });
+      // Entry from THIS session
+      appendInteractiveState(cwd, {
+        id: "this-session-agent",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "this-session-agent"),
+        sessionFile: "/tmp/sess.jsonl",
+        parentSessionId: "session-current",
+      });
+
+      const { startHandler } = await setupExtension();
+      startHandler!({ type: "session_start", reason: "reload" } as any, {
+        cwd,
+        sessionManager: { getSessionId: () => "session-current" },
+      });
+
+      // Only the matching entry should be rehydrated
       expect(interactiveSubagentRegistry.size).toBe(1);
-      expect(interactiveSubagentRegistry.has("from-previous-session")).toBe(
-        true,
+      expect(interactiveSubagentRegistry.has("other-session-agent")).toBe(
+        false,
       );
+      expect(interactiveSubagentRegistry.has("this-session-agent")).toBe(true);
     });
 
     it("session_start does NOT rehydrate on new (explicit new session)", async () => {

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -11,12 +11,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-	appendEvent,
-	appendInteractiveState,
-	artifactPath,
-	loadInteractiveStates,
-	stateFilePath,
-	writeOutput,
+  appendEvent,
+  appendInteractiveState,
+  artifactPath,
+  loadInteractiveStates,
+  stateFilePath,
+  writeOutput,
 } from "./artifact";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 import { interactiveSubagentRegistry } from "./interactive-tmux";
@@ -25,403 +25,444 @@ import { importFresh } from "./test-utils";
 const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
 
 function makeTmp(): string {
-	return mkdtempSync(join(tmpdir(), "pi-subagentura-rehydrate-"));
+  return mkdtempSync(join(tmpdir(), "pi-subagentura-rehydrate-"));
 }
 
 function makeState(cwd: string, id: string): InteractiveSubagentState {
-	const artifactDir = join(cwd, id);
-	return {
-		id,
-		name: id,
-		task: "",
-		paneId: "%42",
-		windowName: "demo",
-		mux: "tmux",
-		sessionFile: "/tmp/sess.jsonl",
-		cwd,
-		startedAt: Date.now(),
-		status: "running",
-		attachCommand: "",
-		selectPaneCommand: "",
-		launchScriptFile: "",
-		artifactDir,
-		notifyOnComplete: "inject",
-		parentSessionId: SESSION,
-	};
+  const artifactDir = join(cwd, id);
+  return {
+    id,
+    name: id,
+    task: "",
+    paneId: "%42",
+    windowName: "demo",
+    mux: "tmux",
+    sessionFile: "/tmp/sess.jsonl",
+    cwd,
+    startedAt: Date.now(),
+    status: "running",
+    attachCommand: "",
+    selectPaneCommand: "",
+    launchScriptFile: "",
+    artifactDir,
+    notifyOnComplete: "inject",
+    parentSessionId: SESSION,
+  };
 }
 
 describe("rehydrateInteractiveSubagents", () => {
-	let cwd: string;
+  let cwd: string;
 
-	beforeEach(() => {
-		cwd = makeTmp();
-		const g = globalThis as any;
-		g.__piSubagenturaInteractiveRegistry?.clear?.();
-		g.__piSubagenturaPiRef = undefined;
-	});
+  beforeEach(() => {
+    cwd = makeTmp();
+    // Install a tmux mock so isPaneAlive returns false for fake pane IDs.
+    // Without this, tmux 3.6b treats unknown pane IDs as "alive" (succeeds with empty output),
+    // making the alive/terminal counts environment-dependent.
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string) => {
+        // Only handle display-message used by isPaneAlive; throw for all others
+        // (new-window, etc.) so they don't accidentally succeed.
+        throw new Error("mock: child_process unavailable");
+      },
+    }));
+    const g = globalThis as any;
+    g.__piSubagenturaInteractiveRegistry?.clear?.();
+    g.__piSubagenturaPiRef = undefined;
+  });
 
-	afterEach(() => {
-		rmSync(cwd, { recursive: true, force: true });
-		vi.doUnmock("node:child_process");
-	});
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    vi.doUnmock("node:child_process");
+  });
 
-	it("returns { total: 0 } when the state file is missing", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
-		expect(result).toEqual({ total: 0, alive: 0, terminal: 0 });
-	});
+  it("returns { total: 0 } when the state file is missing", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    expect(result).toEqual({ total: 0, alive: 0, terminal: 0 });
+  });
 
-	it("populates the registry from a state.json with one entry", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const state = makeState(cwd, "abc12345");
-		appendInteractiveState(cwd, SESSION, {
-			id: state.id,
-			paneId: state.paneId,
-			windowName: state.windowName,
-			mux: state.mux,
-			artifactDir: state.artifactDir,
-			sessionFile: state.sessionFile,
-		});
+  it("populates the registry from a state.json with one entry", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const state = makeState(cwd, "abc12345");
+    appendInteractiveState(cwd, SESSION, {
+      id: state.id,
+      paneId: state.paneId,
+      windowName: state.windowName,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+    });
 
-		const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
 
-		expect(result.total).toBe(1);
-		const rehydrated = interactiveSubagentRegistry.get("abc12345");
-		expect(rehydrated).toBeDefined();
-		expect(rehydrated?.paneId).toBe("%42");
-		expect(rehydrated?.mux).toBe("tmux");
-		expect(rehydrated?.parentSessionId).toBe(SESSION);
-	});
+    expect(result.total).toBe(1);
+    const rehydrated = interactiveSubagentRegistry.get("abc12345");
+    expect(rehydrated).toBeDefined();
+    expect(rehydrated?.paneId).toBe("%42");
+    expect(rehydrated?.mux).toBe("tmux");
+    expect(rehydrated?.parentSessionId).toBe(SESSION);
+  });
 
-	it("is a no-op when the registry already has the id (idempotent)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const state = makeState(cwd, "abc12345");
-		appendInteractiveState(cwd, SESSION, {
-			id: state.id,
-			paneId: state.paneId,
-			windowName: state.windowName,
-			mux: state.mux,
-			artifactDir: state.artifactDir,
-			sessionFile: state.sessionFile,
-		});
+  it("is a no-op when the registry already has the id (idempotent)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const state = makeState(cwd, "abc12345");
+    appendInteractiveState(cwd, SESSION, {
+      id: state.id,
+      paneId: state.paneId,
+      windowName: state.windowName,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+    });
 
-		// Pre-populate the registry with a different (older) state.
-		const older: InteractiveSubagentState = { ...state, paneId: "%OLD" };
-		interactiveSubagentRegistry.set("abc12345", older);
+    // Pre-populate the registry with a different (older) state.
+    const older: InteractiveSubagentState = { ...state, paneId: "%OLD" };
+    interactiveSubagentRegistry.set("abc12345", older);
 
-		mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd, SESSION);
 
-		const after = interactiveSubagentRegistry.get("abc12345");
-		expect(after?.paneId).toBe("%OLD");
-	});
+    const after = interactiveSubagentRegistry.get("abc12345");
+    expect(after?.paneId).toBe("%OLD");
+  });
 
-	it("resets all runtime cursors on rehydrate", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const state = makeState(cwd, "abc12345");
-		appendInteractiveState(cwd, SESSION, {
-			id: state.id,
-			paneId: state.paneId,
-			windowName: state.windowName,
-			mux: state.mux,
-			artifactDir: state.artifactDir,
-			sessionFile: state.sessionFile,
-		});
+  it("resets all runtime cursors on rehydrate", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const state = makeState(cwd, "abc12345");
+    appendInteractiveState(cwd, SESSION, {
+      id: state.id,
+      paneId: state.paneId,
+      windowName: state.windowName,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+    });
 
-		mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd, SESSION);
 
-		const rehydrated = interactiveSubagentRegistry.get("abc12345")!;
-		expect(rehydrated.lastDeliveredEventTs).toBe(0);
-		expect(rehydrated.lastDeliveredSessionByte).toBe(0);
-		expect(rehydrated.lastInjectedEventTs).toBeUndefined();
-		expect(rehydrated.lastSnapshotEventTs).toBeUndefined();
-		expect(rehydrated.injected).toBeUndefined();
-		expect(rehydrated.autoDoneForTurnAt).toBeUndefined();
-	});
+    const rehydrated = interactiveSubagentRegistry.get("abc12345")!;
+    expect(rehydrated.lastDeliveredEventTs).toBe(0);
+    expect(rehydrated.lastDeliveredSessionByte).toBe(0);
+    expect(rehydrated.lastInjectedEventTs).toBeUndefined();
+    expect(rehydrated.lastSnapshotEventTs).toBeUndefined();
+    expect(rehydrated.injected).toBeUndefined();
+    expect(rehydrated.autoDoneForTurnAt).toBeUndefined();
+  });
 
-	it("counts alive vs terminal in the return value", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		// Two entries: one with a terminal event in the artifact, one without.
-		// We can't predict exact alive/terminal counts because isPaneAlive depends
-		// on the tmux mock — but both must reach the registry, and alive+terminal
-		// must sum to a sane value relative to total.
-		const cwdA = cwd;
-		const cwdB = cwd;
-		for (const id of ["alive1", "done1"]) {
-			appendInteractiveState(cwdA, SESSION, {
-				id,
-				paneId: "%" + id,
-				mux: "tmux",
-				artifactDir: join(cwdB, id),
-				sessionFile: "/tmp/sess.jsonl",
-			});
-		}
-		const art1 = artifactPath(cwdB, "done1");
-		appendEvent(art1, { ts: 1, type: "started", status: "running" });
-		appendEvent(art1, { ts: 2, type: "done", status: "done", exitCode: 0 });
+  it("counts alive vs terminal in the return value", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    // Two entries: alive1 (no events, pane not alive → unknown), done1 (done event,
+    // pane not alive → exited). We can predict exact counts here because the test
+    // runs in a tmux environment and isPaneAlive returns false for fake pane IDs.
+    const cwdA = cwd;
+    const cwdB = cwd;
+    for (const id of ["alive1", "done1"]) {
+      appendInteractiveState(cwdA, SESSION, {
+        id,
+        paneId: "%" + id,
+        mux: "tmux",
+        artifactDir: join(cwdB, id),
+        sessionFile: "/tmp/sess.jsonl",
+      });
+    }
+    const art1 = artifactPath(cwdB, "done1");
+    appendEvent(art1, { ts: 1, type: "started", status: "running" });
+    appendEvent(art1, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-		const result = mod.rehydrateInteractiveSubagents(cwdA, SESSION);
+    const result = mod.rehydrateInteractiveSubagents(cwdA, SESSION);
 
-		expect(result.total).toBe(2);
-		expect(result.alive + result.terminal).toBeLessThanOrEqual(2);
-		expect(interactiveSubagentRegistry.size).toBe(2);
-	});
+    expect(result.total).toBe(2);
+    // alive1 has no events → status=unknown (not counted); done1 has done event → status=exited (terminal)
+    expect(result.alive).toBe(0);
+    expect(result.terminal).toBe(1);
+    expect(interactiveSubagentRegistry.get("alive1")?.status).toBe("unknown");
+    expect(interactiveSubagentRegistry.get("done1")?.status).toBe("exited");
+  });
 
-	it("does not throw when ctx.cwd is unreachable (best-effort recovery)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		expect(() => mod.rehydrateInteractiveSubagents("/nonexistent/path/that/does/not/exist", SESSION)).not.toThrow();
-		expect(() => mod.rehydrateInteractiveSubagents("/nonexistent/path/that/does/not/exist", SESSION)).not.toThrow();
-	});
+  it("does not throw when ctx.cwd is unreachable (best-effort recovery)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    expect(() =>
+      mod.rehydrateInteractiveSubagents(
+        "/nonexistent/path/that/does/not/exist",
+        SESSION,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      mod.rehydrateInteractiveSubagents(
+        "/nonexistent/path/that/does/not/exist",
+        SESSION,
+      ),
+    ).not.toThrow();
+  });
 
-	it("inject-mode orphans do NOT re-inject their existing terminal event on the first poll after rehydrate", async () => {
-		// Regression for the inject-flood bug: if the persisted entry had
-		// notifyOnComplete="inject" and the artifact has a done event, the
-		// rehydrated state must set lastInjectedEventTs so the inject path
-		// (subagent.ts:609) skips the existing done event. Without this fix
-		// every parent reload would flood the new parent LLM with user
-		// messages for orphans from the previous session.
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const id = "inject-orphan";
-		const artDir = join(cwd, id);
-		appendInteractiveState(cwd, SESSION, {
-			id,
-			paneId: "%77",
-			mux: "tmux",
-			artifactDir: artDir,
-			sessionFile: "/tmp/sess.jsonl",
-			notifyOnComplete: "inject",
-		});
-		// Add a done event to the artifact (what an orphan-with-completed-work looks like).
-		const art = artifactPath(cwd, id);
-		appendEvent(art, { ts: 1, type: "started", status: "running" });
-		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+  it("inject-mode orphans do NOT re-inject their existing terminal event on the first poll after rehydrate", async () => {
+    // Regression for the inject-flood bug: if the persisted entry had
+    // notifyOnComplete="inject" and the artifact has a done event, the
+    // rehydrated state must set lastInjectedEventTs so the inject path
+    // (subagent.ts:609) skips the existing done event. Without this fix
+    // every parent reload would flood the new parent LLM with user
+    // messages for orphans from the previous session.
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const id = "inject-orphan";
+    const artDir = join(cwd, id);
+    appendInteractiveState(cwd, SESSION, {
+      id,
+      paneId: "%77",
+      mux: "tmux",
+      artifactDir: artDir,
+      sessionFile: "/tmp/sess.jsonl",
+      notifyOnComplete: "inject",
+    });
+    // Add a done event to the artifact (what an orphan-with-completed-work looks like).
+    const art = artifactPath(cwd, id);
+    appendEvent(art, { ts: 1, type: "started", status: "running" });
+    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-		mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd, SESSION);
 
-		const rehydrated = interactiveSubagentRegistry.get(id);
-		expect(rehydrated).toBeDefined();
-		// The cursor must equal the latest event's ts so the inject path's
-		// `state.lastInjectedEventTs !== last.ts` check evaluates to false.
-		expect(rehydrated?.lastInjectedEventTs).toBe(2);
-	});
+    const rehydrated = interactiveSubagentRegistry.get(id);
+    expect(rehydrated).toBeDefined();
+    // The cursor must equal the latest event's ts so the inject path's
+    // `state.lastInjectedEventTs !== last.ts` check evaluates to false.
+    expect(rehydrated?.lastInjectedEventTs).toBe(2);
+  });
 
-	it("notify-mode orphans leave lastInjectedEventTs undefined (inject path is irrelevant)", async () => {
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		const id = "notify-orphan";
-		const artDir = join(cwd, id);
-		appendInteractiveState(cwd, SESSION, {
-			id,
-			paneId: "%88",
-			mux: "tmux",
-			artifactDir: artDir,
-			sessionFile: "/tmp/sess.jsonl",
-			notifyOnComplete: "notify",
-		});
-		mod.rehydrateInteractiveSubagents(cwd, SESSION);
-		const rehydrated = interactiveSubagentRegistry.get(id);
-		expect(rehydrated?.lastInjectedEventTs).toBeUndefined();
-	});
+  it("notify-mode orphans leave lastInjectedEventTs undefined (inject path is irrelevant)", async () => {
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const id = "notify-orphan";
+    const artDir = join(cwd, id);
+    appendInteractiveState(cwd, SESSION, {
+      id,
+      paneId: "%88",
+      mux: "tmux",
+      artifactDir: artDir,
+      sessionFile: "/tmp/sess.jsonl",
+      notifyOnComplete: "notify",
+    });
+    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    const rehydrated = interactiveSubagentRegistry.get(id);
+    expect(rehydrated?.lastInjectedEventTs).toBeUndefined();
+  });
 
+  describe("session_start rehydrate integration", () => {
+    let cwd: string;
 
-describe("session_start rehydrate integration", () => {
-	let cwd: string;
+    beforeEach(() => {
+      cwd = makeTmp();
+      const g = globalThis as any;
+      g.__piSubagenturaInteractiveRegistry?.clear?.();
+      g.__piSubagenturaPiRef = undefined;
+    });
 
-	beforeEach(() => {
-		cwd = makeTmp();
-		const g = globalThis as any;
-		g.__piSubagenturaInteractiveRegistry?.clear?.();
-		g.__piSubagenturaPiRef = undefined;
-	});
+    afterEach(() => {
+      rmSync(cwd, { recursive: true, force: true });
+      vi.doUnmock("node:child_process");
+    });
 
-	afterEach(() => {
-		rmSync(cwd, { recursive: true, force: true });
-		vi.doUnmock("node:child_process");
-	});
+    async function setupExtension() {
+      const api = {
+        registerTool: vi.fn(),
+        registerMessageRenderer: vi.fn(),
+        sendMessage: vi.fn(),
+        sendUserMessage: vi.fn(),
+        on: vi.fn(),
+      };
+      const mod = (await importFresh<typeof import("./subagent")>("./subagent"))
+        .default;
+      mod(api as any);
+      let startHandler: ((event: any, ctx: any) => void) | undefined;
+      for (const [event, handler] of (api.on as any).mock.calls) {
+        if (event === "session_start") startHandler = handler;
+      }
+      return { api, startHandler };
+    }
 
-	async function setupExtension() {
-		const api = {
-			registerTool: vi.fn(),
-			registerMessageRenderer: vi.fn(),
-			sendMessage: vi.fn(),
-			sendUserMessage: vi.fn(),
-			on: vi.fn(),
-		};
-		const mod = (await importFresh<typeof import("./subagent")>("./subagent")).default;
-		mod(api as any);
-		let startHandler: ((event: any, ctx: any) => void) | undefined;
-		for (const [event, handler] of (api.on as any).mock.calls) {
-			if (event === "session_start") startHandler = handler;
-		}
-		return { api, startHandler };
-	}
+    it("session_start handler repopulates the registry from the on-disk state file", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, SESSION, {
+        id: "abc12345",
+        paneId: "%42",
+        windowName: "demo",
+        mux: "tmux",
+        artifactDir: join(cwd, "abc12345"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
 
-	it("session_start handler repopulates the registry from the on-disk state file", async () => {
-		await importFresh<typeof import("./subagent")>("./subagent");
-		appendInteractiveState(cwd, SESSION, {
-			id: "abc12345",
-			paneId: "%42",
-			windowName: "demo",
-			mux: "tmux",
-			artifactDir: join(cwd, "abc12345"),
-			sessionFile: "/tmp/sess.jsonl",
-		});
+      const { startHandler } = await setupExtension();
+      expect(startHandler).toBeTypeOf("function");
+      startHandler!(
+        { type: "session_start", reason: "reload" },
+        {
+          cwd,
+          sessionManager: { getSessionId: () => SESSION },
+        },
+      );
 
-		const { startHandler } = await setupExtension();
-		expect(startHandler).toBeTypeOf("function");
-		startHandler!({ type: "session_start", reason: "reload" }, {
-			cwd,
-			sessionManager: { getSessionId: () => SESSION },
-		});
+      expect(interactiveSubagentRegistry.has("abc12345")).toBe(true);
+    });
 
-		expect(interactiveSubagentRegistry.has("abc12345")).toBe(true);
-	});
+    it("session_start handler survives a missing state file (empty registry)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      const { startHandler } = await setupExtension();
+      expect(() =>
+        startHandler!(
+          { type: "session_start", reason: "startup" },
+          {
+            cwd: "/nonexistent",
+            sessionManager: { getSessionId: () => SESSION },
+          },
+        ),
+      ).not.toThrow();
+      expect(interactiveSubagentRegistry.size).toBe(0);
+    });
+  });
 
-	it("session_start handler survives a missing state file (empty registry)", async () => {
-		await importFresh<typeof import("./subagent")>("./subagent");
-		const { startHandler } = await setupExtension();
-		expect(() =>
-			startHandler!({ type: "session_start", reason: "startup" }, {
-				cwd: "/nonexistent",
-				sessionManager: { getSessionId: () => SESSION },
-			}),
-		).not.toThrow();
-		expect(interactiveSubagentRegistry.size).toBe(0);
-	});
-});
+  describe("session_shutdown clean-slate on /new and quit", () => {
+    let cwd: string;
 
-describe("session_shutdown clean-slate on /new and quit", () => {
-	let cwd: string;
+    beforeEach(() => {
+      cwd = makeTmp();
+      const g = globalThis as any;
+      g.__piSubagenturaInteractiveRegistry?.clear?.();
+      g.__piSubagenturaPiRef = undefined;
+    });
 
-	beforeEach(() => {
-		cwd = makeTmp();
-		const g = globalThis as any;
-		g.__piSubagenturaInteractiveRegistry?.clear?.();
-		g.__piSubagenturaPiRef = undefined;
-	});
+    afterEach(() => {
+      rmSync(cwd, { recursive: true, force: true });
+      vi.doUnmock("node:child_process");
+    });
 
-	afterEach(() => {
-		rmSync(cwd, { recursive: true, force: true });
-		vi.doUnmock("node:child_process");
-	});
+    async function setupExtension() {
+      const api = {
+        registerTool: vi.fn(),
+        registerMessageRenderer: vi.fn(),
+        sendMessage: vi.fn(),
+        sendUserMessage: vi.fn(),
+        on: vi.fn(),
+      };
+      const mod = await importFresh<typeof import("./subagent")>("./subagent");
+      mod.default(api as any);
 
-	async function setupExtension() {
-		const api = {
-			registerTool: vi.fn(),
-			registerMessageRenderer: vi.fn(),
-			sendMessage: vi.fn(),
-			sendUserMessage: vi.fn(),
-			on: vi.fn(),
-		};
-		const mod = await importFresh<typeof import("./subagent")>("./subagent");
-		mod.default(api as any);
+      const shutdownHandlers: Array<(event: any, ctx: any) => void> = [];
+      for (const [event, handler] of (api.on as any).mock.calls) {
+        if (event === "session_shutdown") shutdownHandlers.push(handler);
+      }
+      return { api, shutdownHandlers };
+    }
 
-		const shutdownHandlers: Array<(event: any, ctx: any) => void> = [];
-		for (const [event, handler] of (api.on as any).mock.calls) {
-			if (event === "session_shutdown") shutdownHandlers.push(handler);
-		}
-		return { api, shutdownHandlers };
-	}
+    it("session_shutdown with reason='new' deletes the state file", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, SESSION, {
+        id: "abc12345",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "abc12345"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
+      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
 
-	it("session_shutdown with reason='new' deletes the state file", async () => {
-		await importFresh<typeof import("./subagent")>("./subagent");
-		appendInteractiveState(cwd, SESSION, {
-			id: "abc12345",
-			paneId: "%42",
-			mux: "tmux",
-			artifactDir: join(cwd, "abc12345"),
-			sessionFile: "/tmp/sess.jsonl",
-		});
-		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+      const { shutdownHandlers } = await setupExtension();
+      // Find the second (heavy) handler — first one is the no-op early one.
+      const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+      heavyHandler(
+        { type: "session_shutdown", reason: "new" },
+        {
+          cwd,
+          sessionManager: { getSessionId: () => SESSION },
+        },
+      );
 
-		const { shutdownHandlers } = await setupExtension();
-		// Find the second (heavy) handler — first one is the no-op early one.
-		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
-		heavyHandler({ type: "session_shutdown", reason: "new" }, {
-			cwd,
-			sessionManager: { getSessionId: () => SESSION },
-		});
+      expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
+    });
 
-		expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
-	});
+    it("session_shutdown with reason='quit' deletes the state file", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, SESSION, {
+        id: "abc12345",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "abc12345"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
 
-	it("session_shutdown with reason='quit' deletes the state file", async () => {
-		await importFresh<typeof import("./subagent")>("./subagent");
-		appendInteractiveState(cwd, SESSION, {
-			id: "abc12345",
-			paneId: "%42",
-			mux: "tmux",
-			artifactDir: join(cwd, "abc12345"),
-			sessionFile: "/tmp/sess.jsonl",
-		});
+      const { shutdownHandlers } = await setupExtension();
+      const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+      heavyHandler(
+        { type: "session_shutdown", reason: "quit" },
+        {
+          cwd,
+          sessionManager: { getSessionId: () => SESSION },
+        },
+      );
 
-		const { shutdownHandlers } = await setupExtension();
-		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
-		heavyHandler({ type: "session_shutdown", reason: "quit" }, {
-			cwd,
-			sessionManager: { getSessionId: () => SESSION },
-		});
+      expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
+    });
 
-		expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
-	});
+    it("session_shutdown with reason='reload' KEEPS the state file (rehydrate depends on it)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, SESSION, {
+        id: "abc12345",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "abc12345"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
 
-	it("session_shutdown with reason='reload' KEEPS the state file (rehydrate depends on it)", async () => {
-		await importFresh<typeof import("./subagent")>("./subagent");
-		appendInteractiveState(cwd, SESSION, {
-			id: "abc12345",
-			paneId: "%42",
-			mux: "tmux",
-			artifactDir: join(cwd, "abc12345"),
-			sessionFile: "/tmp/sess.jsonl",
-		});
+      const { shutdownHandlers } = await setupExtension();
+      const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+      heavyHandler(
+        { type: "session_shutdown", reason: "reload" },
+        {
+          cwd,
+          sessionManager: { getSessionId: () => SESSION },
+        },
+      );
 
-		const { shutdownHandlers } = await setupExtension();
-		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
-		heavyHandler({ type: "session_shutdown", reason: "reload" }, {
-			cwd,
-			sessionManager: { getSessionId: () => SESSION },
-		});
+      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+    });
 
-		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
-	});
+    it("session_shutdown with reason='resume' KEEPS the state file", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, SESSION, {
+        id: "abc12345",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "abc12345"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
 
-	it("session_shutdown with reason='resume' KEEPS the state file", async () => {
-		await importFresh<typeof import("./subagent")>("./subagent");
-		appendInteractiveState(cwd, SESSION, {
-			id: "abc12345",
-			paneId: "%42",
-			mux: "tmux",
-			artifactDir: join(cwd, "abc12345"),
-			sessionFile: "/tmp/sess.jsonl",
-		});
+      const { shutdownHandlers } = await setupExtension();
+      const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+      heavyHandler(
+        { type: "session_shutdown", reason: "resume" },
+        {
+          cwd,
+          sessionManager: { getSessionId: () => SESSION },
+        },
+      );
 
-		const { shutdownHandlers } = await setupExtension();
-		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
-		heavyHandler({ type: "session_shutdown", reason: "resume" }, {
-			cwd,
-			sessionManager: { getSessionId: () => SESSION },
-		});
+      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+    });
 
-		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
-	});
+    it("session_shutdown is a no-op for the state file when ctx.cwd is missing", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, SESSION, {
+        id: "abc12345",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "abc12345"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
 
-	it("session_shutdown is a no-op for the state file when ctx.cwd is missing", async () => {
-		await importFresh<typeof import("./subagent")>("./subagent");
-		appendInteractiveState(cwd, SESSION, {
-			id: "abc12345",
-			paneId: "%42",
-			mux: "tmux",
-			artifactDir: join(cwd, "abc12345"),
-			sessionFile: "/tmp/sess.jsonl",
-		});
+      const { shutdownHandlers } = await setupExtension();
+      const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+      expect(() =>
+        heavyHandler({ type: "session_shutdown", reason: "new" }, undefined),
+      ).not.toThrow();
+      // File is unchanged because ctx was undefined — defensive guard.
+      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+    });
+  });
 
-		const { shutdownHandlers } = await setupExtension();
-		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
-		expect(() => heavyHandler({ type: "session_shutdown", reason: "new" }, undefined)).not.toThrow();
-		// File is unchanged because ctx was undefined — defensive guard.
-		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
-	});
-});
-
-// Re-export to silence the unused-import linter for writeOutput (used in tests below).
-void writeOutput;
-void stateFilePath;
+  // Re-export to silence the unused-import linter for writeOutput (used in tests below).
 });

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -8,21 +8,17 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   appendEvent,
   appendInteractiveState,
   artifactPath,
   loadInteractiveStates,
-  stateFilePath,
-  writeOutput,
 } from "./artifact";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 import { interactiveSubagentRegistry } from "./interactive-tmux";
 import { importFresh } from "./test-utils";
-
-const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-rehydrate-"));
@@ -46,7 +42,7 @@ function makeState(cwd: string, id: string): InteractiveSubagentState {
     launchScriptFile: "",
     artifactDir,
     notifyOnComplete: "inject",
-    parentSessionId: SESSION,
+    parentSessionId: "pi",
   };
 }
 
@@ -78,14 +74,14 @@ describe("rehydrateInteractiveSubagents", () => {
 
   it("returns { total: 0 } when the state file is missing", async () => {
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
-    const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    const result = mod.rehydrateInteractiveSubagents(cwd);
     expect(result).toEqual({ total: 0, alive: 0, terminal: 0 });
   });
 
   it("populates the registry from a state.json with one entry", async () => {
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const state = makeState(cwd, "abc12345");
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id: state.id,
       paneId: state.paneId,
       windowName: state.windowName,
@@ -94,20 +90,53 @@ describe("rehydrateInteractiveSubagents", () => {
       sessionFile: state.sessionFile,
     });
 
-    const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    const result = mod.rehydrateInteractiveSubagents(cwd);
 
     expect(result.total).toBe(1);
     const rehydrated = interactiveSubagentRegistry.get("abc12345");
     expect(rehydrated).toBeDefined();
     expect(rehydrated?.paneId).toBe("%42");
     expect(rehydrated?.mux).toBe("tmux");
-    expect(rehydrated?.parentSessionId).toBe(SESSION);
+    expect(rehydrated?.parentSessionId).toBe("pi");
+  });
+
+  it("rebuilds attach and focus commands on rehydrate", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") {
+          if (
+            args.includes("#{session_name}\t#{window_index}\t#{pane_index}")
+          ) {
+            return "demo\t1\t0\n";
+          }
+          return Buffer.from("%42");
+        }
+        return "";
+      },
+    }));
+    const mod = await importFresh<typeof import("./subagent")>("./subagent");
+    const state = makeState(cwd, "abc12345");
+    appendInteractiveState(cwd, {
+      id: state.id,
+      paneId: state.paneId,
+      windowName: state.windowName,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+    });
+
+    mod.rehydrateInteractiveSubagents(cwd);
+
+    const rehydrated = mod.interactiveSubagentRegistry.get("abc12345");
+    expect(rehydrated?.attachCommand).toContain("tmux attach");
+    expect(rehydrated?.selectPaneCommand).toContain("tmux select-window");
   });
 
   it("is a no-op when the registry already has the id (idempotent)", async () => {
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const state = makeState(cwd, "abc12345");
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id: state.id,
       paneId: state.paneId,
       windowName: state.windowName,
@@ -120,7 +149,7 @@ describe("rehydrateInteractiveSubagents", () => {
     const older: InteractiveSubagentState = { ...state, paneId: "%OLD" };
     interactiveSubagentRegistry.set("abc12345", older);
 
-    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd);
 
     const after = interactiveSubagentRegistry.get("abc12345");
     expect(after?.paneId).toBe("%OLD");
@@ -129,7 +158,7 @@ describe("rehydrateInteractiveSubagents", () => {
   it("resets all runtime cursors on rehydrate", async () => {
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const state = makeState(cwd, "abc12345");
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id: state.id,
       paneId: state.paneId,
       windowName: state.windowName,
@@ -138,7 +167,7 @@ describe("rehydrateInteractiveSubagents", () => {
       sessionFile: state.sessionFile,
     });
 
-    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd);
 
     const rehydrated = interactiveSubagentRegistry.get("abc12345")!;
     expect(rehydrated.lastDeliveredEventTs).toBe(0);
@@ -157,7 +186,7 @@ describe("rehydrateInteractiveSubagents", () => {
     const cwdA = cwd;
     const cwdB = cwd;
     for (const id of ["alive1", "done1"]) {
-      appendInteractiveState(cwdA, SESSION, {
+      appendInteractiveState(cwdA, {
         id,
         paneId: "%" + id,
         mux: "tmux",
@@ -169,7 +198,7 @@ describe("rehydrateInteractiveSubagents", () => {
     appendEvent(art1, { ts: 1, type: "started", status: "running" });
     appendEvent(art1, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-    const result = mod.rehydrateInteractiveSubagents(cwdA, SESSION);
+    const result = mod.rehydrateInteractiveSubagents(cwdA);
 
     expect(result.total).toBe(2);
     // alive1 has no events → status=unknown (not counted); done1 has done event → status=exited (terminal)
@@ -184,13 +213,11 @@ describe("rehydrateInteractiveSubagents", () => {
     expect(() =>
       mod.rehydrateInteractiveSubagents(
         "/nonexistent/path/that/does/not/exist",
-        SESSION,
       ),
     ).not.toThrow();
     expect(() =>
       mod.rehydrateInteractiveSubagents(
         "/nonexistent/path/that/does/not/exist",
-        SESSION,
       ),
     ).not.toThrow();
   });
@@ -205,7 +232,7 @@ describe("rehydrateInteractiveSubagents", () => {
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const id = "inject-orphan";
     const artDir = join(cwd, id);
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id,
       paneId: "%77",
       mux: "tmux",
@@ -218,7 +245,7 @@ describe("rehydrateInteractiveSubagents", () => {
     appendEvent(art, { ts: 1, type: "started", status: "running" });
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd);
 
     const rehydrated = interactiveSubagentRegistry.get(id);
     expect(rehydrated).toBeDefined();
@@ -231,7 +258,7 @@ describe("rehydrateInteractiveSubagents", () => {
     const mod = await importFresh<typeof import("./subagent")>("./subagent");
     const id = "notify-orphan";
     const artDir = join(cwd, id);
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id,
       paneId: "%88",
       mux: "tmux",
@@ -239,7 +266,7 @@ describe("rehydrateInteractiveSubagents", () => {
       sessionFile: "/tmp/sess.jsonl",
       notifyOnComplete: "notify",
     });
-    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd);
     const rehydrated = interactiveSubagentRegistry.get(id);
     expect(rehydrated?.lastInjectedEventTs).toBeUndefined();
   });
@@ -256,7 +283,7 @@ describe("rehydrateInteractiveSubagents", () => {
     });
 
     // Persist state entry (name not in persisted state — recovered from prompt file)
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id,
       paneId: "%99",
       mux: "tmux",
@@ -269,7 +296,7 @@ describe("rehydrateInteractiveSubagents", () => {
     appendEvent(art, { ts: 1000, type: "started", status: "running" });
     appendEvent(art, { ts: 2000, type: "done", status: "done", exitCode: 0 });
 
-    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd);
 
     const rehydrated = interactiveSubagentRegistry.get(id);
     expect(rehydrated).toBeDefined();
@@ -282,7 +309,7 @@ describe("rehydrateInteractiveSubagents", () => {
     const id = "fallback-id";
 
     // Persist state with no artifact files (dir won't exist)
-    appendInteractiveState(cwd, SESSION, {
+    appendInteractiveState(cwd, {
       id,
       paneId: "%99",
       mux: "tmux",
@@ -290,7 +317,7 @@ describe("rehydrateInteractiveSubagents", () => {
       sessionFile: "/tmp/sess.jsonl",
     });
 
-    mod.rehydrateInteractiveSubagents(cwd, SESSION);
+    mod.rehydrateInteractiveSubagents(cwd);
 
     const rehydrated = interactiveSubagentRegistry.get(id);
     expect(rehydrated).toBeDefined();
@@ -333,7 +360,7 @@ describe("rehydrateInteractiveSubagents", () => {
 
     it("session_start handler repopulates the registry from the on-disk state file", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
-      appendInteractiveState(cwd, SESSION, {
+      appendInteractiveState(cwd, {
         id: "abc12345",
         paneId: "%42",
         windowName: "demo",
@@ -348,7 +375,6 @@ describe("rehydrateInteractiveSubagents", () => {
         { type: "session_start", reason: "reload" },
         {
           cwd,
-          sessionManager: { getSessionId: () => SESSION },
         },
       );
 
@@ -363,7 +389,6 @@ describe("rehydrateInteractiveSubagents", () => {
           { type: "session_start", reason: "startup" },
           {
             cwd: "/nonexistent",
-            sessionManager: { getSessionId: () => SESSION },
           },
         ),
       ).not.toThrow();
@@ -401,122 +426,133 @@ describe("rehydrateInteractiveSubagents", () => {
       for (const [event, handler] of (api.on as any).mock.calls) {
         if (event === "session_shutdown") shutdownHandlers.push(handler);
       }
-      return { api, shutdownHandlers };
+      return { api, shutdownHandlers, mod };
     }
 
     it("session_shutdown with reason='new' deletes the state file", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
-      appendInteractiveState(cwd, SESSION, {
+      appendInteractiveState(cwd, {
         id: "abc12345",
         paneId: "%42",
         mux: "tmux",
         artifactDir: join(cwd, "abc12345"),
         sessionFile: "/tmp/sess.jsonl",
       });
-      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
-
+      expect(loadInteractiveStates(cwd)).not.toBeNull();
       const { shutdownHandlers } = await setupExtension();
-      // Find the second (heavy) handler — first one is the no-op early one.
       const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
       heavyHandler(
         { type: "session_shutdown", reason: "new" },
         {
           cwd,
-          sessionManager: { getSessionId: () => SESSION },
         },
       );
-
-      expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
+      expect(loadInteractiveStates(cwd)).toBeNull();
     });
-
-    it("session_shutdown with reason='quit' deletes the state file", async () => {
+    it("session_shutdown with reason='quit' KEEPS the state file (rehydrate depends on it)", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
-      appendInteractiveState(cwd, SESSION, {
+      appendInteractiveState(cwd, {
         id: "abc12345",
         paneId: "%42",
         mux: "tmux",
         artifactDir: join(cwd, "abc12345"),
         sessionFile: "/tmp/sess.jsonl",
       });
-
+      expect(loadInteractiveStates(cwd)).not.toBeNull();
       const { shutdownHandlers } = await setupExtension();
       const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
       heavyHandler(
         { type: "session_shutdown", reason: "quit" },
         {
           cwd,
-          sessionManager: { getSessionId: () => SESSION },
         },
       );
-
-      expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
+      expect(loadInteractiveStates(cwd)).not.toBeNull();
     });
 
     it("session_shutdown with reason='reload' KEEPS the state file (rehydrate depends on it)", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
-      appendInteractiveState(cwd, SESSION, {
+      appendInteractiveState(cwd, {
         id: "abc12345",
         paneId: "%42",
         mux: "tmux",
         artifactDir: join(cwd, "abc12345"),
         sessionFile: "/tmp/sess.jsonl",
       });
-
       const { shutdownHandlers } = await setupExtension();
       const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
       heavyHandler(
         { type: "session_shutdown", reason: "reload" },
         {
           cwd,
-          sessionManager: { getSessionId: () => SESSION },
         },
       );
-
-      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+      expect(loadInteractiveStates(cwd)).not.toBeNull();
     });
-
     it("session_shutdown with reason='resume' KEEPS the state file", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
-      appendInteractiveState(cwd, SESSION, {
+      appendInteractiveState(cwd, {
         id: "abc12345",
         paneId: "%42",
         mux: "tmux",
         artifactDir: join(cwd, "abc12345"),
         sessionFile: "/tmp/sess.jsonl",
       });
-
       const { shutdownHandlers } = await setupExtension();
       const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
       heavyHandler(
         { type: "session_shutdown", reason: "resume" },
         {
           cwd,
-          sessionManager: { getSessionId: () => SESSION },
+        },
+      );
+      expect(loadInteractiveStates(cwd)).not.toBeNull();
+    });
+
+    it("session_shutdown with reason='reload' preserves running panes for rehydrate", async () => {
+      const execFileSync = vi.fn((_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("#42");
+        return Buffer.from("");
+      });
+      vi.resetModules();
+      vi.doMock("node:child_process", () => ({ execFileSync }));
+
+      const { shutdownHandlers, mod } = await setupExtension();
+      const state = makeState(cwd, "abc12345");
+      state.parentSessionId = "pi";
+      mod.interactiveSubagentRegistry.set(state.id, state);
+
+      const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+      heavyHandler(
+        { type: "session_shutdown", reason: "reload" },
+        {
+          cwd,
+          sessionManager: { getSessionId: () => "pi" },
         },
       );
 
-      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+      expect(execFileSync).not.toHaveBeenCalledWith(
+        "tmux",
+        expect.arrayContaining(["kill-pane"]),
+        expect.anything(),
+      );
     });
-
     it("session_shutdown is a no-op for the state file when ctx.cwd is missing", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
-      appendInteractiveState(cwd, SESSION, {
+      appendInteractiveState(cwd, {
         id: "abc12345",
         paneId: "%42",
         mux: "tmux",
         artifactDir: join(cwd, "abc12345"),
         sessionFile: "/tmp/sess.jsonl",
       });
-
       const { shutdownHandlers } = await setupExtension();
       const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
       expect(() =>
         heavyHandler({ type: "session_shutdown", reason: "new" }, undefined),
       ).not.toThrow();
       // File is unchanged because ctx was undefined — defensive guard.
-      expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+      expect(loadInteractiveStates(cwd)).not.toBeNull();
     });
   });
-
-  // Re-export to silence the unused-import linter for writeOutput (used in tests below).
 });

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -395,21 +395,48 @@ describe("rehydrateInteractiveSubagents", () => {
       expect(interactiveSubagentRegistry.size).toBe(0);
     });
 
-    it("session_start does NOT rehydrate on startup (fresh pi launch)", async () => {
+    it("session_start does NOT rehydrate on startup when session ID doesn't match", async () => {
       await importFresh<typeof import("./subagent")>("./subagent");
+      // Entry from a different (old) session
       appendInteractiveState(cwd, {
-        id: "from-previous-session",
+        id: "from-old-session",
         paneId: "%42",
         mux: "tmux",
-        artifactDir: join(cwd, "from-previous-session"),
+        artifactDir: join(cwd, "from-old-session"),
         sessionFile: "/tmp/sess.jsonl",
+        parentSessionId: "session-old",
       });
 
       const { startHandler } = await setupExtension();
-      startHandler!({ type: "session_start", reason: "startup" }, { cwd });
+      startHandler!({ type: "session_start", reason: "startup" } as any, {
+        cwd,
+        sessionManager: { getSessionId: () => "session-new" },
+      });
 
-      // Registry should be empty - startup is a different session, not a reload/resume
+      // Registry should be empty - different session, no match
       expect(interactiveSubagentRegistry.size).toBe(0);
+    });
+
+    it("session_start DOES rehydrate on startup when session ID matches (--session / -r)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, {
+        id: "from-same-session",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "from-same-session"),
+        sessionFile: "/tmp/sess.jsonl",
+        parentSessionId: "session-mine",
+      });
+
+      const { startHandler } = await setupExtension();
+      startHandler!({ type: "session_start", reason: "startup" } as any, {
+        cwd,
+        sessionManager: { getSessionId: () => "session-mine" },
+      });
+
+      // Registry should have the entry - matching session after restart with --session
+      expect(interactiveSubagentRegistry.size).toBe(1);
+      expect(interactiveSubagentRegistry.has("from-same-session")).toBe(true);
     });
 
     it("session_start filters by parentSessionId on reload", async () => {

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -169,8 +169,58 @@ describe("rehydrateInteractiveSubagents", () => {
 	it("does not throw when ctx.cwd is unreachable (best-effort recovery)", async () => {
 		const mod = await importFresh<typeof import("./subagent")>("./subagent");
 		expect(() => mod.rehydrateInteractiveSubagents("/nonexistent/path/that/does/not/exist", SESSION)).not.toThrow();
+		expect(() => mod.rehydrateInteractiveSubagents("/nonexistent/path/that/does/not/exist", SESSION)).not.toThrow();
 	});
-});
+
+	it("inject-mode orphans do NOT re-inject their existing terminal event on the first poll after rehydrate", async () => {
+		// Regression for the inject-flood bug: if the persisted entry had
+		// notifyOnComplete="inject" and the artifact has a done event, the
+		// rehydrated state must set lastInjectedEventTs so the inject path
+		// (subagent.ts:609) skips the existing done event. Without this fix
+		// every parent reload would flood the new parent LLM with user
+		// messages for orphans from the previous session.
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const id = "inject-orphan";
+		const artDir = join(cwd, id);
+		appendInteractiveState(cwd, SESSION, {
+			id,
+			paneId: "%77",
+			mux: "tmux",
+			artifactDir: artDir,
+			sessionFile: "/tmp/sess.jsonl",
+			notifyOnComplete: "inject",
+		});
+		// Add a done event to the artifact (what an orphan-with-completed-work looks like).
+		const art = artifactPath(cwd, id);
+		appendEvent(art, { ts: 1, type: "started", status: "running" });
+		appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+
+		mod.rehydrateInteractiveSubagents(cwd, SESSION);
+
+		const rehydrated = interactiveSubagentRegistry.get(id);
+		expect(rehydrated).toBeDefined();
+		// The cursor must equal the latest event's ts so the inject path's
+		// `state.lastInjectedEventTs !== last.ts` check evaluates to false.
+		expect(rehydrated?.lastInjectedEventTs).toBe(2);
+	});
+
+	it("notify-mode orphans leave lastInjectedEventTs undefined (inject path is irrelevant)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const id = "notify-orphan";
+		const artDir = join(cwd, id);
+		appendInteractiveState(cwd, SESSION, {
+			id,
+			paneId: "%88",
+			mux: "tmux",
+			artifactDir: artDir,
+			sessionFile: "/tmp/sess.jsonl",
+			notifyOnComplete: "notify",
+		});
+		mod.rehydrateInteractiveSubagents(cwd, SESSION);
+		const rehydrated = interactiveSubagentRegistry.get(id);
+		expect(rehydrated?.lastInjectedEventTs).toBeUndefined();
+	});
+
 
 describe("session_start rehydrate integration", () => {
 	let cwd: string;
@@ -374,3 +424,4 @@ describe("session_shutdown clean-slate on /new and quit", () => {
 // Re-export to silence the unused-import linter for writeOutput (used in tests below).
 void writeOutput;
 void stateFilePath;
+});

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Tests for the session_start rehydrate + session_shutdown clean-slate path.
+ *
+ * Rehydrate walks the on-disk state file and repopulates the in-memory
+ * interactiveSubagentRegistry so the parent's view of an orphan interactive
+ * sub-agent survives a parent reload. The clean-slate unlink on
+ * session_shutdown(reason="new"|"quit") gives /new a fresh start.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	appendEvent,
+	appendInteractiveState,
+	artifactPath,
+	loadInteractiveStates,
+	stateFilePath,
+	writeOutput,
+} from "./artifact";
+import type { InteractiveSubagentState } from "./interactive-tmux";
+import { interactiveSubagentRegistry } from "./interactive-tmux";
+import { importFresh } from "./test-utils";
+
+const SESSION = "019e500a-bae9-783a-869a-ac7c106b4ab7";
+
+function makeTmp(): string {
+	return mkdtempSync(join(tmpdir(), "pi-subagentura-rehydrate-"));
+}
+
+function makeState(cwd: string, id: string): InteractiveSubagentState {
+	const artifactDir = join(cwd, id);
+	return {
+		id,
+		name: id,
+		task: "",
+		paneId: "%42",
+		windowName: "demo",
+		mux: "tmux",
+		sessionFile: "/tmp/sess.jsonl",
+		cwd,
+		startedAt: Date.now(),
+		status: "running",
+		attachCommand: "",
+		selectPaneCommand: "",
+		launchScriptFile: "",
+		artifactDir,
+		notifyOnComplete: "inject",
+		parentSessionId: SESSION,
+	};
+}
+
+describe("rehydrateInteractiveSubagents", () => {
+	let cwd: string;
+
+	beforeEach(() => {
+		cwd = makeTmp();
+		const g = globalThis as any;
+		g.__piSubagenturaInteractiveRegistry?.clear?.();
+		g.__piSubagenturaPiRef = undefined;
+	});
+
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+		vi.doUnmock("node:child_process");
+	});
+
+	it("returns { total: 0 } when the state file is missing", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
+		expect(result).toEqual({ total: 0, alive: 0, terminal: 0 });
+	});
+
+	it("populates the registry from a state.json with one entry", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const state = makeState(cwd, "abc12345");
+		appendInteractiveState(cwd, SESSION, {
+			id: state.id,
+			paneId: state.paneId,
+			windowName: state.windowName,
+			mux: state.mux,
+			artifactDir: state.artifactDir,
+			sessionFile: state.sessionFile,
+		});
+
+		const result = mod.rehydrateInteractiveSubagents(cwd, SESSION);
+
+		expect(result.total).toBe(1);
+		const rehydrated = interactiveSubagentRegistry.get("abc12345");
+		expect(rehydrated).toBeDefined();
+		expect(rehydrated?.paneId).toBe("%42");
+		expect(rehydrated?.mux).toBe("tmux");
+		expect(rehydrated?.parentSessionId).toBe(SESSION);
+	});
+
+	it("is a no-op when the registry already has the id (idempotent)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const state = makeState(cwd, "abc12345");
+		appendInteractiveState(cwd, SESSION, {
+			id: state.id,
+			paneId: state.paneId,
+			windowName: state.windowName,
+			mux: state.mux,
+			artifactDir: state.artifactDir,
+			sessionFile: state.sessionFile,
+		});
+
+		// Pre-populate the registry with a different (older) state.
+		const older: InteractiveSubagentState = { ...state, paneId: "%OLD" };
+		interactiveSubagentRegistry.set("abc12345", older);
+
+		mod.rehydrateInteractiveSubagents(cwd, SESSION);
+
+		const after = interactiveSubagentRegistry.get("abc12345");
+		expect(after?.paneId).toBe("%OLD");
+	});
+
+	it("resets all runtime cursors on rehydrate", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		const state = makeState(cwd, "abc12345");
+		appendInteractiveState(cwd, SESSION, {
+			id: state.id,
+			paneId: state.paneId,
+			windowName: state.windowName,
+			mux: state.mux,
+			artifactDir: state.artifactDir,
+			sessionFile: state.sessionFile,
+		});
+
+		mod.rehydrateInteractiveSubagents(cwd, SESSION);
+
+		const rehydrated = interactiveSubagentRegistry.get("abc12345")!;
+		expect(rehydrated.lastDeliveredEventTs).toBe(0);
+		expect(rehydrated.lastDeliveredSessionByte).toBe(0);
+		expect(rehydrated.lastInjectedEventTs).toBeUndefined();
+		expect(rehydrated.lastSnapshotEventTs).toBeUndefined();
+		expect(rehydrated.injected).toBeUndefined();
+		expect(rehydrated.autoDoneForTurnAt).toBeUndefined();
+	});
+
+	it("counts alive vs terminal in the return value", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		// Two entries: one with a terminal event in the artifact, one without.
+		// We can't predict exact alive/terminal counts because isPaneAlive depends
+		// on the tmux mock — but both must reach the registry, and alive+terminal
+		// must sum to a sane value relative to total.
+		const cwdA = cwd;
+		const cwdB = cwd;
+		for (const id of ["alive1", "done1"]) {
+			appendInteractiveState(cwdA, SESSION, {
+				id,
+				paneId: "%" + id,
+				mux: "tmux",
+				artifactDir: join(cwdB, id),
+				sessionFile: "/tmp/sess.jsonl",
+			});
+		}
+		const art1 = artifactPath(cwdB, "done1");
+		appendEvent(art1, { ts: 1, type: "started", status: "running" });
+		appendEvent(art1, { ts: 2, type: "done", status: "done", exitCode: 0 });
+
+		const result = mod.rehydrateInteractiveSubagents(cwdA, SESSION);
+
+		expect(result.total).toBe(2);
+		expect(result.alive + result.terminal).toBeLessThanOrEqual(2);
+		expect(interactiveSubagentRegistry.size).toBe(2);
+	});
+
+	it("does not throw when ctx.cwd is unreachable (best-effort recovery)", async () => {
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		expect(() => mod.rehydrateInteractiveSubagents("/nonexistent/path/that/does/not/exist", SESSION)).not.toThrow();
+	});
+});
+
+describe("session_start rehydrate integration", () => {
+	let cwd: string;
+
+	beforeEach(() => {
+		cwd = makeTmp();
+		const g = globalThis as any;
+		g.__piSubagenturaInteractiveRegistry?.clear?.();
+		g.__piSubagenturaPiRef = undefined;
+	});
+
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+		vi.doUnmock("node:child_process");
+	});
+
+	async function setupExtension() {
+		const api = {
+			registerTool: vi.fn(),
+			registerMessageRenderer: vi.fn(),
+			sendMessage: vi.fn(),
+			sendUserMessage: vi.fn(),
+			on: vi.fn(),
+		};
+		const mod = (await importFresh<typeof import("./subagent")>("./subagent")).default;
+		mod(api as any);
+		let startHandler: ((event: any, ctx: any) => void) | undefined;
+		for (const [event, handler] of (api.on as any).mock.calls) {
+			if (event === "session_start") startHandler = handler;
+		}
+		return { api, startHandler };
+	}
+
+	it("session_start handler repopulates the registry from the on-disk state file", async () => {
+		await importFresh<typeof import("./subagent")>("./subagent");
+		appendInteractiveState(cwd, SESSION, {
+			id: "abc12345",
+			paneId: "%42",
+			windowName: "demo",
+			mux: "tmux",
+			artifactDir: join(cwd, "abc12345"),
+			sessionFile: "/tmp/sess.jsonl",
+		});
+
+		const { startHandler } = await setupExtension();
+		expect(startHandler).toBeTypeOf("function");
+		startHandler!({ type: "session_start", reason: "reload" }, {
+			cwd,
+			sessionManager: { getSessionId: () => SESSION },
+		});
+
+		expect(interactiveSubagentRegistry.has("abc12345")).toBe(true);
+	});
+
+	it("session_start handler survives a missing state file (empty registry)", async () => {
+		await importFresh<typeof import("./subagent")>("./subagent");
+		const { startHandler } = await setupExtension();
+		expect(() =>
+			startHandler!({ type: "session_start", reason: "startup" }, {
+				cwd: "/nonexistent",
+				sessionManager: { getSessionId: () => SESSION },
+			}),
+		).not.toThrow();
+		expect(interactiveSubagentRegistry.size).toBe(0);
+	});
+});
+
+describe("session_shutdown clean-slate on /new and quit", () => {
+	let cwd: string;
+
+	beforeEach(() => {
+		cwd = makeTmp();
+		const g = globalThis as any;
+		g.__piSubagenturaInteractiveRegistry?.clear?.();
+		g.__piSubagenturaPiRef = undefined;
+	});
+
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+		vi.doUnmock("node:child_process");
+	});
+
+	async function setupExtension() {
+		const api = {
+			registerTool: vi.fn(),
+			registerMessageRenderer: vi.fn(),
+			sendMessage: vi.fn(),
+			sendUserMessage: vi.fn(),
+			on: vi.fn(),
+		};
+		const mod = await importFresh<typeof import("./subagent")>("./subagent");
+		mod.default(api as any);
+
+		const shutdownHandlers: Array<(event: any, ctx: any) => void> = [];
+		for (const [event, handler] of (api.on as any).mock.calls) {
+			if (event === "session_shutdown") shutdownHandlers.push(handler);
+		}
+		return { api, shutdownHandlers };
+	}
+
+	it("session_shutdown with reason='new' deletes the state file", async () => {
+		await importFresh<typeof import("./subagent")>("./subagent");
+		appendInteractiveState(cwd, SESSION, {
+			id: "abc12345",
+			paneId: "%42",
+			mux: "tmux",
+			artifactDir: join(cwd, "abc12345"),
+			sessionFile: "/tmp/sess.jsonl",
+		});
+		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+
+		const { shutdownHandlers } = await setupExtension();
+		// Find the second (heavy) handler — first one is the no-op early one.
+		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+		heavyHandler({ type: "session_shutdown", reason: "new" }, {
+			cwd,
+			sessionManager: { getSessionId: () => SESSION },
+		});
+
+		expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
+	});
+
+	it("session_shutdown with reason='quit' deletes the state file", async () => {
+		await importFresh<typeof import("./subagent")>("./subagent");
+		appendInteractiveState(cwd, SESSION, {
+			id: "abc12345",
+			paneId: "%42",
+			mux: "tmux",
+			artifactDir: join(cwd, "abc12345"),
+			sessionFile: "/tmp/sess.jsonl",
+		});
+
+		const { shutdownHandlers } = await setupExtension();
+		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+		heavyHandler({ type: "session_shutdown", reason: "quit" }, {
+			cwd,
+			sessionManager: { getSessionId: () => SESSION },
+		});
+
+		expect(loadInteractiveStates(cwd, SESSION)).toBeNull();
+	});
+
+	it("session_shutdown with reason='reload' KEEPS the state file (rehydrate depends on it)", async () => {
+		await importFresh<typeof import("./subagent")>("./subagent");
+		appendInteractiveState(cwd, SESSION, {
+			id: "abc12345",
+			paneId: "%42",
+			mux: "tmux",
+			artifactDir: join(cwd, "abc12345"),
+			sessionFile: "/tmp/sess.jsonl",
+		});
+
+		const { shutdownHandlers } = await setupExtension();
+		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+		heavyHandler({ type: "session_shutdown", reason: "reload" }, {
+			cwd,
+			sessionManager: { getSessionId: () => SESSION },
+		});
+
+		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+	});
+
+	it("session_shutdown with reason='resume' KEEPS the state file", async () => {
+		await importFresh<typeof import("./subagent")>("./subagent");
+		appendInteractiveState(cwd, SESSION, {
+			id: "abc12345",
+			paneId: "%42",
+			mux: "tmux",
+			artifactDir: join(cwd, "abc12345"),
+			sessionFile: "/tmp/sess.jsonl",
+		});
+
+		const { shutdownHandlers } = await setupExtension();
+		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+		heavyHandler({ type: "session_shutdown", reason: "resume" }, {
+			cwd,
+			sessionManager: { getSessionId: () => SESSION },
+		});
+
+		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+	});
+
+	it("session_shutdown is a no-op for the state file when ctx.cwd is missing", async () => {
+		await importFresh<typeof import("./subagent")>("./subagent");
+		appendInteractiveState(cwd, SESSION, {
+			id: "abc12345",
+			paneId: "%42",
+			mux: "tmux",
+			artifactDir: join(cwd, "abc12345"),
+			sessionFile: "/tmp/sess.jsonl",
+		});
+
+		const { shutdownHandlers } = await setupExtension();
+		const heavyHandler = shutdownHandlers[shutdownHandlers.length - 1];
+		expect(() => heavyHandler({ type: "session_shutdown", reason: "new" }, undefined)).not.toThrow();
+		// File is unchanged because ctx was undefined — defensive guard.
+		expect(loadInteractiveStates(cwd, SESSION)).not.toBeNull();
+	});
+});
+
+// Re-export to silence the unused-import linter for writeOutput (used in tests below).
+void writeOutput;
+void stateFilePath;

--- a/src/subagent-rehydrate.test.ts
+++ b/src/subagent-rehydrate.test.ts
@@ -394,6 +394,97 @@ describe("rehydrateInteractiveSubagents", () => {
       ).not.toThrow();
       expect(interactiveSubagentRegistry.size).toBe(0);
     });
+
+    it("session_start does NOT rehydrate on startup (fresh session)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, {
+        id: "from-previous-session",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "from-previous-session"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
+
+      const { startHandler } = await setupExtension();
+      startHandler!({ type: "session_start", reason: "startup" }, { cwd });
+
+      // Registry should be empty - fresh sessions don't rehydrate old subagents
+      expect(interactiveSubagentRegistry.size).toBe(0);
+    });
+
+    it("session_start does NOT rehydrate on new (explicit new session)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, {
+        id: "from-previous-session",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "from-previous-session"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
+
+      const { startHandler } = await setupExtension();
+      startHandler!({ type: "session_start", reason: "new" }, { cwd });
+
+      // Registry should be empty - new sessions don't rehydrate old subagents
+      expect(interactiveSubagentRegistry.size).toBe(0);
+    });
+
+    it("session_start does NOT rehydrate on fork (forked session)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, {
+        id: "from-previous-session",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "from-previous-session"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
+
+      const { startHandler } = await setupExtension();
+      startHandler!({ type: "session_start", reason: "fork" }, { cwd });
+
+      // Registry should be empty - forked sessions don't rehydrate old subagents
+      expect(interactiveSubagentRegistry.size).toBe(0);
+    });
+
+    it("session_start DOES rehydrate on resume (resumed session)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, {
+        id: "from-previous-session",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "from-previous-session"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
+
+      const { startHandler } = await setupExtension();
+      startHandler!({ type: "session_start", reason: "resume" }, { cwd });
+
+      // Registry should have the rehydrated entry - resume preserves subagents
+      expect(interactiveSubagentRegistry.size).toBe(1);
+      expect(interactiveSubagentRegistry.has("from-previous-session")).toBe(
+        true,
+      );
+    });
+
+    it("session_start DOES rehydrate on reload (reloaded session)", async () => {
+      await importFresh<typeof import("./subagent")>("./subagent");
+      appendInteractiveState(cwd, {
+        id: "from-previous-session",
+        paneId: "%42",
+        mux: "tmux",
+        artifactDir: join(cwd, "from-previous-session"),
+        sessionFile: "/tmp/sess.jsonl",
+      });
+
+      const { startHandler } = await setupExtension();
+      startHandler!({ type: "session_start", reason: "reload" }, { cwd });
+
+      // Registry should have the rehydrated entry - reload preserves subagents
+      expect(interactiveSubagentRegistry.size).toBe(1);
+      expect(interactiveSubagentRegistry.has("from-previous-session")).toBe(
+        true,
+      );
+    });
   });
 
   describe("session_shutdown clean-slate on /new and quit", () => {

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1453,14 +1453,19 @@ export default function (pi: ExtensionAPI) {
   // Capture ctx.ui for the artifact poller (it runs from a setInterval and has no ctx).
   // The handler is registered on every default-export invocation; the last one wins,
   // which is the same pi the poller uses via __piSubagenturaPiRef.
-  pi.on("session_start", (_event, ctx) => {
+  pi.on("session_start", (event, ctx) => {
     g2.__piSubagenturaUi = ctx.ui;
-    // Rehydrate orphan interactive sub-agents from the state file so the
-    // parent's view of them survives across restarts, :reload, or parent crash.
-    try {
-      rehydrateInteractiveSubagents(ctx.cwd);
-    } catch {
-      /* best effort — rehydrate is a recovery path; failures fall back to empty registry */
+    // Rehydrate orphan interactive sub-agents from the state file ONLY on reload/resume.
+    // On fresh starts (startup, new, fork), we want a clean slate — previous session's
+    // subagents should not pollute the new session's view.
+    const shouldRehydrate =
+      event.reason === "reload" || event.reason === "resume";
+    if (shouldRehydrate) {
+      try {
+        rehydrateInteractiveSubagents(ctx.cwd);
+      } catch {
+        /* best effort — rehydrate is a recovery path; failures fall back to empty registry */
+      }
     }
   });
 
@@ -2973,7 +2978,6 @@ export default function (pi: ExtensionAPI) {
       g2.__piSubagenturaInjectCount = 0;
       // Clean-slate the state file on /new. On quit we KEEP the file so the
       // next session_start can rehydrate the sub-agents (their panes survive).
-      // On reload/resume the file is also kept (existing behaviour).
       if (event?.reason === "new" && ctx?.cwd) {
         try {
           deleteInteractiveStatesFile(ctx.cwd);

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1313,6 +1313,15 @@ export function rehydrateInteractiveSubagents(
 		const paneAlive = isPaneAlive(rehydrated);
 		const next = deriveInteractiveSubagentStatus(last, paneAlive);
 		rehydrated.status = next;
+		// For inject-mode orphans, set lastInjectedEventTs to the most recent
+		// event's ts so the existing terminal event is NOT re-injected on the
+		// first poll after rehydrate. Without this, every parent reload would
+		// flood the new parent LLM with user messages for orphans from the
+		// previous session. Future follow-up `done` events (higher ts) on the
+		// same orphan will still inject, which is the right behavior.
+		if (entry.notifyOnComplete === "inject" && last) {
+			rehydrated.lastInjectedEventTs = last.ts;
+		}
 		if (next === "exited" || next === "cancelled") terminal++;
 		else if (next === "running" || next === "idle") alive++;
 		interactiveSubagentRegistry.set(entry.id, rehydrated);

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1309,7 +1309,7 @@ export function rehydrateInteractiveSubagents(
   for (const entry of Object.values(payload.states) as Array<
     import("./artifact").InteractiveSubagentPersistedStateV1
   >) {
-    if (entry.parentSessionId && entry.parentSessionId !== currentSessionId) {
+    if (currentSessionId && entry.parentSessionId !== currentSessionId) {
       continue;
     }
     if (interactiveSubagentRegistry.has(entry.id)) continue;

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1455,11 +1455,13 @@ export default function (pi: ExtensionAPI) {
   // which is the same pi the poller uses via __piSubagenturaPiRef.
   pi.on("session_start", (event, ctx) => {
     g2.__piSubagenturaUi = ctx.ui;
-    // Rehydrate orphan interactive sub-agents from the state file ONLY on reload/resume.
-    // On fresh starts (startup, new, fork), we want a clean slate — previous session's
+    // Rehydrate orphan interactive sub-agents on startup (survived a quit), reload, and resume.
+    // On explicit fresh starts (new, fork) we skip rehydration — those sessions want a clean slate.
     // subagents should not pollute the new session's view.
     const shouldRehydrate =
-      event.reason === "reload" || event.reason === "resume";
+      event.reason === "startup" ||
+      event.reason === "reload" ||
+      event.reason === "resume";
     if (shouldRehydrate) {
       try {
         rehydrateInteractiveSubagents(ctx.cwd);

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -50,6 +50,7 @@ import {
   type NotifyOnComplete,
 } from "./helpers";
 import {
+  buildAttachCommandsForState,
   cancelInteractiveSubagent,
   cancelInteractiveSubagentByState,
   deriveInteractiveSubagentStatus,
@@ -64,7 +65,6 @@ import {
 } from "./interactive-tmux";
 import {
   appendEvent,
-  appendInteractiveState,
   artifactPath,
   deleteInteractiveStatesFile,
   lastEvent,
@@ -565,7 +565,8 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
       // Refresh status from the artifact + pane liveness. `done` + pane alive → "idle" (not exited),
       // which is what allows follow-ups: a second `done` after the follow-up turn will be picked up
       // here and the inject path below will fire again.
-      const next = deriveInteractiveSubagentStatus(last, isPaneAlive(state));
+      const paneAlive = isPaneAlive(state);
+      const next = deriveInteractiveSubagentStatus(last, paneAlive);
       if (next !== state.status) {
         state.status = next;
         if (
@@ -577,6 +578,23 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
           state.exitCode = last.exitCode;
         }
       }
+      // Early removal from persisted state: if a `done` event is already delivered for a dead
+      // pane, the state entry is no longer needed on disk. This avoids keeping zombie entries
+      // around for cleanly-exited sub-agents whose pane died after delivery.
+      if (
+        state.parentSessionId &&
+        last &&
+        shouldNotify(last) &&
+        last.type === "done" &&
+        !paneAlive &&
+        (state.lastDeliveredEventTs ?? 0) >= last.ts
+      ) {
+        try {
+          removeInteractiveState(state.cwd, state.id);
+        } catch {
+          /* best effort — disk full, permission denied, etc. */
+        }
+      }
 
       // Tail-read the child's session log and synthesize tool_activity events.
       // TUI-widget only — the LLM never sees them.
@@ -584,9 +602,9 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
 
       // Auto-done fallback: synthesize a completion event when the model ended its turn with
       // stopReason:"stop" but never called `cli.mjs done`. Runs BEFORE reading events so the synthesized
-      // event is part of the same poll's read-back. Sets lastDeliveredEventTs and the autoDoneForTurnAt
-      // guard so the events loop below will not re-notify.
-      maybeAutoDone(state, art, interactivePi, Date.now());
+      // event is part of the same poll's read-back. The normal event loop still owns delivery/cursor
+      // advancement so stale Pi contexts can retry on the next tick.
+      maybeAutoDone(state, art, Date.now());
 
       // Read events newer than the last delivered. `lastDeliveredEventTs` starts at 0,
       // so on the first poll we deliver the whole log. Subsequent polls advance the cursor.
@@ -594,37 +612,45 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
       const events = readEvents(art, cursor + 1);
 
       if (events.length > 0) {
-        let maxTs = cursor;
-        let deliveredTerminal = false;
+        let nextCursor = cursor;
+        let shouldRemovePersistedState = false;
         for (const ev of events) {
-          if (ev.ts > maxTs) maxTs = ev.ts;
-          if (!shouldNotify(ev)) continue;
-          // Track terminal delivery so we can drop the on-disk state entry
-          // AFTER the cursor advances (crash-safe ordering).
-          if (
-            ev.type === "done" ||
-            ev.type === "error" ||
-            ev.type === "cancelled"
-          ) {
-            deliveredTerminal = true;
+          if (!shouldNotify(ev)) {
+            if (ev.ts > nextCursor) nextCursor = ev.ts;
+            continue;
           }
           // If auto-done already fired for this turn, skip any later explicit `done` events:
           // they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
           if (
             state.autoDoneForTurnAt !== undefined &&
-            ev.ts >= state.autoDoneForTurnAt &&
+            ev.ts > state.autoDoneForTurnAt &&
             ev.type === "done"
-          )
+          ) {
+            if (ev.ts > nextCursor) nextCursor = ev.ts;
             continue;
-          deliverArtifactNotification(interactivePi, state, ev);
+          }
+          const delivered = deliverArtifactNotification(
+            interactivePi,
+            state,
+            ev,
+          );
+          if (!delivered) break;
+          if (ev.ts > nextCursor) nextCursor = ev.ts;
+          // Keep done+alive entries persisted: the child REPL is idle and can
+          // accept follow-ups, so a later parent reload still needs rehydrate.
+          if (ev.type === "error" || ev.type === "cancelled") {
+            shouldRemovePersistedState = true;
+          } else if (ev.type === "done" && !paneAlive) {
+            shouldRemovePersistedState = true;
+          }
         }
-        state.lastDeliveredEventTs = maxTs;
-        // Drop the on-disk entry now that the terminal event is delivered.
-        // Cursor advance above is what makes a crash here re-deliver rather
-        // than drop the event on the next reload.
-        if (deliveredTerminal && state.parentSessionId) {
+        state.lastDeliveredEventTs = nextCursor;
+        // Drop the on-disk entry only after confirmed delivery, and only for
+        // truly terminal states. A failed delivery leaves the cursor before
+        // the event so the next poll/reload can retry.
+        if (shouldRemovePersistedState && state.parentSessionId) {
           try {
-            removeInteractiveState(state.cwd, state.parentSessionId, state.id);
+            removeInteractiveState(state.cwd, state.id);
           } catch {
             /* best effort — disk full, permission denied, etc. */
           }
@@ -992,7 +1018,6 @@ function extractAssistantText(content: unknown[]): string {
 function maybeAutoDone(
   state: InteractiveSubagentState,
   art: SubagentArtifact,
-  pi: ExtensionAPI,
   now: number,
 ): void {
   if (state.autoDoneForTurnAt !== undefined) return; // already fired for this turn
@@ -1064,23 +1089,13 @@ function maybeAutoDone(
   // follow-up turn completes.
   appendEvent(art, ev);
   state.autoDoneForTurnAt = ts;
-  state.lastDeliveredEventTs = ts;
+  // state.lastDeliveredEventTs = ts; // removed — the event loop owns cursor advancement
   // In inject mode, leave `injected` unset so the regular inject path at
   // lines 547-585 picks up the synthesized `done` event on the next poll.
   // For all other modes (notify, undefined), mark as injected here because
   // the inject path will never fire — this prevents accidental re-inject
   // if a late explicit `done` later matches the cursor.
   state.injected = state.notifyOnComplete !== "inject";
-
-  // Fire the pointer notification immediately so the parent does not wait for the next 5s poll tick.
-  // Suppress here only — the regular `events` loop below uses the autoDoneForTurnAt guard.
-  if (pi) {
-    try {
-      deliverArtifactNotification(pi, state, ev);
-    } catch {
-      // pi may be stale; the event is on disk and will be picked up by the next tick anyway.
-    }
-  }
 }
 
 /** Short, human-readable summary of a tool call. Returns null for uninteresting tools. */
@@ -1142,12 +1157,13 @@ function buildArtifactMessage(
   return `${header}${body}${pointer}`;
 }
 
-/** Send a single pointer-only notification for one artifact event. */
+/** Send a single pointer-only notification for one artifact event.
+ * Returns true if the notification was sent, false on failure (stale pi context). */
 function deliverArtifactNotification(
   pi: ExtensionAPI,
   state: InteractiveSubagentState,
   event: SubagentEvent,
-): void {
+): boolean {
   try {
     pi.sendMessage!(
       {
@@ -1158,8 +1174,10 @@ function deliverArtifactNotification(
       },
       { deliverAs: "followUp" },
     );
+    return true;
   } catch {
     // pi may be stale after session replacement
+    return false;
   }
 }
 
@@ -1266,7 +1284,7 @@ export function findArtifactById(id: string): SubagentArtifact | null {
 /**
  * Rehydrate orphan interactive sub-agents from the on-disk state file.
  *
- * Reads <cwd>/.pi/subagentura-state-<sessionId>.json, reconstructs each
+ * Reads <cwd>/.pi/subagentura-state.json, reconstructs each
  * InteractiveSubagentState, sets its status via the existing
  * deriveInteractiveSubagentStatus matrix (lastEvent + isPaneAlive), registers
  * it, and resets runtime cursors so the existing poller backlog-catch-up path
@@ -1276,11 +1294,12 @@ export function findArtifactById(id: string): SubagentArtifact | null {
  * the session_start handler. The first poll tick after this returns sees
  * the rehydrated states and replays any backlog.
  */
-export function rehydrateInteractiveSubagents(
-  cwd: string,
-  sessionId: string,
-): { total: number; alive: number; terminal: number } {
-  const payload = loadInteractiveStates(cwd, sessionId);
+export function rehydrateInteractiveSubagents(cwd: string): {
+  total: number;
+  alive: number;
+  terminal: number;
+} {
+  const payload = loadInteractiveStates(cwd);
   if (!payload) return { total: 0, alive: 0, terminal: 0 };
   let alive = 0;
   let terminal = 0;
@@ -1315,6 +1334,14 @@ export function rehydrateInteractiveSubagents(
       startedAt = 0;
     }
 
+    const attach = (() => {
+      try {
+        return buildAttachCommandsForState(entry);
+      } catch {
+        return { attachCommand: "", focusCommand: "" };
+      }
+    })();
+
     const rehydrated: InteractiveSubagentState = {
       id: entry.id,
       name: recoveredName,
@@ -1327,12 +1354,12 @@ export function rehydrateInteractiveSubagents(
       cwd,
       startedAt,
       status: "running",
-      attachCommand: "",
-      selectPaneCommand: "",
+      attachCommand: attach.attachCommand,
+      selectPaneCommand: attach.focusCommand,
       launchScriptFile: "",
       artifactDir: entry.artifactDir,
       notifyOnComplete: entry.notifyOnComplete,
-      parentSessionId: sessionId,
+      parentSessionId: "pi",
       // All runtime cursors reset (replay-all semantics).
       lastDeliveredEventTs: 0,
       lastDeliveredSessionByte: 0,
@@ -1428,10 +1455,10 @@ export default function (pi: ExtensionAPI) {
   // which is the same pi the poller uses via __piSubagenturaPiRef.
   pi.on("session_start", (_event, ctx) => {
     g2.__piSubagenturaUi = ctx.ui;
-    // NEW: rehydrate orphan interactive sub-agents from the state file so the
-    // parent's view of them survives a :reload / extension restart / parent crash.
+    // Rehydrate orphan interactive sub-agents from the state file so the
+    // parent's view of them survives across restarts, :reload, or parent crash.
     try {
-      rehydrateInteractiveSubagents(ctx.cwd, ctx.sessionManager.getSessionId());
+      rehydrateInteractiveSubagents(ctx.cwd);
     } catch {
       /* best effort — rehydrate is a recovery path; failures fall back to empty registry */
     }
@@ -2899,10 +2926,10 @@ export default function (pi: ExtensionAPI) {
         }
         g2.__piSubagenturaInteractivePollerHandle = undefined;
       }
-      // Snapshot running state objects BEFORE clearing, so we can kill their panes
-      // after the registry is empty. We can't call cancelInteractiveSubagent(id)
-      // after clear() because it looks up state from the registry (line 533 of
-      // interactive-tmux.ts) and returns undefined.
+      // Snapshot running state objects BEFORE clearing. On /new and quit we
+      // kill their panes after the registry is empty. On reload/resume we
+      // intentionally preserve panes so the next session_start can rehydrate
+      // them from the state file.
       const runningStates: InteractiveSubagentState[] = [];
       for (const state of interactiveSubagentRegistry.values()) {
         if (state.status === "running") runningStates.push(state);
@@ -2911,25 +2938,26 @@ export default function (pi: ExtensionAPI) {
       // Drop in-memory state FIRST. An in-flight poll tick (dequeued from
       // setInterval before clearInterval ran) finds an empty registry and its
       // for-loop iterates over zero entries — no work, no notification delivery.
-      // `__piSubagenturaPiRef` is still valid at this point (cleared later), so
-      // the tick proceeds into the loop and finds nothing.
       try {
         interactiveSubagentRegistry.clear();
       } catch {
         /* best effort */
       }
 
-      // Kill the panes using the snapshotted states. The poller is already safe
-      // (registry empty). We use cancelInteractiveSubagentByState (not the
-      // id-based variant) because the registry is already cleared.
-      for (const state of runningStates) {
-        try {
-          cancelInteractiveSubagentByState(state);
-        } catch {
-          /* best effort */
+      const preserveInteractivePanes =
+        event?.reason === "reload" || event?.reason === "resume";
+      if (!preserveInteractivePanes) {
+        // Kill the panes using the already-snapshotted states.
+        // cancelInteractiveSubagentByState is used (not the id-based variant)
+        // because the registry was already cleared above.
+        for (const state of runningStates) {
+          try {
+            cancelInteractiveSubagentByState(state);
+          } catch {
+            /* best effort */
+          }
         }
       }
-
       // Abort all running subagent sessions before clearing
       for (const job of jobRegistry.values()) {
         if (job.status === "running") {
@@ -2943,21 +2971,12 @@ export default function (pi: ExtensionAPI) {
       jobRegistry.clear();
       g2.__piSubagenturaPiRef = undefined;
       g2.__piSubagenturaInjectCount = 0;
-
-      // NEW: clean-slate the state file on /new and quit. On :reload we KEEP
-      // the file so the next session_start can rehydrate from it. Old panes are
-      // killed by the cancelInteractiveSubagent loop above; this just drops the
-      // in-process bookkeeping.
-      if (
-        (event?.reason === "new" || event?.reason === "quit") &&
-        ctx?.cwd &&
-        ctx?.sessionManager?.getSessionId
-      ) {
+      // Clean-slate the state file on /new. On quit we KEEP the file so the
+      // next session_start can rehydrate the sub-agents (their panes survive).
+      // On reload/resume the file is also kept (existing behaviour).
+      if (event?.reason === "new" && ctx?.cwd) {
         try {
-          deleteInteractiveStatesFile(
-            ctx.cwd,
-            ctx.sessionManager.getSessionId(),
-          );
+          deleteInteractiveStatesFile(ctx.cwd);
         } catch {
           /* best effort */
         }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -63,28 +63,32 @@ import {
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import {
-	appendEvent,
-	appendInteractiveState,
-	artifactPath,
-	deleteInteractiveStatesFile,
-	lastEvent,
-	listOutputTurns,
-	loadInteractiveStates,
-	readEvents,
-	readOutput,
-	readOutputForTurn,
-	removeInteractiveState,
-	snapshotOutput,
-	type SubagentArtifact,
-	type SubagentEvent,
+  appendEvent,
+  appendInteractiveState,
+  artifactPath,
+  deleteInteractiveStatesFile,
+  lastEvent,
+  listOutputTurns,
+  loadInteractiveStates,
+  readEvents,
+  readOutput,
+  readOutputForTurn,
+  removeInteractiveState,
+  snapshotOutput,
+  type SubagentArtifact,
+  type SubagentEvent,
 } from "./artifact";
 
 import type { Usage } from "./helpers";
 
-
-
-
-import { closeSync, openSync, readdirSync, readSync, realpathSync, statSync } from "node:fs";
+import {
+  closeSync,
+  openSync,
+  readdirSync,
+  readSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
@@ -589,32 +593,43 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
       const cursor = state.lastDeliveredEventTs ?? 0;
       const events = readEvents(art, cursor + 1);
 
-		if (events.length > 0) {
-			let maxTs = cursor;
-			let deliveredTerminal = false;
-			for (const ev of events) {
-				if (ev.ts > maxTs) maxTs = ev.ts;
-				if (!shouldNotify(ev)) continue;
-				// Track terminal delivery so we can drop the on-disk state entry
-				// AFTER the cursor advances (crash-safe ordering).
-				if (ev.type === "done" || ev.type === "error" || ev.type === "cancelled") {
-					deliveredTerminal = true;
-				}
-				// If auto-done already fired for this turn, skip any later explicit `done` events:
-				// they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
-				if (state.autoDoneForTurnAt !== undefined && ev.ts >= state.autoDoneForTurnAt && ev.type === "done") continue;
-				deliverArtifactNotification(interactivePi, state, ev);
-			}
-			state.lastDeliveredEventTs = maxTs;
-			// Drop the on-disk entry now that the terminal event is delivered.
-			// Cursor advance above is what makes a crash here re-deliver rather
-			// than drop the event on the next reload.
-			if (deliveredTerminal && state.parentSessionId) {
-				try {
-					removeInteractiveState(state.cwd, state.parentSessionId, state.id);
-				} catch { /* best effort — disk full, permission denied, etc. */ }
-			}
-		}
+      if (events.length > 0) {
+        let maxTs = cursor;
+        let deliveredTerminal = false;
+        for (const ev of events) {
+          if (ev.ts > maxTs) maxTs = ev.ts;
+          if (!shouldNotify(ev)) continue;
+          // Track terminal delivery so we can drop the on-disk state entry
+          // AFTER the cursor advances (crash-safe ordering).
+          if (
+            ev.type === "done" ||
+            ev.type === "error" ||
+            ev.type === "cancelled"
+          ) {
+            deliveredTerminal = true;
+          }
+          // If auto-done already fired for this turn, skip any later explicit `done` events:
+          // they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
+          if (
+            state.autoDoneForTurnAt !== undefined &&
+            ev.ts >= state.autoDoneForTurnAt &&
+            ev.type === "done"
+          )
+            continue;
+          deliverArtifactNotification(interactivePi, state, ev);
+        }
+        state.lastDeliveredEventTs = maxTs;
+        // Drop the on-disk entry now that the terminal event is delivered.
+        // Cursor advance above is what makes a crash here re-deliver rather
+        // than drop the event on the next reload.
+        if (deliveredTerminal && state.parentSessionId) {
+          try {
+            removeInteractiveState(state.cwd, state.parentSessionId, state.id);
+          } catch {
+            /* best effort — disk full, permission denied, etc. */
+          }
+        }
+      }
 
       // Per-turn snapshot: on a NEW `done` event, copy the latest output.md into output-N.md so turn
       // history survives the child overwriting output.md each turn. Runs in every notifyOnComplete mode,
@@ -630,8 +645,6 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
         snapshotOutput(art, turnNumber);
         state.lastSnapshotEventTs = last.ts;
       }
-
-
 
       // Inject-mode delivery: on a NEW `done` event, push output.md into the parent LLM's next turn.
       // Per-turn (not per-sub-agent) — `lastInjectedEventTs` is compared against the current `done`'s `ts`
@@ -1248,7 +1261,6 @@ export function findArtifactById(id: string): SubagentArtifact | null {
     }
   }
   return null;
-
 }
 
 /**
@@ -1265,70 +1277,72 @@ export function findArtifactById(id: string): SubagentArtifact | null {
  * the rehydrated states and replays any backlog.
  */
 export function rehydrateInteractiveSubagents(
-	cwd: string,
-	sessionId: string,
+  cwd: string,
+  sessionId: string,
 ): { total: number; alive: number; terminal: number } {
-	const payload = loadInteractiveStates(cwd, sessionId);
-	if (!payload) return { total: 0, alive: 0, terminal: 0 };
-	let alive = 0;
-	let terminal = 0;
-	for (const entry of Object.values(payload.states) as Array<
-		import("./artifact").InteractiveSubagentPersistedStateV1
-	>) {
-		if (interactiveSubagentRegistry.has(entry.id)) continue;
-		const rehydrated: InteractiveSubagentState = {
-			id: entry.id,
-			// Display fields: placeholders. formatInteractiveState is approximate
-			// after rehydrate; the registry entry is enough to address the pane,
-			// which is all the live ops need.
-			name: entry.id,
-			task: "",
-			paneId: entry.paneId,
-			windowName: entry.windowName,
-			mux: entry.mux,
-			muxSession: entry.muxSession,
-			sessionFile: entry.sessionFile,
-			cwd,
-			startedAt: 0,
-			status: "running",
-			attachCommand: "",
-			selectPaneCommand: "",
-			launchScriptFile: "",
-			artifactDir: entry.artifactDir,
-			notifyOnComplete: entry.notifyOnComplete,
-			parentSessionId: sessionId,
-			// All runtime cursors reset (replay-all semantics).
-			lastDeliveredEventTs: 0,
-			lastDeliveredSessionByte: 0,
-			lastInjectedEventTs: undefined,
-			lastSnapshotEventTs: undefined,
-			injected: undefined,
-			autoDoneForTurnAt: undefined,
-			lastStopReason: undefined,
-			lastStopReasonAt: undefined,
-			lastStopText: undefined,
-		};
-		const art = artifactPath(dirname(entry.artifactDir), basename(entry.artifactDir));
-		const last = lastEvent(art);
-		const paneAlive = isPaneAlive(rehydrated);
-		const next = deriveInteractiveSubagentStatus(last, paneAlive);
-		rehydrated.status = next;
-		// For inject-mode orphans, set lastInjectedEventTs to the most recent
-		// event's ts so the existing terminal event is NOT re-injected on the
-		// first poll after rehydrate. Without this, every parent reload would
-		// flood the new parent LLM with user messages for orphans from the
-		// previous session. Future follow-up `done` events (higher ts) on the
-		// same orphan will still inject, which is the right behavior.
-		if (entry.notifyOnComplete === "inject" && last) {
-			rehydrated.lastInjectedEventTs = last.ts;
-		}
-		if (next === "exited" || next === "cancelled") terminal++;
-		else if (next === "running" || next === "idle") alive++;
-		interactiveSubagentRegistry.set(entry.id, rehydrated);
-	}
-	return { total: Object.keys(payload.states).length, alive, terminal };
+  const payload = loadInteractiveStates(cwd, sessionId);
+  if (!payload) return { total: 0, alive: 0, terminal: 0 };
+  let alive = 0;
+  let terminal = 0;
+  for (const entry of Object.values(payload.states) as Array<
+    import("./artifact").InteractiveSubagentPersistedStateV1
+  >) {
+    if (interactiveSubagentRegistry.has(entry.id)) continue;
+    const rehydrated: InteractiveSubagentState = {
+      id: entry.id,
+      // Display fields: placeholders. formatInteractiveState is approximate
+      // after rehydrate; the registry entry is enough to address the pane,
+      // which is all the live ops need.
+      name: entry.id,
+      task: "",
+      paneId: entry.paneId,
+      windowName: entry.windowName,
+      mux: entry.mux,
+      muxSession: entry.muxSession,
+      sessionFile: entry.sessionFile,
+      cwd,
+      startedAt: 0,
+      status: "running",
+      attachCommand: "",
+      selectPaneCommand: "",
+      launchScriptFile: "",
+      artifactDir: entry.artifactDir,
+      notifyOnComplete: entry.notifyOnComplete,
+      parentSessionId: sessionId,
+      // All runtime cursors reset (replay-all semantics).
+      lastDeliveredEventTs: 0,
+      lastDeliveredSessionByte: 0,
+      lastInjectedEventTs: undefined,
+      lastSnapshotEventTs: undefined,
+      injected: undefined,
+      autoDoneForTurnAt: undefined,
+      lastStopReason: undefined,
+      lastStopReasonAt: undefined,
+      lastStopText: undefined,
+    };
+    const art = artifactPath(
+      dirname(entry.artifactDir),
+      basename(entry.artifactDir),
+    );
+    const last = lastEvent(art);
+    const paneAlive = isPaneAlive(rehydrated);
+    const next = deriveInteractiveSubagentStatus(last, paneAlive);
+    rehydrated.status = next;
+    // For inject-mode orphans, set lastInjectedEventTs to the most recent
+    // event's ts so the existing terminal event is NOT re-injected on the
+    // first poll after rehydrate. Without this, every parent reload would
+    // flood the new parent LLM with user messages for orphans from the
+    // previous session. Future follow-up `done` events (higher ts) on the
+    // same orphan will still inject, which is the right behavior.
+    if (entry.notifyOnComplete === "inject" && last) {
+      rehydrated.lastInjectedEventTs = last.ts;
+    }
+    if (next === "exited" || next === "cancelled") terminal++;
+    else if (next === "running" || next === "idle") alive++;
+    interactiveSubagentRegistry.set(entry.id, rehydrated);
+  }
+  return { total: Object.keys(payload.states).length, alive, terminal };
 }
-
 
 function sanitizeOutput(text: string): string {
   return text.replace(
@@ -2212,20 +2226,19 @@ export default function (pi: ExtensionAPI) {
       const name = params.name ?? `Subagent: ${taskPreview || "interactive"}`;
       const targetCwd = params.cwd ?? ctx.cwd;
 
-		try {
-			const state = launchInteractiveSubagent({
-				name,
-				task: params.task,
-				persona: params.persona,
-				model: params.model,
-				cwd: targetCwd,
-				contextText,
-				background: params.background, // defaults to true (hidden) inside the helper
-				notifyOnComplete: params.notifyOnComplete ?? "inject",
-				muxPreference: params.mux, // pass through user's mux preference
-				parentSessionId: ctx.sessionManager.getSessionId(),
-			});
-
+      try {
+        const state = launchInteractiveSubagent({
+          name,
+          task: params.task,
+          persona: params.persona,
+          model: params.model,
+          cwd: targetCwd,
+          contextText,
+          background: params.background, // defaults to true (hidden) inside the helper
+          notifyOnComplete: params.notifyOnComplete ?? "inject",
+          muxPreference: params.mux, // pass through user's mux preference
+          parentSessionId: ctx.sessionManager.getSessionId(),
+        });
 
         const displayMode = state.windowName
           ? "background (new window/tab)"
@@ -2850,61 +2863,63 @@ export default function (pi: ExtensionAPI) {
   // ── Session shutdown: abort all jobs, kill tmux panes, stop the poller ─
   (pi as any).on?.(
     "session_shutdown",
-    (event: { reason?: string }, ctx: { cwd?: string; sessionManager?: { getSessionId?: () => string } }) => {
+    (
+      event: { reason?: string },
+      ctx: { cwd?: string; sessionManager?: { getSessionId?: () => string } },
+    ) => {
       const g2 = typeof global !== "undefined" ? global : globalThis;
 
-
-    // Stop the global poller so it doesn't fire after we're gone. Without
-    // clearInterval the handle would keep the event loop alive across restarts.
-    if (g2.__piSubagenturaInteractivePollerHandle) {
-      try {
-        clearInterval(g2.__piSubagenturaInteractivePollerHandle);
-      } catch {
-        /* defensive */
+      // Stop the global poller so it doesn't fire after we're gone. Without
+      // clearInterval the handle would keep the event loop alive across restarts.
+      if (g2.__piSubagenturaInteractivePollerHandle) {
+        try {
+          clearInterval(g2.__piSubagenturaInteractivePollerHandle);
+        } catch {
+          /* defensive */
+        }
+        g2.__piSubagenturaInteractivePollerHandle = undefined;
       }
-      g2.__piSubagenturaInteractivePollerHandle = undefined;
-    }
-    // Snapshot running state objects BEFORE clearing, so we can kill their panes
-    // after the registry is empty. We can't call cancelInteractiveSubagent(id)
-    // after clear() because it looks up state from the registry (line 533 of
-    // interactive-tmux.ts) and returns undefined.
-    const runningStates: InteractiveSubagentState[] = [];
-    for (const state of interactiveSubagentRegistry.values()) {
-      if (state.status === "running") runningStates.push(state);
-    }
+      // Snapshot running state objects BEFORE clearing, so we can kill their panes
+      // after the registry is empty. We can't call cancelInteractiveSubagent(id)
+      // after clear() because it looks up state from the registry (line 533 of
+      // interactive-tmux.ts) and returns undefined.
+      const runningStates: InteractiveSubagentState[] = [];
+      for (const state of interactiveSubagentRegistry.values()) {
+        if (state.status === "running") runningStates.push(state);
+      }
 
-    // Drop in-memory state FIRST. An in-flight poll tick (dequeued from
-    // setInterval before clearInterval ran) finds an empty registry and its
-    // for-loop iterates over zero entries — no work, no notification delivery.
-    // `__piSubagenturaPiRef` is still valid at this point (cleared later), so
-    // the tick proceeds into the loop and finds nothing.
-    try {
-      interactiveSubagentRegistry.clear();
-    } catch {
-      /* best effort */
-    }
-
-    // Kill the panes using the snapshotted states. The poller is already safe
-    // (registry empty). We use cancelInteractiveSubagentByState (not the
-    // id-based variant) because the registry is already cleared.
-    for (const state of runningStates) {
+      // Drop in-memory state FIRST. An in-flight poll tick (dequeued from
+      // setInterval before clearInterval ran) finds an empty registry and its
+      // for-loop iterates over zero entries — no work, no notification delivery.
+      // `__piSubagenturaPiRef` is still valid at this point (cleared later), so
+      // the tick proceeds into the loop and finds nothing.
       try {
-        cancelInteractiveSubagentByState(state);
+        interactiveSubagentRegistry.clear();
       } catch {
         /* best effort */
       }
-    }
 
-    // Abort all running subagent sessions before clearing
-    for (const job of jobRegistry.values()) {
-      if (job.status === "running") {
+      // Kill the panes using the snapshotted states. The poller is already safe
+      // (registry empty). We use cancelInteractiveSubagentByState (not the
+      // id-based variant) because the registry is already cleared.
+      for (const state of runningStates) {
         try {
-          job.session.abort().catch(() => {});
+          cancelInteractiveSubagentByState(state);
         } catch {
-          /* session may already be disposed */
+          /* best effort */
         }
       }
-    }
+
+      // Abort all running subagent sessions before clearing
+      for (const job of jobRegistry.values()) {
+        if (job.status === "running") {
+          try {
+            job.session.abort().catch(() => {});
+          } catch {
+            /* session may already be disposed */
+          }
+        }
+      }
       jobRegistry.clear();
       g2.__piSubagenturaPiRef = undefined;
       g2.__piSubagenturaInjectCount = 0;
@@ -2919,7 +2934,10 @@ export default function (pi: ExtensionAPI) {
         ctx?.sessionManager?.getSessionId
       ) {
         try {
-          deleteInteractiveStatesFile(ctx.cwd, ctx.sessionManager.getSessionId());
+          deleteInteractiveStatesFile(
+            ctx.cwd,
+            ctx.sessionManager.getSessionId(),
+          );
         } catch {
           /* best effort */
         }
@@ -2928,29 +2946,23 @@ export default function (pi: ExtensionAPI) {
   );
 }
 
-
-
-
 // ── Re-exports ───────────────────────────────────────────────────────
 // Re-export helpers so external consumers (e.g. tests importing from subagent.ts)
 // don't need to know about the internal helpers.ts split.
 export {
-	formatUsage,
-	SubagentResult,
-	SubagentLiveStatus,
-	ACTIVE_TOOL_DEBOUNCE_MS,
-	// ── Async exports ──
-	jobRegistry,
-	MAX_REGISTRY_SIZE,
-	pruneOldestJob,
-	pruneCompletedJobs,
-	scheduleJobCleanup,
-	startSubagentJob,
-	type JobState,
-	type JobStatus,
-	type NotifyOnComplete,
+  formatUsage,
+  SubagentResult,
+  SubagentLiveStatus,
+  ACTIVE_TOOL_DEBOUNCE_MS,
+  // ── Async exports ──
+  jobRegistry,
+  MAX_REGISTRY_SIZE,
+  pruneOldestJob,
+  pruneCompletedJobs,
+  scheduleJobCleanup,
+  startSubagentJob,
+  type JobState,
+  type JobStatus,
+  type NotifyOnComplete,
 } from "./helpers";
 export { interactiveSubagentRegistry } from "./interactive-tmux";
-
-
-

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -63,27 +63,24 @@ import {
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import {
-  appendEvent,
-  artifactPath,
-  lastEvent,
-  listOutputTurns,
-  readEvents,
-  readOutput,
-  readOutputForTurn,
-  snapshotOutput,
-  type SubagentArtifact,
-  type SubagentEvent,
+	appendEvent,
+	appendInteractiveState,
+	artifactPath,
+	lastEvent,
+	listOutputTurns,
+	readEvents,
+	readOutput,
+	readOutputForTurn,
+	removeInteractiveState,
+	snapshotOutput,
+	type SubagentArtifact,
+	type SubagentEvent,
 } from "./artifact";
+
 import type { Usage } from "./helpers";
 
-import {
-  closeSync,
-  openSync,
-  readdirSync,
-  readSync,
-  realpathSync,
-  statSync,
-} from "node:fs";
+import { closeSync, openSync, readdirSync, readSync, realpathSync, statSync } from "node:fs";
+
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
@@ -587,23 +584,32 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
       const cursor = state.lastDeliveredEventTs ?? 0;
       const events = readEvents(art, cursor + 1);
 
-      if (events.length > 0) {
-        let maxTs = cursor;
-        for (const ev of events) {
-          if (ev.ts > maxTs) maxTs = ev.ts;
-          if (!shouldNotify(ev)) continue;
-          // If auto-done already fired for this turn, skip any later explicit `done` events:
-          // they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
-          if (
-            state.autoDoneForTurnAt !== undefined &&
-            ev.ts >= state.autoDoneForTurnAt &&
-            ev.type === "done"
-          )
-            continue;
-          deliverArtifactNotification(interactivePi, state, ev);
-        }
-        state.lastDeliveredEventTs = maxTs;
-      }
+		if (events.length > 0) {
+			let maxTs = cursor;
+			let deliveredTerminal = false;
+			for (const ev of events) {
+				if (ev.ts > maxTs) maxTs = ev.ts;
+				if (!shouldNotify(ev)) continue;
+				// Track terminal delivery so we can drop the on-disk state entry
+				// AFTER the cursor advances (crash-safe ordering).
+				if (ev.type === "done" || ev.type === "error" || ev.type === "cancelled") {
+					deliveredTerminal = true;
+				}
+				// If auto-done already fired for this turn, skip any later explicit `done` events:
+				// they would be duplicates. Errors and cancelled still flow through (the explicit signal is more accurate).
+				if (state.autoDoneForTurnAt !== undefined && ev.ts >= state.autoDoneForTurnAt && ev.type === "done") continue;
+				deliverArtifactNotification(interactivePi, state, ev);
+			}
+			state.lastDeliveredEventTs = maxTs;
+			// Drop the on-disk entry now that the terminal event is delivered.
+			// Cursor advance above is what makes a crash here re-deliver rather
+			// than drop the event on the next reload.
+			if (deliveredTerminal && state.parentSessionId) {
+				try {
+					removeInteractiveState(state.cwd, state.parentSessionId, state.id);
+				} catch { /* best effort — disk full, permission denied, etc. */ }
+			}
+		}
 
       // Per-turn snapshot: on a NEW `done` event, copy the latest output.md into output-N.md so turn
       // history survives the child overwriting output.md each turn. Runs in every notifyOnComplete mode,
@@ -619,6 +625,8 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
         snapshotOutput(art, turnNumber);
         state.lastSnapshotEventTs = last.ts;
       }
+
+
 
       // Inject-mode delivery: on a NEW `done` event, push output.md into the parent LLM's next turn.
       // Per-turn (not per-sub-agent) — `lastInjectedEventTs` is compared against the current `done`'s `ts`
@@ -2111,18 +2119,20 @@ export default function (pi: ExtensionAPI) {
       const name = params.name ?? `Subagent: ${taskPreview || "interactive"}`;
       const targetCwd = params.cwd ?? ctx.cwd;
 
-      try {
-        const state = launchInteractiveSubagent({
-          name,
-          task: params.task,
-          persona: params.persona,
-          model: params.model,
-          cwd: targetCwd,
-          contextText,
-          background: params.background, // defaults to true (hidden) inside the helper
-          notifyOnComplete: params.notifyOnComplete ?? "inject",
-          muxPreference: params.mux, // pass through user's mux preference
-        });
+		try {
+			const state = launchInteractiveSubagent({
+				name,
+				task: params.task,
+				persona: params.persona,
+				model: params.model,
+				cwd: targetCwd,
+				contextText,
+				background: params.background, // defaults to true (hidden) inside the helper
+				notifyOnComplete: params.notifyOnComplete ?? "inject",
+				muxPreference: params.mux, // pass through user's mux preference
+				parentSessionId: ctx.sessionManager.getSessionId(),
+			});
+
 
         const displayMode = state.windowName
           ? "background (new window/tab)"
@@ -2810,19 +2820,20 @@ export default function (pi: ExtensionAPI) {
 // Re-export helpers so external consumers (e.g. tests importing from subagent.ts)
 // don't need to know about the internal helpers.ts split.
 export {
-  formatUsage,
-  SubagentResult,
-  SubagentLiveStatus,
-  ACTIVE_TOOL_DEBOUNCE_MS,
-  // ── Async exports ──
-  jobRegistry,
-  MAX_REGISTRY_SIZE,
-  pruneOldestJob,
-  pruneCompletedJobs,
-  scheduleJobCleanup,
-  startSubagentJob,
-  type JobState,
-  type JobStatus,
-  type NotifyOnComplete,
+	formatUsage,
+	SubagentResult,
+	SubagentLiveStatus,
+	ACTIVE_TOOL_DEBOUNCE_MS,
+	// ── Async exports ──
+	jobRegistry,
+	MAX_REGISTRY_SIZE,
+	pruneOldestJob,
+	pruneCompletedJobs,
+	scheduleJobCleanup,
+	startSubagentJob,
+	type JobState,
+	type JobStatus,
+	type NotifyOnComplete,
 } from "./helpers";
 export { interactiveSubagentRegistry } from "./interactive-tmux";
+

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -2950,7 +2950,9 @@ export default function (pi: ExtensionAPI) {
       }
 
       const preserveInteractivePanes =
-        event?.reason === "reload" || event?.reason === "resume";
+        event?.reason === "reload" ||
+        event?.reason === "resume" ||
+        event?.reason === "quit";
       if (!preserveInteractivePanes) {
         // Kill the panes using the already-snapshotted states.
         // cancelInteractiveSubagentByState is used (not the id-based variant)
@@ -2976,7 +2978,7 @@ export default function (pi: ExtensionAPI) {
       jobRegistry.clear();
       g2.__piSubagenturaPiRef = undefined;
       g2.__piSubagenturaInjectCount = 0;
-      // Clean-slate the state file on /new. On quit we KEEP the file so the
+      // Clean-slate the state file on /new. On quit/reload/resume we KEEP the file so the
       // next session_start can rehydrate the sub-agents (their panes survive).
       if (event?.reason === "new" && ctx?.cwd) {
         try {

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -66,8 +66,10 @@ import {
 	appendEvent,
 	appendInteractiveState,
 	artifactPath,
+	deleteInteractiveStatesFile,
 	lastEvent,
 	listOutputTurns,
+	loadInteractiveStates,
 	readEvents,
 	readOutput,
 	readOutputForTurn,
@@ -78,6 +80,9 @@ import {
 } from "./artifact";
 
 import type { Usage } from "./helpers";
+
+
+
 
 import { closeSync, openSync, readdirSync, readSync, realpathSync, statSync } from "node:fs";
 
@@ -1243,8 +1248,79 @@ export function findArtifactById(id: string): SubagentArtifact | null {
     }
   }
   return null;
+
 }
-/** Sanitize a string by redacting common sensitive patterns (API keys, tokens, JWTs). */
+
+/**
+ * Rehydrate orphan interactive sub-agents from the on-disk state file.
+ *
+ * Reads <cwd>/.pi/subagentura-state-<sessionId>.json, reconstructs each
+ * InteractiveSubagentState, sets its status via the existing
+ * deriveInteractiveSubagentStatus matrix (lastEvent + isPaneAlive), registers
+ * it, and resets runtime cursors so the existing poller backlog-catch-up path
+ * replays any events that landed during downtime.
+ *
+ * Idempotent — skips ids already in the registry. Designed to be called from
+ * the session_start handler. The first poll tick after this returns sees
+ * the rehydrated states and replays any backlog.
+ */
+export function rehydrateInteractiveSubagents(
+	cwd: string,
+	sessionId: string,
+): { total: number; alive: number; terminal: number } {
+	const payload = loadInteractiveStates(cwd, sessionId);
+	if (!payload) return { total: 0, alive: 0, terminal: 0 };
+	let alive = 0;
+	let terminal = 0;
+	for (const entry of Object.values(payload.states) as Array<
+		import("./artifact").InteractiveSubagentPersistedStateV1
+	>) {
+		if (interactiveSubagentRegistry.has(entry.id)) continue;
+		const rehydrated: InteractiveSubagentState = {
+			id: entry.id,
+			// Display fields: placeholders. formatInteractiveState is approximate
+			// after rehydrate; the registry entry is enough to address the pane,
+			// which is all the live ops need.
+			name: entry.id,
+			task: "",
+			paneId: entry.paneId,
+			windowName: entry.windowName,
+			mux: entry.mux,
+			muxSession: entry.muxSession,
+			sessionFile: entry.sessionFile,
+			cwd,
+			startedAt: 0,
+			status: "running",
+			attachCommand: "",
+			selectPaneCommand: "",
+			launchScriptFile: "",
+			artifactDir: entry.artifactDir,
+			notifyOnComplete: entry.notifyOnComplete,
+			parentSessionId: sessionId,
+			// All runtime cursors reset (replay-all semantics).
+			lastDeliveredEventTs: 0,
+			lastDeliveredSessionByte: 0,
+			lastInjectedEventTs: undefined,
+			lastSnapshotEventTs: undefined,
+			injected: undefined,
+			autoDoneForTurnAt: undefined,
+			lastStopReason: undefined,
+			lastStopReasonAt: undefined,
+			lastStopText: undefined,
+		};
+		const art = artifactPath(dirname(entry.artifactDir), basename(entry.artifactDir));
+		const last = lastEvent(art);
+		const paneAlive = isPaneAlive(rehydrated);
+		const next = deriveInteractiveSubagentStatus(last, paneAlive);
+		rehydrated.status = next;
+		if (next === "exited" || next === "cancelled") terminal++;
+		else if (next === "running" || next === "idle") alive++;
+		interactiveSubagentRegistry.set(entry.id, rehydrated);
+	}
+	return { total: Object.keys(payload.states).length, alive, terminal };
+}
+
+
 function sanitizeOutput(text: string): string {
   return text.replace(
     /(sk-[A-Za-z0-9]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|sk-ant-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|-----BEGIN[\s\w]+KEY-----|AKIA[\w]{16}|ghp_[\w]{36}|gho_[\w]{36}|ghu_[\w]{36}|xox[abp]-[\w-]+|AIza[\w-]{35}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})/g,
@@ -1309,7 +1385,15 @@ export default function (pi: ExtensionAPI) {
   // which is the same pi the poller uses via __piSubagenturaPiRef.
   pi.on("session_start", (_event, ctx) => {
     g2.__piSubagenturaUi = ctx.ui;
+    // NEW: rehydrate orphan interactive sub-agents from the state file so the
+    // parent's view of them survives a :reload / extension restart / parent crash.
+    try {
+      rehydrateInteractiveSubagents(ctx.cwd, ctx.sessionManager.getSessionId());
+    } catch {
+      /* best effort — rehydrate is a recovery path; failures fall back to empty registry */
+    }
   });
+
   pi.on("session_shutdown", () => {
     // Don't null the ui ref here — the poller may still fire one last tick on shutdown,
     // and stale ctx errors are already caught at the call sites.
@@ -2755,8 +2839,11 @@ export default function (pi: ExtensionAPI) {
   });
 
   // ── Session shutdown: abort all jobs, kill tmux panes, stop the poller ─
-  (pi as any).on?.("session_shutdown", () => {
-    const g2 = typeof global !== "undefined" ? global : globalThis;
+  (pi as any).on?.(
+    "session_shutdown",
+    (event: { reason?: string }, ctx: { cwd?: string; sessionManager?: { getSessionId?: () => string } }) => {
+      const g2 = typeof global !== "undefined" ? global : globalThis;
+
 
     // Stop the global poller so it doesn't fire after we're gone. Without
     // clearInterval the handle would keep the event loop alive across restarts.
@@ -2809,12 +2896,31 @@ export default function (pi: ExtensionAPI) {
         }
       }
     }
+      jobRegistry.clear();
+      g2.__piSubagenturaPiRef = undefined;
+      g2.__piSubagenturaInjectCount = 0;
 
-    jobRegistry.clear();
-    g2.__piSubagenturaPiRef = undefined;
-    g2.__piSubagenturaInjectCount = 0;
-  });
+      // NEW: clean-slate the state file on /new and quit. On :reload we KEEP
+      // the file so the next session_start can rehydrate from it. Old panes are
+      // killed by the cancelInteractiveSubagent loop above; this just drops the
+      // in-process bookkeeping.
+      if (
+        (event?.reason === "new" || event?.reason === "quit") &&
+        ctx?.cwd &&
+        ctx?.sessionManager?.getSessionId
+      ) {
+        try {
+          deleteInteractiveStatesFile(ctx.cwd, ctx.sessionManager.getSessionId());
+        } catch {
+          /* best effort */
+        }
+      }
+    },
+  );
 }
+
+
+
 
 // ── Re-exports ───────────────────────────────────────────────────────
 // Re-export helpers so external consumers (e.g. tests importing from subagent.ts)
@@ -2836,4 +2942,6 @@ export {
 	type NotifyOnComplete,
 } from "./helpers";
 export { interactiveSubagentRegistry } from "./interactive-tmux";
+
+
 

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1365,7 +1365,7 @@ export function rehydrateInteractiveSubagents(
       launchScriptFile: "",
       artifactDir: entry.artifactDir,
       notifyOnComplete: entry.notifyOnComplete,
-      parentSessionId: "pi",
+      parentSessionId: entry.parentSessionId ?? "pi",
       // All runtime cursors reset (replay-all semantics).
       lastDeliveredEventTs: 0,
       lastDeliveredSessionByte: 0,
@@ -1381,15 +1381,13 @@ export function rehydrateInteractiveSubagents(
     const paneAlive = isPaneAlive(rehydrated);
     const next = deriveInteractiveSubagentStatus(last, paneAlive);
     rehydrated.status = next;
-    // For inject-mode orphans, set lastInjectedEventTs to the most recent
-    // event's ts so the existing terminal event is NOT re-injected on the
-    // first poll after rehydrate. Without this, every parent reload would
-    // flood the new parent LLM with user messages for orphans from the
-    // previous session. Future follow-up `done` events (higher ts) on the
-    // same orphan will still inject, which is the right behavior.
-    if (entry.notifyOnComplete === "inject" && last) {
-      rehydrated.lastInjectedEventTs = last.ts;
-    }
+    // Deliberately do NOT suppress re-injection here. The inject-mode path
+    // fires on every NEW `done` event (line 682, `lastInjectedEventTs !== last.ts`).
+    // On rehydrate, cursors are reset to 0 and lastInjectedEventTs starts as undefined,
+    // so the first poll will re-inject the latest terminal event for inject-mode orphans.
+    // This means exactly one extra inject per sub-agent on parent reload, which is
+    // acceptable — it's better than silently dropping a result that completed during
+    // the reload downtime (the pre-fix behavior).
     if (next === "exited" || next === "cancelled") terminal++;
     else if (next === "running" || next === "idle") alive++;
     interactiveSubagentRegistry.set(entry.id, rehydrated);
@@ -2300,6 +2298,7 @@ export default function (pi: ExtensionAPI) {
           background: params.background, // defaults to true (hidden) inside the helper
           notifyOnComplete: params.notifyOnComplete ?? "inject",
           muxPreference: params.mux, // pass through user's mux preference
+          parentCwd: ctx.cwd,
           parentSessionId: ctx.sessionManager.getSessionId(),
         });
 

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1461,12 +1461,13 @@ export default function (pi: ExtensionAPI) {
   // which is the same pi the poller uses via __piSubagenturaPiRef.
   pi.on("session_start", (event, ctx) => {
     g2.__piSubagenturaUi = ctx.ui;
-    // Rehydrate orphan interactive sub-agents from the state file ONLY on reload/resume.
+    // Rehydrate on startup (resumed session after quit), reload, and resume.
     // The session ID filter ensures only subagents created in this specific session
-    // are rehydrated — not subagents from a different session that survived a quit.
-    // On explicit fresh starts (new, fork) we also skip rehydration.
+    // are rehydrated. On 'new' and 'fork' we skip — those are explicit fresh starts.
     const shouldRehydrate =
-      event.reason === "reload" || event.reason === "resume";
+      event.reason === "startup" ||
+      event.reason === "reload" ||
+      event.reason === "resume";
     if (shouldRehydrate) {
       try {
         rehydrateInteractiveSubagents(

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1294,7 +1294,10 @@ export function findArtifactById(id: string): SubagentArtifact | null {
  * the session_start handler. The first poll tick after this returns sees
  * the rehydrated states and replays any backlog.
  */
-export function rehydrateInteractiveSubagents(cwd: string): {
+export function rehydrateInteractiveSubagents(
+  cwd: string,
+  currentSessionId?: string,
+): {
   total: number;
   alive: number;
   terminal: number;
@@ -1306,6 +1309,9 @@ export function rehydrateInteractiveSubagents(cwd: string): {
   for (const entry of Object.values(payload.states) as Array<
     import("./artifact").InteractiveSubagentPersistedStateV1
   >) {
+    if (entry.parentSessionId && entry.parentSessionId !== currentSessionId) {
+      continue;
+    }
     if (interactiveSubagentRegistry.has(entry.id)) continue;
     // ── Recover display fields from on-disk files ──
     // Recovery is best-effort and must never throw; on missing files we
@@ -1455,16 +1461,18 @@ export default function (pi: ExtensionAPI) {
   // which is the same pi the poller uses via __piSubagenturaPiRef.
   pi.on("session_start", (event, ctx) => {
     g2.__piSubagenturaUi = ctx.ui;
-    // Rehydrate orphan interactive sub-agents on startup (survived a quit), reload, and resume.
-    // On explicit fresh starts (new, fork) we skip rehydration — those sessions want a clean slate.
-    // subagents should not pollute the new session's view.
+    // Rehydrate orphan interactive sub-agents from the state file ONLY on reload/resume.
+    // The session ID filter ensures only subagents created in this specific session
+    // are rehydrated — not subagents from a different session that survived a quit.
+    // On explicit fresh starts (new, fork) we also skip rehydration.
     const shouldRehydrate =
-      event.reason === "startup" ||
-      event.reason === "reload" ||
-      event.reason === "resume";
+      event.reason === "reload" || event.reason === "resume";
     if (shouldRehydrate) {
       try {
-        rehydrateInteractiveSubagents(ctx.cwd);
+        rehydrateInteractiveSubagents(
+          ctx.cwd,
+          ctx.sessionManager?.getSessionId?.(),
+        );
       } catch {
         /* best effort — rehydrate is a recovery path; failures fall back to empty registry */
       }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1288,12 +1288,36 @@ export function rehydrateInteractiveSubagents(
     import("./artifact").InteractiveSubagentPersistedStateV1
   >) {
     if (interactiveSubagentRegistry.has(entry.id)) continue;
+    // ── Recover display fields from on-disk files ──
+    // Recovery is best-effort and must never throw; on missing files we
+    // fall back to placeholder values (entry.id for name, 0 for startedAt).
+    const art = artifactPath(
+      dirname(entry.artifactDir),
+      basename(entry.artifactDir),
+    );
+
+    let recoveredName: string;
+    try {
+      const files = readdirSync(entry.artifactDir);
+      const promptFile = files.find((f) => f.endsWith("-prompt.md"));
+      recoveredName = promptFile
+        ? promptFile.slice(0, -"-prompt.md".length)
+        : entry.id;
+    } catch {
+      recoveredName = entry.id;
+    }
+
+    let startedAt: number;
+    try {
+      const events = readEvents(art);
+      startedAt = events.length > 0 ? events[0].ts : 0;
+    } catch {
+      startedAt = 0;
+    }
+
     const rehydrated: InteractiveSubagentState = {
       id: entry.id,
-      // Display fields: placeholders. formatInteractiveState is approximate
-      // after rehydrate; the registry entry is enough to address the pane,
-      // which is all the live ops need.
-      name: entry.id,
+      name: recoveredName,
       task: "",
       paneId: entry.paneId,
       windowName: entry.windowName,
@@ -1301,7 +1325,7 @@ export function rehydrateInteractiveSubagents(
       muxSession: entry.muxSession,
       sessionFile: entry.sessionFile,
       cwd,
-      startedAt: 0,
+      startedAt,
       status: "running",
       attachCommand: "",
       selectPaneCommand: "",
@@ -1320,10 +1344,6 @@ export function rehydrateInteractiveSubagents(
       lastStopReasonAt: undefined,
       lastStopText: undefined,
     };
-    const art = artifactPath(
-      dirname(entry.artifactDir),
-      basename(entry.artifactDir),
-    );
     const last = lastEvent(art);
     const paneAlive = isPaneAlive(rehydrated);
     const next = deriveInteractiveSubagentStatus(last, paneAlive);


### PR DESCRIPTION
## Summary

When a parent Pi process reloads (extension restart, parent crash) while a tmux/zellij-backed interactive sub-agent is still alive, the parent's view of the sub-agent is wiped. The pane is still alive in the mux, the artifact on disk is intact, but the in-memory registry is gone — so `get_interactive_subagent_status`, `send_interactive_subagent_message`, `cancel_interactive_subagent`, and the poller's notification path all return `not_found` for the orphan.

This PR adds per-session persistence to project-local `.pi/` so the next `session_start` rehydrates the registry, the existing poller backlog-catch-up replays events that landed during downtime, and the user sees their orphans with their full state intact.

## Design

**File layout** — per (cwd, sessionId), one file:
```
<cwd>/.pi/subagentura-state-<sessionId>.json
```
`sessionId` comes from `ctx.sessionManager.getSessionId()` (stable across `:reload`/`:resume`, fresh on `/new`). One file per parent session means multiple pi instances in the same cwd don't clobber each other.

**Schema (v1)** — 8 fields per entry, the minimum to call `sendCommandToPane`, `isPaneAlive`, `cancelInteractiveSubagent`, and the poller's `tailReadSessionLog`: id, paneId, windowName?, mux, muxSession?, artifactDir, sessionFile, notifyOnComplete?.

**Cursor reset on rehydrate** — `lastDeliveredEventTs=0`, `lastInjectedEventTs=...`, all runtime cursors reset so the existing backlog-catch-up path replays events. For inject-mode orphans, `lastInjectedEventTs` is set to the latest event's ts so the existing terminal event is treated as already-injected (no flood of user messages on the new parent LLM).

**Cleanup-on-terminal** — the poller removes the file entry after delivering a done/error/cancelled event. Cursor advance precedes the file rewrite (crash-safe).

## Changes since initial review

- **Real display fields on rehydrate**: `name` is now recovered from the prompt file label in the artifact directory (fallback: entry id). `startedAt` is recovered from the first event's timestamp in `events.ndjson` (fallback: `0`). A rehydrated sub-agent no longer shows placeholders in `get_interactive_subagent_status`.
- **Documented concurrency invariant**: Added `SAFETY` comments above `appendInteractiveState` / `removeInteractiveState` explaining the single-event-loop assumption.
- **Schema-version warning**: `loadInteractiveStates` now logs a `debugLog("warn", ...)` when rejecting an unknown schema version, so a future schema change is visible in debug output.