### PR TITLE
feat: show sent interactive follow-up messages

### DIFF
--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -33,6 +33,12 @@ import { InteractiveParams } from "../schemas";
 
 const SUBAGENT_ID_RE = /^[a-f0-9]{8}$/;
 const MAX_FOLLOWUP_BYTES = 64 * 1024;
+const MAX_FOLLOWUP_PREVIEW_CHARS = 500;
+
+function formatFollowupPreview(message: string): string {
+  if (message.length <= MAX_FOLLOWUP_PREVIEW_CHARS) return message;
+  return `${message.slice(0, MAX_FOLLOWUP_PREVIEW_CHARS)}… [truncated; ${message.length} chars total]`;
+}
 
 export function findArtifactById(id: string): SubagentArtifact | null {
   // Sub-agent ids are randomBytes(4).toString("hex") at spawn time, i.e. 8 hex
@@ -429,17 +435,24 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
           isError: true,
         };
       }
+      const messagePreview = formatFollowupPreview(params.message);
+      const messageTruncated =
+        params.message.length > MAX_FOLLOWUP_PREVIEW_CHARS;
       return {
         content: [
           {
             type: "text",
-            text: `Sent follow-up to interactive sub-agent ${params.id} (${params.message.length} chars) in pane ${state.paneId}.`,
+            text:
+              `Sent follow-up to interactive sub-agent ${params.id} (${params.message.length} chars) in pane ${state.paneId}.` +
+              `\n\nMessage sent:\n${messagePreview}`,
           },
         ],
         details: {
           id: params.id,
           paneId: state.paneId,
           messageLength: params.message.length,
+          messagePreview,
+          messageTruncated,
           status: "sent",
         },
       };

--- a/tests/subagent-send-message.test.ts
+++ b/tests/subagent-send-message.test.ts
@@ -104,6 +104,28 @@ describe("send_interactive_subagent_message", () => {
       "Sent follow-up to interactive sub-agent abc12345",
     );
     expect(result.content[0].text).toContain("pane %99");
+    expect(result.content[0].text).toContain("Message sent:\nnow do step 2");
+  });
+
+  it("shows the sent message and trims an oversized preview", async () => {
+    mockGet.mockReturnValue(runningState());
+    mockSendCommandToPane.mockReturnValue(undefined);
+    const message = "a".repeat(600);
+    const toolDef = getToolDef(api, "send_interactive_subagent_message");
+    const result = await toolDef.execute("call-long", {
+      id: "abc12345",
+      message,
+    });
+
+    const text = result.content[0].text as string;
+    expect(text).toContain("Message sent:");
+    expect(text).toContain("a".repeat(500));
+    expect(text).toContain("… [truncated; 600 chars total]");
+    expect(text).not.toContain(message);
+    expect(result.details).toMatchObject({
+      messagePreview: "a".repeat(500) + "… [truncated; 600 chars total]",
+      messageTruncated: true,
+    });
   });
 
   it("accepts 'idle' sub-agents (the follow-up case — child between turns, REPL open)", async () => {


### PR DESCRIPTION
## Summary
- show the actual message in successful `send_interactive_subagent_message` results
- trim previews over 500 characters while reporting truncation metadata
- add regression coverage for short and long messages

## Validation
- `npm test` (494 tests)
- `npm run typecheck`
- `npm run format:check`
- `npm run pack:check`