### PR TITLE
test: harden release and maintenance checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,9 @@ jobs:
             exit 1
           fi
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
       - name: "Verify published tarball is loadable (regression: v2.0.0 missing helpers.ts)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ A public [Pi](https://pi.dev) extension that adds in-process and attachable sub-
 - **Pi extension** — single entry point: `./src/subagent.ts` (declared in `package.json#pi.extensions`).
 - **TypeScript, ESM, strict mode**, `target: ESNext`, Node ≥ 18.
 - **Runtime deps** are minimal: `ndjson`, `is-path-inside`. Pi SDKs are peer dependencies.
-- **Tests** are `vitest` and live next to source as `*.test.ts` (20 test files, ~7000 lines of test code).
+- **Tests** are `vitest` and live in `tests/` as `*.test.ts` (27 test files, ~12k lines of test code).
 - **CI** is a single GitHub Actions workflow: typecheck → tests → published-tarball smoke → pack dry-run.
 
 ## Build / test / verify
@@ -26,21 +26,29 @@ The pre-push hook (`simple-git-hooks` → `lint-staged` → `prettier --check`) 
 
 ## Source layout (the 30-second tour)
 
-| File                           | Purpose                                                                                                                                                                             |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/subagent.ts`              | **Main entry.** ~2.5k LOC. All tool registration, the auto-done fallback, the per-turn snapshot logic, the interactive sub-agent poller. Most of the project's behavior lives here. |
-| `src/helpers.ts`               | `startSubagentJob` primitive (in-process sub-agent runner), `resolveModel`, `findSubagentArtifact` for the `read_subagent_artifact` tool.                                           |
-| `src/artifact.ts`              | The on-disk artifact protocol: `events.ndjson`, `output.md`, `output-N.md` snapshots, atomic writes via `*.tmp` + `renameSync`.                                                     |
-| `src/interactive-tmux.ts`      | Spawns `pi --session ...` in a tmux pane; provides `send_interactive_subagent_message` and the follow-up-turn machinery.                                                            |
-| `src/multiplexer*.ts`          | Pluggable multiplexer backend. tmux and zellij. The registry lets us detect the host's available backend at runtime.                                                                |
-| `src/subagent-artifact-cli.ts` | The tiny `cli.mjs` wrapper that the child shells out to. The protocol is: write `output.md`, then call `cli.mjs done N`.                                                            |
-| `src/workflow.ts`              | The `workflow` tool (v1, on `feat/workflow-tool` branch — see "Known quirks" below).                                                                                                |
-| `src/test-utils.ts`            | `importFresh` helper used by tests that need to reset module-level state (interactive sub-agent registry, mux mock, etc.).                                                          |
+| File                           | Purpose                                                                                                                                                                                                           |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/subagent.ts`              | **Entrypoint/barrel.** ~100 LOC. Default export registers all tool groups and session handlers; re-exports internals for test access.                                                                             |
+| `src/tools/in-process.ts`      | `subagent_with_context`, `subagent_isolated`, async job management tools (`get_subagent_status`, `get_subagent_result`, `cancel_subagent`, `prune_subagent_jobs`), and `list_available_models`.                   |
+| `src/tools/interactive.ts`     | Interactive sub-agent tools (`subagent_interactive`, `get_interactive_subagent_status`, `cancel_interactive_subagent`, `send_interactive_subagent_message`, `list_subagent_artifacts`, `read_subagent_artifact`). |
+| `src/session-handlers.ts`      | `session_start`/`session_shutdown` handlers; poller interval setup/teardown on extension load/reload/shutdown.                                                                                                    |
+| `src/artifact-poller.ts`       | Per-tick artifact walk, session-JSONL tail-reading, `tool_activity` event appending, auto-done fallback, and notification delivery.                                                                               |
+| `src/rehydrate.ts`             | Reconstruct `InteractiveSubagentState` from on-disk state file on session start/reload/resume. Idempotent; resets cursors for backlog replay.                                                                     |
+| `src/helpers.ts`               | `startSubagentJob` primitive (in-process sub-agent runner), `resolveModel`, `formatUsage`, job registry and cleanup.                                                                                              |
+| `src/artifact.ts`              | On-disk artifact protocol: `events.ndjson`, `output.md`, `output-N.md` snapshots, atomic writes via `*.tmp` + `renameSync`, state file helpers.                                                                   |
+| `src/interactive-tmux.ts`      | `InteractiveSubagentState` and registry, launch-script builder, mux backend dispatch (is-alive, send-keys, kill-pane).                                                                                            |
+| `src/multiplexer*.ts`          | Pluggable multiplexer interface + tmux and zellij backends. Registry auto-detects available backend at runtime.                                                                                                   |
+| `src/subagent-artifact-cli.ts` | Tiny `cli.mjs` wrapper called by the child: `cli.mjs done N` / `cli.mjs error "msg"`.                                                                                                                             |
+| `src/notifications.ts`         | Notification delivery (notify/inject), `MAX_INJECT` concurrent cap, inject-count tracking.                                                                                                                        |
+| `src/rendering.ts`             | TUI rendering helpers: `renderSubagentCall`, `renderSubagentResult`, `renderInteractiveStateSummary`.                                                                                                             |
+| `src/schemas.ts`               | TypeBox schemas for tool parameter validation (`BaseParams`, `InteractiveParams`, etc.).                                                                                                                          |
+| `src/workflow.ts`              | The `workflow` tool (v1, on `feat/workflow-tool` branch — see "Known quirks" below).                                                                                                                              |
+| `src/test-utils.ts`            | `importFresh` helper used by tests to reset module-level state (interactive sub-agent registry, mux mock, etc.).                                                                                                  |
 
 ## Code conventions
 
 - **Follow existing project style.** This codebase uses 2-space indents, double quotes, semicolons, trailing commas, and ~80-char lines (matches prettier defaults with `{}` config). Don't reformat unrelated code.
-- **Functions under ~50 lines** is the soft guideline; the per-tool block in `subagent.ts` and the per-test `it()` blocks run longer when they need to.
+- **Functions under ~50 lines** is the soft guideline; the per-tool blocks in `src/tools/in-process.ts` and `src/tools/interactive.ts`, and the per-test `it()` blocks run longer when they need to.
 - **Comments only for non-obvious logic** — protocol invariants, the "why" of a guard, the "what this is NOT" of a deliberate limitation. No restating the code.
 - **Declare all variables BEFORE conditional blocks that may return early.** `const`/`let` are hoisted into the TDZ; `if (cond) { return ... }` references before declaration throw at runtime. TypeScript's `no-use-before-define` (strict mode) catches this.
 - **Errors must be explicit.** No silent `catch {}`. If you must swallow, comment why. `try { ... } catch { /* reason */ }` is the pattern.
@@ -50,13 +58,13 @@ The pre-push hook (`simple-git-hooks` → `lint-staged` → `prettier --check`) 
 
 These are non-obvious behaviors that have bitten people. Read them before touching the relevant code.
 
-### The auto-done-fallback (`src/subagent.ts` → `maybeAutoDone`)
+### The auto-done-fallback (`src/artifact-poller.ts` → `maybeAutoDone`)
 
 The `auto-done-fallback` synthesizes a completion event when a child ends a turn with `stopReason: "stop"` but never calls `cli.mjs done` (a common LLM failure mode). It is **time-bounded** by `AUTO_DONE_DEBOUNCE_MS` (10s default).
 
 **The guard is `readEvents(art).some(ev => isTerminal(ev))`, NOT `lastEvent(art)`.** This was a real bug: `tailReadSessionLog` runs immediately before the fallback and can append `tool_activity` rows to `events.ndjson` _after_ the child's explicit `done`. `lastEvent` would then return a `tool_activity` and the guard would miss, causing a double-notify. See commit `01cd745` for the postmortem and the regression test. **Do not "simplify" this back to `lastEvent()`.**
 
-### `lastDeliveredEventTs` is the only poller cursor
+### `lastDeliveredEventTs` is the only poller cursor (`src/artifact-poller.ts`)
 
 Every notification delivery advances `state.lastDeliveredEventTs` to the highest `ev.ts` it delivered. The next poll calls `readEvents(art, cursor + 1)`. **Never read events without going through this cursor** — you will re-deliver notifications and double-fire.
 
