### PR TITLE
feat: add subagent thinking levels

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,10 @@ import { resolve } from "node:path";
 import { getModel, getProviders } from "@earendil-works/pi-ai/compat";
 import type { Model } from "@earendil-works/pi-ai";
 
-import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type {
+  AgentToolResult,
+  ThinkingLevel,
+} from "@earendil-works/pi-agent-core";
 
 import {
   createAgentSession,
@@ -109,12 +112,19 @@ export interface Usage {
 }
 
 export type SubagentResult =
-  | { isError: false; output: string; usage: Usage; model?: string }
+  | {
+      isError: false;
+      output: string;
+      usage: Usage;
+      model?: string;
+      thinkingLevel?: ThinkingLevel;
+    }
   | {
       isError: true;
       output: string;
       usage: Usage;
       model?: undefined;
+      thinkingLevel?: ThinkingLevel;
       errorMessage: string;
     };
 
@@ -123,6 +133,8 @@ export interface SubagentLiveStatus {
   activeTool?: { name: string; args: Record<string, unknown> };
   output: string;
   usage: Usage;
+  /** Effective level after Pi's model-capability clamping. */
+  thinkingLevel?: ThinkingLevel;
 }
 
 // ── Async Job Types ─────────────────────────────────────────────────
@@ -141,6 +153,8 @@ export interface JobState {
   startedAt: number;
   promise: Promise<SubagentResult>;
   modelLabel?: string;
+  /** Effective level after Pi's model-capability clamping. */
+  thinkingLevel?: ThinkingLevel;
   /** Notification mode requested by spawner's notifyOnComplete param */
   notifyOnComplete?: NotifyOnComplete;
   /** Whether completion notifications should trigger a parent LLM turn. */
@@ -324,6 +338,7 @@ export function buildLiveUpdate(
       status: "running",
       subagentStatus: status,
       model,
+      thinkingLevel: status.thinkingLevel,
     },
   };
 }
@@ -342,6 +357,8 @@ export interface StartSubagentJobParams {
   maxAge?: number;
   /** Parent session's model registry for resolving extension-added models (e.g. minimax) */
   parentModelRegistry?: ModelRegistry;
+  /** Thinking/reasoning level. Pass through to createAgentSession. */
+  thinkingLevel?: ThinkingLevel;
 }
 
 export interface StartSubagentJobResult {
@@ -350,6 +367,8 @@ export interface StartSubagentJobResult {
   session: AgentSession;
   liveStatus: SubagentLiveStatus;
   modelLabel?: string;
+  /** Effective session level after model-capability clamping. */
+  thinkingLevel?: ThinkingLevel;
   /** Warning when modelOverride was specified but not found — lists available models */
   modelWarning?: string;
 }
@@ -376,6 +395,7 @@ export async function startSubagentJob(
     onUpdate,
     defaultModel,
     parentModelRegistry,
+    thinkingLevel,
   } = params;
 
   // Enforce registry size cap before adding a new job
@@ -474,12 +494,16 @@ export async function startSubagentJob(
     sessionManager: SessionManager.inMemory(),
     model: targetModel,
     cwd,
+    ...(thinkingLevel ? { thinkingLevel } : {}),
   });
   const session = (
     await createAgentSession(
       sessionOptions as unknown as Parameters<typeof createAgentSession>[0],
     )
   ).session;
+  const effectiveThinkingLevel =
+    thinkingLevel === undefined ? undefined : session.thinkingLevel;
+  liveStatus.thinkingLevel = effectiveThinkingLevel;
   debugLog("info", "session_created", {
     jobId,
     sessionModel: session.model
@@ -653,6 +677,7 @@ export async function startSubagentJob(
           output: finalOutput || "(no output)",
           usage,
           model: undefined,
+          thinkingLevel: effectiveThinkingLevel,
           errorMessage: session.agent.state.errorMessage,
         };
       } else {
@@ -663,6 +688,7 @@ export async function startSubagentJob(
           model: session.model
             ? `${session.model.provider}/${session.model.id}`
             : undefined,
+          thinkingLevel: effectiveThinkingLevel,
         };
       }
     } catch (err) {
@@ -685,6 +711,7 @@ export async function startSubagentJob(
           turns: 0,
         },
         model: undefined,
+        thinkingLevel: effectiveThinkingLevel,
         isError: true,
         errorMessage: msg,
       };
@@ -710,5 +737,13 @@ export async function startSubagentJob(
     return result;
   })();
 
-  return { jobId, jobPromise, session, liveStatus, modelLabel, modelWarning };
+  return {
+    jobId,
+    jobPromise,
+    session,
+    liveStatus,
+    modelLabel,
+    thinkingLevel: effectiveThinkingLevel,
+    modelWarning,
+  };
 }

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -23,6 +23,7 @@
  * of the codebase compiles unchanged.
  */
 
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -329,6 +330,7 @@ export function buildPiInteractiveCommand(params: {
   systemPromptFile?: string;
   model?: string;
   cwd: string;
+  thinkingLevel?: ThinkingLevel;
 }): string {
   const escape = (v: string) => `'${v.replace(/'/g, `'\\''`)}'`;
   const parts = [
@@ -340,6 +342,9 @@ export function buildPiInteractiveCommand(params: {
   ];
   if (params.model) {
     parts.push("--model", escape(params.model));
+  }
+  if (params.thinkingLevel) {
+    parts.push("--thinking", escape(params.thinkingLevel));
   }
   if (params.systemPromptFile) {
     parts.push("--append-system-prompt", escape(params.systemPromptFile));
@@ -425,6 +430,8 @@ export function launchInteractiveSubagent(params: {
    * If omitted, falls back to `cwd` (backward-compatible for tests).
    */
   parentCwd?: string;
+  /** Thinking/reasoning level for the child Pi process. */
+  thinkingLevel?: ThinkingLevel;
 }): InteractiveSubagentState {
   const id = randomBytes(4).toString("hex");
   const cwd = resolve(params.cwd);
@@ -537,6 +544,7 @@ export function launchInteractiveSubagent(params: {
       systemPromptFile,
       model: params.model,
       cwd,
+      thinkingLevel: params.thinkingLevel,
     });
     writeLaunchScript(paths.launchScriptFile, command, paths.artifactDir);
     const escape = (v: string) => `'${v.replace(/'/g, `'\\''`)}'`;

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -1,4 +1,5 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { formatUsage } from "./helpers";
@@ -6,6 +7,10 @@ import type { SubagentDetails } from "./subagent";
 import type { SubagentResult } from "./helpers";
 import { sanitizeOutput } from "./notifications";
 import type { InteractiveSubagentState } from "./interactive-tmux";
