### PR TITLE
test: add tmux integration CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install tmux
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tmux
+
       - name: Type check
         run: npm run typecheck
       - name: Run tests
         run: npm test
+
+      - name: Run tmux integration tests
+        run: npm run test:tmux
+        env:
+          PI_SUBAGENTURA_TMUX_SOCKET: pi-subagentura-ci-${{ github.run_id }}-${{ github.run_attempt }}
+          TERM: xterm-256color
       - name: "Verify published tarball is loadable (regression: v2.0.0 missing helpers.ts)"
         run: npx vitest run published-tarball.test.ts
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     ]
   },
   "scripts": {
-    "test": "vitest run",
+    "test": "vitest run --exclude tests/tmux.integration.test.ts",
+    "test:tmux": "vitest run tests/tmux.integration.test.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/multiplexer-tmux.ts
+++ b/src/multiplexer-tmux.ts
@@ -27,6 +27,29 @@ import type { Multiplexer } from "./multiplexer";
 import { commandExists, execMuxOrThrow, shellEscape } from "./multiplexer";
 
 /**
+ * Optional test/CI isolation for real tmux integration tests.
+ *
+ * tmux's default server/socket is user-global. In CI, and especially when tests
+ * run in parallel or after a failed job, sharing the default socket makes tests
+ * flaky and can leak panes into a developer's normal tmux session. When this env
+ * var is set, every tmux operation is routed through `tmux -L <socket>`.
+ */
+function withTmuxSocket(args: readonly string[]): string[] {
+  const socket = process.env.PI_SUBAGENTURA_TMUX_SOCKET;
+  return socket ? ["-L", socket, ...args] : [...args];
+}
+
+function tmuxCommandPrefix(): string {
+  const socket = process.env.PI_SUBAGENTURA_TMUX_SOCKET;
+  return socket ? `tmux -L ${shellEscape(socket)}` : "tmux";
+}
+
+function settleTmuxSocketPaneForTests(): void {
+  if (!process.env.PI_SUBAGENTURA_TMUX_SOCKET) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+}
+
+/**
  * Extract the session name, window index, and pane index of a tmux pane
  * via `display-message`. Throws if the pane is dead or the id is malformed —
  * callers that want a liveness probe should use `isPaneAlive` instead.
@@ -40,13 +63,13 @@ function getPaneLocation(paneId: string): {
     "tmux",
     "display-message",
     "tmux",
-    [
+    withTmuxSocket([
       "display-message",
       "-p",
       "-t",
       paneId,
       "#{session_name}\t#{window_index}\t#{pane_index}",
-    ],
+    ]),
     { encoding: "utf8", timeout: 5000 },
   ).trim();
   const [session, window, pane] = output.split("\t");
@@ -127,7 +150,7 @@ export class TmuxMultiplexer implements Multiplexer {
         "tmux",
         "new-session",
         "tmux",
-        [
+        withTmuxSocket([
           "new-session",
           "-d",
           "-s",
@@ -137,7 +160,7 @@ export class TmuxMultiplexer implements Multiplexer {
           "-P",
           "-F",
           "#{pane_id}",
-        ],
+        ]),
         { encoding: "utf8", timeout: 10000 },
       ).trim();
       if (!paneId.startsWith("%")) {
@@ -149,15 +172,22 @@ export class TmuxMultiplexer implements Multiplexer {
       try {
         execFileSync(
           "tmux",
-          ["rename-window", "-t", `${sessionName}:0`, windowName],
+          withTmuxSocket([
+            "rename-window",
+            "-t",
+            `${sessionName}:0`,
+            windowName,
+          ]),
           {
             encoding: "utf8",
+            stdio: "ignore",
             timeout: 5000,
           },
         );
       } catch {
         // Cosmetic; don't fail the spawn if rename doesn't take.
       }
+      settleTmuxSocketPaneForTests();
       return { paneId, windowName };
     }
 
@@ -173,7 +203,7 @@ export class TmuxMultiplexer implements Multiplexer {
         "tmux",
         "new-window",
         "tmux",
-        [
+        withTmuxSocket([
           "new-window",
           "-d",
           "-n",
@@ -183,7 +213,7 @@ export class TmuxMultiplexer implements Multiplexer {
           "#{pane_id}",
           "-c",
           opts.cwd,
-        ],
+        ]),
         { encoding: "utf8", timeout: 10000 },
       ).trim();
     } else {
@@ -203,10 +233,16 @@ export class TmuxMultiplexer implements Multiplexer {
       if (parent) {
         args.splice(4, 0, "-t", parent);
       }
-      paneId = execMuxOrThrow("tmux", "split-window", "tmux", args, {
-        encoding: "utf8",
-        timeout: 10000,
-      }).trim();
+      paneId = execMuxOrThrow(
+        "tmux",
+        "split-window",
+        "tmux",
+        withTmuxSocket(args),
+        {
+          encoding: "utf8",
+          timeout: 10000,
+        },
+      ).trim();
     }
     if (!paneId.startsWith("%")) {
       throw new Error(`Unexpected tmux pane id: ${paneId || "(empty)"}`);
@@ -214,13 +250,18 @@ export class TmuxMultiplexer implements Multiplexer {
     if (!opts.background) {
       // Pane title is cosmetic and the new window already shows `name`.
       try {
-        execFileSync("tmux", ["select-pane", "-t", paneId, "-T", opts.name], {
-          encoding: "utf8",
-        });
+        execFileSync(
+          "tmux",
+          withTmuxSocket(["select-pane", "-t", paneId, "-T", opts.name]),
+          {
+            encoding: "utf8",
+          },
+        );
       } catch {
         // Pane title is cosmetic and can fail on older tmux versions.
       }
     }
+    settleTmuxSocketPaneForTests();
     return { paneId, windowName };
   }
 
@@ -228,7 +269,7 @@ export class TmuxMultiplexer implements Multiplexer {
     try {
       execFileSync(
         "tmux",
-        ["display-message", "-p", "-t", paneId, "#{pane_id}"],
+        withTmuxSocket(["display-message", "-p", "-t", paneId, "#{pane_id}"]),
         {
           stdio: "ignore",
           timeout: 5000,
@@ -245,7 +286,7 @@ export class TmuxMultiplexer implements Multiplexer {
       "tmux",
       "send-keys",
       "tmux",
-      ["send-keys", "-t", paneId, "-l", text],
+      withTmuxSocket(["send-keys", "-t", paneId, "-l", text]),
       {
         encoding: "utf8",
         timeout: 5000,
@@ -258,7 +299,7 @@ export class TmuxMultiplexer implements Multiplexer {
       "tmux",
       "send-keys Enter",
       "tmux",
-      ["send-keys", "-t", paneId, "Enter"],
+      withTmuxSocket(["send-keys", "-t", paneId, "Enter"]),
       {
         encoding: "utf8",
         timeout: 5000,
@@ -268,7 +309,7 @@ export class TmuxMultiplexer implements Multiplexer {
 
   killPane(paneId: string): void {
     try {
-      execFileSync("tmux", ["kill-pane", "-t", paneId], {
+      execFileSync("tmux", withTmuxSocket(["kill-pane", "-t", paneId]), {
         stdio: "ignore",
         timeout: 5000,
       });
@@ -289,17 +330,19 @@ export class TmuxMultiplexer implements Multiplexer {
       // chaining — the attach errors with "nested sessions" but the
       // select-window still runs.
       const location = getPaneLocation(opts.paneId);
+      const tmux = tmuxCommandPrefix();
       return {
-        attachCommand: `tmux attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(opts.windowName)}`,
-        focusCommand: `tmux select-window -t ${shellEscape(opts.windowName)}`,
+        attachCommand: `${tmux} attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(opts.windowName)}`,
+        focusCommand: `${tmux} select-window -t ${shellEscape(opts.windowName)}`,
       };
     }
     // Visible split: attach by pane id inside the parent's window.
     const location = getPaneLocation(opts.paneId);
     const targetWindow = `${location.session}:${location.window}`;
+    const tmux = tmuxCommandPrefix();
     return {
-      attachCommand: `tmux attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(targetWindow)} \\; select-pane -t ${shellEscape(opts.paneId)}`,
-      focusCommand: `tmux select-pane -t ${shellEscape(opts.paneId)}`,
+      attachCommand: `${tmux} attach -t ${shellEscape(location.session)} \\; select-window -t ${shellEscape(targetWindow)} \\; select-pane -t ${shellEscape(opts.paneId)}`,
+      focusCommand: `${tmux} select-pane -t ${shellEscape(opts.paneId)}`,
     };
   }
 }
@@ -319,7 +362,14 @@ export function readPaneExitCode(paneId: string): number | null {
   try {
     const value = execFileSync(
       "tmux",
-      ["show-options", "-p", "-v", "-t", paneId, "@pi-exit-code"],
+      withTmuxSocket([
+        "show-options",
+        "-p",
+        "-v",
+        "-t",
+        paneId,
+        "@pi-exit-code",
+      ]),
       // stderr must be ignored: while the child is still running the
       // option is unset and tmux would otherwise print
       // `invalid option: @pi-exit-code` to the parent's stderr (the

--- a/tests/tmux.integration.test.ts
+++ b/tests/tmux.integration.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  cancelInteractiveSubagent,
+  interactiveSubagentRegistry,
+  launchInteractiveSubagent,
+  sendCommandToPane,
+} from "../src/interactive-tmux";
+import { __resetMuxInstances } from "../src/multiplexer";
+
+const socket =
+  process.env.PI_SUBAGENTURA_TMUX_SOCKET ??
+  `pi-subagentura-test-${process.pid}`;
+
+const savedEnv = {
+  PATH: process.env.PATH,
+  TMUX: process.env.TMUX,
+  TMUX_PANE: process.env.TMUX_PANE,
+  ZELLIJ_SESSION_NAME: process.env.ZELLIJ_SESSION_NAME,
+  PI_SUBAGENTURA_TMUX_SOCKET: process.env.PI_SUBAGENTURA_TMUX_SOCKET,
+  PI_CODING_AGENT_SESSION_DIR: process.env.PI_CODING_AGENT_SESSION_DIR,
+  ZDOTDIR: process.env.ZDOTDIR,
+};
+
+let tempRoot: string;
+
+function tmux(args: readonly string[]): string {
+  return execFileSync("tmux", ["-L", socket, ...args], {
+    encoding: "utf8",
+  });
+}
+
+function restoreEnv(name: keyof typeof savedEnv): void {
+  const value = savedEnv[name];
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function installFakePiBin(root: string): void {
+  const binDir = join(root, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  const piPath = join(binDir, "pi");
+  writeFileSync(
+    piPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+echo "fake pi started: $*" >> "$ARTIFACT_DIR/fake-pi.log"
+echo "fake initial result" > "$ARTIFACT_DIR/output.md"
+"$ARTIFACT_DIR/cli.mjs" done 0
+
+# Stay alive like a REPL so sendCommandToPane can deliver follow-up turns.
+while IFS= read -r line; do
+  echo "followup: $line" >> "$ARTIFACT_DIR/followups.log"
+  echo "fake followup result: $line" > "$ARTIFACT_DIR/output.md"
+  "$ARTIFACT_DIR/cli.mjs" done 0
+done
+`,
+  );
+  chmodSync(piPath, 0o700);
+  writeFileSync(join(root, ".zshenv"), `export PATH=${binDir}:$PATH\n`);
+
+  process.env.PATH = `${binDir}:${process.env.PATH ?? ""}`;
+  process.env.ZDOTDIR = root;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 5000,
+): Promise<void> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(message);
+}
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "pi-subagentura-tmux-"));
+  installFakePiBin(tempRoot);
+
+  process.env.PI_SUBAGENTURA_TMUX_SOCKET = socket;
+  process.env.PI_CODING_AGENT_SESSION_DIR = join(tempRoot, "sessions");
+
+  // Force the relaxed tmux path that creates a detached session. Without this,
+  // running the test locally inside tmux would try to target the developer's
+  // real parent pane from the isolated CI socket.
+  delete process.env.TMUX;
+  delete process.env.TMUX_PANE;
+  delete process.env.ZELLIJ_SESSION_NAME;
+
+  interactiveSubagentRegistry.clear();
+  __resetMuxInstances();
+});
+
+afterEach(() => {
+  try {
+    execFileSync("tmux", ["-L", socket, "kill-server"], {
+      stdio: "ignore",
+    });
+  } catch {
+    // The server may already be gone if a test failed before creating it.
+  }
+
+  interactiveSubagentRegistry.clear();
+  __resetMuxInstances();
+
+  restoreEnv("PATH");
+  restoreEnv("TMUX");
+  restoreEnv("TMUX_PANE");
+  restoreEnv("ZELLIJ_SESSION_NAME");
+  restoreEnv("PI_SUBAGENTURA_TMUX_SOCKET");
+  restoreEnv("PI_CODING_AGENT_SESSION_DIR");
+  restoreEnv("ZDOTDIR");
+
+  rmSync(tempRoot, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+});
+
+test("launches an interactive subagent in an isolated tmux session", async () => {
+  const cwd = mkdtempSync(join(tempRoot, "workspace-"));
+
+  const state = launchInteractiveSubagent({
+    name: "CI tmux child",
+    task: "do fake work",
+    cwd,
+    muxPreference: "tmux",
+    background: true,
+    notifyOnComplete: "notify",
+  });
+
+  expect(state.mux).toBe("tmux");
+  expect(state.paneId).toMatch(/^%/);
+  expect(state.attachCommand).toContain(`tmux -L '${socket}' attach`);
+
+  await waitFor(() => {
+    const eventsFile = join(state.artifactDir, "events.ndjson");
+    return (
+      existsSync(join(state.artifactDir, "output.md")) &&
+      existsSync(eventsFile) &&
+      readFileSync(eventsFile, "utf8").includes('"type":"done"')
+    );
+  }, "timed out waiting for fake pi to finish initial turn");
+
+  expect(readFileSync(join(state.artifactDir, "output.md"), "utf8")).toContain(
+    "fake initial result",
+  );
+
+  const events = readFileSync(join(state.artifactDir, "events.ndjson"), "utf8");
+  expect(events).toContain('"type":"started"');
+  expect(events).toContain('"type":"done"');
+});
+
+test("sends a follow-up message into the same tmux pane", async () => {
+  const cwd = mkdtempSync(join(tempRoot, "workspace-"));
+
+  const state = launchInteractiveSubagent({
+    name: "Followup child",
+    task: "initial",
+    cwd,
+    muxPreference: "tmux",
+    background: true,
+  });
+
+  await waitFor(
+    () => existsSync(join(state.artifactDir, "output.md")),
+    "timed out waiting for fake pi to start",
+  );
+
+  sendCommandToPane(state, "second message");
+
+  await waitFor(
+    () =>
+      existsSync(join(state.artifactDir, "followups.log")) &&
+      readFileSync(join(state.artifactDir, "followups.log"), "utf8").includes(
+        "second message",
+      ),
+    "timed out waiting for follow-up to reach fake pi",
+  );
+});
+
+test("cancel writes the cancellation marker and kills the tmux pane", async () => {
+  const cwd = mkdtempSync(join(tempRoot, "workspace-"));
+
+  const state = launchInteractiveSubagent({
+    name: "Cancel child",
+    task: "long work",
+    cwd,
+    muxPreference: "tmux",
+    background: true,
+  });
+
+  const cancelled = cancelInteractiveSubagent(state.id);
+
+  expect(cancelled?.status).toBe("cancelled");
+  expect(existsSync(join(state.artifactDir, ".cancelled"))).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add a separate tmux integration test script that uses a socket-isolated tmux server
- route tmux backend operations through PI_SUBAGENTURA_TMUX_SOCKET for CI/test isolation
- install tmux in CI and run the integration suite separately from unit tests

## Validation
- npm run typecheck
- npm test
- npm run test:tmux
- npm run format:check
- npm run pack:check