### PR TITLE
feat: add cancellable sub-agent flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,10 @@
     "src/workflow-ui.ts",
     "src/workflow-tree-ui.ts",
     "src/workflow-picker-ui.ts",
-    "src/workflow-tool.ts"
+    "src/workflow-tool.ts",
+    "src/abortable-wait.ts",
+    "src/cancel-all-flows.ts",
+    "src/cancel-all-flows-registration.ts"
   ],
   "engines": {
     "node": ">=18.0.0"

--- a/src/abortable-wait.ts
+++ b/src/abortable-wait.ts
@@ -9,10 +9,13 @@
  * the race/catch/cleanup pattern.
  */
 
-export interface AbortableWaitResult<T> {
-  aborted: boolean;
-  value?: T;
-}
+const ABORT_SENTINEL = Symbol("abortable-wait-abort");
+
+export type AbortableWaitResult<T> =
+  | {
+      aborted: true;
+    }
+  | { aborted: false; value: T };
 
 export async function abortableWait<T>(
   promise: Promise<T>,
@@ -28,19 +31,15 @@ export async function abortableWait<T>(
 
   let abortHandler: (() => void) | undefined;
   try {
-    const abortPromise = new Promise<never>((_, reject) => {
-      abortHandler = () => {
-        reject(new DOMException("Aborted", "AbortError"));
-      };
+    const abortPromise = new Promise<typeof ABORT_SENTINEL>((resolve) => {
+      abortHandler = () => resolve(ABORT_SENTINEL);
       signal.addEventListener("abort", abortHandler, { once: true });
     });
-    const value = await Promise.race([promise, abortPromise]);
-    return { aborted: false, value };
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "AbortError") {
+    const result = await Promise.race([promise, abortPromise]);
+    if (result === ABORT_SENTINEL) {
       return { aborted: true };
     }
-    throw err;
+    return { aborted: false, value: result as T };
   } finally {
     if (abortHandler) {
       signal.removeEventListener("abort", abortHandler);

--- a/src/abortable-wait.ts
+++ b/src/abortable-wait.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared helper for abort-signal-aware promise racing.
+ *
+ * Races a promise against an AbortSignal. If the signal fires before the
+ * promise resolves, returns `{ aborted: true }`. Otherwise returns
+ * `{ aborted: false, value }`.
+ *
+ * Used by get_subagent_result and get_workflow_result to avoid duplicating
+ * the race/catch/cleanup pattern.
+ */
+
+export interface AbortableWaitResult<T> {
+  aborted: boolean;
+  value?: T;
+}
+
+export async function abortableWait<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<AbortableWaitResult<T>> {
+  if (!signal) {
+    return { aborted: false, value: await promise };
+  }
+
+  if (signal.aborted) {
+    return { aborted: true };
+  }
+
+  let abortHandler: (() => void) | undefined;
+  try {
+    const abortPromise = new Promise<never>((_, reject) => {
+      abortHandler = () => {
+        reject(new DOMException("Aborted", "AbortError"));
+      };
+      signal.addEventListener("abort", abortHandler, { once: true });
+    });
+    const value = await Promise.race([promise, abortPromise]);
+    return { aborted: false, value };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      return { aborted: true };
+    }
+    throw err;
+  } finally {
+    if (abortHandler) {
+      signal.removeEventListener("abort", abortHandler);
+    }
+  }
+}

--- a/src/cancel-all-flows-registration.ts
+++ b/src/cancel-all-flows-registration.ts
@@ -14,6 +14,10 @@ export function registerCancelAllFlows(pi: ExtensionAPI): void {
       description:
         "Cancel all active sub-agent flows (jobs, workflows, running interactive agents)",
       handler: async (ctx) => {
+        // Stop foreground token use before waiting on child cancellations
+        if (typeof ctx.abort === "function") {
+          ctx.abort();
+        }
         const result = await cancelAllFlows();
         const parts: string[] = [];
         if (result.jobsAborted > 0) parts.push(`${result.jobsAborted} job(s)`);
@@ -28,11 +32,6 @@ export function registerCancelAllFlows(pi: ExtensionAPI): void {
           ctx.ui.notify("No active flows to cancel.", "info");
         } else {
           ctx.ui.notify(`Cancelled: ${parts.join(", ")}`, "warning");
-        }
-
-        // Interrupt the foreground agent turn so Escape-like UX is consistent
-        if (typeof ctx.abort === "function") {
-          ctx.abort();
         }
       },
     });
@@ -44,6 +43,10 @@ export function registerCancelAllFlows(pi: ExtensionAPI): void {
       description:
         "Cancel all active sub-agent flows (jobs, workflows, running interactive agents)",
       handler: async (_args, ctx) => {
+        // Stop foreground token use before waiting on child cancellations
+        if (typeof ctx.abort === "function") {
+          ctx.abort();
+        }
         const result = await cancelAllFlows();
         const parts: string[] = [];
         if (result.jobsAborted > 0) parts.push(`${result.jobsAborted} job(s)`);
@@ -58,11 +61,6 @@ export function registerCancelAllFlows(pi: ExtensionAPI): void {
           ctx.ui.notify("No active flows to cancel.", "info");
         } else {
           ctx.ui.notify(`Cancelled: ${parts.join(", ")}`, "warning");
-        }
-
-        // Interrupt the foreground agent turn so Escape-like UX is consistent
-        if (typeof ctx.abort === "function") {
-          ctx.abort();
         }
       },
     });

--- a/src/cancel-all-flows-registration.ts
+++ b/src/cancel-all-flows-registration.ts
@@ -1,0 +1,70 @@
+/**
+ * Registers the ctrl+alt+x shortcut and /cancel-all-flows command.
+ *
+ * Both invoke the shared cancelAllFlows helper.
+ */
+
+import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { cancelAllFlows } from "./cancel-all-flows";
+
+export function registerCancelAllFlows(pi: ExtensionAPI): void {
+  // ── ctrl+alt+x shortcut ────────────────────────────────────────────
+  if (typeof pi.registerShortcut === "function") {
+    pi.registerShortcut("ctrl+alt+x", {
+      description:
+        "Cancel all active sub-agent flows (jobs, workflows, running interactive agents)",
+      handler: async (ctx) => {
+        const result = await cancelAllFlows();
+        const parts: string[] = [];
+        if (result.jobsAborted > 0) parts.push(`${result.jobsAborted} job(s)`);
+        if (result.workflowsAborted > 0)
+          parts.push(`${result.workflowsAborted} workflow(s)`);
+        if (result.interactiveKilled > 0)
+          parts.push(`${result.interactiveKilled} interactive agent(s)`);
+        if (result.interactivePreserved > 0)
+          parts.push(`${result.interactivePreserved} idle agent(s) preserved`);
+
+        if (parts.length === 0) {
+          ctx.ui.notify("No active flows to cancel.", "info");
+        } else {
+          ctx.ui.notify(`Cancelled: ${parts.join(", ")}`, "warning");
+        }
+
+        // Interrupt the foreground agent turn so Escape-like UX is consistent
+        if (typeof ctx.abort === "function") {
+          ctx.abort();
+        }
+      },
+    });
+  }
+
+  // ── /cancel-all-flows command fallback ──────────────────────────────
+  if (typeof pi.registerCommand === "function") {
+    pi.registerCommand("cancel-all-flows", {
+      description:
+        "Cancel all active sub-agent flows (jobs, workflows, running interactive agents)",
+      handler: async (_args, ctx) => {
+        const result = await cancelAllFlows();
+        const parts: string[] = [];
+        if (result.jobsAborted > 0) parts.push(`${result.jobsAborted} job(s)`);
+        if (result.workflowsAborted > 0)
+          parts.push(`${result.workflowsAborted} workflow(s)`);
+        if (result.interactiveKilled > 0)
+          parts.push(`${result.interactiveKilled} interactive agent(s)`);
+        if (result.interactivePreserved > 0)
+          parts.push(`${result.interactivePreserved} idle agent(s) preserved`);
+
+        if (parts.length === 0) {
+          ctx.ui.notify("No active flows to cancel.", "info");
+        } else {
+          ctx.ui.notify(`Cancelled: ${parts.join(", ")}`, "warning");
+        }
+
+        // Interrupt the foreground agent turn so Escape-like UX is consistent
+        if (typeof ctx.abort === "function") {
+          ctx.abort();
+        }
+      },
+    });
+  }
+}

--- a/src/cancel-all-flows.ts
+++ b/src/cancel-all-flows.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared helper to cancel ALL active flows.
+ *
+ * Used by:
+ * - ctrl+alt+x shortcut
+ * - /cancel-all-flows command
+ *
+ * Preserves idle interactive panes (they consume no tokens).
+ * Preserves done/error/cancelled jobs and workflows.
+ */
+
+import { jobRegistry, scheduleJobCleanup } from "./helpers";
+import {
+  cancelInteractiveSubagent,
+  interactiveSubagentRegistry,
+} from "./interactive-tmux";
+import { workflowJobRegistry } from "./workflow-jobs";
+
+export interface CancelAllResult {
+  jobsAborted: number;
+  workflowsAborted: number;
+  interactiveKilled: number;
+  interactivePreserved: number;
+}
+
+export async function cancelAllFlows(): Promise<CancelAllResult> {
+  const result: CancelAllResult = {
+    jobsAborted: 0,
+    workflowsAborted: 0,
+    interactiveKilled: 0,
+    interactivePreserved: 0,
+  };
+
+  // 1. Abort all running in-process subagent jobs
+  for (const job of jobRegistry.values()) {
+    if (job.status === "running") {
+      try {
+        await job.session.abort();
+      } catch {
+        /* session may already be disposed */
+      }
+      job.status = "cancelled";
+      scheduleJobCleanup(job.id, true);
+      result.jobsAborted++;
+    }
+  }
+
+  // 2. Abort all running workflows
+  for (const workflow of workflowJobRegistry.values()) {
+    if (workflow.status === "running") {
+      workflow.abort.abort();
+      workflow.status = "cancelled";
+      result.workflowsAborted++;
+    }
+  }
+
+  // 3. Kill running interactive agents; preserve idle ones
+  for (const state of interactiveSubagentRegistry.values()) {
+    if (state.status === "running") {
+      try {
+        const cancelled = cancelInteractiveSubagent(state.id);
+        if (cancelled) {
+          result.interactiveKilled++;
+        }
+      } catch {
+        /* best effort */
+      }
+    } else if (state.status === "idle") {
+      // Idle panes consume no tokens — preserve them
+      result.interactivePreserved++;
+    }
+  }
+
+  return result;
+}

--- a/src/cancel-all-flows.ts
+++ b/src/cancel-all-flows.ts
@@ -48,6 +48,7 @@ export async function cancelAllFlows(): Promise<CancelAllResult> {
   // 2. Abort all running workflows
   for (const workflow of workflowJobRegistry.values()) {
     if (workflow.status === "running") {
+      workflow.suppressCompletionNotification = true;
       workflow.abort.abort();
       workflow.status = "cancelled";
       result.workflowsAborted++;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -149,6 +149,8 @@ export interface JobState {
   notificationDelivered?: boolean;
   /** Set true by get_subagent_result to suppress redundant notification */
   resultRetrieved?: boolean;
+  /** Active get_subagent_result waits suppress settlement notifications. */
+  activeResultWaits?: number;
   /** Optional TTL in ms for completed job retention */
   maxAge?: number;
 }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -36,6 +36,7 @@ import {
 import { registerInteractiveSubagentTools } from "./tools/interactive";
 import { registerSessionHandlers } from "./session-handlers";
 import { registerChildProtocol } from "./child-protocol";
+import { registerCancelAllFlows } from "./cancel-all-flows-registration";
 import { renderSubagentNotify } from "./rendering";
 /** @internal Session-rehydration helper used by session-handlers.ts */
 export { rehydrateInteractiveSubagents } from "./rehydrate";
@@ -95,6 +96,9 @@ export default function (pi: ExtensionAPI) {
   registerInProcessSubagentTools(pi);
   registerInteractiveSubagentTools(pi);
   registerInProcessMaintenanceTools(pi);
+
+  // ── Cancel-all-flows shortcut and command ──────────────────────
+  registerCancelAllFlows(pi);
 }
 
 /**

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -26,6 +26,7 @@ import {
   type SubagentResult,
   type Usage,
 } from "../helpers";
+import { abortableWait } from "../abortable-wait";
 import {
   completionTriggersTurn,
   deliverNotification,
@@ -644,8 +645,38 @@ function registerGetSubagentResultTool(pi: ExtensionAPI): void {
         };
       }
 
+      // If signal is already aborted, return immediately without setting resultRetrieved
+      if (signal?.aborted) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Wait for job ${params.jobId} cancelled.`,
+            },
+          ],
+          details: { jobId: params.jobId, status: "wait_cancelled" },
+          isError: true,
+        };
+      }
+
+      // Race job.promise against the abort signal
+      const waitResult = await abortableWait(job.promise, signal);
+      if (waitResult.aborted) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Wait for job ${params.jobId} cancelled.`,
+            },
+          ],
+          details: { jobId: params.jobId, status: "wait_cancelled" },
+          isError: true,
+        };
+      }
+      const result = waitResult.value!;
+
+      // Only set resultRetrieved after successful completion (not on abort)
       job.resultRetrieved = true;
-      const result = await job.promise;
 
       if ((job.status as JobStatus) === "cancelled") {
         return {

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -110,7 +110,8 @@ function settleAsyncJob(
   if (
     jobState.notifyOnComplete &&
     !jobState.notificationDelivered &&
-    !jobState.resultRetrieved
+    !jobState.resultRetrieved &&
+    (jobState.activeResultWaits ?? 0) === 0
   ) {
     deliverNotification(jobState, result);
   }
@@ -659,8 +660,15 @@ function registerGetSubagentResultTool(pi: ExtensionAPI): void {
         };
       }
 
-      // Race job.promise against the abort signal
-      const waitResult = await abortableWait(job.promise, signal);
+      // Active waits suppress settlement notifications without treating an
+      // aborted wait as a retrieved result.
+      job.activeResultWaits = (job.activeResultWaits ?? 0) + 1;
+      let waitResult: Awaited<ReturnType<typeof abortableWait<SubagentResult>>>;
+      try {
+        waitResult = await abortableWait(job.promise, signal);
+      } finally {
+        job.activeResultWaits = Math.max(0, (job.activeResultWaits ?? 1) - 1);
+      }
       if (waitResult.aborted) {
         return {
           content: [

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -1,4 +1,5 @@
 import { Type } from "typebox";
+import { abortableWait } from "./abortable-wait";
 import { startSubagentJob, debugLog } from "./helpers";
 import { launchInteractiveSubagent } from "./interactive-tmux";
 import {
@@ -11,6 +12,7 @@ import {
   deleteWorkflowScript,
   type WorkflowAgentRunner,
   type WorkflowMeta,
+  type WorkflowRunResult,
 } from "./workflow-core";
 import {
   getWorkflowCompletionPresentation,
@@ -448,7 +450,11 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
         description: "Workflow ID returned by an async `workflow` spawn.",
       }),
     }),
-    async execute(_id: string, params: any): Promise<any> {
+    async execute(
+      _id: string,
+      params: any,
+      signal?: AbortSignal,
+    ): Promise<any> {
       const st = workflowJobRegistry.get(params.workflowId);
       if (!st) {
         return {
@@ -459,42 +465,40 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
           isError: true,
         };
       }
-      try {
-        const run = await st.promise;
-        const resultText =
-          typeof run.result === "string" ? run.result : stringify(run.result);
-        const presentation = getWorkflowCompletionPresentation(
-          "done",
-          run.errorCount,
-        );
+
+      // If signal is already aborted, return immediately
+      if (signal?.aborted) {
         return {
           content: [
             {
               type: "text",
-              text: (() => {
-                const prefix = presentation.icon ? `${presentation.icon} ` : "";
-                const label = presentation.icon
-                  ? presentation.label
-                  : "complete";
-                return (
-                  `${prefix}Workflow "${run.meta.name}" ${label} — ` +
-                  `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} tokens.\n\n${resultText}`
-                );
-              })(),
+              text: `Wait for workflow ${st.id} cancelled.`,
             },
           ],
-          details: {
-            status: "done",
-            presentationStatus: presentation.label,
-            workflowId: st.id,
-            name: run.meta.name,
-            agentsSpawned: run.agentsSpawned,
-            errorCount: run.errorCount,
-            tokensSpent: run.tokensSpent,
-            phases: run.phases,
-          },
+          details: { status: "wait_cancelled", workflowId: st.id },
+          isError: true,
         };
+      }
+
+      // Race st.promise against the abort signal
+      let run: WorkflowRunResult;
+      try {
+        const waitResult = await abortableWait(st.promise, signal);
+        if (waitResult.aborted) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Wait for workflow ${st.id} cancelled.`,
+              },
+            ],
+            details: { status: "wait_cancelled", workflowId: st.id },
+            isError: true,
+          };
+        }
+        run = waitResult.value!;
       } catch (err) {
+        // Non-abort errors preserve the original structured handling
         const msg = err instanceof Error ? err.message : String(err);
         return {
           content: [
@@ -504,6 +508,38 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
           isError: true,
         };
       }
+
+      const resultText =
+        typeof run.result === "string" ? run.result : stringify(run.result);
+      const presentation = getWorkflowCompletionPresentation(
+        "done",
+        run.errorCount,
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text: (() => {
+              const prefix = presentation.icon ? `${presentation.icon} ` : "";
+              const label = presentation.icon ? presentation.label : "complete";
+              return (
+                `${prefix}Workflow "${run.meta.name}" ${label} — ` +
+                `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} tokens.\n\n${resultText}`
+              );
+            })(),
+          },
+        ],
+        details: {
+          status: "done",
+          presentationStatus: presentation.label,
+          workflowId: st.id,
+          name: run.meta.name,
+          agentsSpawned: run.agentsSpawned,
+          errorCount: run.errorCount,
+          tokensSpent: run.tokensSpent,
+          phases: run.phases,
+        },
+      };
     },
   });
 

--- a/tests/cancellation-flows.test.ts
+++ b/tests/cancellation-flows.test.ts
@@ -156,8 +156,7 @@ describe("abortableWait shared helper", () => {
       Promise.resolve("hello"),
       new AbortController().signal,
     );
-    expect(result.aborted).toBe(false);
-    expect(result.value).toBe("hello");
+    expect(result).toEqual({ aborted: false, value: "hello" });
   });
 
   it("returns aborted when signal fires before promise resolves", async () => {
@@ -181,6 +180,13 @@ describe("abortableWait shared helper", () => {
     await expect(
       abortableWait(Promise.reject(err), new AbortController().signal),
     ).rejects.toThrow("real error");
+  });
+
+  it("propagates an underlying AbortError rejection", async () => {
+    const err = new DOMException("underlying failure", "AbortError");
+    await expect(
+      abortableWait(Promise.reject(err), new AbortController().signal),
+    ).rejects.toBe(err);
   });
 
   it("cleans up abort listener after normal completion", async () => {
@@ -426,7 +432,7 @@ describe("get_workflow_result abort-aware wait", () => {
     workflowJobRegistry.set("wf-test-3", {
       id: "wf-test-3",
       status: "error",
-      promise: Promise.reject(new Error("worker crashed")),
+      promise: Promise.reject(new DOMException("worker crashed", "AbortError")),
       abort: new AbortController(),
     } as any);
 
@@ -598,39 +604,62 @@ describe("shortcut and command registration", () => {
     expect(commands["cancel-all-flows"].description).toMatch(/cancel/i);
   });
 
-  it("shortcut handler calls ctx.abort() after cancelling flows", async () => {
+  it("calls ctx.abort() before awaiting child cancellation", async () => {
     const { registerCancelAllFlows } =
       await import("../src/cancel-all-flows-registration");
-
+    const cancelAllFlowsModule = await import("../src/cancel-all-flows");
+    const events: string[] = [];
     let shortcutHandler: any;
+    let commandHandler: any;
+
     const api = {
       registerShortcut: (_key: string, opts: any) => {
         shortcutHandler = opts.handler;
       },
-      registerCommand: vi.fn(),
+      registerCommand: (_name: string, opts: any) => {
+        commandHandler = opts.handler;
+      },
     };
-
     registerCancelAllFlows(api as any);
 
-    // Mock cancelAllFlows to return some counts
-    const cancelAllFlowsModule = await import("../src/cancel-all-flows");
-    vi.spyOn(cancelAllFlowsModule, "cancelAllFlows").mockResolvedValue({
-      jobsAborted: 2,
-      workflowsAborted: 1,
+    const result = {
+      jobsAborted: 1,
+      workflowsAborted: 0,
       interactiveKilled: 0,
       interactivePreserved: 0,
+    };
+    const cancelSpy = vi.spyOn(cancelAllFlowsModule, "cancelAllFlows");
+    const mockNotify = vi.fn();
+    const mockAbort = vi.fn(() => events.push("abort"));
+    const ctx = { ui: { notify: mockNotify }, abort: mockAbort };
+
+    let resolveCancellation!: (value: typeof result) => void;
+    const pendingCancellation = new Promise<typeof result>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    cancelSpy.mockImplementationOnce(() => {
+      events.push("cancel-start");
+      return pendingCancellation;
     });
 
-    const mockAbort = vi.fn();
-    const mockNotify = vi.fn();
-    const ctx = {
-      ui: { notify: mockNotify },
-      abort: mockAbort,
-    };
+    const shortcutPromise = shortcutHandler(ctx);
+    expect(events).toEqual(["abort", "cancel-start"]);
+    resolveCancellation(result);
+    await shortcutPromise;
 
-    await shortcutHandler(ctx);
+    events.length = 0;
+    let resolveCommandCancellation!: (value: typeof result) => void;
+    const pendingCommandCancellation = new Promise<typeof result>((resolve) => {
+      resolveCommandCancellation = resolve;
+    });
+    cancelSpy.mockImplementationOnce(() => {
+      events.push("cancel-start");
+      return pendingCommandCancellation;
+    });
 
-    // ctx.abort() should be called to interrupt the foreground agent
-    expect(mockAbort).toHaveBeenCalledOnce();
+    const commandPromise = commandHandler("", ctx);
+    expect(events).toEqual(["abort", "cancel-start"]);
+    resolveCommandCancellation(result);
+    await commandPromise;
   });
 });

--- a/tests/cancellation-flows.test.ts
+++ b/tests/cancellation-flows.test.ts
@@ -77,6 +77,7 @@ import type { JobState, SubagentResult } from "../src/helpers";
 import { jobRegistry, scheduleJobCleanup } from "../src/helpers";
 import { registerInProcessSubagentTools } from "../src/tools/in-process";
 import { abortableWait } from "../src/abortable-wait";
+import { deliverNotification } from "../src/notifications";
 import {
   interactiveSubagentRegistry,
   cancelInteractiveSubagent,
@@ -325,6 +326,46 @@ describe("get_subagent_result abort-aware wait", () => {
     expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
     expect(job.resultRetrieved).toBe(true);
   });
+
+  it("marks an active result wait before settlement notification", async () => {
+    const jobId = "active-result-wait";
+    let resolveJob!: (value: SubagentResult) => void;
+    const jobPromise = new Promise<SubagentResult>((resolve) => {
+      resolveJob = resolve;
+    });
+    mockStartSubagentJob.mockResolvedValue({
+      jobId,
+      jobPromise,
+      session: { abort: vi.fn() },
+      liveStatus: createJobState({ id: jobId }).liveStatus,
+      modelLabel: "test/model",
+    });
+    const spawnTool = getToolDef(api, "subagent_isolated");
+    await spawnTool.execute(
+      "spawn-call",
+      { task: "test", async: true, notifyOnComplete: "inject" },
+      undefined,
+      undefined,
+      mockCtx(),
+    );
+    const wait = toolDef.execute(
+      "result-call",
+      { jobId },
+      new AbortController().signal,
+      undefined,
+      mockCtx(),
+    );
+
+    resolveJob({
+      output: "done",
+      usage: createJobState({ id: jobId }).liveStatus.usage,
+      isError: false,
+    });
+    await wait;
+
+    expect(deliverNotification).not.toHaveBeenCalled();
+    expect(jobRegistry.get(jobId)?.resultRetrieved).toBe(true);
+  });
 });
 
 describe("get_workflow_result abort-aware wait", () => {
@@ -520,6 +561,12 @@ describe("cancelAllFlows helper", () => {
     expect(workflowJobRegistry.get("wf-1")!.status).toBe("cancelled");
     expect(workflowJobRegistry.get("wf-2")!.status).toBe("cancelled");
     expect(workflowJobRegistry.get("wf-3")!.status).toBe("done");
+    expect(
+      workflowJobRegistry.get("wf-1")!.suppressCompletionNotification,
+    ).toBe(true);
+    expect(
+      workflowJobRegistry.get("wf-2")!.suppressCompletionNotification,
+    ).toBe(true);
 
     workflowJobRegistry.clear();
   });

--- a/tests/cancellation-flows.test.ts
+++ b/tests/cancellation-flows.test.ts
@@ -1,0 +1,636 @@
+/**
+ * Regression tests for cancellation flow improvements.
+ *
+ * Covers:
+ * 1. get_subagent_result abort-aware wait (Escape cancels wait, not job)
+ * 2. get_workflow_result abort-aware wait (Escape cancels wait, not workflow)
+ * 3. cancelAllFlows helper (shared cancel-all logic)
+ * 4. resultRetrieved NOT set when wait is aborted
+ * 5. shortcut and command registration
+ * 6. abortableWait shared helper
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────
+
+const {
+  mockStartSubagentJob,
+  mockDebugLog,
+  mockFormatUsage,
+  mockBuildLiveUpdate,
+} = vi.hoisted(() => ({
+  mockStartSubagentJob: vi.fn(),
+  mockDebugLog: vi.fn(),
+  mockFormatUsage: vi.fn().mockReturnValue("mock-usage"),
+  mockBuildLiveUpdate: vi.fn().mockReturnValue({
+    content: [{ type: "text", text: "" }],
+    details: {},
+  }),
+}));
+
+const { mockConvertToLlm, mockSerializeConversation } = vi.hoisted(() => ({
+  mockConvertToLlm: vi.fn().mockReturnValue([]),
+  mockSerializeConversation: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("../src/helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/helpers")>();
+  return {
+    ...actual,
+    startSubagentJob: mockStartSubagentJob,
+    debugLog: mockDebugLog,
+    formatUsage: mockFormatUsage,
+    buildLiveUpdate: mockBuildLiveUpdate,
+  };
+});
+
+vi.mock("../src/notifications", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/notifications")>();
+  return { ...actual, deliverNotification: vi.fn() };
+});
+
+vi.mock("../src/interactive-tmux", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/interactive-tmux")>();
+  return {
+    ...actual,
+    interactiveSubagentRegistry: new Map(),
+    isTmuxAvailable: () => false,
+    cancelInteractiveSubagent: vi.fn().mockReturnValue(undefined),
+  };
+});
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+  return {
+    ...actual,
+    convertToLlm: mockConvertToLlm,
+    serializeConversation: mockSerializeConversation,
+  };
+});
+
+// ── Imports ────────────────────────────────────────────────────────────
+
+import type { JobState, SubagentResult } from "../src/helpers";
+import { jobRegistry, scheduleJobCleanup } from "../src/helpers";
+import { registerInProcessSubagentTools } from "../src/tools/in-process";
+import { abortableWait } from "../src/abortable-wait";
+import {
+  interactiveSubagentRegistry,
+  cancelInteractiveSubagent,
+} from "../src/interactive-tmux";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function mockCtx(overrides: Record<string, any> = {}) {
+  return {
+    cwd: "/tmp/test",
+    model: undefined,
+    modelRegistry: undefined,
+    sessionManager: {
+      getBranch: () => [],
+      getSessionId: () => "test-session",
+    },
+    ui: { setStatus: vi.fn(), notify: vi.fn() },
+    ...overrides,
+  };
+}
+
+function createJobState(
+  overrides: Partial<JobState> & { id: string },
+): JobState {
+  return {
+    status: "running",
+    liveStatus: {
+      turn: 1,
+      output: "",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    },
+    session: { abort: vi.fn().mockResolvedValue(undefined) } as any,
+    startedAt: Date.now(),
+    promise: Promise.resolve({
+      output: "test output",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+      isError: false,
+    } as SubagentResult),
+    ...overrides,
+  };
+}
+
+function setupExtension() {
+  const registeredTools: Record<string, any> = {};
+  const api = {
+    registerTool: (tool: any) => {
+      registeredTools[tool.name] = tool;
+    },
+  };
+  registerInProcessSubagentTools(api as any);
+  return { api, registeredTools };
+}
+
+function getToolDef(api: ReturnType<typeof setupExtension>, name: string) {
+  return api.registeredTools[name];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("abortableWait shared helper", () => {
+  it("returns value when promise resolves before signal", async () => {
+    const result = await abortableWait(
+      Promise.resolve("hello"),
+      new AbortController().signal,
+    );
+    expect(result.aborted).toBe(false);
+    expect(result.value).toBe("hello");
+  });
+
+  it("returns aborted when signal fires before promise resolves", async () => {
+    const ac = new AbortController();
+    const never = new Promise<string>(() => {});
+    const p = abortableWait(never, ac.signal);
+    setTimeout(() => ac.abort(), 5);
+    const result = await p;
+    expect(result.aborted).toBe(true);
+  });
+
+  it("returns aborted when signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const result = await abortableWait(Promise.resolve("x"), ac.signal);
+    expect(result.aborted).toBe(true);
+  });
+
+  it("passes through non-abort errors", async () => {
+    const err = new Error("real error");
+    await expect(
+      abortableWait(Promise.reject(err), new AbortController().signal),
+    ).rejects.toThrow("real error");
+  });
+
+  it("cleans up abort listener after normal completion", async () => {
+    const ac = new AbortController();
+    const removeSpy = vi.spyOn(ac.signal, "removeEventListener");
+    await abortableWait(Promise.resolve("ok"), ac.signal);
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+});
+
+describe("get_subagent_result abort-aware wait", () => {
+  let api: ReturnType<typeof setupExtension>;
+  let toolDef: ReturnType<typeof getToolDef>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    jobRegistry.clear();
+    api = setupExtension();
+    toolDef = getToolDef(api, "get_subagent_result");
+  });
+
+  it("returns wait_cancelled when signal is already aborted", async () => {
+    const jobId = "pre-aborted";
+    const job = createJobState({
+      id: jobId,
+      promise: new Promise<SubagentResult>(() => {}), // never resolves
+    });
+    jobRegistry.set(jobId, job);
+
+    const ac = new AbortController();
+    ac.abort(); // pre-aborted
+
+    const result = await toolDef.execute(
+      "call-1",
+      { jobId },
+      ac.signal,
+      undefined,
+      mockCtx(),
+    );
+
+    expect(result.content[0].text).toMatch(/cancelled/i);
+    expect(result.details.status).toBe("wait_cancelled");
+    // resultRetrieved should NOT be set when wait is aborted
+    expect(job.resultRetrieved).toBeFalsy();
+  });
+
+  it("returns wait_cancelled when signal fires during wait", async () => {
+    const jobId = "abort-during-wait";
+    let resolveJob!: (value: SubagentResult) => void;
+    const deferred = new Promise<SubagentResult>((resolve) => {
+      resolveJob = resolve;
+    });
+
+    const job = createJobState({ id: jobId, promise: deferred });
+    jobRegistry.set(jobId, job);
+
+    const ac = new AbortController();
+
+    // Start the tool call
+    const toolPromise = toolDef.execute(
+      "call-1",
+      { jobId },
+      ac.signal,
+      undefined,
+      mockCtx(),
+    );
+
+    // Fire abort after a tick
+    setTimeout(() => ac.abort(), 10);
+
+    const result = await toolPromise;
+
+    expect(result.content[0].text).toMatch(/cancelled/i);
+    expect(result.details.status).toBe("wait_cancelled");
+
+    // The job promise should still be pending — we did NOT cancel the job
+    expect(job.status).toBe("running");
+
+    // Resolve the deferred to avoid unhandled rejection
+    resolveJob({
+      output: "ignored",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+      isError: false,
+    });
+  });
+
+  it("does NOT set resultRetrieved when wait is aborted", async () => {
+    const jobId = "no-result-retrieved";
+    const job = createJobState({
+      id: jobId,
+      promise: new Promise<SubagentResult>(() => {}),
+    });
+    jobRegistry.set(jobId, job);
+
+    const ac = new AbortController();
+    ac.abort();
+
+    await toolDef.execute("call-1", { jobId }, ac.signal, undefined, mockCtx());
+
+    // Key invariant: resultRetrieved must be false when wait is aborted
+    expect(job.resultRetrieved).toBeFalsy();
+  });
+
+  it("cleans up abort listener after normal completion", async () => {
+    const jobId = "clean-listener";
+    const job = createJobState({
+      id: jobId,
+      promise: Promise.resolve({
+        output: "done",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          cost: 0,
+          turns: 0,
+        },
+        isError: false,
+      }),
+    });
+    jobRegistry.set(jobId, job);
+
+    const ac = new AbortController();
+    const removeSpy = vi.spyOn(ac.signal, "removeEventListener");
+
+    await toolDef.execute("call-1", { jobId }, ac.signal, undefined, mockCtx());
+
+    // After normal completion, the abort listener should be removed
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(job.resultRetrieved).toBe(true);
+  });
+});
+
+describe("get_workflow_result abort-aware wait", () => {
+  // These tests import workflow-tool lazily to avoid side effects
+
+  it("returns wait_cancelled when signal is already aborted", async () => {
+    const { workflowJobRegistry } = await import("../src/workflow-jobs");
+    const { registerWorkflowTool } = await import("../src/workflow-tool");
+
+    const registeredTools: Record<string, any> = {};
+    const api = {
+      registerTool: (tool: any) => {
+        registeredTools[tool.name] = tool;
+      },
+    };
+    registerWorkflowTool(api as any);
+    const toolDef = registeredTools["get_workflow_result"];
+
+    workflowJobRegistry.set("wf-test-1", {
+      id: "wf-test-1",
+      status: "running",
+      promise: new Promise(() => {}), // never resolves
+      abort: new AbortController(),
+    } as any);
+
+    const ac = new AbortController();
+    ac.abort();
+
+    const result = await toolDef.execute(
+      "call-1",
+      { workflowId: "wf-test-1" },
+      ac.signal,
+    );
+
+    expect(result.content[0].text).toMatch(/cancelled/i);
+    expect(result.details.status).toBe("wait_cancelled");
+
+    workflowJobRegistry.delete("wf-test-1");
+  });
+
+  it("returns wait_cancelled when signal fires during wait", async () => {
+    const { workflowJobRegistry } = await import("../src/workflow-jobs");
+    const { registerWorkflowTool } = await import("../src/workflow-tool");
+
+    const registeredTools: Record<string, any> = {};
+    const api = {
+      registerTool: (tool: any) => {
+        registeredTools[tool.name] = tool;
+      },
+    };
+    registerWorkflowTool(api as any);
+    const toolDef = registeredTools["get_workflow_result"];
+
+    let resolveWf!: (value: any) => void;
+    const deferred = new Promise((resolve) => {
+      resolveWf = resolve;
+    });
+
+    workflowJobRegistry.set("wf-test-2", {
+      id: "wf-test-2",
+      status: "running",
+      promise: deferred,
+      abort: new AbortController(),
+    } as any);
+
+    const ac = new AbortController();
+    const toolPromise = toolDef.execute(
+      "call-1",
+      { workflowId: "wf-test-2" },
+      ac.signal,
+    );
+
+    setTimeout(() => ac.abort(), 10);
+
+    const result = await toolPromise;
+
+    expect(result.content[0].text).toMatch(/cancelled/i);
+    expect(result.details.status).toBe("wait_cancelled");
+
+    // Resolve to avoid unhandled rejection
+    resolveWf({
+      result: "ignored",
+      meta: { name: "test" },
+      agentsSpawned: 0,
+      errorCount: 0,
+      tokensSpent: 0,
+      phases: [],
+    });
+    workflowJobRegistry.delete("wf-test-2");
+  });
+
+  it("returns structured error for non-abort promise rejection", async () => {
+    const { workflowJobRegistry } = await import("../src/workflow-jobs");
+    const { registerWorkflowTool } = await import("../src/workflow-tool");
+
+    const registeredTools: Record<string, any> = {};
+    const api = {
+      registerTool: (tool: any) => {
+        registeredTools[tool.name] = tool;
+      },
+    };
+    registerWorkflowTool(api as any);
+    const toolDef = registeredTools["get_workflow_result"];
+
+    workflowJobRegistry.set("wf-test-3", {
+      id: "wf-test-3",
+      status: "error",
+      promise: Promise.reject(new Error("worker crashed")),
+      abort: new AbortController(),
+    } as any);
+
+    const result = await toolDef.execute("call-1", { workflowId: "wf-test-3" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/worker crashed/);
+    expect(result.details.error).toBe("worker crashed");
+
+    workflowJobRegistry.delete("wf-test-3");
+  });
+});
+
+describe("cancelAllFlows helper", () => {
+  beforeEach(() => {
+    jobRegistry.clear();
+    vi.clearAllMocks();
+  });
+
+  it("aborts all running in-process jobs and sets status to cancelled", async () => {
+    const { cancelAllFlows } = await import("../src/cancel-all-flows");
+
+    const abort1 = vi.fn().mockResolvedValue(undefined);
+    const abort2 = vi.fn().mockResolvedValue(undefined);
+
+    jobRegistry.set("job-1", {
+      id: "job-1",
+      status: "running",
+      session: { abort: abort1 },
+    } as any);
+    jobRegistry.set("job-2", {
+      id: "job-2",
+      status: "running",
+      session: { abort: abort2 },
+    } as any);
+    jobRegistry.set("job-3", {
+      id: "job-3",
+      status: "done",
+      session: { abort: vi.fn() },
+    } as any);
+
+    const result = await cancelAllFlows();
+
+    expect(abort1).toHaveBeenCalledOnce();
+    expect(abort2).toHaveBeenCalledOnce();
+    expect(result.jobsAborted).toBe(2);
+
+    // Verify status was set to cancelled (matching per-ID cancel semantics)
+    expect(jobRegistry.get("job-1")!.status).toBe("cancelled");
+    expect(jobRegistry.get("job-2")!.status).toBe("cancelled");
+    // Done job should be untouched
+    expect(jobRegistry.get("job-3")!.status).toBe("done");
+  });
+
+  it("aborts all running workflows and sets status to cancelled", async () => {
+    const { cancelAllFlows } = await import("../src/cancel-all-flows");
+    const { workflowJobRegistry } = await import("../src/workflow-jobs");
+
+    const abortCtrl1 = new AbortController();
+    const abortCtrl2 = new AbortController();
+
+    workflowJobRegistry.set("wf-1", {
+      id: "wf-1",
+      status: "running",
+      abort: abortCtrl1,
+    } as any);
+    workflowJobRegistry.set("wf-2", {
+      id: "wf-2",
+      status: "running",
+      abort: abortCtrl2,
+    } as any);
+    workflowJobRegistry.set("wf-3", {
+      id: "wf-3",
+      status: "done",
+      abort: new AbortController(),
+    } as any);
+
+    const result = await cancelAllFlows();
+
+    expect(abortCtrl1.signal.aborted).toBe(true);
+    expect(abortCtrl2.signal.aborted).toBe(true);
+    expect(result.workflowsAborted).toBe(2);
+
+    // Verify status was set to cancelled
+    expect(workflowJobRegistry.get("wf-1")!.status).toBe("cancelled");
+    expect(workflowJobRegistry.get("wf-2")!.status).toBe("cancelled");
+    expect(workflowJobRegistry.get("wf-3")!.status).toBe("done");
+
+    workflowJobRegistry.clear();
+  });
+
+  it("kills running interactive agents via cancelInteractiveSubagent and preserves idle ones", async () => {
+    const { cancelAllFlows } = await import("../src/cancel-all-flows");
+
+    // Setup mock to return a state for running-1 (successful cancellation)
+    vi.mocked(cancelInteractiveSubagent).mockImplementation((id: string) => {
+      if (id === "running-1") {
+        return { id, status: "cancelled" } as any;
+      }
+      return undefined;
+    });
+
+    // Add states directly to the real registry
+    interactiveSubagentRegistry.set("running-1", {
+      id: "running-1",
+      status: "running",
+      paneId: "pane-1",
+      mux: "tmux",
+      artifactDir: "/tmp/art1",
+    } as any);
+    interactiveSubagentRegistry.set("idle-1", {
+      id: "idle-1",
+      status: "idle",
+      paneId: "pane-2",
+      mux: "tmux",
+      artifactDir: "/tmp/art2",
+    } as any);
+
+    const result = await cancelAllFlows();
+
+    // Verify cancelInteractiveSubagent was called for running agent
+    expect(cancelInteractiveSubagent).toHaveBeenCalledWith("running-1");
+    // Should kill running but not idle
+    expect(result.interactiveKilled).toBe(1);
+    expect(result.interactivePreserved).toBe(1);
+
+    // Clean up
+    interactiveSubagentRegistry.clear();
+    vi.mocked(cancelInteractiveSubagent).mockReset();
+  });
+
+  it("returns zero counts when nothing is running", async () => {
+    jobRegistry.clear();
+    const { workflowJobRegistry } = await import("../src/workflow-jobs");
+    workflowJobRegistry.clear();
+
+    const { cancelAllFlows } = await import("../src/cancel-all-flows");
+    const result = await cancelAllFlows();
+
+    expect(result.jobsAborted).toBe(0);
+    expect(result.workflowsAborted).toBe(0);
+    expect(result.interactiveKilled).toBe(0);
+  });
+});
+
+describe("shortcut and command registration", () => {
+  it("registers ctrl+alt+x shortcut and /cancel-all-flows command", async () => {
+    const { registerCancelAllFlows } =
+      await import("../src/cancel-all-flows-registration");
+
+    const shortcuts: Record<string, any> = {};
+    const commands: Record<string, any> = {};
+    const mockAbort = vi.fn();
+
+    const api = {
+      registerShortcut: (key: string, opts: any) => {
+        shortcuts[key] = opts;
+      },
+      registerCommand: (name: string, opts: any) => {
+        commands[name] = opts;
+      },
+    };
+
+    registerCancelAllFlows(api as any);
+
+    expect(shortcuts["ctrl+alt+x"]).toBeDefined();
+    expect(commands["cancel-all-flows"]).toBeDefined();
+    expect(shortcuts["ctrl+alt+x"].description).toMatch(/cancel/i);
+    expect(commands["cancel-all-flows"].description).toMatch(/cancel/i);
+  });
+
+  it("shortcut handler calls ctx.abort() after cancelling flows", async () => {
+    const { registerCancelAllFlows } =
+      await import("../src/cancel-all-flows-registration");
+
+    let shortcutHandler: any;
+    const api = {
+      registerShortcut: (_key: string, opts: any) => {
+        shortcutHandler = opts.handler;
+      },
+      registerCommand: vi.fn(),
+    };
+
+    registerCancelAllFlows(api as any);
+
+    // Mock cancelAllFlows to return some counts
+    const cancelAllFlowsModule = await import("../src/cancel-all-flows");
+    vi.spyOn(cancelAllFlowsModule, "cancelAllFlows").mockResolvedValue({
+      jobsAborted: 2,
+      workflowsAborted: 1,
+      interactiveKilled: 0,
+      interactivePreserved: 0,
+    });
+
+    const mockAbort = vi.fn();
+    const mockNotify = vi.fn();
+    const ctx = {
+      ui: { notify: mockNotify },
+      abort: mockAbort,
+    };
+
+    await shortcutHandler(ctx);
+
+    // ctx.abort() should be called to interrupt the foreground agent
+    expect(mockAbort).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- make `get_subagent_result` and `get_workflow_result` waits abort-aware without cancelling background work
- add `ctrl+alt+x` and `/cancel-all-flows` to stop foreground work and cancel every active background flow
- preserve idle interactive panes and existing per-ID cancellation tools
- add regression coverage for abort races, status transitions, interactive cancellation, and control registration

## Verification
- `npm run typecheck`
- `npm test` — 951 tests passed
- `npm run format:check`
- `npm run pack:check`