+
+function thinkingSuffix(level?: ThinkingLevel): string {
+  return level ? ` · thinking: ${level}` : "";
+}
 
 // ── Rendering ────────────────────────────────────────────────────────
 
@@ -20,6 +25,12 @@ export function renderSubagentCall(
   text += theme.fg("accent", taskPreview);
   if (args.model) {
     text += theme.fg("dim", ` @${args.model}`);
+  }
+  if (args.thinkingLevel) {
+    text += theme.fg(
+      "dim",
+      thinkingSuffix(String(args.thinkingLevel) as ThinkingLevel),
+    );
   }
   if (args.async) {
     text += theme.fg("accent", " [async]");
@@ -43,6 +54,8 @@ export function renderSubagentResult(
       result.details?.status === "running" ? result.details : undefined;
     const status = runningDetails?.subagentStatus;
     const model = runningDetails?.model;
+    const thinkingLevel =
+      runningDetails?.thinkingLevel ?? status?.thinkingLevel;
 
     let text =
       theme.fg("accent", "● ") + theme.fg("toolTitle", "Sub-agent working");
@@ -67,7 +80,7 @@ export function renderSubagentResult(
       const usageStr = formatUsage(status.usage, model);
       if (usageStr) {
         text += `
-  ${theme.fg("muted", usageStr)}`;
+  ${theme.fg("muted", usageStr)}${theme.fg("dim", thinkingSuffix(thinkingLevel))}`;
       }
 
       if (status.output) {
@@ -87,20 +100,38 @@ export function renderSubagentResult(
     result.content.find(
       (c): c is { type: "text"; text: string } => c.type === "text",
     )?.text ?? "";
+  const resultDetails = result.details as
+    { usageSummary?: string; thinkingLevel?: ThinkingLevel } | undefined;
 
   if (result.isError) {
+    const thinking = thinkingSuffix(resultDetails?.thinkingLevel);
     if (!expanded) {
       const preview = truncateToWidth(text.replace(/\s+/g, " "), 120);
-      return new Text(theme.fg("error", preview), 0, 0);
+      return new Text(
+        thinking
+          ? `${theme.fg("dim", thinking)}\n${theme.fg("error", preview)}`
+          : theme.fg("error", preview),
+        0,
+        0,
+      );
     }
-    return new Text(theme.fg("error", text), 0, 0);
+    return new Text(
+      thinking
+        ? `${theme.fg("dim", thinking)}\n${theme.fg("error", text)}`
+        : theme.fg("error", text),
+      0,
+      0,
+    );
   }
 
-  const usageStr = (result.details as { usageSummary?: string } | undefined)
-    ?.usageSummary;
+  const usageStr = resultDetails?.usageSummary;
+  const thinking = thinkingSuffix(resultDetails?.thinkingLevel);
 
   if (usageStr) {
-    const header = theme.fg("success", "✓ ") + theme.fg("muted", usageStr);
+    const header =
+      theme.fg("success", "✓ ") +
+      theme.fg("muted", usageStr) +
+      theme.fg("dim", thinking);
     if (!expanded) {
       return new Text(header, 0, 0);
     }
@@ -109,9 +140,19 @@ export function renderSubagentResult(
 
   if (!expanded) {
     const preview = truncateToWidth(text.replace(/\s+/g, " "), 120);
-    return new Text(theme.fg("dim", preview), 0, 0);
+    return new Text(
+      thinking
+        ? `${theme.fg("dim", thinking)}\n${theme.fg("dim", preview)}`
+        : theme.fg("dim", preview),
+      0,
+      0,
+    );
   }
-  return new Text(text, 0, 0);
+  return new Text(
+    thinking ? `${theme.fg("dim", thinking)}\n${text}` : text,
+    0,
+    0,
+  );
 }
 
 /**
@@ -125,7 +166,10 @@ export function renderAsyncSpawn(
   const jobId = details.jobId;
   const text =
     theme.fg("accent", "⚡ ") +
-    theme.fg("toolTitle", `Sub-agent started — job ${jobId}`) +
+    theme.fg(
+      "toolTitle",
+      `Sub-agent started — job ${jobId}${thinkingSuffix(details.thinkingLevel)}`,
+    ) +
     "\n" +
     theme.fg("dim", "  Use get_subagent_status to check progress.");
   return new Text(text, 0, 0);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,4 +1,19 @@
+import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
+
+const THINKING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+function thinkingLevelSchema(description: string) {
+  return StringEnum(THINKING_LEVELS, { description });
+}
 
 export const BaseParams = Type.Object({
   task: Type.String({ description: "Task to delegate to the sub-agent" }),
@@ -13,6 +28,11 @@ export const BaseParams = Type.Object({
       description:
         "Override model (e.g. 'anthropic/claude-sonnet-4-5'). Default: inherit from current session.",
     }),
+  ),
+  thinkingLevel: Type.Optional(
+    thinkingLevelSchema(
+      'Thinking/reasoning level. Default: from settings, else "medium". Higher levels use more tokens. Clamped to model capabilities automatically.',
+    ),
   ),
   cwd: Type.Optional(
     Type.String({
@@ -98,6 +118,11 @@ export const InteractiveParams = Type.Object({
     Type.String({
       description: "Optional model override for the child Pi process",
     }),
+  ),
+  thinkingLevel: Type.Optional(
+    thinkingLevelSchema(
+      'Thinking/reasoning level for the child Pi process. Default: from settings, else "medium". Clamped to model capabilities.',
+    ),
   ),
   cwd: Type.Optional(
     Type.String({ description: "Working directory for the child Pi process" }),

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -19,6 +19,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   type JobState,
@@ -51,13 +52,24 @@ export { rehydrateInteractiveSubagents } from "./rehydrate";
  * - `"invalid_id"` — caller passed an unrecognised id
  */
 export type SubagentDetails =
-  | { status: "started"; jobId: string; contextMessages: number }
-  | { status: "running"; subagentStatus: SubagentLiveStatus; model?: string }
+  | {
+      status: "started";
+      jobId: string;
+      contextMessages: number;
+      thinkingLevel?: ThinkingLevel;
+    }
+  | {
+      status: "running";
+      subagentStatus: SubagentLiveStatus;
+      model?: string;
+      thinkingLevel?: ThinkingLevel;
+    }
   | {
       status: "done" | "error";
       usage: Usage;
       model?: string;
       usageSummary?: string;
+      thinkingLevel?: ThinkingLevel;
       contextMessages?: number;
     }
   | { status: "cancelled" | "not_found" }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -323,6 +323,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
             jobId,
             status: "started",
             contextMessages: messages.length,
+            thinkingLevel,
           },
         };
       }
@@ -493,6 +494,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
             jobId,
             status: "started",
             contextMessages: 0,
+            thinkingLevel,
           },
         };
       }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -4,7 +4,10 @@ import {
   type ExtensionAPI,
   type ModelRegistry,
 } from "@earendil-works/pi-coding-agent";
-import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type {
+  AgentToolResult,
+  ThinkingLevel,
+} from "@earendil-works/pi-agent-core";
 import type { Model } from "@earendil-works/pi-ai";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
@@ -48,12 +51,18 @@ interface RunningFooterContext {
 
 type InProcessSubagentDetails =
   | { status: "started"; jobId: string; contextMessages: number }
-  | { status: "running"; subagentStatus: SubagentLiveStatus; model?: string }
+  | {
+      status: "running";
+      subagentStatus: SubagentLiveStatus;
+      model?: string;
+      thinkingLevel?: ThinkingLevel;
+    }
   | {
       status: "done" | "error";
       usage: Usage;
       model?: string;
       usageSummary?: string;
+      thinkingLevel?: ThinkingLevel;
       contextMessages?: number;
     }
   | { status: "cancelled" | "not_found"; jobId?: string };
@@ -139,6 +148,7 @@ async function runSubagent(
   onUpdate: ((partial: AgentToolResult<any>) => void) | undefined,
   defaultModel: Model<any> | undefined,
   parentModelRegistry: ModelRegistry | undefined,
+  thinkingLevel?: ThinkingLevel,
 ): Promise<SubagentResult> {
   try {
     const { jobPromise, modelWarning } = await startSubagentJob({
@@ -151,6 +161,7 @@ async function runSubagent(
       onUpdate,
       defaultModel,
       parentModelRegistry,
+      thinkingLevel,
     });
     const result = await jobPromise;
     if (modelWarning && !result.isError) {
@@ -193,6 +204,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
       "The sub-agent sees everything discussed so far plus the new task.",
       "Model is inherited by default. Use the model param to override (e.g. 'minimax/MiniMax-M2.7').",
       "Use list_available_models to see which models have configured auth before setting model.",
+      "Use thinkingLevel to control reasoning depth (off|minimal|low|medium|high|xhigh|max). Higher levels use more tokens.",
       "Streams output in real-time when sync.",
       "",
       "Examples:",
@@ -251,6 +263,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
           liveStatus,
           modelLabel,
           modelWarning,
+          thinkingLevel,
         } = await startSubagentJob({
           task: params.task,
           persona: params.persona,
@@ -262,6 +275,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
           defaultModel: ctx.model,
           maxAge: params.maxAge,
           parentModelRegistry: ctx.modelRegistry,
+          thinkingLevel: params.thinkingLevel,
         });
         const jobState: JobState = {
           id: jobId,
@@ -271,6 +285,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
           startedAt: Date.now(),
           promise: jobPromise,
           modelLabel,
+          thinkingLevel,
           notifyOnComplete:
             params.notifyOnComplete === "inject"
               ? "inject"
@@ -334,6 +349,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
         onUpdate,
         ctx.model,
         ctx.modelRegistry,
+        params.thinkingLevel,
       );
 
       const usageStr = formatUsage(result.usage, result.model);
@@ -342,6 +358,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
         contextMessages: messages.length,
         usage: result.usage,
         model: result.model,
+        thinkingLevel: result.thinkingLevel,
         usageSummary: usageStr,
       };
 
@@ -378,6 +395,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
       "Only receives the task and optional persona. No conversation history.",
       "Model is inherited by default. Use the model param to override (e.g. 'minimax/MiniMax-M2.7').",
       "Use list_available_models to see which models have configured auth before setting model.",
+      "Use thinkingLevel to control reasoning depth (off|minimal|low|medium|high|xhigh|max). Higher levels use more tokens.",
       "Streams output in real-time when sync.",
       "",
       "Examples:",
@@ -415,6 +433,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
           liveStatus,
           modelLabel,
           modelWarning,
+          thinkingLevel,
         } = await startSubagentJob({
           task: params.task,
           persona: params.persona,
@@ -426,6 +445,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
           defaultModel: ctx.model,
           maxAge: params.maxAge,
           parentModelRegistry: ctx.modelRegistry,
+          thinkingLevel: params.thinkingLevel,
         });
         const jobState: JobState = {
           id: jobId,
@@ -435,6 +455,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
           startedAt: Date.now(),
           promise: jobPromise,
           modelLabel,
+          thinkingLevel,
           notifyOnComplete:
             params.notifyOnComplete === "inject"
               ? "inject"
@@ -486,6 +507,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
         onUpdate,
         ctx.model,
         ctx.modelRegistry,
+        params.thinkingLevel,
       );
 
       const usageStr = formatUsage(result.usage, result.model);
@@ -494,6 +516,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
         contextMessages: 0,
         usage: result.usage,
         model: result.model,
+        thinkingLevel: result.thinkingLevel,
         usageSummary: usageStr,
       };
 
@@ -561,6 +584,7 @@ function registerGetSubagentStatusTool(pi: ExtensionAPI): void {
             usage: result.usage,
             model: result.model,
             usageSummary: usageStr,
+            thinkingLevel: result.thinkingLevel,
           },
           isError: result.isError,
         };
@@ -666,6 +690,7 @@ function registerGetSubagentResultTool(pi: ExtensionAPI): void {
         usage: result.usage,
         model: result.model,
         usageSummary: usageStr,
+        thinkingLevel: result.thinkingLevel,
       };
 
       return {

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -167,6 +167,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
           muxPreference: params.mux, // pass through user's mux preference
           parentCwd: ctx.cwd,
           parentSessionId: ctx.sessionManager.getSessionId(),
+          thinkingLevel: params.thinkingLevel,
         });
 
         const displayMode = state.windowName
@@ -182,7 +183,11 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
                 `Artifact: ${state.artifactDir}\nAttach: ${state.attachCommand}\nFocus: ${state.selectPaneCommand}\nSession: ${state.sessionFile}`,
             },
           ],
-          details: { ...state, status: "started" },
+          details: {
+            ...state,
+            status: "started",
+            thinkingLevel: params.thinkingLevel,
+          },
         };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -217,7 +217,13 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
 
     renderResult(result, _options, theme) {
       const details = result.details as
-        Partial<InteractiveSubagentState> | undefined;
+        | (Partial<InteractiveSubagentState> & { thinkingLevel?: string })
+        | undefined;
+      const id = details?.id ?? "unknown";
+      const paneId = details?.paneId ?? "unknown";
+      const thinking = details?.thinkingLevel
+        ? ` · thinking: ${details.thinkingLevel}`
+        : "";
       if ((result as any).isError) {
         const first = result.content?.[0];
         const text =
@@ -226,12 +232,10 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
             : "Failed to start interactive sub-agent";
         return new Text(theme.fg("error", text), 0, 0);
       }
-      const id = details?.id ?? "unknown";
-      const paneId = details?.paneId ?? "unknown";
       return new Text(
         theme.fg("accent", "⚡ ") +
           theme.fg("toolTitle", `Interactive sub-agent ${id}`) +
-          theme.fg("dim", ` — pane ${paneId}`),
+          theme.fg("dim", ` — pane ${paneId}${thinking}`),
         0,
         0,
       );

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -8,6 +8,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { join } from "node:path";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { SubagentResult, Usage } from "./helpers";
 
 // ── Limits ───────────────────────────────────────────────────────────
@@ -52,6 +53,8 @@ export interface WorkflowAgentOpts {
   isolation?: string;
   /** Accepted for fidelity but a no-op in v2. */
   agentType?: string;
+  /** Thinking/reasoning level for the sub-agent. Clamped to model capabilities. */
+  thinkingLevel?: ThinkingLevel;
 }
 
 /** Injectable spawn function — the real one wraps startSubagentJob / launchInteractiveSubagent. */
@@ -62,6 +65,8 @@ export type WorkflowAgentRunner = (req: {
   signal?: AbortSignal;
   isolation?: string;
   label?: string;
+  /** Thinking/reasoning level for the sub-agent. */
+  thinkingLevel?: ThinkingLevel;
   /**
    * Optional callback for emitting progress events from inside the runner.
    * Used to surface fallback warnings and forward mid-agent live status.

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -57,6 +57,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       signal,
       isolation,
       label,
+      thinkingLevel,
       onProgress,
     }) => {
       // Track last update time per agent label to throttle mid-agent previews
@@ -83,6 +84,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
             cwd: ctx.cwd,
             contextText: null,
             background: true,
+            thinkingLevel,
           });
           const result = await awaitInteractiveResult(state, signal);
           return result;
@@ -120,6 +122,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
         },
         defaultModel: ctx.model,
         parentModelRegistry: ctx.modelRegistry,
+        thinkingLevel,
       });
       return jobPromise;
     };
@@ -197,7 +200,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       "",
       "Injected helpers/globals:",
       "  agent(prompt, opts?)   -> spawn one isolated sub-agent. opts: { schema?, label?, phase?,",
-      "                            model?, persona?, isolation? }. Without schema returns the final text;",
+      "                            model?, persona?, isolation?, thinkingLevel? (off|minimal|low|medium|high|xhigh|max) }. Without schema returns the final text;",
       "                            with schema returns a value validated against the supported JSON Schema",
       "                            subset (type, enum, required/properties, additionalProperties, items,",
       "                            minItems, maxItems), or null after retries. Returns null on error",

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -187,6 +187,7 @@ async function executeScript(
             signal: engine.signal,
             isolation,
             label: agentOpts.label,
+            thinkingLevel: agentOpts.thinkingLevel,
             onProgress: (ev) => emit({ ...ev, phase: agentOpts.phase }),
           });
           const outTokens = res.usage?.output ?? 0;

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -127,6 +127,21 @@ describe("renderSubagentCall", () => {
     );
   });
 
+  it("renders the requested thinking level beside the model", () => {
+    const result = renderSubagentCall(
+      {
+        task: "analyze",
+        model: "anthropic/claude-sonnet-4-5",
+        thinkingLevel: "high",
+      },
+      testTheme,
+      "subagent_with_context",
+    );
+    expect(t(result)).toBe(
+      "subagent_with_context analyze @anthropic/claude-sonnet-4-5 · thinking: high",
+    );
+  });
+
   it("appends the [async] badge when args.async is truthy", () => {
     const result = renderSubagentCall(
       { task: "analyze", async: true },
@@ -186,6 +201,47 @@ describe("renderSubagentResult", () => {
     expect(result).toBeInstanceOf(MockText);
     expect(t(result)).toMatch(/⚡ Sub-agent started — job job-42/);
     expect(t(result)).toMatch(/get_subagent_status/);
+  });
+
+  it("renders the requested thinking level for an interactive spawn result", () => {
+    const result = renderSubagentResult(
+      {
+        content: [],
+        details: {
+          status: "started" as const,
+          jobId: "job-43",
+          contextMessages: 0,
+          thinkingLevel: "high",
+        },
+      },
+      { expanded: false, isPartial: false },
+      testTheme,
+      undefined,
+    );
+    expect(t(result)).toContain("· thinking: high");
+  });
+  it("renders the effective thinking level in a partial result", () => {
+    formatUsageMock.mockReturnValue("~1.0K tokens gpt-4");
+    const result = renderSubagentResult(
+      {
+        content: [],
+        details: {
+          status: "running" as const,
+          model: "gpt-4",
+          thinkingLevel: "low",
+          subagentStatus: {
+            turn: 1,
+            output: "progress",
+            usage: sampleUsage,
+            thinkingLevel: "low",
+          },
+        },
+      },
+      { expanded: false, isPartial: true },
+      testTheme,
+      undefined,
+    );
+    expect(t(result)).toContain("· thinking: low");
   });
 
   // ── Partial / running ─────────────────────────────────
@@ -402,6 +458,22 @@ describe("renderSubagentResult", () => {
     expect(result).toBeInstanceOf(MockText);
     // Only the header (✓ + usage) — no output body
     expect(t(result)).toBe("\u2713 ~1.5K tokens");
+  });
+
+  it("renders the effective thinking level in a final result", () => {
+    const result = renderSubagentResult(
+      {
+        content: [{ type: "text", text: "done" }],
+        details: {
+          usageSummary: "~1.5K tokens gpt-4",
+          thinkingLevel: "low",
+        },
+      },
+      { expanded: false, isPartial: false },
+      testTheme,
+      undefined,
+    );
+    expect(t(result)).toBe("✓ ~1.5K tokens gpt-4 · thinking: low");
   });
 
   it("renders final success result with usage expanded (header + full text)", () => {

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -128,6 +128,23 @@ describe("BaseParams", () => {
     expect(check(BaseParams)({ task: "t", model: 1 })).toBe(false);
   });
 
+  it("accepts Pi thinking levels and rejects unknown values", () => {
+    for (const thinkingLevel of [
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]) {
+      expect(check(BaseParams)({ task: "t", thinkingLevel })).toBe(true);
+    }
+    expect(check(BaseParams)({ task: "t", thinkingLevel: "extreme" })).toBe(
+      false,
+    );
+  });
+
   /* ---------- optional `cwd` ---------- */
 
   it("accepts missing cwd", () => {
@@ -447,6 +464,23 @@ describe("InteractiveParams", () => {
 
   it("rejects model as array", () => {
     expect(check(InteractiveParams)({ task: "t", model: [] })).toBe(false);
+  });
+
+  it("accepts Pi thinking levels and rejects unknown values", () => {
+    for (const thinkingLevel of [
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]) {
+      expect(check(InteractiveParams)({ task: "t", thinkingLevel })).toBe(true);
+    }
+    expect(
+      check(InteractiveParams)({ task: "t", thinkingLevel: "extreme" }),
+    ).toBe(false);
   });
 
   /* ---------- optional `cwd` ---------- */

--- a/tests/thinking-level-effective.test.ts
+++ b/tests/thinking-level-effective.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockBuildSessionOptions,
+  mockCreateCompatibleSessionRuntime,
+  mockCreateAgentSession,
+} = vi.hoisted(() => ({
+  mockBuildSessionOptions: vi.fn(),
+  mockCreateCompatibleSessionRuntime: vi.fn(),
+  mockCreateAgentSession: vi.fn(),
+}));
+
+vi.mock("../src/pi-sdk-compat", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/pi-sdk-compat")>();
+  return {
+    ...actual,
+    buildSessionOptions: mockBuildSessionOptions,
+    createCompatibleSessionRuntime: mockCreateCompatibleSessionRuntime,
+  };
+});
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+  return {
+    ...actual,
+    createAgentSession: mockCreateAgentSession,
+    SessionManager: { inMemory: vi.fn(() => ({})) },
+  };
+});
+
+import { jobRegistry, startSubagentJob } from "../src/helpers";
+
+function createSession(thinkingLevel: string) {
+  return {
+    thinkingLevel,
+    model: undefined,
+    subscribe: vi.fn(() => () => undefined),
+    prompt: vi.fn(async () => undefined),
+    agent: { state: { messages: [], errorMessage: null } },
+    dispose: vi.fn(),
+  };
+}
+
+function params(
+  thinkingLevel?:
+    "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
+) {
+  return {
+    task: "test task",
+    persona: undefined,
+    modelOverride: undefined,
+    cwd: "/tmp",
+    contextText: null,
+    signal: undefined,
+    onUpdate: undefined,
+    defaultModel: undefined,
+    ...(thinkingLevel === undefined ? {} : { thinkingLevel }),
+  };
+}
+
+describe("startSubagentJob effective thinking level", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    jobRegistry.clear();
+    mockCreateCompatibleSessionRuntime.mockResolvedValue({
+      kind: "modern",
+      modelRuntime: {},
+    });
+    mockBuildSessionOptions.mockReturnValue({});
+  });
+
+  it("threads explicit requested options to the SDK and exposes effective level", async () => {
+    const session = createSession("low");
+    mockCreateAgentSession.mockResolvedValue({ session });
+
+    const started = await startSubagentJob(params("high"));
+    const result = await started.jobPromise;
+
+    expect(mockBuildSessionOptions.mock.calls[0][1]).toMatchObject({
+      thinkingLevel: "high",
+    });
+    expect(started.thinkingLevel).toBe("low");
+    expect(started.liveStatus.thinkingLevel).toBe("low");
+    expect(result.thinkingLevel).toBe("low");
+  });
+
+  it("keeps thinking-level details omitted when the request omits it", async () => {
+    const session = createSession("medium");
+    mockCreateAgentSession.mockResolvedValue({ session });
+
+    const started = await startSubagentJob(params());
+    const result = await started.jobPromise;
+
+    expect(mockBuildSessionOptions.mock.calls[0][1]).not.toHaveProperty(
+      "thinkingLevel",
+    );
+    expect(started.thinkingLevel).toBeUndefined();
+    expect(started.liveStatus.thinkingLevel).toBeUndefined();
+    expect(result.thinkingLevel).toBeUndefined();
+  });
+});

--- a/tests/thinking-level.test.ts
+++ b/tests/thinking-level.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Behavioral tests for thinkingLevel propagation across sub-agent spawn surfaces.
+ *
+ * Verifies that thinkingLevel is correctly passed through production code:
+ * 1. In-process subagent tools (sync and async) pass to startSubagentJob
+ * 2. Interactive subagent CLI command includes --thinking flag
+ * 3. Workflow agent() calls pass thinkingLevel to the runner
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_THINKING_LEVELS: ThinkingLevel[] = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+
+// ---------------------------------------------------------------------------
+// Test: buildPiInteractiveCommand includes --thinking flag (REAL function)
+// ---------------------------------------------------------------------------
+
+describe("buildPiInteractiveCommand thinkingLevel", () => {
+  let buildPiInteractiveCommand: typeof import("../src/interactive-tmux.js").buildPiInteractiveCommand;
+
+  beforeEach(async () => {
+    const mod = await import("../src/interactive-tmux.js");
+    buildPiInteractiveCommand = mod.buildPiInteractiveCommand;
+  });
+
+  it("includes --thinking flag when thinkingLevel is provided", () => {
+    const command = buildPiInteractiveCommand({
+      sessionFile: "/tmp/test-session.jsonl",
+      name: "test-agent",
+      promptFile: "/tmp/prompt.md",
+      cwd: "/tmp",
+      thinkingLevel: "high",
+    });
+    expect(command).toContain("--thinking 'high'");
+  });
+
+  it("omits --thinking flag when thinkingLevel is undefined", () => {
+    const command = buildPiInteractiveCommand({
+      sessionFile: "/tmp/test-session.jsonl",
+      name: "test-agent",
+      promptFile: "/tmp/prompt.md",
+      cwd: "/tmp",
+    });
+    expect(command).not.toContain("--thinking");
+  });
+
+  it("omits --thinking flag when thinkingLevel is empty string", () => {
+    const command = buildPiInteractiveCommand({
+      sessionFile: "/tmp/test-session.jsonl",
+      name: "test-agent",
+      promptFile: "/tmp/prompt.md",
+      cwd: "/tmp",
+      thinkingLevel: "" as any,
+    });
+    expect(command).not.toContain("--thinking");
+  });
+
+  it.each(VALID_THINKING_LEVELS)(
+    "includes --thinking for level: %s",
+    (level) => {
+      const command = buildPiInteractiveCommand({
+        sessionFile: "/tmp/test-session.jsonl",
+        name: "test-agent",
+        promptFile: "/tmp/prompt.md",
+        cwd: "/tmp",
+        thinkingLevel: level,
+      });
+      expect(command).toContain(`--thinking '${level}'`);
+    },
+  );
+
+  it("includes --thinking before the prompt file argument", () => {
+    const command = buildPiInteractiveCommand({
+      sessionFile: "/tmp/test-session.jsonl",
+      name: "test-agent",
+      promptFile: "/tmp/prompt.md",
+      cwd: "/tmp",
+      thinkingLevel: "low",
+    });
+    const thinkingIdx = command.indexOf("--thinking");
+    const promptIdx = command.indexOf("@/tmp/prompt.md");
+    expect(thinkingIdx).toBeLessThan(promptIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: In-process subagent tools pass thinkingLevel to startSubagentJob
+// ---------------------------------------------------------------------------
+
+// Hoisted mocks at module level
+const { mockStartSubagentJob, mockConvertToLlm, mockSerializeConversation } =
+  vi.hoisted(() => ({
+    mockStartSubagentJob: vi.fn(),
+    mockConvertToLlm: vi.fn(),
+    mockSerializeConversation: vi.fn(),
+  }));
+
+vi.mock("../src/helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/helpers")>();
+  return {
+    ...actual,
+    startSubagentJob: mockStartSubagentJob,
+  };
+});
+
+vi.mock("../src/interactive-tmux", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/interactive-tmux")>();
+  return {
+    ...actual,
+    interactiveSubagentRegistry: new Map(),
+    isTmuxAvailable: () => false,
+  };
+});
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+  return {
+    ...actual,
+    convertToLlm: mockConvertToLlm,
+    serializeConversation: mockSerializeConversation,
+  };
+});
+
+import { registerInProcessSubagentTools } from "../src/tools/in-process";
+
+describe("in-process subagent thinkingLevel propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartSubagentJob.mockResolvedValue({
+      jobId: "test-job",
+      jobPromise: Promise.resolve({
+        output: "done",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          cost: 0,
+          turns: 1,
+        },
+        isError: false,
+      }),
+      session: { abort: vi.fn() },
+      liveStatus: {
+        turn: 0,
+        output: "",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          cost: 0,
+          turns: 0,
+        },
+      },
+    });
+  });
+
+  function mockCtx(overrides: Record<string, any> = {}) {
+    return {
+      cwd: "/tmp",
+      ui: { setStatus: vi.fn() },
+      sessionManager: {
+        getBranch: vi.fn().mockReturnValue([]),
+        getSessionId: vi.fn().mockReturnValue("test-session"),
+      },
+      model: undefined,
+      modelRegistry: {
+        getAvailable: vi.fn().mockReturnValue([]),
+        getAll: vi.fn().mockReturnValue([]),
+        find: vi.fn(),
+      },
+      ...overrides,
+    };
+  }
+
+  function setupExtension() {
+    const api = {
+      registerTool: vi.fn(),
+      registerMessageRenderer: vi.fn(),
+    };
+    registerInProcessSubagentTools(api as any);
+    return api;
+  }
+
+  function getToolDef(
+    api: { registerTool: ReturnType<typeof vi.fn> },
+    name: string,
+  ) {
+    return api.registerTool.mock.calls.find(
+      ([t]: any[]) => t.name === name,
+    )?.[0];
+  }
+
+  it("subagent_with_context sync passes thinkingLevel to startSubagentJob", async () => {
+    const api = setupExtension();
+    const toolDef = getToolDef(api, "subagent_with_context");
+    expect(toolDef).toBeDefined();
+
+    // Provide branch with messages for the sync path
+    const branchMessages = [
+      { type: "message", message: { role: "user", content: "Hello" } },
+      { type: "message", message: { role: "assistant", content: "Hi there" } },
+    ];
+
+    mockConvertToLlm.mockReturnValue([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+    mockSerializeConversation.mockReturnValue(
+      "User: Hello\nAssistant: Hi there",
+    );
+
+    const ctx = mockCtx({
+      sessionManager: {
+        getBranch: vi.fn().mockReturnValue(branchMessages),
+        getSessionId: vi.fn().mockReturnValue("test-session"),
+      },
+    });
+
+    await toolDef.execute(
+      "call-1",
+      {
+        task: "test task",
+        thinkingLevel: "high",
+      },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(mockStartSubagentJob).toHaveBeenCalled();
+    const callArgs = mockStartSubagentJob.mock.calls[0][0];
+    expect(callArgs.thinkingLevel).toBe("high");
+  });
+
+  it("subagent_with_context sync omits thinkingLevel when undefined", async () => {
+    const api = setupExtension();
+    const toolDef = getToolDef(api, "subagent_with_context");
+    expect(toolDef).toBeDefined();
+
+    // Provide branch with messages for the sync path
+    const branchMessages = [
+      { type: "message", message: { role: "user", content: "Hello" } },
+      { type: "message", message: { role: "assistant", content: "Hi there" } },
+    ];
+
+    mockConvertToLlm.mockReturnValue([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+    mockSerializeConversation.mockReturnValue(
+      "User: Hello\nAssistant: Hi there",
+    );
+
+    const ctx = mockCtx({
+      sessionManager: {
+        getBranch: vi.fn().mockReturnValue(branchMessages),
+        getSessionId: vi.fn().mockReturnValue("test-session"),
+      },
+    });
+
+    await toolDef.execute(
+      "call-1",
+      { task: "test task" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(mockStartSubagentJob).toHaveBeenCalled();
+    const callArgs = mockStartSubagentJob.mock.calls[0][0];
+    expect(callArgs.thinkingLevel).toBeUndefined();
+  });
+
+  it("subagent_isolated sync passes thinkingLevel to startSubagentJob", async () => {
+    const api = setupExtension();
+    const toolDef = getToolDef(api, "subagent_isolated");
+    expect(toolDef).toBeDefined();
+
+    const ctx = mockCtx();
+    await toolDef.execute(
+      "call-1",
+      { task: "test task", thinkingLevel: "xhigh" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(mockStartSubagentJob).toHaveBeenCalled();
+    const callArgs = mockStartSubagentJob.mock.calls[0][0];
+    expect(callArgs.thinkingLevel).toBe("xhigh");
+  });
+
+  it("subagent_isolated sync omits thinkingLevel when undefined", async () => {
+    const api = setupExtension();
+    const toolDef = getToolDef(api, "subagent_isolated");
+    expect(toolDef).toBeDefined();
+
+    const ctx = mockCtx();
+    await toolDef.execute(
+      "call-1",
+      { task: "test task" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(mockStartSubagentJob).toHaveBeenCalled();
+    const callArgs = mockStartSubagentJob.mock.calls[0][0];
+    expect(callArgs.thinkingLevel).toBeUndefined();
+  });
+
+  it("subagent_with_context async:true passes thinkingLevel to startSubagentJob", async () => {
+    const api = setupExtension();
+    const toolDef = getToolDef(api, "subagent_with_context");
+    expect(toolDef).toBeDefined();
+
+    const branchMessages = [
+      { type: "message", message: { role: "user", content: "Hello" } },
+      { type: "message", message: { role: "assistant", content: "Hi there" } },
+    ];
+    mockConvertToLlm.mockReturnValue([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+    mockSerializeConversation.mockReturnValue(
+      "User: Hello\nAssistant: Hi there",
+    );
+
+    const ctx = mockCtx({
+      sessionManager: {
+        getBranch: vi.fn().mockReturnValue(branchMessages),
+        getSessionId: vi.fn().mockReturnValue("test-session"),
+      },
+    });
+
+    await toolDef.execute(
+      "call-1",
+      { task: "test task", async: true, thinkingLevel: "high" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(mockStartSubagentJob).toHaveBeenCalled();
+    const callArgs = mockStartSubagentJob.mock.calls[0][0];
+    expect(callArgs.thinkingLevel).toBe("high");
+  });
+
+  it("subagent_isolated async:true passes thinkingLevel to startSubagentJob", async () => {
+    const api = setupExtension();
+    const toolDef = getToolDef(api, "subagent_isolated");
+    expect(toolDef).toBeDefined();
+
+    await toolDef.execute(
+      "call-1",
+      { task: "test task", async: true, thinkingLevel: "xhigh" },
+      undefined,
+      undefined,
+      mockCtx(),
+    );
+
+    expect(mockStartSubagentJob).toHaveBeenCalled();
+    const callArgs = mockStartSubagentJob.mock.calls[0][0];
+    expect(callArgs.thinkingLevel).toBe("xhigh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: Workflow agent() passes thinkingLevel to runner
+// ---------------------------------------------------------------------------
+
+describe("workflow agent thinkingLevel propagation", () => {
+  it("agent() with thinkingLevel passes it to the runner", async () => {
+    const { runWorkflow } = await import("../src/workflow");
+
+    let capturedReq: any = null;
+    const mockRunner: import("../src/workflow-core.js").WorkflowAgentRunner =
+      async (req) => {
+        capturedReq = req;
+        return {
+          isError: false,
+          output: "result",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            cost: 0,
+            turns: 1,
+          },
+          model: "test/model",
+        };
+      };
+
+    const meta = `export const meta = { name: "test", description: "test workflow" };`;
+    const body = `return await agent("hello", { thinkingLevel: "high" });`;
+
+    await runWorkflow(meta + "\n" + body, { runAgent: mockRunner });
+
+    expect(capturedReq).not.toBeNull();
+    expect(capturedReq.thinkingLevel).toBe("high");
+  });
+
+  it("agent() without thinkingLevel omits it from runner request", async () => {
+    const { runWorkflow } = await import("../src/workflow");
+
+    let capturedReq: any = null;
+    const mockRunner: import("../src/workflow-core.js").WorkflowAgentRunner =
+      async (req) => {
+        capturedReq = req;
+        return {
+          isError: false,
+          output: "result",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            cost: 0,
+            turns: 1,
+          },
+          model: "test/model",
+        };
+      };
+
+    const meta = `export const meta = { name: "test", description: "test workflow" };`;
+    const body = `return await agent("hello");`;
+
+    await runWorkflow(meta + "\n" + body, { runAgent: mockRunner });
+
+    expect(capturedReq).not.toBeNull();
+    expect(capturedReq.thinkingLevel).toBeUndefined();
+  });
+
+  it("agent() with all thinkingLevel values passes correctly", async () => {
+    const { runWorkflow } = await import("../src/workflow");
+
+    for (const level of VALID_THINKING_LEVELS) {
+      let capturedReq: any = null;
+      const mockRunner: import("../src/workflow-core.js").WorkflowAgentRunner =
+        async (req) => {
+          capturedReq = req;
+          return {
+            isError: false,
+            output: "result",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              cost: 0,
+              turns: 1,
+            },
+            model: "test/model",
+          };
+        };
+
+      const meta = `export const meta = { name: "test", description: "test workflow" };`;
+      const body = `return await agent("hello", { thinkingLevel: "${level}" });`;
+
+      await runWorkflow(meta + "\n" + body, { runAgent: mockRunner });
+
+      expect(capturedReq.thinkingLevel).toBe(level);
+    }
+  });
+});

--- a/tests/thinking-level.test.ts
+++ b/tests/thinking-level.test.ts
@@ -137,11 +137,12 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
 });
 
 import { registerInProcessSubagentTools } from "../src/tools/in-process";
+import { registerInteractiveSubagentTools } from "../src/tools/interactive";
 
 describe("in-process subagent thinkingLevel propagation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockStartSubagentJob.mockResolvedValue({
+    mockStartSubagentJob.mockImplementation(async (params) => ({
       jobId: "test-job",
       jobPromise: Promise.resolve({
         output: "done",
@@ -168,7 +169,8 @@ describe("in-process subagent thinkingLevel propagation", () => {
           turns: 0,
         },
       },
-    });
+      thinkingLevel: params.thinkingLevel,
+    }));
   });
 
   function mockCtx(overrides: Record<string, any> = {}) {
@@ -350,7 +352,7 @@ describe("in-process subagent thinkingLevel propagation", () => {
       },
     });
 
-    await toolDef.execute(
+    const result = await toolDef.execute(
       "call-1",
       { task: "test task", async: true, thinkingLevel: "high" },
       undefined,
@@ -361,6 +363,7 @@ describe("in-process subagent thinkingLevel propagation", () => {
     expect(mockStartSubagentJob).toHaveBeenCalled();
     const callArgs = mockStartSubagentJob.mock.calls[0][0];
     expect(callArgs.thinkingLevel).toBe("high");
+    expect(result.details.thinkingLevel).toBe("high");
   });
 
   it("subagent_isolated async:true passes thinkingLevel to startSubagentJob", async () => {
@@ -368,7 +371,7 @@ describe("in-process subagent thinkingLevel propagation", () => {
     const toolDef = getToolDef(api, "subagent_isolated");
     expect(toolDef).toBeDefined();
 
-    await toolDef.execute(
+    const result = await toolDef.execute(
       "call-1",
       { task: "test task", async: true, thinkingLevel: "xhigh" },
       undefined,
@@ -379,6 +382,35 @@ describe("in-process subagent thinkingLevel propagation", () => {
     expect(mockStartSubagentJob).toHaveBeenCalled();
     const callArgs = mockStartSubagentJob.mock.calls[0][0];
     expect(callArgs.thinkingLevel).toBe("xhigh");
+    expect(result.details.thinkingLevel).toBe("xhigh");
+  });
+});
+
+describe("interactive subagent thinkingLevel rendering", () => {
+  it("renders the requested thinking level in the spawn result", () => {
+    const api = { registerTool: vi.fn() };
+    registerInteractiveSubagentTools(api as any);
+    const toolDef = api.registerTool.mock.calls.find(
+      ([tool]: any[]) => tool.name === "subagent_interactive",
+    )?.[0];
+    const theme = {
+      fg: vi.fn((_color: string, text: string) => text),
+      bold: vi.fn((text: string) => text),
+    };
+
+    toolDef.renderResult(
+      {
+        content: [{ type: "text", text: "started" }],
+        details: { id: "agent-1", paneId: "%1", thinkingLevel: "high" },
+      },
+      {},
+      theme,
+    );
+
+    expect(theme.fg).toHaveBeenCalledWith(
+      "dim",
+      expect.stringContaining("thinking: high"),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add optional `thinkingLevel` selection to direct, interactive, and per-workflow sub-agents
- pass Pi-native levels through SDK sessions and interactive `--thinking`, preserving defaults when omitted
- show requested thinking levels in call headers and effective clamped levels in live/final in-process status
- use Google-compatible `StringEnum` schemas and cover sync, async, interactive, workflow, schema, and rendering paths

## Verification
- `npm test` — 960 tests passed
- `npm run typecheck`
- `npm run format:check`
- `npm run pack:check`
