### PR TITLE
fix: notify parent after interactive subagent failures

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -88,9 +88,8 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
       );
       const last = lastEvent(art);
 
-      // Refresh status from the artifact + pane liveness. `done` + pane alive → "idle" (not exited),
-      // which is what allows follow-ups: a second `done` after the follow-up turn will be picked up
-      // here and the inject path below will fire again.
+      // Refresh status from the artifact + pane liveness. `done` or recoverable `error` + pane alive
+      // becomes "idle", which allows the parent to send a follow-up after a failed model turn.
       const paneAlive = isPaneAlive(state);
       const next = deriveInteractiveSubagentStatus(last, paneAlive);
       if (next !== state.status) {
@@ -126,10 +125,10 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
       // TUI-widget only — the LLM never sees them.
       tailReadSessionLog(state, art);
 
-      // Auto-done fallback: synthesize a completion event when the model ended its turn with
-      // stopReason:"stop" but never called `cli.mjs done`. Runs BEFORE reading events so the synthesized
-      // event is part of the same poll's read-back. The normal event loop still owns delivery/cursor
-      // advancement so stale Pi contexts can retry on the next tick.
+      // Auto-completion fallback: synthesize a terminal event when the child ended a model turn
+      // without calling `cli.mjs done` or `cli.mjs error`. Runs BEFORE reading events so the
+      // synthesized event is part of the same poll's read-back. The normal event loop still owns
+      // delivery/cursor advancement so stale Pi contexts can retry on the next tick.
       maybeAutoDone(state, art, Date.now());
 
       // Read events newer than the last delivered. `lastDeliveredEventTs` starts at 0,
@@ -164,7 +163,7 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
           if (ev.ts > nextCursor) nextCursor = ev.ts;
           // Keep done+alive entries persisted: the child REPL is idle and can
           // accept follow-ups, so a later parent reload still needs rehydrate.
-          if (ev.type === "error" || ev.type === "cancelled") {
+          if (ev.type === "cancelled" || (ev.type === "error" && !paneAlive)) {
             shouldRemovePersistedState = true;
           } else if (ev.type === "done" && !paneAlive) {
             shouldRemovePersistedState = true;
@@ -478,7 +477,7 @@ function processSessionLogEntry(
     return;
   }
 
-  // Assistant message: extract toolCall blocks AND record stopReason for the auto-done fallback.
+  // Assistant message: extract toolCall blocks AND record terminal stopReason for the fallback.
   if (msg.role === "assistant" && Array.isArray(msg.content)) {
     const ts = (msg.timestamp as number) ?? Date.now();
     const stopReason = (msg as { stopReason?: string }).stopReason;
@@ -490,12 +489,10 @@ function processSessionLogEntry(
     ) {
       state.lastStopReason = stopReason;
       state.lastStopReasonAt = ts;
-      // Capture the textual summary the model produced for the final turn. Used as fallback
-      // content when auto-synthesizing an `error` event for a child that stopped without writing output.md.
-      if (stopReason === "stop") {
-        const text = extractAssistantText(msg.content);
-        if (text) state.lastStopText = text;
-      }
+      // Capture the textual summary for fallback error notifications. The provider may include
+      // useful transport/model details in the assistant text even when output.md is absent.
+      const text = extractAssistantText(msg.content);
+      if (text) state.lastStopText = text;
     }
     for (const rawBlock of msg.content) {
       const block = rawBlock as
@@ -535,19 +532,16 @@ function extractAssistantText(content: unknown[]): string {
 // ── Auto-done fallback ────────────────────────────────────────────────
 
 /**
- * Auto-done fallback. The protocol requires the child to call `cli.mjs done` after writing
- * output.md, but LLMs routinely forget. We observe the child's session log and synthesize a
- * completion event when:
- *   1. The most recent assistant message had stopReason "stop" (the model finished a turn naturally), AND
+ * Completion fallback. The protocol requires the child to call `cli.mjs done` or `cli.mjs error`,
+ * but provider failures and interrupted model turns can leave neither event. We observe the child's
+ * session log and synthesize a terminal event when:
+ *   1. The most recent assistant message had stopReason "stop", "length", or "error", AND
  *   2. The model has not produced any new session-log activity for AUTO_DONE_DEBOUNCE_MS, AND
  *   3. No explicit done/error/cancelled event is in the artifact log yet, AND
  *   4. We have not already synthesized one for this turn.
  *
- * The synthesized event is appended to events.ndjson so the regular poller path picks it up; we also
- * advance the cursor and the `injected` flag so a late-arriving explicit `done` (or a duplicate poller pass)
- * does not double-notify. When output.md is missing, we synthesize `error` instead and include the child's
- * last assistant text as a fallback message — most models inline a summary in chat even when the actual
- * result landed at a different path.
+ * A natural "stop" with output becomes a synthetic done event. Missing output or a provider/length
+ * failure becomes an error event, which still reaches the parent through the normal notification path.
  */
 function maybeAutoDone(
   state: InteractiveSubagentState,
@@ -555,9 +549,13 @@ function maybeAutoDone(
   now: number,
 ): void {
   if (state.autoDoneForTurnAt !== undefined) return; // already fired for this turn
-
-  if (state.lastStopReason !== "stop") return;
-
+  if (
+    state.lastStopReason !== "stop" &&
+    state.lastStopReason !== "length" &&
+    state.lastStopReason !== "error"
+  ) {
+    return;
+  }
   const stopAt = state.lastStopReasonAt ?? 0;
 
   if (now - stopAt < AUTO_DONE_DEBOUNCE_MS) return;
@@ -586,13 +584,14 @@ function maybeAutoDone(
 
   if (existingTerminal) return;
 
-  // Detect output.md state. We want to synthesize `done` only when the model has actually produced a result.
+  // Only a natural stop with output is a successful completion. Provider errors and truncated
+  // turns must notify the parent even if output.md happens to contain partial content.
   const output = readOutput(art);
   const hasOutput = output !== null && output.length > 0;
-
+  const isSuccessfulStop = state.lastStopReason === "stop" && hasOutput;
   const ts = now;
   let ev: SubagentEvent;
-  if (hasOutput) {
+  if (isSuccessfulStop) {
     ev = {
       ts,
       type: "done",
@@ -602,7 +601,10 @@ function maybeAutoDone(
     };
   } else {
     const fallback = state.lastStopText;
-    const baseMessage = "sub-agent stopped without writing output.md";
+    const baseMessage =
+      state.lastStopReason === "stop"
+        ? "sub-agent stopped without writing output.md"
+        : `sub-agent turn ended with stopReason:${state.lastStopReason}`;
     const FALLBACK_SLICE = 500;
     const message =
       fallback && fallback.length > 0

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -87,7 +87,7 @@ When your task is done, follow this checklist in order. The parent is a parent a
   4. Run exactly one of these bash commands. \$ARTIFACT_DIR is exported to your shell by the wrapper, so the quoted forms expand correctly even if the path contains spaces:
 
        "$ARTIFACT_DIR/cli.mjs" done 0       # success
-       "$ARTIFACT_DIR/cli.mjs" error "short reason"   # unrecoverable failure
+       "$ARTIFACT_DIR/cli.mjs" error "short reason"   # failed turn; keep the REPL open for recovery
 
   5. Stay in the REPL. Do not call \`/exit\` or press Ctrl-D. The REPL stays open after step 4 so the user (or the parent) can follow up; the wrapper's EXIT trap will only fire if you actually exit. If you exit, the wrapper will treat it as a crash and the parent will not see your final answer.
 
@@ -96,7 +96,7 @@ Do not call 'cancelled' yourself — the parent agent writes that event only whe
 For reference: ${cliPath} is the lifecycle CLI. Each invocation appends one NDJSON line to events.ndjson. The parent reads that file every few seconds. The atomic write pattern (write to .tmp, then rename onto output.md) is fine if you want crash-safety.
 
 ─── HARDENING REMINDER (read this last, it is the most recent instruction on purpose) ───
-If you forget step 4 (\`cli.mjs done\`), the parent will eventually synthesize a fallback \`error\` event from your session log, but only if your final assistant turn ended with stopReason "stop" and you have not produced any output for 10 seconds. That fallback may not include the full result if output.md is missing. The reliable path is: write output.md FIRST, then call \`cli.mjs done 0\`. If the wrapper detects an auto-fallback it will not double-inject, so do not worry about being late — but a late done is still better than no done. If you have finished your work, your single next action should be the \`cli.mjs done\` command, not another tool call.`;
+If you forget step 4 (\`cli.mjs done\` or \`cli.mjs error\`), the parent will synthesize a fallback event from your session log after 10 seconds of inactivity when the final stopReason is \`stop\`, \`length\`, or \`error\`. The fallback is delivered to the parent through the normal notify/inject path, so provider failures do not disappear silently. If the pane is still alive, the parent can send a follow-up prompt after an error; do not exit the REPL. The reliable path is: write output.md FIRST, then call \`cli.mjs done 0\`. If you have finished your work, your single next action should be the appropriate \`cli.mjs\` command, not another tool call.`;
 }
 
 /**
@@ -105,7 +105,7 @@ If you forget step 4 (\`cli.mjs done\`), the parent will eventually synthesize a
  * - "running"  — child is processing a turn (last artifact event is "started" or absent)
  * - "idle"     — child finished a turn, REPL is open, pane alive; ready for a follow-up prompt
  * - "cancelled" — parent called cancel_interactive_subagent; terminal, no follow-up allowed
- * - "exited"   — child pi process is actually gone (pane dead, or it called `error`); terminal
+ * - "exited"   — child pi process is actually gone (pane dead); terminal
  * - "unknown"  — can't determine (rare; pane dead but no recorded event)
  */
 export type InteractiveSubagentStatus =
@@ -153,7 +153,8 @@ export interface InteractiveSubagentState {
   /**
    * Lifecycle status. Transition triggers:
    * - spawn sets "running" (interactive-tmux.ts setup)
-   * - cli.mjs done / error event in events.ndjson sets "exited" or "cancelled"
+   * - cli.mjs done / error event in events.ndjson sets "idle" when the pane remains alive
+   * - pane death or an error event with a dead pane sets "exited"
    * - user-msg after "exited" revives to "running" so follow-up turns can fire
    *   auto-done again (subagent.ts processSessionLogEntry)
    * - cancel_interactive_subagent tool sets "cancelled"
@@ -769,8 +770,9 @@ export function cancelInteractiveSubagentByState(
  * Pure status-decision matrix used by both `pruneDeadInteractiveSubagents` (here) and the
  * artifact poller in `subagent.ts`. Pulled out so the rules are testable without a live tmux.
  *
- * Semantics: a `done` event means "this turn is finished" — the child's REPL stays open and the
- * child is ready for a follow-up prompt. Only `error` / pane-dead / `cancelled` are terminal.
+ * Semantics: a `done` or recoverable `error` event means "this turn is finished" — the child's
+ * REPL stays open and the child is ready for a follow-up prompt. Only a dead pane or an explicit
+ * `cancelled` event is terminal.
  */
 export function deriveInteractiveSubagentStatus(
   lastEvent: SubagentEvent | null,
@@ -778,7 +780,7 @@ export function deriveInteractiveSubagentStatus(
 ): InteractiveSubagentStatus {
   if (lastEvent) {
     if (lastEvent.type === "cancelled") return "cancelled";
-    if (lastEvent.type === "error") return "exited"; // child declared it unrecoverable; terminal
+    if (lastEvent.type === "error") return paneAlive ? "idle" : "exited";
     if (lastEvent.type === "done") return paneAlive ? "idle" : "exited";
   }
   return paneAlive ? "running" : "unknown";

--- a/tests/interactive-tmux.test.ts
+++ b/tests/interactive-tmux.test.ts
@@ -392,8 +392,8 @@ describe("interactive-tmux", () => {
     it("done event + pane dead → 'exited' (terminal)", () => {
       expect(deriveInteractiveSubagentStatus(doneEv, false)).toBe("exited");
     });
-    it("error event + pane alive → 'exited' (child declared it unrecoverable)", () => {
-      expect(deriveInteractiveSubagentStatus(errorEv, true)).toBe("exited");
+    it("error event + pane alive → 'idle' (failed turn can be retried)", () => {
+      expect(deriveInteractiveSubagentStatus(errorEv, true)).toBe("idle");
     });
     it("error event + pane dead → 'exited'", () => {
       expect(deriveInteractiveSubagentStatus(errorEv, false)).toBe("exited");

--- a/tests/subagent-auto-done.test.ts
+++ b/tests/subagent-auto-done.test.ts
@@ -193,6 +193,42 @@ describe("auto-done fallback", () => {
     );
   });
 
+  it("notifies the parent when a provider error stops a turn without an explicit error event", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { state, artifactDir } = makeState({
+      outputContent: "partial result",
+    });
+    state.lastStopReason = "error";
+    state.lastStopText = "WebSocket transport failed after streaming began";
+    state.notifyOnComplete = "notify";
+    state.triggerTurnOnComplete = true;
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    const sendMessage = vi.fn();
+    mod.pollArtifactChanges({ sendMessage } as any);
+
+    const art = artifactPath(dirname(artifactDir), state.id);
+    const events = readEvents(art);
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    expect(err && err.type === "error" ? err.message : "").toContain(
+      "stopReason:error",
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0][0].content).toContain(
+      "WebSocket transport failed",
+    );
+    expect(sendMessage.mock.calls[0][1]).toMatchObject({
+      deliverAs: "followUp",
+      triggerTurn: true,
+    });
+
+    // The live REPL remains recoverable; the next poll transitions it to idle.
+    mod.pollArtifactChanges({ sendMessage } as any);
+    expect(state.status).toBe("idle");
+  });
+
   it("does NOT synthesize for stopReason 'toolUse' (model is mid-turn, not finished)", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -213,8 +249,8 @@ describe("auto-done fallback", () => {
     expect(state.status).toBe("running");
   });
 
-  it.each(["length", "error", "aborted"] as const)(
-    "does NOT auto-synthesize for stopReason '%s'",
+  it.each(["length", "error"] as const)(
+    "auto-synthesizes an error for stopReason '%s'",
     async (reason) => {
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -226,12 +262,26 @@ describe("auto-done fallback", () => {
 
       const art = artifactPath(dirname(artifactDir), state.id);
       const events = readEvents(art);
-      const synthesized = events.find(
-        (e) => e.type === "done" || e.type === "error",
-      );
-      expect(synthesized).toBeUndefined();
+      const synthesized = events.find((e) => e.type === "error");
+      expect(synthesized).toBeDefined();
+      expect(
+        synthesized && synthesized.type === "error" ? synthesized.message : "",
+      ).toContain(`stopReason:${reason}`);
     },
   );
+
+  it("does NOT auto-synthesize for stopReason 'aborted'", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { state, artifactDir } = makeState({ outputContent: "result" });
+    state.lastStopReason = "aborted";
+    mod.interactiveSubagentRegistry.set(state.id, state);
+
+    mod.pollArtifactChanges({} as any);
+
+    const art = artifactPath(dirname(artifactDir), state.id);
+    expect(readEvents(art).some((e) => e.type === "error")).toBe(false);
+  });
 
   it("does NOT synthesize before the debounce window elapses", async () => {
     const mod =
@@ -563,7 +613,7 @@ describe("auto-done fallback", () => {
     expect(state.lastStopText).toBe("Done. Wrote the result.");
   });
 
-  it("does NOT capture lastStopText for non-'stop' stopReasons", async () => {
+  it("captures lastStopText for provider and length stopReasons", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const { state } = makeState({});
@@ -583,7 +633,7 @@ describe("auto-done fallback", () => {
     mod.pollArtifactChanges({} as any);
 
     expect(state.lastStopReason).toBe("length");
-    expect(state.lastStopText).toBeUndefined();
+    expect(state.lastStopText).toBe("I hit the token limit.");
   });
 
   it("a user message in the session log clears the per-turn stop-capture (lastStopReason, lastStopReasonAt, lastStopText)", async () => {

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -954,7 +954,13 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     expect(loaded?.states[id]).toBeDefined();
     expect(state.status).toBe("idle");
   });
-  it("removes the state.json entry after delivering an error event", async () => {
+  it("removes the state.json entry after delivering an error event when the pane is dead", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => {
+        throw new Error("pane dead");
+      },
+    }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const { cwd, id, state } = makePersistedState();
@@ -971,6 +977,33 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
 
     const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeUndefined();
+    expect(state.status).toBe("exited");
+  });
+
+  it("keeps the state.json entry after an error when the pane is alive", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("#99");
+        return "";
+      },
+    }));
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    const art = artifactPath(join(state.artifactDir, ".."), id);
+    appendEvent(art, {
+      ts: 1,
+      type: "error",
+      status: "error",
+      message: "provider failed",
+    });
+
+    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+    expect(loadInteractiveStates(cwd)?.states[id]).toBeDefined();
+    expect(state.status).toBe("idle");
   });
 
   it("removes the state.json entry after delivering a cancelled event", async () => {


### PR DESCRIPTION
## Summary
- synthesize error completion events for provider/length stop reasons when the child omitted `cli.mjs error`
- keep failed interactive subagents idle and recoverable while their pane remains alive
- retain persisted state for live failed agents so follow-up/reload recovery remains possible
- add regression coverage for parent notification, trigger-turn delivery, and dead/alive cleanup

## `triggerTurnOnComplete`
`triggerTurnOnComplete` is already present on `master` for interactive state, launch parameters, schemas, and notification delivery. The regression test verifies a synthesized provider failure uses `{ deliverAs: "followUp", triggerTurn: true }`.

## Validation
- `npm test` — 496 tests passed
- `npm run typecheck` — passed
- `npm run format:check` — passed
- `npm run pack:check` — passed
- No `lint` script is defined in `package.json`