@@ -123,7 +131,7 @@ Future follow-up `done` events (higher ts) still inject normally.
 - **One concern per commit.** Bug fixes and the tests that prove them go in the same commit. A doc clarification of a previous fix is a separate commit.
 - **Never force-push to `master`.** Feature branches are disposable; the trunk is not.
 - **Branch naming**: `feat/<short-desc>`, `fix/<short-desc>`, `chore/<short-desc>`. No ticket numbers unless the repo uses them (it doesn't, yet).
-- **Releases**: bump version with `npm version patch|minor|major`, push `--follow-tags`. The `publish.yml` workflow uses OIDC trusted publishing — no `NPM_TOKEN` secret exists or should exist.
+- **Releases**: see [CONTRIBUTING.md](./CONTRIBUTING.md#release-flow) for the full release flow and version/tag collision recovery. The `publish.yml` workflow uses OIDC trusted publishing — no `NPM_TOKEN` secret exists or should exist.
 
 ## Workflow
 
@@ -142,27 +150,36 @@ Future follow-up `done` events (higher ts) still inject normally.
 
 ## File map at a glance
 
-````
+```
 src/
-  subagent.ts                      # MAIN — tools, poller, auto-done fallback, rehydrate ~3k LOC
-  helpers.ts                       # startSubagentJob, resolveModel
-  artifact.ts                      # events.ndjson + output.md protocol + persisted state helpers
-  interactive-tmux.ts              # tmux/zellij pane management
-  multiplexer{,-tmux,-zellij}.ts   # mux backend abstraction
-  subagent-artifact-cli.ts         # the cli.mjs wrapper
-  workflow.ts                      # (feat/workflow-tool) workflow tool
-  ndjson.d.ts                      # ambient types for the `ndjson` dep
+  subagent.ts                      # Entrypoint/barrel — registers tools, re-exports internals
+  tools/
+    in-process.ts                  # subagent_with_context, subagent_isolated, async tools
+    interactive.ts                 # subagent_interactive, get/send/cancel/read/list tools
+  session-handlers.ts              # session_start/shutdown handlers, poller setup
+  artifact-poller.ts               # per-tick artifact walk, auto-done fallback, notifications
+  rehydrate.ts                     # reconstruct InteractiveSubagentState from state file
+  helpers.ts                       # startSubagentJob, resolveModel, job registry
+  artifact.ts                      # events.ndjson + output.md protocol, state file helpers
+  interactive-tmux.ts              # InteractiveSubagentState, registry, mux dispatch
+  multiplexer{,-tmux,-zellij}.ts   # mux backend abstraction (tmux + zellij)
+  subagent-artifact-cli.ts         # cli.mjs wrapper
+  notifications.ts                 # notify/inject delivery, MAX_INJECT cap
+  rendering.ts                     # TUI render helpers
+  schemas.ts                       # TypeBox tool-param schemas
+  workflow.ts                      # workflow tool
+  ndjson.d.ts                      # ambient types for the ndjson dep
 
-  *.test.ts                        # 20 test files, ~7k lines
   test-utils.ts                    # importFresh helper for module-reset tests
+tests/
+  *.test.ts                        # 27 test files, ~12k lines
 .github/
   workflows/                       # CI (ci.yml) and publish (publish.yml)
-docs/                              # Managed by the separate pi-docs package; do not edit```
-
+docs/                              # Managed by the separate pi-docs package; do not edit
+```
 
 ## When in doubt
 
 - The existing tests in the same directory are the best documentation of intended behavior.
-- `src/subagent-auto-done.test.ts`, `src/subagent-notify.test.ts`, and `src/subagent-rehydrate.test.ts` together define the artifact-protocol contract — if you're not sure what `events.ndjson` is supposed to contain, those tests are the spec.
+- `tests/subagent-auto-done.test.ts`, `tests/subagent-notify.test.ts`, `tests/subagent-rehydrate-core.test.ts`, and `tests/subagent-rehydrate-artifacts.test.ts` together define the artifact-protocol contract — if you're not sure what `events.ndjson` is supposed to contain, those tests are the spec.
 - The release flow is in `CONTRIBUTING.md`. The dev loop (typecheck + test + format) is above. If a step seems to be missing from this file, it probably is — add it.
-````

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,14 +24,59 @@ npm run pack:check
 
 ## Release flow
 
-The publish workflow runs when a `v*` tag is pushed and the tag matches the version in `package.json`.
+The publish workflow (`.github/workflows/publish.yml`) runs when a `v*` tag is pushed
+and the tag matches the version in `package.json`. It uses OIDC trusted publishing —
+no `NPM_TOKEN` secret exists or should exist.
 
-Typical release flow:
+### Pre-release verification
+
+Before cutting a release, run the full verification suite:
 
 ```bash
-npm version patch
+npm run typecheck
+npm test
+npm run format:check
+npm run pack:check
+```
+
+### Normal release
+
+```bash
+# 1. Bump version and create the git tag
+npm version patch          # or minor, or major
+
+# 2. Push the commit and tag to trigger publish.yml
 git push origin master --follow-tags
 ```
+
+GitHub Actions runs typecheck, tests, published-tarball smoke, and pack:check
+before publishing. If any step fails, the package is not published — fix the
+issue and retry.
+
+### Version / tag collision recovery
+
+If `npm version patch` fails because the target version or tag already exists:
+
+1. **Check remote tags** — `git fetch --tags origin` then `git tag -l 'v*'`
+   to see what has already been tagged and published. `npm view
+pi-subagentura versions` shows versions on the registry.
+
+2. **Choose the next available version** — if `v2.3.4` exists, bump to
+   `v2.3.5` (or whatever the appropriate next version is). You can also use
+   `npm version <exact-version>` to set a specific version, e.g.
+   `npm version 2.3.5`.
+
+3. **Never force-push or delete a published tag.** The publish workflow uses
+   OIDC trusted publishing and the tag—version match as its release gate.
+   Force-pushing moves a tag that npm already published, creating a confusing
+   mismatch between the Git ref and the published package. If the tag exists
+   locally but the release was aborted before the git push, delete just the
+   local tag (`git tag -d v2.3.4`) and re-run `npm version patch`.
+
+4. **If a patch is needed on an already-released version**, you must bump to
+   a new version — npm does not allow re-publishing the same version number.
+   Release a patch-level increment: `npm version patch` produces `v2.3.5` if
+   `v2.3.4` is current.
 
 ## Reporting issues
 

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -22,15 +22,21 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import isPathInside from "is-path-inside";
 import ndjson from "ndjson";
 import { debugLog } from "./helpers";
 import type { MuxName } from "./multiplexer";
+
+/** Current schema version for the interactive state file. */
+const CURRENT_STATE_SCHEMA_VERSION = 1;
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -245,7 +251,147 @@ export function lastEvent(art: SubagentArtifact): SubagentEvent | null {
   return events.length > 0 ? events[events.length - 1] : null;
 }
 
-// ── Persisted interactive state (project-local, per parent session) ───────────
+// ── Cleanup / TTL ───────────────────────────────────────────────────
+
+export interface CleanupResult {
+  removed: number;
+  /** Number of directories that matched the TTL but were skipped (active or recent). */
+  skipped: number;
+  /** Non-fatal error messages encountered during cleanup. */
+  errors: string[];
+  dryRun: boolean;
+}
+
+export interface CleanupOptions {
+  /**
+   * Set of sub-agent IDs that are currently tracked/active in the registry.
+   * Directories matching these IDs are always preserved regardless of age.
+   */
+  activeIds?: Set<string>;
+  /** If true, report what would be deleted without actually deleting. */
+  dryRun?: boolean;
+  /** Override "now" for testing (unix-ms timestamp). Defaults to Date.now(). */
+  now?: number;
+}
+
+/**
+ * Delete artifact directories under `rootDir` whose last activity (dir mtime or latest
+ * event timestamp) is older than `ttlMs` from now. Skips directories whose id is in
+ * `activeIds`. Returns a summary with counts and any errors.
+ *
+ * ## Path safety
+ *
+ * - If `rootDir` does not exist, returns a zero-summary (not an error).
+ * - The root itself is validated: it must not be `/`, empty, or a path that resolves
+ *   to `/`.
+ * - Every child directory is resolved via `realpathSync` and checked with
+ *   `is-path-inside` before any deletion, preventing symlink-escape attacks.
+ * - Entries that fail the containment check are reported as errors but the loop
+ *   continues (best-effort).
+ *
+ * ## TTL semantics
+ *
+ * An artifact dir is considered "recent" (skipped) if ANY of these holds:
+ *   1. Its id is in `activeIds`.
+ *   2. The directory's mtime (`statSync(dir).mtimeMs`) is >= `now - ttlMs`.
+ *   3. The artifact's events.ndjson has at least one event whose `ts` is >= `now - ttlMs`.
+ */
+export function cleanupOldArtifacts(
+  rootDir: string,
+  ttlMs: number,
+  options?: CleanupOptions,
+): CleanupResult {
+  const result: CleanupResult = {
+    removed: 0,
+    skipped: 0,
+    errors: [],
+    dryRun: !!options?.dryRun,
+  };
+  const now = options?.now ?? Date.now();
+  const cutoff = now - ttlMs;
+  const activeIds = options?.activeIds;
+
+  // Validate rootDir: must exist, must not be empty, must not resolve to /.
+  if (!rootDir || rootDir.length === 0) {
+    result.errors.push("rootDir is empty");
+    return result;
+  }
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(rootDir);
+    if (realRoot === "/") {
+      result.errors.push("rootDir resolves to filesystem root (/)");
+      return result;
+    }
+    // If the path doesn't exist, return a zero-summary (no error — it's empty, nothing to clean).
+  } catch (err) {
+    const nodeErr = err as NodeJS.ErrnoException;
+    if (nodeErr.code === "ENOENT") return result;
+    result.errors.push(`cannot resolve rootDir: ${err}`);
+    return result;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(realRoot);
+  } catch (err) {
+    result.errors.push(`cannot read rootDir: ${err}`);
+    return result;
+  }
+
+  for (const name of entries) {
+    const candidate = join(realRoot, name);
+    try {
+      const st = statSync(candidate);
+      if (!st.isDirectory()) continue;
+
+      // Path-traversal check: resolve realpath and verify it is inside rootDir.
+      let realCandidate: string;
+      try {
+        realCandidate = realpathSync(candidate);
+      } catch {
+        result.errors.push(`cannot resolve ${name} — skipping`);
+        continue;
+      }
+      if (!isPathInside(realCandidate, realRoot)) {
+        result.errors.push(
+          `path traversal blocked: ${name} resolves outside rootDir`,
+        );
+        continue;
+      }
+
+      // Active-ids check.
+      if (activeIds?.has(name)) {
+        result.skipped++;
+        continue;
+      }
+
+      // TTL check: dir mtime.
+      if (st.mtimeMs >= cutoff) {
+        result.skipped++;
+        continue;
+      }
+
+      // TTL check: latest event ts in events.ndjson.
+      const art = artifactPath(realRoot, name);
+      const last = lastEvent(art);
+      if (last && last.ts >= cutoff) {
+        result.skipped++;
+        continue;
+      }
+
+      // Past all checks — delete (or dry-run report).
+      if (!options?.dryRun) {
+        rmSync(candidate, { recursive: true, force: true });
+      }
+      result.removed++;
+    } catch (err) {
+      result.errors.push(`error processing ${name}: ${err}`);
+    }
+  }
+
+  return result;
+}
 
 /**
 
@@ -295,19 +441,18 @@ export interface InteractiveSubagentStateFile {
 export function stateFilePath(cwd: string): string {
   return join(cwd, ".pi", "subagentura-state.json");
 }
+
 /**
  * Read the state file. Returns null on missing file, malformed
- * JSON, or schemaVersion mismatch. Never throws — defensive readers for untrusted input
+ * JSON, or unsupported schemaVersion. Never throws — defensive readers for untrusted input
  * (the file could be hand-edited or partial from a crash mid-rename).
  */
-
 export function loadInteractiveStates(
   cwd: string,
 ): InteractiveSubagentStateFile | null {
   const file = stateFilePath(cwd);
 
   let content: string;
-
   try {
     content = readFileSync(file, "utf8");
   } catch {
@@ -315,7 +460,6 @@ export function loadInteractiveStates(
   }
 
   let parsed: unknown;
-
   try {
     parsed = JSON.parse(content);
   } catch {
@@ -325,29 +469,65 @@ export function loadInteractiveStates(
   if (!parsed || typeof parsed !== "object") return null;
 
   const obj = parsed as Record<string, unknown>;
+  return migrateStatePayload(obj);
+}
 
-  if (obj.schemaVersion !== 1) {
-    debugLog("warn", "state-file-unknown-schema", {
-      schemaVersion: obj.schemaVersion as number,
-    });
-    return null;
-  }
+/**
+ * Migrate a parsed (and validated-to-be-an-object) state file payload
+ * from any known older schema version to the current version.
+ *
+ * Returns the migrated payload on success, or null if the version is
+ * unknown / unsupported (i.e. a future version this code does not
+ * know how to migrate from).
+ */
+function migrateStatePayload(
+  obj: Record<string, unknown>,
+): InteractiveSubagentStateFile | null {
+  const version = obj.schemaVersion;
+  const rawStates = obj.states;
 
-  if (!obj.states || typeof obj.states !== "object") {
+  // Helper: produce a valid states object from an untrusted value.
+  const asStates = (
+    v: unknown,
+  ): { [id: string]: InteractiveSubagentPersistedStateV1 } =>
+    v && typeof v === "object"
+      ? (v as { [id: string]: InteractiveSubagentPersistedStateV1 })
+      : {};
+
+  // No schema version → assume oldest known (v1 format).
+  if (version === undefined || version === null) {
+    debugLog("warn", "state-file-missing-schema", {});
     return {
-      schemaVersion: 1,
+      schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
       parent: String(obj.parent ?? "pi"),
-      states: {},
+      states: asStates(rawStates),
     };
   }
 
-  return {
-    schemaVersion: 1,
+  // Known version → return validated shape.
+  if (version === 1) {
+    return {
+      schemaVersion: 1,
+      parent: String(obj.parent ?? "pi"),
+      states: asStates(rawStates),
+    };
+  }
 
-    parent: String(obj.parent ?? "pi"),
+  // Negative or zero — treat as an old version, migrate to current.
+  if (typeof version === "number" && version < 1) {
+    debugLog("warn", "state-file-old-schema", { schemaVersion: version });
+    return {
+      schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
+      parent: String(obj.parent ?? "pi"),
+      states: asStates(rawStates),
+    };
+  }
 
-    states: obj.states as { [id: string]: InteractiveSubagentPersistedStateV1 },
-  };
+  // Future / unknown — cannot migrate safely.
+  debugLog("error", "state-file-unsupported-schema", {
+    schemaVersion: version as number,
+  });
+  return null;
 }
 /**
  * Atomically write the state file. Creates .pi/ if needed.
@@ -357,10 +537,9 @@ export function saveInteractiveStates(
   cwd: string,
   payload: InteractiveSubagentStateFile,
 ): void {
-  if (payload.schemaVersion !== 1) {
+  if (payload.schemaVersion !== CURRENT_STATE_SCHEMA_VERSION) {
     throw new Error(`unsupported schemaVersion: ${payload.schemaVersion}`);
   }
-
   const file = stateFilePath(cwd);
 
   mkdirSync(join(cwd, ".pi"), { recursive: true, mode: 0o700 });

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -275,8 +275,9 @@ export interface CleanupOptions {
 }
 
 /**
- * Delete artifact directories under `rootDir` whose last activity (dir mtime or latest
- * event timestamp) is older than `ttlMs` from now. Skips directories whose id is in
+ * Delete artifact directories under `rootDir`. Supports both a flat
+ * `<root>/<id>` layout and the production nested layout
+ * `<root>/<cwdLabel>/artifacts/<id>`. Skips directories whose id is in
  * `activeIds`. Returns a summary with counts and any errors.
  *
  * ## Path safety
@@ -296,6 +297,117 @@ export interface CleanupOptions {
  *   2. The directory's mtime (`statSync(dir).mtimeMs`) is >= `now - ttlMs`.
  *   3. The artifact's events.ndjson has at least one event whose `ts` is >= `now - ttlMs`.
  */
+function hasDirectArtifactFiles(dir: string): boolean {
+  return (
+    existsSync(join(dir, "events.ndjson")) || existsSync(join(dir, "output.md"))
+  );
+}
+
+function discoverArtifactRoots(realRoot: string): string[] {
+  const roots = new Set<string>();
+  const nestedRoot = join(realRoot, "artifacts");
+  try {
+    const nestedStat = statSync(nestedRoot);
+    if (nestedStat.isDirectory() && !hasDirectArtifactFiles(nestedRoot)) {
+      roots.add(realpathSync(nestedRoot));
+    }
+  } catch {
+    /* no direct artifacts child */
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(realRoot);
+  } catch {
+    return roots.size > 0 ? [...roots] : [realRoot];
+  }
+
+  for (const name of entries) {
+    if (name === "artifacts") continue;
+    const candidate = join(realRoot, name);
+    try {
+      const st = statSync(candidate);
+      if (!st.isDirectory()) continue;
+      const childArtifactsRoot = join(candidate, "artifacts");
+      if (!statSync(childArtifactsRoot).isDirectory()) continue;
+      roots.add(realpathSync(childArtifactsRoot));
+    } catch {
+      /* ignore unreadable / missing entries */
+    }
+  }
+
+  if (roots.size === 0) roots.add(realRoot);
+  return [...roots];
+}
+
+function cleanupArtifactRoot(
+  artifactRoot: string,
+  realRoot: string,
+  cutoff: number,
+  activeIds: Set<string> | undefined,
+  result: CleanupResult,
+  options?: CleanupOptions,
+): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(artifactRoot);
+  } catch (err) {
+    result.errors.push(`cannot read artifactRoot ${artifactRoot}: ${err}`);
+    return;
+  }
+
+  for (const name of entries) {
+    const candidate = join(artifactRoot, name);
+    try {
+      const st = statSync(candidate);
+      if (!st.isDirectory()) continue;
+
+      // Path-traversal check: resolve realpath and verify it is inside rootDir.
+      let realCandidate: string;
+      try {
+        realCandidate = realpathSync(candidate);
+      } catch {
+        result.errors.push(`cannot resolve ${name} — skipping`);
+        continue;
+      }
+      if (!isPathInside(realCandidate, realRoot)) {
+        result.errors.push(
+          `path traversal blocked: ${name} resolves outside rootDir`,
+        );
+        continue;
+      }
+
+      // Active-ids check.
+      if (activeIds?.has(name)) {
+        result.skipped++;
+        continue;
+      }
+
+      // TTL check: dir mtime.
+      if (st.mtimeMs >= cutoff) {
+        result.skipped++;
+        continue;
+      }
+
+      // TTL check: latest event ts in events.ndjson.
+      const art = artifactPath(artifactRoot, name);
+      const last = lastEvent(art);
+      if (last && last.ts >= cutoff) {
+        result.skipped++;
+        continue;
+      }
+
+      // Past all checks — delete (or dry-run report).
+      if (!options?.dryRun) {
+        rmSync(candidate, { recursive: true, force: true });
+      }
+      result.removed++;
+    } catch (err) {
+      result.errors.push(`error processing ${name}: ${err}`);
+    }
+  }
+}
+
 export function cleanupOldArtifacts(
   rootDir: string,
   ttlMs: number,
@@ -331,63 +443,16 @@ export function cleanupOldArtifacts(
     return result;
   }
 
-  let entries: string[];
-  try {
-    entries = readdirSync(realRoot);
-  } catch (err) {
-    result.errors.push(`cannot read rootDir: ${err}`);
-    return result;
-  }
-
-  for (const name of entries) {
-    const candidate = join(realRoot, name);
-    try {
-      const st = statSync(candidate);
-      if (!st.isDirectory()) continue;
-
-      // Path-traversal check: resolve realpath and verify it is inside rootDir.
-      let realCandidate: string;
-      try {
-        realCandidate = realpathSync(candidate);
-      } catch {
-        result.errors.push(`cannot resolve ${name} — skipping`);
-        continue;
-      }
-      if (!isPathInside(realCandidate, realRoot)) {
-        result.errors.push(
-          `path traversal blocked: ${name} resolves outside rootDir`,
-        );
-        continue;
-      }
-
-      // Active-ids check.
-      if (activeIds?.has(name)) {
-        result.skipped++;
-        continue;
-      }
-
-      // TTL check: dir mtime.
-      if (st.mtimeMs >= cutoff) {
-        result.skipped++;
-        continue;
-      }
-
-      // TTL check: latest event ts in events.ndjson.
-      const art = artifactPath(realRoot, name);
-      const last = lastEvent(art);
-      if (last && last.ts >= cutoff) {
-        result.skipped++;
-        continue;
-      }
-
-      // Past all checks — delete (or dry-run report).
-      if (!options?.dryRun) {
-        rmSync(candidate, { recursive: true, force: true });
-      }
-      result.removed++;
-    } catch (err) {
-      result.errors.push(`error processing ${name}: ${err}`);
-    }
+  const artifactRoots = discoverArtifactRoots(realRoot);
+  for (const artifactRoot of artifactRoots) {
+    cleanupArtifactRoot(
+      artifactRoot,
+      realRoot,
+      cutoff,
+      activeIds,
+      result,
+      options,
+    );
   }
 
   return result;

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -319,7 +319,8 @@ function discoverArtifactRoots(realRoot: string): string[] {
   try {
     entries = readdirSync(realRoot);
   } catch {
-    return roots.size > 0 ? [...roots] : [realRoot];
+    roots.add(realRoot);
+    return [...roots];
   }
 
   for (const name of entries) {
@@ -336,7 +337,7 @@ function discoverArtifactRoots(realRoot: string): string[] {
     }
   }
 
-  if (roots.size === 0) roots.add(realRoot);
+  roots.add(realRoot);
   return [...roots];
 }
 
@@ -377,6 +378,8 @@ function cleanupArtifactRoot(
         continue;
       }
 
+      // Only directories that actually look like artifact dirs are eligible.
+      if (!hasDirectArtifactFiles(candidate)) continue;
       // Active-ids check.
       if (activeIds?.has(name)) {
         result.skipped++;

--- a/src/multiplexer-tmux.ts
+++ b/src/multiplexer-tmux.ts
@@ -24,7 +24,7 @@
 
 import { execFileSync } from "node:child_process";
 import type { Multiplexer } from "./multiplexer";
-import { commandExists, shellEscape } from "./multiplexer";
+import { commandExists, execMuxOrThrow, shellEscape } from "./multiplexer";
 
 /**
  * Extract the session name, window index, and pane index of a tmux pane
@@ -36,7 +36,9 @@ function getPaneLocation(paneId: string): {
   window: string;
   pane: string;
 } {
-  const output = execFileSync(
+  const output = execMuxOrThrow(
+    "tmux",
+    "display-message",
     "tmux",
     [
       "display-message",
@@ -121,7 +123,9 @@ export class TmuxMultiplexer implements Multiplexer {
     // `tmux attach -t <session-name>` after the spawn returns.
     if (!process.env.TMUX) {
       const sessionName = `pi-subagent-${opts.id ?? safeSegment(opts.name)}`;
-      const paneId = execFileSync(
+      const paneId = execMuxOrThrow(
+        "tmux",
+        "new-session",
         "tmux",
         [
           "new-session",
@@ -165,7 +169,9 @@ export class TmuxMultiplexer implements Multiplexer {
       // select it. Each background sub-agent gets its own named window
       // so they don't clobber each other in the tmux window list.
       windowName = opts.windowName ?? safeSegment(opts.name);
-      paneId = execFileSync(
+      paneId = execMuxOrThrow(
+        "tmux",
+        "new-window",
         "tmux",
         [
           "new-window",
@@ -197,7 +203,7 @@ export class TmuxMultiplexer implements Multiplexer {
       if (parent) {
         args.splice(4, 0, "-t", parent);
       }
-      paneId = execFileSync("tmux", args, {
+      paneId = execMuxOrThrow("tmux", "split-window", "tmux", args, {
         encoding: "utf8",
         timeout: 10000,
       }).trim();
@@ -235,17 +241,29 @@ export class TmuxMultiplexer implements Multiplexer {
   }
 
   sendKeys(paneId: string, text: string): void {
-    execFileSync("tmux", ["send-keys", "-t", paneId, "-l", text], {
-      encoding: "utf8",
-      timeout: 5000,
-    });
+    execMuxOrThrow(
+      "tmux",
+      "send-keys",
+      "tmux",
+      ["send-keys", "-t", paneId, "-l", text],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+      },
+    );
   }
 
   sendEnter(paneId: string): void {
-    execFileSync("tmux", ["send-keys", "-t", paneId, "Enter"], {
-      encoding: "utf8",
-      timeout: 5000,
-    });
+    execMuxOrThrow(
+      "tmux",
+      "send-keys Enter",
+      "tmux",
+      ["send-keys", "-t", paneId, "Enter"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+      },
+    );
   }
 
   killPane(paneId: string): void {

--- a/src/multiplexer-zellij.ts
+++ b/src/multiplexer-zellij.ts
@@ -29,7 +29,7 @@
 
 import { execFileSync } from "node:child_process";
 import type { Multiplexer } from "./multiplexer";
-import { commandExists, shellEscape } from "./multiplexer";
+import { commandExists, execMuxOrThrow, shellEscape } from "./multiplexer";
 
 /** Sanitize a free-form name into a safe segment for zellij tab/session names. */
 function safeSegment(value: string): string {
@@ -110,10 +110,16 @@ export class ZellijMultiplexer implements Multiplexer {
     if (!isInZellij) {
       // Relaxed path: parent not in zellij. Create a background session.
       session = `pi-subagent-${opts.id ?? safeSegment(opts.name)}`;
-      execFileSync("zellij", ["attach", "--create-background", session], {
-        encoding: "utf8",
-        timeout: 10000,
-      });
+      execMuxOrThrow(
+        "zellij",
+        "attach --create-background",
+        "zellij",
+        ["attach", "--create-background", session],
+        {
+          encoding: "utf8",
+          timeout: 10000,
+        },
+      );
     } else {
       session = process.env.ZELLIJ_SESSION_NAME ?? "";
     }
@@ -158,7 +164,9 @@ export class ZellijMultiplexer implements Multiplexer {
           // create the new tab, just won't restore focus.
         }
       }
-      execFileSync(
+      execMuxOrThrow(
+        "zellij",
+        "new-tab",
         "zellij",
         [...sessionFlag, "action", "new-tab", "--name", windowName],
         {
@@ -190,7 +198,9 @@ export class ZellijMultiplexer implements Multiplexer {
       // `opts.parentPane` is intentionally ignored. No `--close-on-exit`:
       // that flag makes a trailing `<COMMAND>` mandatory, and we want a
       // plain shell pane that outlives the launch script (like tmux's split).
-      execFileSync(
+      execMuxOrThrow(
+        "zellij",
+        "new-pane",
         "zellij",
         [...sessionFlag, "action", "new-pane", "--direction", "right"],
         {
@@ -251,7 +261,9 @@ export class ZellijMultiplexer implements Multiplexer {
    * character. Does NOT submit (no Enter).
    */
   sendKeys(paneId: string, text: string, session?: string): void {
-    execFileSync(
+    execMuxOrThrow(
+      "zellij",
+      "write-chars",
       "zellij",
       [
         ...this.sessionFlag(session),
@@ -269,7 +281,9 @@ export class ZellijMultiplexer implements Multiplexer {
    * Send a single Enter / Return key to the pane (decimal 13 = Enter key).
    */
   sendEnter(paneId: string, session?: string): void {
-    execFileSync(
+    execMuxOrThrow(
+      "zellij",
+      "write 13",
       "zellij",
       [
         ...this.sessionFlag(session),

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -23,7 +23,7 @@
  *   4. Throw with a setup hint pointing at both backends.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, type ExecSyncOptions } from "node:child_process";
 import { TmuxMultiplexer } from "./multiplexer-tmux";
 import { ZellijMultiplexer } from "./multiplexer-zellij";
 
@@ -269,4 +269,57 @@ export function commandExists(command: string): boolean {
 /** POSIX-style single-quote escape. Safe for paths, names, and command args. */
 export function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Execute a mux command with improved error diagnostics.
+ *
+ * On failure, re-throws a new `Error` with the mux name, operation context,
+ * and relevant stderr/stdout/exit-status details from the underlying exec
+ * failure. The original error is preserved as `cause`.
+ *
+ * @param muxName   Backend name ("tmux" or "zellij") — identifies the tool in the error.
+ * @param operation Human-readable description (e.g. "new-window", "send-keys").
+ * @param cmd       The command binary (e.g. "tmux", "zellij").
+ * @param args      Command arguments (passed through to execFileSync).
+ * @param options   execFileSync options (e.g. `{ encoding: "utf8", timeout: 5000 }`).
+ * @returns The stdout as a string.
+ */
+export function execMuxOrThrow(
+  muxName: string,
+  operation: string,
+  cmd: string,
+  args: readonly string[],
+  options: ExecSyncOptions,
+): string {
+  try {
+    const result = execFileSync(cmd, args, options);
+    return typeof result === "string" ? result : result.toString();
+  } catch (err) {
+    const execErr = err as Error & {
+      stderr?: Buffer | string;
+      stdout?: Buffer | string;
+      status?: number;
+    };
+    const details: string[] = [];
+    if (execErr.status != null) {
+      details.push(`exit code ${execErr.status}`);
+    }
+    const stderrStr =
+      execErr.stderr != null ? String(execErr.stderr).trim() : "";
+    if (stderrStr) {
+      details.push(`stderr: ${stderrStr}`);
+    }
+    const stdoutStr =
+      execErr.stdout != null ? String(execErr.stdout).trim() : "";
+    if (stdoutStr && stdoutStr.length <= 200) {
+      details.push(`stdout: ${stdoutStr}`);
+    } else if (stdoutStr) {
+      details.push(`stdout: <${stdoutStr.length} bytes>`);
+    }
+    const suffix = details.length > 0 ? ": " + details.join(", ") : "";
+    throw new Error(`[${muxName}] ${operation} failed${suffix}`, {
+      cause: err,
+    });
+  }
 }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1,22 +1,21 @@
 /**
- * Sub-Engine Extension - Spawn in-process sub-agents via the SDK
+ * pi-subagentura — In-process and interactive sub-agent tools for Pi.
  *
- * Tools:
- *   - subagent_with_context: Inherits full conversation history + task + persona
- *   - subagent_isolated: Fresh context window, task + optional persona only
- *   - get_subagent_status: Poll async subagent job for live preview
- *   - get_subagent_result: Block until async job completes, return final output
- *   - cancel_subagent: Abort a running async job
- *   - prune_subagent_jobs: Remove all completed and failed jobs from the registry
- *   - interactive sub-agent tools: registered from ./tools/interactive
- *   - list_available_models: List all known models with auth status for model validation
+ * ## Public API
  *
- * Both spawn tools support optional `async` param for background execution.
- * When async: true, the job starts and the main agent continues immediately -
- * it does NOT block waiting for the sub-agent. Use get_subagent_status to poll
- * for progress and get_subagent_result when ready to collect output.
+ * **Extension entry** — default export: the extension activator function.
  *
- * Runs in the same process — no subprocess overhead.
+ * **Type** — `SubagentDetails`: discriminated-union partial-result type surfaced
+ * to the parent session's message renderer.
+ *
+ * ## Internal / testing re-exports
+ *
+ * The named exports below are re-exported from implementation modules for test
+ * access and internal wiring. They are NOT part of the supported public API
+ * and may change without a major version bump. Prefer importing from the source
+ * module (`./helpers`, `./interactive-tmux`, etc.) if you depend on them.
+ *
+ * @module pi-subagentura
  */
 
 import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -35,7 +34,19 @@ import {
 } from "./tools/in-process";
 import { registerInteractiveSubagentTools } from "./tools/interactive";
 import { registerSessionHandlers } from "./session-handlers";
+/** @internal Session-rehydration helper used by session-handlers.ts */
 export { rehydrateInteractiveSubagents } from "./rehydrate";
+/**
+ * Discriminated union describing the live status of a sub-agent job.
+ * Used by `renderSubagentResult` and surfaced via `AgentToolResult.details`.
+ *
+ * Cases:
+ * - `"started"` — async job launched, jobId available
+ * - `"running"` — (in-process only) polling for live status
+ * - `"done"` | `"error"` — completed with usage info
+ * - `"cancelled"` | `"not_found"` — terminal states
+ * - `"invalid_id"` — caller passed an unrecognised id
+ */
 export type SubagentDetails =
   | { status: "started"; jobId: string; contextMessages: number }
   | { status: "running"; subagentStatus: SubagentLiveStatus; model?: string }
@@ -57,12 +68,22 @@ export default function (pi: ExtensionAPI) {
   registerInProcessMaintenanceTools(pi);
 }
 
+/**
+ * ── Internal helpers (re-exported for test access) ──
+ *
+ * These are implementation details of the in-process sub-agent machinery.
+ * They are re-exported here so that tests and internal consumers (e.g.
+ * session-handlers.ts) can import them through the package entry point.
+ *
+ * API consumers SHOULD NOT depend on these exports directly — they may
+ * be renamed, moved, or removed in a minor release.
+ */
 export {
   formatUsage,
   SubagentResult,
   SubagentLiveStatus,
   ACTIVE_TOOL_DEBOUNCE_MS,
-  // ── Async exports ──
+  // ── Async job machinery ──
   jobRegistry,
   MAX_REGISTRY_SIZE,
   pruneOldestJob,
@@ -73,7 +94,11 @@ export {
   type JobStatus,
   type NotifyOnComplete,
 } from "./helpers";
+/** @internal Interactive-subagent registry, consumed by session-handlers and tests */
 export { interactiveSubagentRegistry } from "./interactive-tmux";
+/** @internal Inject-count guard; exported for test assertions */
 export { getInjectCount, MAX_INJECT } from "./notifications";
+/** @internal Artifact-change poller; exported for test access */
 export { pollArtifactChanges } from "./artifact-poller";
+/** @internal Interactive-artifact lookup; exported for test access */
 export { findArtifactById } from "./tools/interactive";

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -8,7 +8,10 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Model } from "@earendil-works/pi-ai";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { FOOTER_KEY } from "../artifact-poller";
+import { cleanupOldArtifacts, type CleanupResult } from "../artifact";
 import {
   buildLiveUpdate,
   debugLog,
@@ -24,6 +27,7 @@ import {
   type Usage,
 } from "../helpers";
 import { deliverNotification } from "../notifications";
+import { interactiveSubagentRegistry } from "../interactive-tmux";
 import { renderSubagentCall, renderSubagentResult } from "../rendering";
 import {
   BaseParams,
@@ -911,6 +915,125 @@ function registerPruneSubagentJobsTool(pi: ExtensionAPI): void {
   });
 }
 
+function registerCleanupArtifactsTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "cleanup_subagent_artifacts",
+    label: "Cleanup Subagent Artifacts",
+    description: [
+      "Delete old interactive sub-agent artifact directories past a TTL threshold.",
+      "Preserves directories whose sub-agent is still tracked in the live registry",
+      "or whose last activity (dir mtime or latest event timestamp) is within the TTL window.",
+      "",
+      "Path-safety: validates every directory is inside the artifact root and blocks",
+      "path-traversal attempts. Dry-run mode reports what would be deleted without",
+      "actually deleting.",
+    ].join("\n"),
+    parameters: Type.Object({
+      ttlMs: Type.Number({
+        description:
+          "Age threshold in milliseconds. Directories with no activity more recent than this are candidates for deletion.",
+        minimum: 60_000,
+      }),
+      rootDir: Type.Optional(
+        Type.String({
+          description: [
+            "Artifact root directory to scan. Defaults to the session's artifacts parent:",
+            "$PI_CODING_AGENT_SESSION_DIR/subagentura/<cwdLabel>/ (if env var is set) or",
+            "~/.pi/agent/sessions/subagentura/<cwdLabel>/",
+          ].join("\n"),
+        }),
+      ),
+      dryRun: Type.Optional(
+        Type.Boolean({
+          description:
+            "If true, report what would be deleted without actually deleting. Defaults to true for safety.",
+        }),
+      ),
+    }),
+
+    async execute(_toolCallId, params): Promise<any> {
+      const activeIds = new Set<string>();
+      for (const state of interactiveSubagentRegistry.values()) {
+        activeIds.add(state.id);
+      }
+
+      const dryRun = params.dryRun !== false; // default true for safety
+      const defaultTtlMs = 24 * 60 * 60 * 1000; // 24 hours
+      const ttlMs = params.ttlMs ?? defaultTtlMs;
+
+      const rootDir =
+        params.rootDir ??
+        (() => {
+          const sessionDir =
+            process.env.PI_CODING_AGENT_SESSION_DIR ??
+            join(homedir(), ".pi", "agent", "sessions");
+          return join(sessionDir, "subagentura");
+        })();
+
+      const result: CleanupResult = cleanupOldArtifacts(rootDir, ttlMs, {
+        activeIds,
+        dryRun,
+      });
+
+      const lines = [
+        `Cleanup ${dryRun ? "(dry run) " : ""}— ${result.removed} removed, ${result.skipped} skipped, ${result.errors.length} errors`,
+      ];
+      for (const err of result.errors) {
+        lines.push(`  error: ${err}`);
+      }
+
+      return {
+        content: [{ type: "text", text: lines.join("\n") }],
+        details: { ...result },
+      };
+    },
+
+    renderCall(_args, theme) {
+      return new Text(
+        theme.fg("toolTitle", theme.bold("cleanup_subagent_artifacts")),
+        0,
+        0,
+      );
+    },
+
+    renderResult(result, _options, theme, _context) {
+      const details = result.details as Partial<CleanupResult> | undefined;
+      const removed = details?.removed ?? 0;
+      const skipped = details?.skipped ?? 0;
+      const errors = details?.errors?.length ?? 0;
+      const dryRun = details?.dryRun ?? false;
+      if (dryRun) {
+        return new Text(
+          removed > 0 || errors > 0
+            ? theme.fg(
+                "warning",
+                `~ Cleanup: ${removed} would be removed, ${skipped} skipped, ${errors} errors`,
+              )
+            : theme.fg(
+                "dim",
+                `~ No old artifacts found (${skipped} active/skipped)`,
+              ),
+          0,
+          0,
+        );
+      }
+      return new Text(
+        removed > 0
+          ? theme.fg(
+              "success",
+              `✓ Cleaned ${removed} artifact dirs, ${skipped} skipped, ${errors} errors`,
+            )
+          : theme.fg(
+              "dim",
+              `No old artifacts to clean (${skipped} active/skipped)`,
+            ),
+        0,
+        0,
+      );
+    },
+  });
+}
+
 export function registerInProcessSubagentTools(pi: ExtensionAPI): void {
   registerSubagentWithContextTool(pi);
   registerSubagentIsolatedTool(pi);
@@ -922,4 +1045,5 @@ export function registerInProcessSubagentTools(pi: ExtensionAPI): void {
 export function registerInProcessMaintenanceTools(pi: ExtensionAPI): void {
   registerListAvailableModelsTool(pi);
   registerPruneSubagentJobsTool(pi);
+  registerCleanupArtifactsTool(pi);
 }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -937,9 +937,10 @@ function registerCleanupArtifactsTool(pi: ExtensionAPI): void {
       rootDir: Type.Optional(
         Type.String({
           description: [
-            "Artifact root directory to scan. Defaults to the session's artifacts parent:",
-            "$PI_CODING_AGENT_SESSION_DIR/subagentura/<cwdLabel>/ (if env var is set) or",
-            "~/.pi/agent/sessions/subagentura/<cwdLabel>/",
+            "Artifact root directory to scan. Defaults to the session root:",
+            "$PI_CODING_AGENT_SESSION_DIR/subagentura/ (if env var is set) or",
+            "~/.pi/agent/sessions/subagentura/.",
+            "The cleanup pass traverses each <cwdLabel>/artifacts subtree.",
           ].join("\n"),
         }),
       ),
@@ -958,8 +959,7 @@ function registerCleanupArtifactsTool(pi: ExtensionAPI): void {
       }
 
       const dryRun = params.dryRun !== false; // default true for safety
-      const defaultTtlMs = 24 * 60 * 60 * 1000; // 24 hours
-      const ttlMs = params.ttlMs ?? defaultTtlMs;
+      const ttlMs = params.ttlMs;
 
       const rootDir =
         params.rootDir ??

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -7,14 +7,16 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
   appendEvent,
   appendInteractiveState,
   artifactPath,
+  cleanupOldArtifacts,
   deleteInteractiveStatesFile,
   ensureArtifactDir,
   lastEvent,
@@ -293,6 +295,183 @@ describe("artifact", () => {
     const art = artifactPath(root, "snap6-nonexistent");
     expect(listOutputTurns(art)).toEqual([]);
   });
+
+  describe("cleanupOldArtifacts", () => {
+    let root: string;
+
+    beforeEach(() => {
+      root = makeTmp();
+    });
+
+    afterEach(() => {
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    function makeArtifact(id: string, mtimeAgoMs: number): string {
+      const dir = artifactPath(root, id);
+      ensureArtifactDir(dir);
+      // Set mtime to a specific time
+      const mtime = new Date(Date.now() - mtimeAgoMs);
+      statSync(dir.dir); // ensure it exists
+      // Write events.ndjson to set up the artifact
+      writeOutput(dir, "result");
+      return dir.dir;
+    }
+
+    function setDirMtime(dir: string, mtimeAgoMs: number): void {
+      const t = new Date(Date.now() - mtimeAgoMs);
+      // We can't directly set mtime on Node; use futimes or utimesSync
+      // Instead, control the test via 'now' parameter
+      void dir;
+      void mtimeAgoMs;
+    }
+
+    it("returns zero when rootDir is empty", () => {
+      const result = cleanupOldArtifacts(root, 60_000, { now: Date.now() });
+      expect(result.removed).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("returns zero when rootDir does not exist", () => {
+      const result = cleanupOldArtifacts(join(root, "missing"), 60_000, {
+        now: Date.now(),
+      });
+      expect(result.removed).toBe(0);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("rejects empty rootDir with an error", () => {
+      const result = cleanupOldArtifacts("", 60_000);
+      expect(result.removed).toBe(0);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toMatch(/empty/);
+    });
+
+    it("rejects filesystem root (/) as rootDir", () => {
+      const result = cleanupOldArtifacts("/", 60_000);
+      expect(result.removed).toBe(0);
+      expect(result.errors.length).toBeGreaterThan(0);
+      // fs root is blocked
+      expect(result.errors[0]).toMatch(/filesystem root/);
+    });
+
+    it("deletes old artifact dirs past TTL", () => {
+      const old1dir = makeArtifact("old1", 200_000);
+      const old2dir = makeArtifact("old2", 200_000);
+
+      // Use a far-future `now` so that freshly-created dirs appear old (mtime < cutoff).
+      const futureNow = Date.now() + 1_000_000;
+      const result = cleanupOldArtifacts(root, 100_000, { now: futureNow });
+
+      expect(result.removed).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toEqual([]);
+      // old dirs are deleted
+      expect(existsSync(old1dir)).toBe(false);
+      expect(existsSync(old2dir)).toBe(false);
+    });
+
+    it("preserves artifact dirs with activeIds", () => {
+      makeArtifact("active1", 200_000);
+      makeArtifact("inactive1", 200_000);
+
+      // Far-future now so both appear old; activeIds protects 'active1'.
+      const futureNow = Date.now() + 1_000_000;
+      const result = cleanupOldArtifacts(root, 60_000, {
+        activeIds: new Set(["active1"]),
+        now: futureNow,
+      });
+
+      expect(result.removed).toBe(1);
+      expect(result.skipped).toBe(1); // active1 skipped
+      expect(existsSync(artifactPath(root, "active1").dir)).toBe(true);
+      expect(existsSync(artifactPath(root, "inactive1").dir)).toBe(false);
+    });
+
+    it("dry run does not delete any directories", () => {
+      makeArtifact("old1", 200_000);
+      makeArtifact("old2", 200_000);
+
+      const futureNow = Date.now() + 1_000_000;
+      const result = cleanupOldArtifacts(root, 60_000, {
+        dryRun: true,
+        now: futureNow,
+      });
+
+      expect(result.removed).toBe(2);
+      expect(result.dryRun).toBe(true);
+      // Directories still exist
+      expect(existsSync(artifactPath(root, "old1").dir)).toBe(true);
+      expect(existsSync(artifactPath(root, "old2").dir)).toBe(true);
+    });
+
+    it("preserves artifacts with recent event timestamps even when dir mtime is old", () => {
+      const old = makeArtifact("old-but-recent-event", 200_000);
+      const art = artifactPath(root, "old-but-recent-event");
+      // Append a recent event (within TTL)
+      appendEvent(art, { ts: Date.now(), type: "started", status: "running" });
+
+      const result = cleanupOldArtifacts(root, 100_000, {
+        now: Date.now() + 50_000, // make mtime and dir old
+      });
+
+      // The recent event (ts = Date.now()) is < now+50k, so cutoff = now+50k-100k
+      // Wait — this is confusing. Let me be explicit:
+      // If now = Date.now() + 50000 and ttl = 100000, cutoff = now - 100000 = Date.now() - 50000
+      // The event ts = Date.now() which is >= cutoff, so it's recent
+      expect(result.skipped).toBe(1);
+      expect(result.removed).toBe(0);
+    });
+
+    it("prevents path traversal via realpath check", () => {
+      // Create a dir inside root with a symlink pointing outside
+      const outsideDir = join(root, "../outside");
+      mkdirSync(outsideDir, { recursive: true });
+      writeFileSync(join(outsideDir, "secret.txt"), "leaked");
+
+      const symlinkDir = join(root, "evil-link");
+      symlinkSync(outsideDir, symlinkDir);
+
+      const result = cleanupOldArtifacts(root, 60_000, {
+        now: Date.now(),
+      });
+
+      // Symlink should be detected as path traversal
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toMatch(/path traversal/);
+      expect(result.removed).toBe(0);
+      // Outside dir must not be deleted
+      expect(existsSync(outsideDir)).toBe(true);
+      expect(existsSync(join(outsideDir, "secret.txt"))).toBe(true);
+    });
+
+    it("skips loose files in the artifact root", () => {
+      writeFileSync(join(root, "stray.txt"), "not a dir");
+      makeArtifact("old1", 200_000);
+
+      const futureNow = Date.now() + 1_000_000;
+      const result = cleanupOldArtifacts(root, 100_000, {
+        now: futureNow,
+      });
+
+      expect(result.removed).toBe(1);
+      expect(result.errors).toEqual([]);
+      // Stray file should still exist
+      expect(existsSync(join(root, "stray.txt"))).toBe(true);
+    });
+
+    it("dryRun flag is reflected in the result", () => {
+      const live = cleanupOldArtifacts(root, 60_000, { dryRun: true });
+      expect(live.dryRun).toBe(true);
+
+      const real = cleanupOldArtifacts(root, 60_000, { dryRun: false });
+      expect(real.dryRun).toBe(false);
+
+      const defaultResult = cleanupOldArtifacts(root, 60_000);
+      expect(defaultResult.dryRun).toBe(false);
+    });
+  });
 });
 
 describe("persisted interactive state helpers", () => {
@@ -370,6 +549,62 @@ describe("persisted interactive state helpers", () => {
     );
 
     expect(loadInteractiveStates(root)).toBeNull();
+  });
+
+  it("loadInteractiveStates migrates a file with no schemaVersion field", () => {
+    const file = stateFilePath(root);
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      file,
+      JSON.stringify({ parent: "pi", states: { abc12345: SAMPLE } }),
+      { mode: 0o600 },
+    );
+    const loaded = loadInteractiveStates(root);
+    expect(loaded).toEqual({
+      schemaVersion: 1,
+      parent: "pi",
+      states: { abc12345: SAMPLE },
+    });
+  });
+
+  it("loadInteractiveStates migrates a file with schemaVersion 0", () => {
+    const file = stateFilePath(root);
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: 0,
+        parent: "pi",
+        states: { abc12345: SAMPLE },
+      }),
+      { mode: 0o600 },
+    );
+    const loaded = loadInteractiveStates(root);
+    expect(loaded).toEqual({
+      schemaVersion: 1,
+      parent: "pi",
+      states: { abc12345: SAMPLE },
+    });
+  });
+
+  it("loadInteractiveStates migrates a file with schemaVersion -1", () => {
+    const file = stateFilePath(root);
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: -1,
+        parent: "pi",
+        states: { abc12345: SAMPLE },
+      }),
+      { mode: 0o600 },
+    );
+    const loaded = loadInteractiveStates(root);
+    expect(loaded).toEqual({
+      schemaVersion: 1,
+      parent: "pi",
+      states: { abc12345: SAMPLE },
+    });
   });
 
   it("loadInteractiveStates returns empty states when the file exists but has no states key", () => {

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -471,6 +471,48 @@ describe("artifact", () => {
       const defaultResult = cleanupOldArtifacts(root, 60_000);
       expect(defaultResult.dryRun).toBe(false);
     });
+
+    it("preserves nested cwdLabel/artifacts layout and active IDs", () => {
+      const sessionRoot = join(root, "sessions", "subagentura");
+      const activeArt = artifactPath(
+        join(sessionRoot, "project-a-123", "artifacts"),
+        "active1",
+      );
+      const staleArt = artifactPath(
+        join(sessionRoot, "project-b-456", "artifacts"),
+        "old1",
+      );
+
+      for (const art of [activeArt, staleArt]) {
+        ensureArtifactDir(art);
+        appendEvent(art, {
+          ts: Date.now(),
+          type: "started",
+          status: "running",
+        });
+        writeOutput(art, "result");
+      }
+
+      const futureNow = Date.now() + 1_000_000;
+      const result = cleanupOldArtifacts(sessionRoot, 100_000, {
+        activeIds: new Set(["active1"]),
+        now: futureNow,
+      });
+
+      expect(result.removed).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toEqual([]);
+      expect(existsSync(join(sessionRoot, "project-a-123"))).toBe(true);
+      expect(existsSync(join(sessionRoot, "project-a-123", "artifacts"))).toBe(
+        true,
+      );
+      expect(existsSync(activeArt.dir)).toBe(true);
+      expect(existsSync(join(sessionRoot, "project-b-456"))).toBe(true);
+      expect(existsSync(join(sessionRoot, "project-b-456", "artifacts"))).toBe(
+        true,
+      );
+      expect(existsSync(staleArt.dir)).toBe(false);
+    });
   });
 });
 

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -8,6 +8,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -319,11 +320,8 @@ describe("artifact", () => {
     }
 
     function setDirMtime(dir: string, mtimeAgoMs: number): void {
-      const t = new Date(Date.now() - mtimeAgoMs);
-      // We can't directly set mtime on Node; use futimes or utimesSync
-      // Instead, control the test via 'now' parameter
-      void dir;
-      void mtimeAgoMs;
+      const time = new Date(Date.now() - mtimeAgoMs);
+      utimesSync(dir, time, time);
     }
 
     it("returns zero when rootDir is empty", () => {
@@ -512,6 +510,59 @@ describe("artifact", () => {
         true,
       );
       expect(existsSync(staleArt.dir)).toBe(false);
+    });
+
+    it("cleans root-level flat artifact dirs alongside nested cwdLabel artifacts", () => {
+      const sessionRoot = join(root, "sessions", "subagentura");
+      const nestedActive = artifactPath(
+        join(sessionRoot, "project-a-123", "artifacts"),
+        "active1",
+      );
+      const nestedOld = artifactPath(
+        join(sessionRoot, "project-b-456", "artifacts"),
+        "old1",
+      );
+      const flatOld = artifactPath(sessionRoot, "flat-old");
+
+      const oldTs = Date.now() - 200_000;
+      for (const art of [nestedActive, nestedOld, flatOld]) {
+        ensureArtifactDir(art);
+        appendEvent(art, {
+          ts: oldTs,
+          type: "started",
+          status: "running",
+        });
+        writeOutput(art, "result");
+        setDirMtime(art.dir, 200_000);
+      }
+
+      const result = cleanupOldArtifacts(sessionRoot, 100_000, {
+        activeIds: new Set(["active1"]),
+        now: Date.now(),
+      });
+
+      expect(result.removed).toBe(2);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toEqual([]);
+      expect(existsSync(nestedActive.dir)).toBe(true);
+      expect(existsSync(nestedOld.dir)).toBe(false);
+      expect(existsSync(flatOld.dir)).toBe(false);
+    });
+
+    it("does not delete bare cwdLabel dirs without an artifacts child", () => {
+      const sessionRoot = join(root, "sessions", "subagentura");
+      const bareCwdLabel = join(sessionRoot, "project-a-123");
+      mkdirSync(bareCwdLabel, { recursive: true });
+      setDirMtime(bareCwdLabel, 200_000);
+
+      const result = cleanupOldArtifacts(sessionRoot, 100_000, {
+        now: Date.now(),
+      });
+
+      expect(result.removed).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toEqual([]);
+      expect(existsSync(bareCwdLabel)).toBe(true);
     });
   });
 });

--- a/tests/multiplexer-tmux.test.ts
+++ b/tests/multiplexer-tmux.test.ts
@@ -1,0 +1,706 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { importFresh } from "./test-utils";
+
+/** Standard tmux pane id returned by mocks when creating a new pane. */
+const MOCK_PANE_ID = "%42";
+/**
+ * Tab-separated session/window/pane output matching real
+ * `display-message -p -t <id> "#{session_name}\t#{window_index}\t#{pane_index}"`.
+ */
+const MOCK_LOCATION = "main\t1\t0\n";
+
+function installMockExec(scenario: (args: string[]) => string) {
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => scenario(args as string[]),
+  }));
+}
+
+describe("multiplexer-tmux", () => {
+  afterEach(() => {
+    vi.doUnmock("node:child_process");
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  isAvailable                                                        */
+  /* ------------------------------------------------------------------ */
+
+  it("isAvailable returns true when tmux binary exists and TMUX env var is set", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    installMockExec((args) => {
+      // /bin/sh -lc "command -v 'tmux'" succeeds
+      if (args.includes("-lc")) return "";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(new TmuxMultiplexer().isAvailable()).toBe(true);
+  });
+
+  it("isAvailable is binary-only: returns true even when TMUX env var is unset", async () => {
+    // Symmetric with ZellijMultiplexer: isAvailable must NOT require TMUX.
+    installMockExec((args) => {
+      if (args.includes("-lc")) return "";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(new TmuxMultiplexer().isAvailable()).toBe(true);
+  });
+
+  it("isAvailable returns false when tmux binary is not on PATH", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    installMockExec((args) => {
+      if (args.includes("-lc")) throw new Error("command not found");
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(new TmuxMultiplexer().isAvailable()).toBe(false);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — background mode (new-window)                          */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane background mode uses new-window -d -n and returns % prefixed paneId + windowName", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%1";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "new-window") return `${MOCK_PANE_ID}\n`;
+      // createPane doesn't call display-message; buildsAttachCommands does.
+      // sendKeys / sendEnter / isPaneAlive are not called here.
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const result = new TmuxMultiplexer().createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: true,
+    });
+
+    expect(result.paneId).toBe(MOCK_PANE_ID);
+    expect(result.windowName).toBe("demo");
+
+    const nw = calls.find((a) => a[0] === "new-window");
+    expect(nw).toBeDefined();
+    // -d = detached; -n = name; -P -F #{pane_id} = print pane id
+    expect(nw).toContain("-d");
+    expect(nw).toContain("-n");
+    expect(nw).toContain("demo");
+    expect(nw).toContain("-P");
+    expect(nw).toContain("-F");
+    expect(nw).toContain("#{pane_id}");
+    // Working directory
+    expect(nw).toContain("-c");
+    expect(nw).toContain("/tmp");
+  });
+
+  it("createPane background mode uses explicit windowName when provided", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%1";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "new-window") return "%99\n";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const result = new TmuxMultiplexer().createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: true,
+      windowName: "my-custom-name",
+    });
+
+    expect(result.paneId).toBe("%99");
+    expect(result.windowName).toBe("my-custom-name");
+
+    const nw = calls.find((a) => a[0] === "new-window");
+    expect(nw).toContain("my-custom-name");
+  });
+
+  it("createPane throws when tmux returns a non-% pane id (unexpected format)", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%1";
+    installMockExec((args) => {
+      if (args[0] === "new-window") return "42\n"; // missing % prefix
+      if (args.includes("-lc")) return ""; // commandExists
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(() =>
+      new TmuxMultiplexer().createPane({
+        name: "Demo",
+        cwd: "/tmp",
+        background: true,
+      }),
+    ).toThrow(/Unexpected tmux pane id/);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — visible split mode (split-window)                     */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane visible split mode uses split-window -h -d and returns paneId with parentPane", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%1";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "split-window") return `${MOCK_PANE_ID}\n`;
+      if (args[0] === "select-pane") return "";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const result = new TmuxMultiplexer().createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: false,
+      parentPane: "%5",
+    });
+
+    expect(result.paneId).toBe(MOCK_PANE_ID);
+    // Visible split has no windowName (same window as parent)
+    expect(result.windowName).toBeUndefined();
+
+    const sw = calls.find((a) => a[0] === "split-window");
+    expect(sw).toBeDefined();
+    expect(sw).toContain("-h");
+    expect(sw).toContain("-d");
+    expect(sw).toContain("-P");
+    expect(sw).toContain("-F");
+    expect(sw).toContain("#{pane_id}");
+    expect(sw).toContain("-c");
+    expect(sw).toContain("/tmp");
+    // -t targets the parent pane
+    expect(sw).toContain("-t");
+    expect(sw).toContain("%5");
+
+    // Cosmetic: sets pane title
+    const sp = calls.find((a) => a[0] === "select-pane");
+    expect(sp).toBeDefined();
+    expect(sp).toContain("-T");
+    expect(sp).toContain("Demo");
+  });
+
+  it("createPane visible split falls back to TMUX_PANE when parentPane is omitted", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%9";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "split-window") return "%88\n";
+      if (args[0] === "select-pane") return "";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    new TmuxMultiplexer().createPane({
+      name: "T",
+      cwd: "/tmp",
+      background: false,
+      // parentPane omitted — should use TMUX_PANE
+    });
+
+    const sw = calls.find((a) => a[0] === "split-window");
+    expect(sw).toContain("-t");
+    expect(sw).toContain("%9");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — relaxed path (parent not in tmux)                     */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane relaxed path creates a new detached session when TMUX is unset", async () => {
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "new-session") return `${MOCK_PANE_ID}\n`;
+      if (args[0] === "rename-window") return "";
+      if (args.includes("-lc")) return ""; // commandExists
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const result = new TmuxMultiplexer().createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: true,
+      id: "abc12345",
+    });
+
+    expect(result.paneId).toBe(MOCK_PANE_ID);
+    // Relaxed path always defines windowName (renamed from default "0")
+    expect(result.windowName).toBe("demo");
+
+    const ns = calls.find((a) => a[0] === "new-session");
+    expect(ns).toBeDefined();
+    expect(ns).toContain("-d");
+    expect(ns).toContain("-s");
+    expect(ns).toContain("pi-subagent-abc12345");
+    expect(ns).toContain("-c");
+    expect(ns).toContain("/tmp");
+    expect(ns).toContain("-P");
+    expect(ns).toContain("-F");
+    expect(ns).toContain("#{pane_id}");
+
+    const rn = calls.find((a) => a[0] === "rename-window");
+    expect(rn).toBeDefined();
+    expect(rn).toContain("pi-subagent-abc12345:0");
+    expect(rn).toContain("demo");
+  });
+
+  it("createPane relaxed path validates pane id starts with %", async () => {
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+    installMockExec((args) => {
+      if (args[0] === "new-session") return "XX\n"; // bad format
+      if (args.includes("-lc")) return "";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(() =>
+      new TmuxMultiplexer().createPane({
+        name: "Demo",
+        cwd: "/tmp",
+        background: true,
+        id: "abc12345",
+      }),
+    ).toThrow(/Unexpected tmux pane id/);
+  });
+
+  it("createPane relaxed path throws when tmux binary is not available", async () => {
+    delete process.env.TMUX;
+    installMockExec((args) => {
+      if (args.includes("-lc")) throw new Error("command not found");
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(() =>
+      new TmuxMultiplexer().createPane({
+        name: "Demo",
+        cwd: "/tmp",
+        background: true,
+        id: "abc12345",
+      }),
+    ).toThrow(/tmux is not available/);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  isPaneAlive                                                        */
+  /* ------------------------------------------------------------------ */
+
+  it("isPaneAlive returns true when display-message succeeds", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    installMockExec((args) => {
+      if (args[0] === "display-message") return "#{pane_id}\n";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(new TmuxMultiplexer().isPaneAlive("%42")).toBe(true);
+  });
+
+  it("isPaneAlive returns false when display-message throws", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    installMockExec((args) => {
+      if (args[0] === "display-message") throw new Error("no such pane");
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(new TmuxMultiplexer().isPaneAlive("%99")).toBe(false);
+  });
+
+  it("isPaneAlive uses correct tmux args: display-message -p -t paneId #{pane_id}", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "display-message") return "#{pane_id}\n";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    new TmuxMultiplexer().isPaneAlive("%42");
+
+    const dm = calls.find((a) => a[0] === "display-message");
+    expect(dm).toBeDefined();
+    expect(dm).toContain("-p");
+    expect(dm).toContain("-t");
+    expect(dm).toContain("%42");
+    expect(dm).toContain("#{pane_id}");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  sendKeys + sendEnter                                               */
+  /* ------------------------------------------------------------------ */
+
+  it("sendKeys calls send-keys -l with the text", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    new TmuxMultiplexer().sendKeys("%42", "echo hello");
+
+    const sk = calls.find((a) => a[0] === "send-keys");
+    expect(sk).toBeDefined();
+    expect(sk).toContain("-t");
+    expect(sk).toContain("%42");
+    expect(sk).toContain("-l");
+    expect(sk).toContain("echo hello");
+  });
+
+  it("sendKeys sends text with newlines verbatim", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    new TmuxMultiplexer().sendKeys("%42", "line1\nline2");
+
+    const sk = calls.find((a) => a[0] === "send-keys");
+    expect(sk).toBeDefined();
+    expect(sk).toContain("line1\nline2");
+  });
+
+  it("sendEnter calls send-keys with Enter key name", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    new TmuxMultiplexer().sendEnter("%42");
+
+    const sk = calls.find((a) => a[0] === "send-keys");
+    expect(sk).toBeDefined();
+    expect(sk).toContain("-t");
+    expect(sk).toContain("%42");
+    // zellij sends "13" (byte value); tmux uses the named key "Enter"
+    expect(sk).toContain("Enter");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  killPane                                                           */
+  /* ------------------------------------------------------------------ */
+
+  it("killPane calls kill-pane -t with the pane id", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    new TmuxMultiplexer().killPane("%42");
+
+    const kp = calls.find((a) => a[0] === "kill-pane");
+    expect(kp).toBeDefined();
+    expect(kp).toContain("-t");
+    expect(kp).toContain("%42");
+  });
+
+  it("killPane does not throw on error (best-effort)", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    installMockExec(() => {
+      throw new Error("no such pane");
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(() => new TmuxMultiplexer().killPane("%99")).not.toThrow();
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  buildAttachCommands — with windowName (background mode)            */
+  /* ------------------------------------------------------------------ */
+
+  it("buildAttachCommands with windowName returns session+select-window commands via getPaneLocation", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "display-message") return MOCK_LOCATION;
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const cmds = new TmuxMultiplexer().buildAttachCommands({
+      paneId: "%42",
+      windowName: "demo",
+    });
+
+    // getPaneLocation was called (display-message)
+    expect(calls.some((a) => a[0] === "display-message")).toBe(true);
+
+    expect(cmds.attachCommand).toContain("tmux attach -t 'main'");
+    // \; is the tmux command separator for chaining
+    expect(cmds.attachCommand).toContain("\\;");
+    expect(cmds.attachCommand).toContain("select-window -t 'demo'");
+
+    expect(cmds.focusCommand).toBe("tmux select-window -t 'demo'");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  buildAttachCommands — without windowName (split mode)              */
+  /* ------------------------------------------------------------------ */
+
+  it("buildAttachCommands without windowName returns chain targeting session:window + select-pane", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "display-message") return MOCK_LOCATION;
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const cmds = new TmuxMultiplexer().buildAttachCommands({
+      paneId: "%42",
+    });
+
+    expect(cmds.attachCommand).toBe(
+      "tmux attach -t 'main' \\; select-window -t 'main:1' \\; select-pane -t '%42'",
+    );
+    expect(cmds.focusCommand).toBe("tmux select-pane -t '%42'");
+  });
+
+  it("buildAttachCommands getPaneLocation consumes the tab-separated display-message output", async () => {
+    // Contract: display-message with #{session_name}\t#{window_index}\t#{pane_index}
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      // Output format: session_name\twindow_index\tpane_index (tab-separated)
+      if (args[0] === "display-message") return "my-session\t3\t2\n";
+      return "";
+    });
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+
+    const cmds = new TmuxMultiplexer().buildAttachCommands({
+      paneId: "%42",
+    });
+
+    // session=my-session, window=3, pane=2
+    expect(cmds.attachCommand).toContain("'my-session'");
+    expect(cmds.attachCommand).toContain("'my-session:3'");
+    expect(cmds.attachCommand).toContain("'%42'");
+
+    // The display-message format template must include all three fields
+    // (they're tab-separated into one arg element, so check substring).
+    const fm = calls.find((a) => a[0] === "display-message");
+    expect(fm).toBeDefined();
+    const formatArg = fm!.find((s) => s.includes("#{session_name}"));
+    expect(formatArg).toBeDefined();
+    expect(formatArg!).toContain("#{window_index}");
+    expect(formatArg!).toContain("#{pane_index}");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  readPaneExitCode — command contract (subset; detailed tests in     */
+  /*  interactive-tmux.test.ts cover return values)                      */
+  /* ------------------------------------------------------------------ */
+
+  it("readPaneExitCode uses show-options -p -v -t paneId @pi-exit-code", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const calls: string[][] = [];
+    installMockExec((args) => {
+      calls.push(args);
+      if (args[0] === "show-options") return "0\n";
+      return "";
+    });
+    const { readPaneExitCode } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    readPaneExitCode("%42");
+
+    const so = calls.find((a) => a[0] === "show-options");
+    expect(so).toBeDefined();
+    expect(so).toContain("-p"); // pane-scoped
+    expect(so).toContain("-v"); // value only (no name)
+    expect(so).toContain("-t");
+    expect(so).toContain("%42");
+    expect(so).toContain("@pi-exit-code");
+  });
+
+  it("readPaneExitCode suppresses stderr to avoid leaking 'invalid option' into parent TUI", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    const capturedOptions: Array<Record<string, unknown> | undefined> = [];
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string, args: string[], options?: unknown) => {
+        capturedOptions.push(options as Record<string, unknown> | undefined);
+        if (args[0] === "show-options") throw new Error("unset");
+        return "";
+      },
+    }));
+    const { readPaneExitCode } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    expect(readPaneExitCode("%42")).toBeNull();
+
+    const opts = capturedOptions.find(
+      (o) => o && Array.isArray((o as any).stdio),
+    );
+    expect(opts).toBeDefined();
+    const stdio = (opts as any).stdio as [string, string, string];
+    expect(stdio[2]).toBe("ignore");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  improved diagnostics on command failure                           */
+/* ------------------------------------------------------------------ */
+
+it("buildAttachCommands throws improved diagnostic on display-message failure", async () => {
+  process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args[0] === "display-message") {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("can't find pane: %99");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    },
+  }));
+  const { TmuxMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-tmux")
+  >("../src/multiplexer-tmux");
+  expect(() =>
+    new TmuxMultiplexer().buildAttachCommands({ paneId: "%99" }),
+  ).toThrow(
+    /\[tmux\] display-message failed.*exit code 1.*stderr: can't find pane/,
+  );
+});
+
+it("createPane background throws improved diagnostic on new-window failure", async () => {
+  process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args.includes("-lc")) return ""; // commandExists succeeds
+      if (args[0] === "new-window") {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("no such session");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    },
+  }));
+  const { TmuxMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-tmux")
+  >("../src/multiplexer-tmux");
+  expect(() =>
+    new TmuxMultiplexer().createPane({
+      name: "Test",
+      cwd: "/tmp",
+      background: true,
+    }),
+  ).toThrow(/\[tmux\] new-window failed.*exit code 1.*stderr: no such session/);
+});
+
+it("sendKeys throws improved diagnostic on send-keys failure", async () => {
+  process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args[0] === "send-keys" && args.includes("-l")) {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("can't find pane: %99");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    },
+  }));
+  const { TmuxMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-tmux")
+  >("../src/multiplexer-tmux");
+  expect(() => new TmuxMultiplexer().sendKeys("%99", "echo hi")).toThrow(
+    /\[tmux\] send-keys failed.*exit code 1.*stderr: can't find pane/,
+  );
+});
+
+it("sendEnter throws improved diagnostic on send-keys Enter failure", async () => {
+  process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args[0] === "send-keys" && args.includes("Enter")) {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("no such pane: %99");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    },
+  }));
+  const { TmuxMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-tmux")
+  >("../src/multiplexer-tmux");
+  expect(() => new TmuxMultiplexer().sendEnter("%99")).toThrow(
+    /\[tmux\] send-keys Enter failed.*exit code 1.*stderr: no such pane/,
+  );
+});

--- a/tests/multiplexer-zellij.test.ts
+++ b/tests/multiplexer-zellij.test.ts
@@ -445,7 +445,7 @@ describe("multiplexer-zellij", () => {
     expect(cmds.focusCommand).toBe("zellij action focus-pane-id 42");
   });
 
-  it("attachCommand for visible split does NOT use tmux \; chaining (zellij doesn't support it)", async () => {
+  it("attachCommand for visible split does NOT use tmux ; chaining (zellij doesn't support it)", async () => {
     process.env.ZELLIJ = "0";
     process.env.ZELLIJ_SESSION_NAME = "main";
 
@@ -534,4 +534,285 @@ describe("multiplexer-zellij", () => {
     const mux = new ZellijMultiplexer();
     expect(mux.isPaneAlive("42")).toBe(false);
   });
+
+  /* ------------------------------------------------------------------ */
+  /*  plugin_<n> prefix normalization                                    */
+  /* ------------------------------------------------------------------ */
+
+  it("isPaneAlive normalizes plugin_<n> prefix (symmetric with terminal_<n>)", async () => {
+    process.env.ZELLIJ = "0";
+    installMockExec((_f, args) => {
+      if (args.includes("list-panes")) {
+        // list-panes --json returns bare integer ids, never plugin_ prefix
+        return JSON.stringify([{ id: 42 }]);
+      }
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    // plugin_42 should normalize to bare integer 42 for list-panes lookup
+    expect(mux.isPaneAlive("plugin_42")).toBe(true);
+    // Non-existent pane should still return false
+    expect(mux.isPaneAlive("plugin_99")).toBe(false);
+  });
+
+  it("sendKeys normalizes plugin_<n> prefix in pane id", async () => {
+    process.env.ZELLIJ = "0";
+    const calls: string[][] = [];
+    installMockExec((_f, args) => {
+      calls.push(args);
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    mux.sendKeys("plugin_7", "echo hi");
+
+    const wc = calls.find((a) => a.includes("write-chars"));
+    expect(wc).toEqual(expect.arrayContaining(["--pane-id", "7"]));
+    expect(wc).not.toContain("plugin_7");
+  });
+
+  it("sendEnter normalizes plugin_<n> prefix in pane id", async () => {
+    process.env.ZELLIJ = "0";
+    const calls: string[][] = [];
+    installMockExec((_f, args) => {
+      calls.push(args);
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    mux.sendEnter("plugin_7");
+
+    const w = calls.find(
+      (a) => a.includes("write") && !a.includes("write-chars"),
+    );
+    expect(w).toEqual(expect.arrayContaining(["--pane-id", "7"]));
+    expect(w).not.toContain("plugin_7");
+  });
+
+  it("killPane normalizes plugin_<n> prefix in pane id", async () => {
+    process.env.ZELLIJ = "0";
+    const calls: string[][] = [];
+    installMockExec((_f, args) => {
+      calls.push(args);
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    mux.killPane("plugin_7");
+
+    const cp = calls.find((a) => a.includes("close-pane"));
+    expect(cp).toEqual(expect.arrayContaining(["--pane-id", "7"]));
+    expect(cp).not.toContain("plugin_7");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — failures                                              */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane throws when no panes are detectable after creation", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    installMockExec((_f, args) => {
+      if (args.includes("list-panes") && args.includes("--json")) {
+        // Both before and after return completely empty
+        return JSON.stringify([]);
+      }
+      if (args.includes("new-tab")) return "";
+      if (args.includes("current-tab-info")) return "position: 0\n";
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    expect(() =>
+      mux.createPane({
+        name: "Demo",
+        cwd: "/tmp",
+        background: true,
+      }),
+    ).toThrow(/Failed to determine pane ID/);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  createPane — background with explicit windowName                   */
+  /* ------------------------------------------------------------------ */
+
+  it("createPane background mode passes explicit windowName to new-tab --name", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    const calls: string[][] = [];
+    let listCallCount = 0;
+    installMockExec((_f, args) => {
+      calls.push(args);
+      if (args.includes("list-panes") && args.includes("--json")) {
+        listCallCount++;
+        return listCallCount === 1
+          ? JSON.stringify([{ id: 1, tab_position: 0 }])
+          : JSON.stringify([
+              { id: 1, tab_position: 0 },
+              { id: 2, tab_position: 1 },
+            ]);
+      }
+      // Return position for current-tab-info so tab-focus restore is exercised
+      if (args.includes("current-tab-info")) return "position: 0\n";
+      return "";
+    });
+
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    const result = mux.createPane({
+      name: "Demo",
+      cwd: "/tmp",
+      background: true,
+      windowName: "my-custom-tab",
+    });
+
+    expect(result.windowName).toBe("my-custom-tab");
+    // The new-tab call must carry --name my-custom-tab
+    const nt = calls.find((a) => a.includes("new-tab"));
+    expect(nt).toBeDefined();
+    expect(nt).toContain("--name");
+    expect(nt).toContain("my-custom-tab");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  improved diagnostics on command failure                           */
+/* ------------------------------------------------------------------ */
+
+it("createPane relaxed path throws improved diagnostic on attach failure", async () => {
+  delete process.env.ZELLIJ;
+  delete process.env.ZELLIJ_SESSION_NAME;
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args.includes("-lc")) return ""; // commandExists succeeds
+      if (args[0] === "attach" && args.includes("--create-background")) {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("no server running");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    },
+  }));
+  const { ZellijMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-zellij")
+  >("../src/multiplexer-zellij");
+  const mux = new ZellijMultiplexer();
+  expect(() =>
+    mux.createPane({
+      name: "Test",
+      cwd: "/tmp",
+      background: true,
+      id: "abc12345",
+    }),
+  ).toThrow(
+    /\[zellij\] attach --create-background failed.*exit code 1.*stderr: no server running/,
+  );
+});
+
+it("createPane background throws improved diagnostic on new-tab failure", async () => {
+  process.env.ZELLIJ = "0";
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args.includes("-lc")) return ""; // commandExists succeeds
+      if (args.includes("new-tab")) {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("cannot create tab: session is read-only");
+        err.status = 1;
+        throw err;
+      }
+      return ""; // list-panes, current-tab-info all return empty
+    },
+  }));
+  const { ZellijMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-zellij")
+  >("../src/multiplexer-zellij");
+  const mux = new ZellijMultiplexer();
+  expect(() =>
+    mux.createPane({
+      name: "Test",
+      cwd: "/tmp",
+      background: true,
+    }),
+  ).toThrow(
+    /\[zellij\] new-tab failed.*exit code 1.*stderr: cannot create tab/,
+  );
+});
+
+it("sendKeys throws improved diagnostic on write-chars failure", async () => {
+  process.env.ZELLIJ = "0";
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args.includes("write-chars")) {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("no such pane: 99");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    },
+  }));
+  const { ZellijMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-zellij")
+  >("../src/multiplexer-zellij");
+  const mux = new ZellijMultiplexer();
+  expect(() => mux.sendKeys("99", "echo hi")).toThrow(
+    /\[zellij\] write-chars failed.*exit code 1.*stderr: no such pane: 99/,
+  );
+});
+
+it("sendEnter throws improved diagnostic on write 13 failure", async () => {
+  process.env.ZELLIJ = "0";
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => {
+      if (args.includes("write") && !args.includes("write-chars")) {
+        const err = new Error("Command failed") as Error & {
+          stderr?: Buffer;
+          status?: number;
+        };
+        err.stderr = Buffer.from("pane not found: 99");
+        err.status = 1;
+        throw err;
+      }
+      return "";
+    },
+  }));
+  const { ZellijMultiplexer } = await importFresh<
+    typeof import("../src/multiplexer-zellij")
+  >("../src/multiplexer-zellij");
+  const mux = new ZellijMultiplexer();
+  expect(() => mux.sendEnter("99")).toThrow(
+    /\[zellij\] write 13 failed.*exit code 1.*stderr: pane not found: 99/,
+  );
 });

--- a/tests/publish-workflow.test.ts
+++ b/tests/publish-workflow.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Tests that the GitHub Actions publish workflow (.github/workflows/publish.yml)
+ * maintains key invariants that protect the npm publish process.
+ *
+ * These tests are structural: they parse the YAML (without js-yaml) and verify
+ * the shape, ordering, and content of workflow steps. They do NOT execute
+ * the workflow or shell out to actions/validate.
+ *
+ * What is verified:
+ *   - Trigger: only v* tags trigger publish
+ *   - Permissions: id-token: write is present (trusted publishing / OIDC)
+ *   - Pre-publish validation runs before npm publish:
+ *       typecheck → tests → tarball smoke → pack:check → publish
+ *   - Tag-version mismatch is checked before typecheck (early-exit)
+ *   - npm publish uses --provenance and --access public
+ *   - npm ci (not npm install) is used
+ *   - Node version is 24 with npm cache
+ *   - Every pre-publish validation step exists (typecheck, test, tarball, pack)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const REPO = resolve(fileURLToPath(import.meta.url), "..", "..");
+const WORKFLOW_PATH = resolve(REPO, ".github/workflows/publish.yml");
+
+/**
+ * Minimal YAML parser for the simple structure of .github/workflows/*.yml.
+ *
+ * Handles: mappings, sequences (at any indent level), quoted scalars,
+ * block scalars (|), and nested combinations. Does NOT handle: anchors,
+ * aliases, tags, complex keys, flow collections, or multi-document streams.
+ */
+function parseSimpleYaml(text: string): unknown {
+  const lines = text.split("\n");
+  let pos = 0;
+
+  /** Consume the next non-empty line, stripping trailing whitespace. */
+  function peek(): { indent: number; content: string } | null {
+    while (pos < lines.length) {
+      const rawLine = lines[pos++];
+      const trimmed = rawLine.trimEnd();
+      if (trimmed === "") continue;
+      const indent = rawLine.length - rawLine.trimStart().length;
+      const content = trimmed.slice(indent);
+      return { indent, content };
+    }
+    return null;
+  }
+
+  /** Peek without consuming. */
+  function lookahead(): { indent: number; content: string } | null {
+    const saved = pos;
+    const r = peek();
+    pos = saved;
+    return r;
+  }
+
+  /** Skip the content lines of a block scalar (| or >). */
+  function skipBlockScalar(headerIndent: number): void {
+    while (true) {
+      const n = lookahead();
+      if (!n) break;
+      if (n.indent <= headerIndent) break;
+      peek(); // consume
+    }
+  }
+
+  /** Unquote a scalar string if wrapped in matching quotes. */
+  function unquote(s: string): string {
+    if (s.length < 2) return s;
+    const first = s[0];
+    const last = s[s.length - 1];
+    if (first === last && (first === '"' || first === "'"))
+      return s.slice(1, -1);
+    return s;
+  }
+
+  /** Check if a value is a block scalar indicator. */
+  function isBlockScalar(v: string): boolean {
+    return v === "|" || v === ">" || v === "|-" || v === ">-";
+  }
+
+  /** Parse children of a mapping key that has no inline value. */
+  function parseChildren(keyIndent: number): unknown {
+    const next = lookahead();
+    if (!next) return null;
+    if (next.indent <= keyIndent) return null;
+    if (next.content.startsWith("- ")) return parseSequence(next.indent);
+    return parseMapping(next.indent);
+  }
+
+  /** Parse a mapping block at a given indent level. */
+  function parseMapping(indent: number): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    while (true) {
+      const next = lookahead();
+      if (!next) break;
+      if (next.indent < indent) break;
+      if (next.indent !== indent) break;
+
+      const line = peek()!; // safe: lookahead() confirmed non-null
+      const colonIdx = line.content.indexOf(":");
+      if (colonIdx === -1) break;
+
+      const key = line.content.slice(0, colonIdx).trim();
+      const rest = line.content.slice(colonIdx + 1).trim();
+
+      if (rest) {
+        if (isBlockScalar(rest)) {
+          skipBlockScalar(line.indent);
+          result[key] = rest; // placeholder; we don't parse the body
+        } else {
+          result[key] = unquote(rest);
+        }
+      } else {
+        result[key] = parseChildren(line.indent);
+      }
+    }
+    return result;
+  }
+
+  /** Parse a sequence where items are all at seqIndent. */
+  function parseSequence(seqIndent: number): unknown[] {
+    const result: unknown[] = [];
+
+    while (true) {
+      const next = lookahead();
+      if (!next) break;
+      if (next.indent < seqIndent) break;
+      if (next.indent !== seqIndent) break;
+      if (!next.content.startsWith("- ")) break;
+
+      const line = peek()!; // safe: lookahead() confirmed non-null
+      const itemIndent = line.indent;
+      const rest = line.content.slice(2).trimStart();
+
+      if (!rest) {
+        // Bare "-" followed by indented children only
+        const child = lookahead();
+        if (child && child.indent > itemIndent) {
+          result.push(parseMapping(child.indent));
+        } else {
+          result.push(null);
+        }
+      } else {
+        const colonIdx = rest.indexOf(":");
+        if (colonIdx >= 0) {
+          // Inline mapping entry: "- key: value" possibly with more properties
+          const item: Record<string, unknown> = {};
+          const k = rest.slice(0, colonIdx).trim();
+          const v = rest.slice(colonIdx + 1).trim();
+          if (v) {
+            if (isBlockScalar(v)) {
+              skipBlockScalar(itemIndent);
+              item[k] = v; // placeholder
+            } else {
+              item[k] = unquote(v);
+            }
+          } else {
+            item[k] = parseChildren(itemIndent);
+          }
+
+          // Sibling properties at itemIndent + 2
+          const propIndent = itemIndent + 2;
+          while (true) {
+            const n = lookahead();
+            if (!n) break;
+            if (n.indent < propIndent) break;
+            // Stop if next sequence item at seqIndent
+            if (n.indent === seqIndent && n.content.startsWith("- ")) break;
+            if (n.indent !== propIndent) break;
+
+            const pline = peek()!; // safe: lookahead() confirmed non-null
+            const pcolon = pline.content.indexOf(":");
+            if (pcolon === -1) break;
+            const pk = pline.content.slice(0, pcolon).trim();
+            const pr = pline.content.slice(pcolon + 1).trim();
+            if (pr) {
+              if (isBlockScalar(pr)) {
+                skipBlockScalar(pline.indent);
+                item[pk] = pr; // placeholder
+              } else {
+                item[pk] = unquote(pr);
+              }
+            } else {
+              item[pk] = parseChildren(pline.indent);
+            }
+          }
+          result.push(item);
+        } else {
+          // Scalar sequence element
+          result.push(unquote(rest));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  // Root: mapping at indent 0
+  return parseMapping(0);
+}
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+}
+
+/** Extract the ordered steps array from the parsed workflow. */
+function extractSteps(parsed: unknown): WorkflowStep[] {
+  const root = parsed as Record<string, unknown>;
+  const jobs = root.jobs as Record<string, unknown>;
+  const publish = jobs?.publish as Record<string, unknown>;
+  return (publish?.steps as WorkflowStep[]) ?? [];
+}
+
+/** Return the index of the first step whose `run` contains the given string. */
+function findStepIndex(steps: WorkflowStep[], runContains: string): number {
+  return steps.findIndex(
+    (s) => typeof s.run === "string" && s.run.includes(runContains),
+  );
+}
+
+/** Return the index of the first step whose `uses` starts with the given prefix. */
+function findUseStepIndex(steps: WorkflowStep[], usesPrefix: string): number {
+  return steps.findIndex(
+    (s) => typeof s.uses === "string" && s.uses.startsWith(usesPrefix),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("publish workflow (.github/workflows/publish.yml)", () => {
+  const raw = readFileSync(WORKFLOW_PATH, "utf-8");
+  const parsed = parseSimpleYaml(raw);
+  const root = parsed as Record<string, unknown>;
+  const steps = extractSteps(parsed);
+  const publishStepIdx = findStepIndex(steps, "npm publish");
+
+  // ---- Trigger ----
+
+  describe("trigger", () => {
+    it('only runs on tags matching "v*"', () => {
+      const on = root.on as Record<string, unknown>;
+      const push = on?.push as Record<string, unknown>;
+      const tags = push?.tags as string[];
+      expect(tags).toBeDefined();
+      expect(tags).toContain("v*");
+      expect(tags).toHaveLength(1);
+    });
+  });
+
+  // ---- Permissions ----
+
+  describe("permissions", () => {
+    it("grants id-token: write for OIDC / trusted publishing", () => {
+      const perms = root.permissions as Record<string, unknown>;
+      expect(perms).toBeDefined();
+      expect(perms.contents).toBe("read");
+      expect(perms["id-token"]).toBe("write");
+    });
+  });
+
+  // ---- Pre-publish validation ordering ----
+
+  describe("validation runs before publish", () => {
+    it("has a typecheck step before npm publish", () => {
+      const idx = findStepIndex(steps, "typecheck");
+      expect(idx).not.toBe(-1);
+      expect(idx).toBeLessThan(publishStepIdx);
+    });
+
+    it("has a test step (npm test) before npm publish", () => {
+      const idx = findStepIndex(steps, "npm test");
+      expect(idx).not.toBe(-1);
+      expect(idx).toBeLessThan(publishStepIdx);
+    });
+
+    it("has a tarball smoke-test step before npm publish", () => {
+      const idx = findStepIndex(steps, "published-tarball.test");
+      expect(idx).not.toBe(-1);
+      expect(idx).toBeLessThan(publishStepIdx);
+    });
+
+    it("has a pack:check step before npm publish", () => {
+      const idx = findStepIndex(steps, "pack:check");
+      expect(idx).not.toBe(-1);
+      expect(idx).toBeLessThan(publishStepIdx);
+    });
+
+    it("the publish step is after all validation steps", () => {
+      const packIdx = findStepIndex(steps, "pack:check");
+      const tarballIdx = findStepIndex(steps, "published-tarball.test");
+      const testIdx = findStepIndex(steps, "npm test");
+      const typecheckIdx = findStepIndex(steps, "typecheck");
+      const lastValidation = Math.max(
+        packIdx,
+        tarballIdx,
+        testIdx,
+        typecheckIdx,
+      );
+      expect(publishStepIdx).toBeGreaterThan(lastValidation);
+    });
+
+    it("publish is the final step in the job", () => {
+      expect(publishStepIdx).toBe(steps.length - 1);
+    });
+  });
+
+  // ---- Tag-version mismatch check ----
+
+  describe("tag-version verification", () => {
+    it("has a 'Verify tag matches package version' step", () => {
+      const idx = steps.findIndex((s) =>
+        (s.name ?? "").includes("Verify tag matches package version"),
+      );
+      expect(idx).not.toBe(-1);
+    });
+
+    it("runs before typecheck (early-exit before expensive steps)", () => {
+      const verifyIdx = steps.findIndex((s) =>
+        (s.name ?? "").includes("Verify tag matches package version"),
+      );
+      const typecheckIdx = findStepIndex(steps, "typecheck");
+      expect(verifyIdx).toBeLessThan(typecheckIdx);
+    });
+  });
+
+  // ---- npm publish flags ----
+
+  describe("npm publish flags", () => {
+    it("uses --provenance for OIDC attestation", () => {
+      const step = steps[publishStepIdx];
+      expect(step?.run).toContain("--provenance");
+    });
+
+    it("uses --access public for public packages", () => {
+      const step = steps[publishStepIdx];
+      expect(step?.run).toContain("--access public");
+    });
+  });
+
+  // ---- Dependencies installation ----
+
+  describe("dependency installation", () => {
+    it("uses npm ci (not npm install) for deterministic installs", () => {
+      const ciIdx = findStepIndex(steps, "npm ci");
+      expect(ciIdx).not.toBe(-1);
+      expect(findStepIndex(steps, "npm install")).toBe(-1);
+    });
+
+    it("runs before typecheck and tests", () => {
+      const ciIdx = findStepIndex(steps, "npm ci");
+      const typecheckIdx = findStepIndex(steps, "typecheck");
+      expect(ciIdx).toBeLessThan(typecheckIdx);
+    });
+  });
+
+  // ---- Runner setup ----
+
+  describe("runner setup", () => {
+    it("uses ubuntu-latest", () => {
+      const jobs = root.jobs as Record<string, unknown>;
+      const publish = jobs?.publish as Record<string, unknown>;
+      expect(publish?.["runs-on"]).toBe("ubuntu-latest");
+    });
+
+    it("sets up Node.js v24 with npm cache", () => {
+      const setupStep = steps.find((s) =>
+        (s.uses ?? "").startsWith("actions/setup-node"),
+      );
+      expect(setupStep).toBeDefined();
+      expect(setupStep!.with).toBeDefined();
+      const withOpts = setupStep!.with as Record<string, unknown>;
+      expect(withOpts["node-version"]).toBe("24");
+      expect(withOpts["cache"]).toBe("npm");
+      expect(withOpts["registry-url"]).toBe("https://registry.npmjs.org");
+    });
+
+    it("uses actions/checkout@v6 and actions/setup-node@v6", () => {
+      expect(findUseStepIndex(steps, "actions/checkout@")).not.toBe(-1);
+      expect(findUseStepIndex(steps, "actions/setup-node@")).not.toBe(-1);
+      // Pin major versions are v6
+      const checkoutStep = steps.find((s) =>
+        (s.uses ?? "").startsWith("actions/checkout@"),
+      );
+      expect(checkoutStep!.uses).toBe("actions/checkout@v6");
+      const setupStep = steps.find((s) =>
+        (s.uses ?? "").startsWith("actions/setup-node@"),
+      );
+      expect(setupStep!.uses).toBe("actions/setup-node@v6");
+    });
+  });
+
+  // ---- Just-in-case: the raw file is readable ----
+
+  it("the workflow file exists and is non-empty", () => {
+    expect(raw.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/published-tarball.test.ts
+++ b/tests/published-tarball.test.ts
@@ -21,6 +21,8 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -38,6 +40,11 @@ const PKG = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
   version: string;
   files: string[];
 };
+const NM_SMOKE_DIR = join(
+  REPO,
+  "node_modules",
+  ".pi-subagentura-smoke-" + PKG.version,
+);
 
 interface PackResult {
   tgz: string;
@@ -116,9 +123,15 @@ describe("published tarball", () => {
     const r = pack(work);
     entries = r.entries;
     pkgDir = r.pkgDir;
+    // Copy extracted tarball into node_modules so Vite resolves bare specifiers
+    if (existsSync(NM_SMOKE_DIR))
+      rmSync(NM_SMOKE_DIR, { recursive: true, force: true });
+    cpSync(pkgDir, NM_SMOKE_DIR, { recursive: true });
   });
 
   afterAll(() => {
+    if (existsSync(NM_SMOKE_DIR))
+      rmSync(NM_SMOKE_DIR, { recursive: true, force: true });
     rmSync(work, { recursive: true, force: true });
   });
 
@@ -162,5 +175,57 @@ describe("published tarball", () => {
       failures,
       failures.length === 0 ? "" : `\n${failures.join("\n")}`,
     ).toEqual([]);
+  });
+
+  it("extension entrypoint can be imported like Pi does", async () => {
+    // Pi reads package.json#pi.extensions → ["./src/subagent.ts"],
+    // resolves relative to the package root, and does a dynamic import
+    const pkgJson = JSON.parse(
+      readFileSync(join(NM_SMOKE_DIR, "package.json"), "utf-8"),
+    );
+    const extensions = pkgJson.pi?.extensions;
+    expect(extensions).toBeDefined();
+    expect(Array.isArray(extensions)).toBe(true);
+    expect(extensions!.length).toBeGreaterThan(0);
+    const entrypoint = extensions![0];
+    expect(entrypoint).toBe("./src/subagent.ts");
+
+    // Dynamic import like Pi does — resolves the relative path against the package root
+    const mod = await import(join(NM_SMOKE_DIR, entrypoint));
+
+    // Default export is the extension registration function
+    expect(typeof mod.default).toBe("function");
+
+    // Key named exports that Pi references
+    expect(typeof mod.formatUsage).toBe("function");
+    expect(mod.jobRegistry).toBeDefined();
+  });
+
+  describe("package.json `files` array", () => {
+    it("includes every local import of every shipped .ts file (static check)", () => {
+      const tsFiles = PKG.files.filter((f) => f.endsWith(".ts"));
+      const failures: string[] = [];
+      for (const f of tsFiles) {
+        const source = readFileSync(join(REPO, f), "utf8");
+        for (const mod of localImports(source)) {
+          if (!resolvesInFiles(mod)) {
+            failures.push(
+              `${f} imports './${mod}' but 'src/${mod}.ts' (or 'src/${mod}/index.ts') is not in package.json 'files'`,
+            );
+          }
+        }
+      }
+      expect(
+        failures,
+        failures.length === 0 ? "" : `\n${failures.join("\n")}`,
+      ).toEqual([]);
+    });
+
+    function resolvesInFiles(mod: string): boolean {
+      return (
+        PKG.files.includes(`src/${mod}.ts`) ||
+        PKG.files.includes(`src/${mod}/index.ts`)
+      );
+    }
   });
 });

--- a/tests/subagent-api-surface.test.ts
+++ b/tests/subagent-api-surface.test.ts
@@ -1,0 +1,115 @@
+/**
+ * API surface lock-down test for pi-subagentura.
+ *
+ * This file documents the intended public API of the package and guards
+ * against accidental additions or removals of exported symbols.
+ *
+ * **Public (intentionally supported):**
+ *   - `default`           — Extension activator function (primary entry)
+ *   - `SubagentDetails`   — Discriminated-union type for tool-result details
+ *
+ * **Testing / internal (re-exported for test access; NOT part of the
+ *    supported public API — may change without a minor bump):**
+ *   - `rehydrateInteractiveSubagents`
+ *   - `formatUsage`
+ *   - `SubagentResult`
+ *   - `SubagentLiveStatus`
+ *   - `ACTIVE_TOOL_DEBOUNCE_MS`
+ *   - `jobRegistry`
+ *   - `MAX_REGISTRY_SIZE`
+ *   - `pruneOldestJob`
+ *   - `pruneCompletedJobs`
+ *   - `scheduleJobCleanup`
+ *   - `startSubagentJob`
+ *   - `JobState`          (type-only, erased at runtime)
+ *   - `JobStatus`         (type-only, erased at runtime)
+ *   - `NotifyOnComplete`  (type-only, erased at runtime)
+ *   - `interactiveSubagentRegistry`
+ *   - `getInjectCount`
+ *   - `MAX_INJECT`
+ *   - `pollArtifactChanges`
+ *   - `findArtifactById`
+ *
+ * If you add a new export to src/subagent.ts you MUST add it to the
+ * set below (and document why it's needed there).  Tests that verify new
+ * export names without updating this lock will fail intentionally.
+ */
+
+import { describe, expect, it } from "vitest";
+
+// ── Compile-time guard for type-only exports ───────────────────────────
+//
+// TypeScript's `export { type X }` syntax makes X available for explicit
+// named import but excludes it from `typeof import(…)`.  The imports below
+// will fail to compile if any type-only export is removed or renamed.
+// The unused dummy function prevents the "unused type" lint from firing
+// without emitting any runtime code.
+
+import type { JobState } from "../src/subagent";
+import type { JobStatus } from "../src/subagent";
+import type { NotifyOnComplete } from "../src/subagent";
+import type { SubagentDetails } from "../src/subagent";
+
+function _typeExportGuard(
+  _a: JobState,
+  _b: JobStatus,
+  _c: NotifyOnComplete,
+  _d: SubagentDetails,
+): void {}
+
+// ── Expected export inventory ──────────────────────────────────────────
+//
+// (a) Runtime-visible named exports (value exports visible via Object.keys)
+const RUNTIME_EXPORTS = [
+  "ACTIVE_TOOL_DEBOUNCE_MS",
+  "MAX_INJECT",
+  "MAX_REGISTRY_SIZE",
+  "SubagentLiveStatus",
+  "SubagentResult",
+  "findArtifactById",
+  "formatUsage",
+  "getInjectCount",
+  "interactiveSubagentRegistry",
+  "jobRegistry",
+  "pollArtifactChanges",
+  "pruneCompletedJobs",
+  "pruneOldestJob",
+  "rehydrateInteractiveSubagents",
+  "scheduleJobCleanup",
+  "startSubagentJob",
+] as const;
+
+// (b) Type-only exports (export type …, erased at runtime)
+const TYPE_ONLY_EXPORTS = [
+  "JobState",
+  "JobStatus",
+  "NotifyOnComplete",
+  "SubagentDetails",
+] as const;
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("subagent API surface", () => {
+  it("default export is the extension activator function", async () => {
+    const mod = await import("../src/subagent");
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("runtime-visible named exports are the expected set", async () => {
+    const mod = await import("../src/subagent");
+
+    const actualRuntime = Object.keys(mod)
+      .filter((k) => k !== "default")
+      .sort();
+
+    expect(actualRuntime).toEqual([...RUNTIME_EXPORTS].sort());
+  });
+
+  it("type-only exports are not present at runtime (erased by tsc)", async () => {
+    const mod = await import("../src/subagent");
+
+    for (const name of TYPE_ONLY_EXPORTS) {
+      expect(mod).not.toHaveProperty(name);
+    }
+  });
+});

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -2,43 +2,41 @@ import { describe, expect, it, vi } from "vitest";
 import registerExtension from "../src/subagent";
 
 describe("extension registration", () => {
-  describe("extension registration", () => {
-    it("registers the expected tools without throwing", () => {
-      const api = {
-        registerTool: vi.fn(),
-        registerMessageRenderer: vi.fn(),
-        on: vi.fn(),
-      };
+  it("registers the expected tools without throwing", () => {
+    const api = {
+      registerTool: vi.fn(),
+      registerMessageRenderer: vi.fn(),
+      on: vi.fn(),
+    };
 
-      expect(() => registerExtension(api as any)).not.toThrow();
+    expect(() => registerExtension(api as any)).not.toThrow();
 
-      const names = api.registerTool.mock.calls
-        .map(([tool]: any[]) => tool.name)
-        .sort();
-      expect(names).toEqual(
-        [
-          "cancel_interactive_subagent",
-          "cancel_subagent",
-          "cancel_workflow",
-          "cleanup_subagent_artifacts",
-          "get_interactive_subagent_status",
-          "get_subagent_result",
-          "get_subagent_status",
-          "get_workflow_result",
-          "get_workflow_status",
-          "list_available_models",
-          "list_subagent_artifacts",
-          "list_workflows",
-          "prune_subagent_jobs",
-          "read_subagent_artifact",
-          "save_workflow",
-          "send_interactive_subagent_message",
-          "subagent_interactive",
-          "subagent_isolated",
-          "subagent_with_context",
-          "workflow",
-        ].sort(),
-      );
-    });
+    const names = api.registerTool.mock.calls
+      .map(([tool]: any[]) => tool.name)
+      .sort();
+    expect(names).toEqual(
+      [
+        "cancel_interactive_subagent",
+        "cancel_subagent",
+        "cancel_workflow",
+        "cleanup_subagent_artifacts",
+        "get_interactive_subagent_status",
+        "get_subagent_result",
+        "get_subagent_status",
+        "get_workflow_result",
+        "get_workflow_status",
+        "list_available_models",
+        "list_subagent_artifacts",
+        "list_workflows",
+        "prune_subagent_jobs",
+        "read_subagent_artifact",
+        "save_workflow",
+        "send_interactive_subagent_message",
+        "subagent_interactive",
+        "subagent_isolated",
+        "subagent_with_context",
+        "workflow",
+      ].sort(),
+    );
   });
 });

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -11,7 +11,7 @@ describe("extension registration", () => {
       };
 
       expect(() => registerExtension(api as any)).not.toThrow();
-      expect(api.registerTool).toHaveBeenCalledTimes(19);
+      expect(api.registerTool).toHaveBeenCalledTimes(20);
     });
   });
 });

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -3,7 +3,7 @@ import registerExtension from "../src/subagent";
 
 describe("extension registration", () => {
   describe("extension registration", () => {
-    it("registers all tools without throwing", () => {
+    it("registers the expected tools without throwing", () => {
       const api = {
         registerTool: vi.fn(),
         registerMessageRenderer: vi.fn(),
@@ -11,7 +11,34 @@ describe("extension registration", () => {
       };
 
       expect(() => registerExtension(api as any)).not.toThrow();
-      expect(api.registerTool).toHaveBeenCalledTimes(20);
+
+      const names = api.registerTool.mock.calls
+        .map(([tool]: any[]) => tool.name)
+        .sort();
+      expect(names).toEqual(
+        [
+          "cancel_interactive_subagent",
+          "cancel_subagent",
+          "cancel_workflow",
+          "cleanup_subagent_artifacts",
+          "get_interactive_subagent_status",
+          "get_subagent_result",
+          "get_subagent_status",
+          "get_workflow_result",
+          "get_workflow_status",
+          "list_available_models",
+          "list_subagent_artifacts",
+          "list_workflows",
+          "prune_subagent_jobs",
+          "read_subagent_artifact",
+          "save_workflow",
+          "send_interactive_subagent_message",
+          "subagent_interactive",
+          "subagent_isolated",
+          "subagent_with_context",
+          "workflow",
+        ].sort(),
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Harden release and maintenance checks across the project — CI gates, mux diagnostics, artifact cleanup TTL, state migration, and comprehensive tests.

### Changes

- **CI**: Add typecheck step to publish workflow before tests
- **Tests**: New `publish-workflow.test.ts` validates the CI gate pipeline
- **Tests**: `published-tarball.test.ts` adds extension entrypoint import and `files[]` completeness check
- **Tests**: `multiplexer-tmux.test.ts` — 28 mux contract tests
- **Tests**: `multiplexer-zellij.test.ts` — pane normalization/diagnostics (31 tests)
- **Tests**: `subagent-api-surface.test.ts` — public API export verification
- **Tests**: `artifact.test.ts` — cleanupOldArtifacts tests + state migration tests
- **Feature**: `cleanupOldArtifacts()` with path-safety checks, TTL, active-IDs protection, dry-run mode
- **Feature**: `cleanup_subagent_artifacts` tool registered for agent use
- **Feature**: `migrateStatePayload()` handles schemaVersion: null/0/negative gracefully
- **Feature**: `execMuxOrThrow()` — improved error diagnostics for mux command failures
- **Refactor**: `subagent.ts` entrypoint reorganized with JSDoc exports and internal re-export annotations
- **Docs**: `AGENTS.md` — updated file map, test counts, code conventions
- **Docs**: `CONTRIBUTING.md` — full release flow with version/tag collision recovery

### Verification

- ✅ `npm run typecheck` — passes
- ✅ `npm test` — 480 tests, 27 test files, all passing
- ✅ `npm run format:check` — all files Prettier-clean
- ✅ `npm run pack:check` — tarball 16 files, matches `package.json#files`