### PR TITLE
fix(workflow): handle protocol-v2 completions

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -17,9 +17,13 @@ import type {
 import {
   artifactPath,
   appendEvent,
+  assertNever,
+  isCompletionEvent,
   readEventBatch,
   removeInteractiveState,
   updateInteractiveState,
+  type CompletionEvent,
+  type CompletionOutcome,
   type SubagentArtifact,
   type SubagentEvent,
 } from "./artifact";
@@ -49,6 +53,22 @@ const WORKFLOW_WIDGET_KEY = "subagentura-workflow-activity";
 /** Maximum widget rows before truncation with "… and N more". */
 const MAX_WIDGET_ROWS = 10;
 const MAX_WORKFLOW_WIDGET_ROWS = 5;
+
+/** Derive delivery status from an already narrowed completion event. */
+function deliveryStatusFromEvent(ev: CompletionEvent): CompletionOutcome {
+  switch (ev.type) {
+    case "done":
+      return "done";
+    case "error":
+      return "error";
+    case "cancelled":
+      return "cancelled";
+    case "completion":
+      return ev.outcome;
+    default:
+      return assertNever(ev);
+  }
+}
 // ── Poller ─────────────────────────────────────────────────────────────
 
 /**
@@ -97,11 +117,8 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
         if ("version" in ev && ev.version === 2 && ev.type === "turn_started") {
           state.activeTurnId = ev.turnId;
         }
-        if (!shouldNotify(ev)) continue;
-        const v2 =
-          "version" in ev && ev.version === 2 && ev.type === "completion"
-            ? ev
-            : null;
+        if (!shouldNotify(ev) || !isCompletionEvent(ev)) continue;
+        const v2 = ev.type === "completion" ? ev : undefined;
         const mode = state.notifyOnComplete ?? "inject";
         const triggerTurn =
           mode === "inject"
@@ -112,13 +129,7 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
           v2?.eventId ??
           (ev as unknown as { eventId?: string }).eventId ??
           `legacy-${record.startOffset}`;
-        const status =
-          v2?.outcome ??
-          (ev.type === "error"
-            ? "error"
-            : ev.type === "cancelled"
-              ? "cancelled"
-              : "done");
+        const status = deliveryStatusFromEvent(ev);
         enqueueDelivery(state, {
           deliveryId: deliveryIdFor({
             parentSessionId: state.parentSessionId ?? "pi",

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -126,7 +126,6 @@ export type CompletionEventV2 = Extract<
   SubagentEventV2,
   { type: "completion" }
 >;
-
 export type SubagentEvent =
   | { ts: number; type: "started"; status: "running"; message?: string }
   | {
@@ -154,6 +153,88 @@ export type SubagentEvent =
     }
   | { ts: number; type: "cancelled"; status: "cancelled"; message?: string }
   | SubagentEventV2;
+
+export type LegacyCompletionEvent = Extract<
+  SubagentEvent,
+  { type: "done" | "error" | "cancelled" }
+>;
+export type TurnTerminalEvent = LegacyCompletionEvent | CompletionEventV2;
+export type CompletionEvent = TurnTerminalEvent;
+
+// ── Exhaustive event classification helpers ────────────────────────
+
+/** Exhaustiveness checker for discriminated unions. */
+export function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${String(value)}`);
+}
+
+/**
+ * Workflow-waiting semantics: authoritative turn completions are legacy
+ * done/error/cancelled events or a v2 completion. A process_exited event is
+ * excluded so the pane-death grace period can observe a final completion flush.
+ */
+export function isTurnTerminal(
+  event: SubagentEvent,
+): event is TurnTerminalEvent {
+  switch (event.type) {
+    case "done":
+    case "error":
+    case "cancelled":
+    case "completion":
+      return true;
+    case "started":
+    case "tool_activity":
+    case "turn_started":
+    case "process_exited":
+      return false;
+    default:
+      return assertNever(event);
+  }
+}
+
+/**
+ * Output-reporting semantics: these events establish that output is no longer
+ * pending for the current observed turn or process.
+ */
+export function isArtifactOutputSettled(event: SubagentEvent): boolean {
+  switch (event.type) {
+    case "done":
+    case "error":
+    case "cancelled":
+    case "completion":
+    case "process_exited":
+      return true;
+    case "started":
+    case "tool_activity":
+    case "turn_started":
+      return false;
+    default:
+      return assertNever(event);
+  }
+}
+
+/**
+ * Notification semantics: only completion/error/cancelled events should trigger
+ * a wakeup notification to the parent. process_exited and activity events do not.
+ */
+export function isCompletionEvent(
+  event: SubagentEvent,
+): event is CompletionEvent {
+  switch (event.type) {
+    case "completion":
+    case "done":
+    case "error":
+    case "cancelled":
+      return true;
+    case "started":
+    case "tool_activity":
+    case "turn_started":
+    case "process_exited":
+      return false;
+    default:
+      return assertNever(event);
+  }
+}
 
 export interface EventRecord {
   event: SubagentEvent;

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -32,6 +32,7 @@ import {
   appendInteractiveState,
   appendCompletionEvent,
   artifactPath,
+  assertNever,
   newEventId,
   type SubagentEvent,
   type PersistedDeliveryIntent,
@@ -788,19 +789,28 @@ export function deriveInteractiveSubagentStatus(
   lastEvent: SubagentEvent | null,
   paneAlive: boolean,
 ): InteractiveSubagentStatus {
-  if (lastEvent) {
-    if (lastEvent.type === "process_exited") {
+  if (!lastEvent) return paneAlive ? "running" : "unknown";
+  switch (lastEvent.type) {
+    case "process_exited":
       return lastEvent.status === "cancelled" ? "cancelled" : "exited";
-    }
-    if (lastEvent.type === "completion") {
+    case "completion":
       if (lastEvent.outcome === "cancelled") return "cancelled";
       return paneAlive ? "idle" : "exited";
-    }
-    if (lastEvent.type === "cancelled") return "cancelled";
-    if (lastEvent.type === "error") return "exited"; // child declared it unrecoverable; terminal
-    if (lastEvent.type === "done") return paneAlive ? "idle" : "exited";
+    case "cancelled":
+      return "cancelled";
+    case "error":
+      // child declared it unrecoverable; terminal
+      return "exited";
+    case "done":
+      return paneAlive ? "idle" : "exited";
+    case "started":
+    case "tool_activity":
+    case "turn_started":
+      // Non-terminal activity events: still running if pane is alive.
+      return paneAlive ? "running" : "unknown";
+    default:
+      return assertNever(lastEvent);
   }
-  return paneAlive ? "running" : "unknown";
 }
 
 export function deriveInteractiveSubagentStatusFromEvents(
@@ -817,44 +827,53 @@ export function foldInteractiveLifecycle(
   event: SubagentEvent,
 ): void {
   lifecycle.startedAt ??= event.ts;
-  if (event.type === "process_exited") {
-    lifecycle.processStatus = event.status;
-    lifecycle.processExitCode = event.exitCode;
-    return;
-  }
-  if (event.type === "turn_started") {
-    lifecycle.currentTurnId = event.turnId;
-    lifecycle.completionTurnId = undefined;
-    lifecycle.completionOutcome = undefined;
-    lifecycle.completionSource = undefined;
-    lifecycle.completionExitCode = undefined;
-    lifecycle.legacyTerminal = undefined;
-    return;
-  }
-  if (event.type === "completion") {
-    if (event.outcome === "cancelled" && event.source === "parent") {
-      lifecycle.parentCancelled = true;
+  switch (event.type) {
+    case "process_exited": {
+      lifecycle.processStatus = event.status;
+      lifecycle.processExitCode = event.exitCode;
+      return;
     }
-    if (!lifecycle.currentTurnId || event.turnId === lifecycle.currentTurnId) {
-      lifecycle.completionTurnId = event.turnId;
-      lifecycle.completionOutcome = event.outcome;
-      lifecycle.completionSource = event.source;
-      lifecycle.completionExitCode = event.exitCode;
+    case "turn_started": {
+      lifecycle.currentTurnId = event.turnId;
+      lifecycle.completionTurnId = undefined;
+      lifecycle.completionOutcome = undefined;
+      lifecycle.completionSource = undefined;
+      lifecycle.completionExitCode = undefined;
+      lifecycle.legacyTerminal = undefined;
+      return;
     }
-    return;
-  }
-  if (event.type === "started") {
-    lifecycle.legacyTerminal = undefined;
-    return;
-  }
-  if (
-    event.type === "done" ||
-    event.type === "error" ||
-    event.type === "cancelled"
-  ) {
-    lifecycle.legacyTerminal = event.status;
-    lifecycle.completionExitCode =
-      "exitCode" in event ? event.exitCode : undefined;
+    case "completion": {
+      if (event.outcome === "cancelled" && event.source === "parent") {
+        lifecycle.parentCancelled = true;
+      }
+      if (
+        !lifecycle.currentTurnId ||
+        event.turnId === lifecycle.currentTurnId
+      ) {
+        lifecycle.completionTurnId = event.turnId;
+        lifecycle.completionOutcome = event.outcome;
+        lifecycle.completionSource = event.source;
+        lifecycle.completionExitCode = event.exitCode;
+      }
+      return;
+    }
+    case "started": {
+      lifecycle.legacyTerminal = undefined;
+      return;
+    }
+    case "done":
+    case "error":
+    case "cancelled": {
+      lifecycle.legacyTerminal = event.status;
+      lifecycle.completionExitCode =
+        "exitCode" in event ? event.exitCode : undefined;
+      return;
+    }
+    case "tool_activity":
+      // Activity events do not affect lifecycle state.
+      return;
+    default:
+      return assertNever(event);
   }
 }
 

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -26,6 +26,7 @@
 import { execFileSync, type ExecSyncOptions } from "node:child_process";
 import { TmuxMultiplexer } from "./multiplexer-tmux";
 import { ZellijMultiplexer } from "./multiplexer-zellij";
+import { assertNever } from "./artifact";
 
 /** Names of the supported multiplexer backends. Kept narrow on purpose. */
 export type MuxName = "tmux" | "zellij";
@@ -193,24 +194,31 @@ export function getMux(opts: GetMuxOptions = {}): Multiplexer {
   const zellij = getOrCreate("zellij", () => new ZellijMultiplexer());
 
   const preference = opts.preference ?? "auto";
-  if (preference === "tmux") return tmux;
-  if (preference === "zellij") return zellij;
+  switch (preference) {
+    case "tmux":
+      return tmux;
+    case "zellij":
+      return zellij;
+    case "auto": {
+      // Prefer the mux already attached to this process. We check env vars
+      // (cheap) before probing availability (one exec call each). If both env
+      // vars are set (e.g., nested sessions — exotic but possible), zellij wins
+      // (it's the more specific signal — ZELLIJ_SESSION_NAME is a single session
+      // name, TMUX can be inherited through nested tmux-in-tmux shells).
+      if (process.env.ZELLIJ_SESSION_NAME && zellij.isAvailable())
+        return zellij;
+      if (process.env.TMUX && tmux.isAvailable()) return tmux;
 
-  // Auto: prefer the mux already attached to this process. We check env vars
-  // (cheap) before probing availability (one exec call each). If both env
-  // vars are set (e.g., nested sessions — exotic but possible), zellij wins
-  // (it's the more specific signal — ZELLIJ_SESSION_NAME is a single session
-  // name, TMUX can be inherited through nested tmux-in-tmux shells).
-  if (process.env.ZELLIJ_SESSION_NAME && zellij.isAvailable()) return zellij;
-  if (process.env.TMUX && tmux.isAvailable()) return tmux;
+      // Neither env var matched. Fall back to whichever backend is available;
+      // tmux first to preserve existing user setups.
+      if (tmux.isAvailable()) return tmux;
+      if (zellij.isAvailable()) return zellij;
 
-  // Neither env var matched. Fall back to whichever backend is available;
-  // tmux first to preserve existing user setups that rely on `tmux` being
-  // on PATH even when the parent isn't attached.
-  if (tmux.isAvailable()) return tmux;
-  if (zellij.isAvailable()) return zellij;
-
-  throw new NoMultiplexerAvailableError();
+      throw new NoMultiplexerAvailableError();
+    }
+    default:
+      return assertNever(preference);
+  }
 }
 
 /* ────────────────────────────────────────────────────────────────────────────

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -10,7 +10,7 @@ import type {
   Usage,
 } from "./helpers";
 import { formatUsage, jobRegistry } from "./helpers";
-import type { SubagentEvent } from "./artifact";
+import { isCompletionEvent, type SubagentEvent } from "./artifact";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 
 /**
@@ -435,12 +435,7 @@ function markOverflowDelivered(pending: PendingJobOverflow): void {
 
 /** True when the event should trigger a wakeup notification to the parent. */
 export function shouldNotify(event: SubagentEvent): boolean {
-  return (
-    event.type === "completion" ||
-    event.type === "done" ||
-    event.type === "error" ||
-    event.type === "cancelled"
-  );
+  return isCompletionEvent(event);
 }
 
 export function sanitizeOutput(text: string): string {

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import {
   artifactPath,
+  isArtifactOutputSettled,
   lastEvent,
   listOutputHistory,
   listOutputTurns,
@@ -603,10 +604,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
           outputText = `(no snapshot for turn ${params.turn} — the poller may not have run yet, or this turn number is past the history)`;
         } else {
           const exited =
-            lastEventValue &&
-            (lastEventValue.type === "done" ||
-              lastEventValue.type === "error" ||
-              lastEventValue.type === "cancelled");
+            lastEventValue && isArtifactOutputSettled(lastEventValue);
           outputText = exited
             ? `(sub-agent exited without writing output.md — last event: ${lastEventValue.type} @ ${lastEventValue.ts})`
             : `(${events.length} events, last: ${lastEventValue ? `${lastEventValue.type} @ ${lastEventValue.ts}` : "(none)"} — output.md not written yet)`;

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -54,6 +54,20 @@ export interface WorkflowAgentOpts {
   agentType?: string;
 }
 
+export type WorkflowAgentProgress =
+  | {
+      kind: "phase";
+      phase: string;
+      message?: string;
+      label?: string;
+    }
+  | {
+      kind: "log";
+      message: string;
+      phase?: string;
+      label?: string;
+    };
+
 /** Injectable spawn function — the real one wraps startSubagentJob / launchInteractiveSubagent. */
 export type WorkflowAgentRunner = (req: {
   prompt: string;
@@ -66,12 +80,7 @@ export type WorkflowAgentRunner = (req: {
    * Optional callback for emitting progress events from inside the runner.
    * Used to surface fallback warnings and forward mid-agent live status.
    */
-  onProgress?: (event: {
-    kind: "log" | "phase";
-    message?: string;
-    phase?: string;
-    label?: string;
-  }) => void;
+  onProgress?: (event: WorkflowAgentProgress) => void;
 }) => Promise<SubagentResult>;
 
 export interface WorkflowMeta {
@@ -82,19 +91,58 @@ export interface WorkflowMeta {
   [k: string]: unknown;
 }
 
-export interface WorkflowProgress {
-  // "agent_start" fires the moment an agent is launched (counter is incremented), so UIs see
-  // mid-run progress. "agent_done" fires after the agent finishes (success, error, or schema fail).
-  kind: "phase" | "log" | "agent_start" | "agent_done";
-  phase?: string;
-  message?: string;
-  label?: string;
-  agentsSpawned: number;
-  errorCount: number;
-  tokensSpent: number;
-  runningCount: number;
-  model?: string;
-}
+export type WorkflowProgress =
+  | {
+      kind: "phase";
+      phase: string;
+      message?: string;
+      label?: string;
+      agentsSpawned: number;
+      errorCount: number;
+      tokensSpent: number;
+      runningCount: number;
+      model?: string;
+    }
+  | {
+      kind: "log";
+      phase?: string;
+      message: string;
+      label?: string;
+      agentsSpawned: number;
+      errorCount: number;
+      tokensSpent: number;
+      runningCount: number;
+      model?: string;
+    }
+  | {
+      kind: "agent_start";
+      phase?: string;
+      message?: string;
+      label?: string;
+      agentsSpawned: number;
+      errorCount: number;
+      tokensSpent: number;
+      runningCount: number;
+      model?: string;
+    }
+  | {
+      kind: "agent_done";
+      phase?: string;
+      message?: string;
+      label?: string;
+      agentsSpawned: number;
+      errorCount: number;
+      tokensSpent: number;
+      runningCount: number;
+      model?: string;
+    };
+
+export type WorkflowProgressUpdate = {
+  [K in WorkflowProgress["kind"]]: Omit<
+    Extract<WorkflowProgress, { kind: K }>,
+    "agentsSpawned" | "errorCount" | "tokensSpent" | "runningCount"
+  >;
+}[WorkflowProgress["kind"]];
 
 export interface WorkflowRunResult {
   meta: WorkflowMeta;

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -1,4 +1,5 @@
 import type { WorkflowProgress } from "./workflow-core";
+import { assertNever } from "./artifact";
 
 // ── Workflow progress renderer ───────────────────────────────────────
 export function renderProgress(p: WorkflowProgress): string {
@@ -7,15 +8,20 @@ export function renderProgress(p: WorkflowProgress): string {
   if (p.errorCount > 0) parts.push(`⚠ ${p.errorCount} error(s)`);
   parts.push(`${p.tokensSpent} tokens`);
   const head = parts.join(", ");
-  if (p.kind === "phase") return `${head}\n  ◆ phase: ${p.phase}`;
-  if (p.kind === "log") return `${head}\n  ${p.message}`;
-  if (p.kind === "agent_start") {
-    const tag = p.model ? ` @${p.model}` : "";
-    return `${head}\n  → started${p.label ? ` ${p.label}` : ""}${tag}`;
+  switch (p.kind) {
+    case "phase":
+      return `${head}\n  ◆ phase: ${p.phase}`;
+    case "log":
+      return `${head}\n  ${p.message}`;
+    case "agent_start": {
+      const tag = p.model ? ` @${p.model}` : "";
+      return `${head}\n  → started${p.label ? ` ${p.label}` : ""}${tag}`;
+    }
+    case "agent_done": {
+      const tag = p.model ? ` @${p.model}` : "";
+      return `${head}\n  → done${p.label ? ` ${p.label}` : ""}${tag}`;
+    }
+    default:
+      return assertNever(p);
   }
-  if (p.kind === "agent_done") {
-    const tag = p.model ? ` @${p.model}` : "";
-    return `${head}\n  → done${p.label ? ` ${p.label}` : ""}${tag}`;
-  }
-  return head;
 }

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -1,7 +1,15 @@
 import { Worker } from "node:worker_threads";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { readEvents, readOutput } from "./artifact";
+import {
+  assertNever,
+  isTurnTerminal,
+  readEvents,
+  readOutput,
+  readOutputForTurnId,
+  type SubagentEvent,
+  type TurnTerminalEvent,
+} from "./artifact";
 import { debugLog } from "./helpers";
 import type { SubagentResult, Usage } from "./helpers";
 import {
@@ -24,6 +32,7 @@ import {
   type WorkflowAgentRunner,
   type WorkflowMeta,
   type WorkflowProgress,
+  type WorkflowProgressUpdate,
   type WorkflowRunResult,
   zeroUsage,
 } from "./workflow-core";
@@ -54,6 +63,21 @@ interface Engine {
     runningCount: number;
   };
   phases: string[];
+}
+
+function withProgressCounters(
+  progress: WorkflowProgressUpdate,
+  counters: Engine["counters"],
+): WorkflowProgress {
+  switch (progress.kind) {
+    case "phase":
+    case "log":
+    case "agent_start":
+    case "agent_done":
+      return { ...progress, ...counters };
+    default:
+      return assertNever(progress);
+  }
 }
 
 export async function runWorkflow(
@@ -117,21 +141,10 @@ async function executeScript(
   args: unknown,
   _depth: number,
 ): Promise<{ meta: WorkflowMeta; result: unknown }> {
-  const emit = (
-    p: Omit<
-      WorkflowProgress,
-      "agentsSpawned" | "errorCount" | "tokensSpent" | "runningCount"
-    >,
-  ) => {
+  const emit = (p: WorkflowProgressUpdate) => {
     if (engine.closed) return;
     if (p.kind === "phase" && p.phase) engine.phases.push(p.phase);
-    engine.onProgress?.({
-      ...p,
-      agentsSpawned: engine.counters.agentsSpawned,
-      errorCount: engine.counters.errorCount,
-      tokensSpent: engine.counters.tokensSpent,
-      runningCount: engine.counters.runningCount,
-    });
+    engine.onProgress?.(withProgressCounters(p, engine.counters));
   };
 
   const runAgentCall = async (payload: {
@@ -180,15 +193,32 @@ async function executeScript(
           const finalPrompt = hasSchema
             ? buildSchemaPrompt(prompt, agentOpts.schema, attempt, lastErr)
             : prompt;
-          const res = await engine.runAgent({
-            prompt: finalPrompt,
-            persona: agentOpts.persona,
-            model: agentOpts.model,
-            signal: engine.signal,
-            isolation,
-            label: agentOpts.label,
-            onProgress: (ev) => emit({ ...ev, phase: agentOpts.phase }),
-          });
+          let res: SubagentResult;
+          try {
+            res = await engine.runAgent({
+              prompt: finalPrompt,
+              persona: agentOpts.persona,
+              model: agentOpts.model,
+              signal: engine.signal,
+              isolation,
+              label: agentOpts.label,
+              onProgress: (ev) => {
+                if (ev.kind === "phase") {
+                  if (ev.phase) {
+                    emit({
+                      ...ev,
+                      phase: agentOpts.phase ?? ev.phase,
+                    });
+                  }
+                  return;
+                }
+                emit({ ...ev, phase: agentOpts.phase });
+              },
+            });
+          } catch (error) {
+            if (!engine.signal.aborted) engine.counters.errorCount++;
+            throw error;
+          }
           const outTokens = res.usage?.output ?? 0;
           tokensDelta += outTokens;
           engine.counters.tokensSpent += outTokens;
@@ -250,9 +280,7 @@ function runWorkflowWorker(
   script: string,
   args: unknown,
   engine: Engine,
-  emit: (
-    p: Omit<WorkflowProgress, "agentsSpawned" | "errorCount" | "tokensSpent">,
-  ) => void,
+  emit: (p: WorkflowProgressUpdate) => void,
   runAgentCall: (payload: {
     prompt: unknown;
     opts?: WorkflowAgentOpts;
@@ -451,6 +479,34 @@ function parseUsageFromSessionFile(sessionFile: string | undefined): Usage {
   }
 }
 
+function findCurrentTurnTerminal(
+  events: SubagentEvent[],
+): TurnTerminalEvent | null {
+  let latestTurnStart = -1;
+  let latestTurnId: string | undefined;
+  for (let index = 0; index < events.length; index++) {
+    const event = events[index];
+    if (event.type === "turn_started") {
+      latestTurnStart = index;
+      latestTurnId = event.turnId;
+    }
+  }
+  if (latestTurnStart >= 0) {
+    for (let index = events.length - 1; index > latestTurnStart; index--) {
+      const event = events[index];
+      if (event.type === "completion" && event.turnId === latestTurnId) {
+        return event;
+      }
+    }
+    return null;
+  }
+  for (let index = events.length - 1; index >= 0; index--) {
+    const event = events[index];
+    if (isTurnTerminal(event)) return event;
+  }
+  return null;
+}
+
 /**
  * Await a process-backed (tmux/zellij) sub-agent's terminal event by polling its artifact dir,
  * then read its output.md. Honors the abort signal and detects a dead pane that never completed.
@@ -478,30 +534,56 @@ export async function awaitInteractiveResult(
       };
     }
     const events = readEvents(art);
-    const terminal = [...events]
-      .reverse()
-      .find(
-        (e) =>
-          e.type === "done" || e.type === "error" || e.type === "cancelled",
-      );
+    const terminal = findCurrentTurnTerminal(events);
     if (terminal) {
-      const output = readOutput(art) ?? "(no output)";
-      if (terminal.type === "done") {
-        return {
-          isError: false,
-          output,
-          usage: parseUsageFromSessionFile(state.sessionFile),
-          model: state.model ?? "process",
-        };
+      const usage = parseUsageFromSessionFile(state.sessionFile);
+      switch (terminal.type) {
+        case "completion":
+          switch (terminal.outcome) {
+            case "done":
+              return {
+                isError: false,
+                output:
+                  readOutputForTurnId(art, terminal.turnId) ?? "(no output)",
+                usage,
+                model: state.model ?? "process",
+              };
+            case "error":
+            case "cancelled":
+              return {
+                isError: true,
+                output:
+                  readOutputForTurnId(art, terminal.turnId) ?? "(no output)",
+                usage,
+                model: undefined,
+                errorMessage:
+                  terminal.errorMessage ??
+                  terminal.message ??
+                  `interactive sub-agent ${terminal.outcome}`,
+              };
+            default:
+              return assertNever(terminal.outcome);
+          }
+        case "done":
+          return {
+            isError: false,
+            output: readOutput(art) ?? "(no output)",
+            usage,
+            model: state.model ?? "process",
+          };
+        case "error":
+        case "cancelled":
+          return {
+            isError: true,
+            output: readOutput(art) ?? "(no output)",
+            usage,
+            model: undefined,
+            errorMessage:
+              terminal.message ?? `interactive sub-agent ${terminal.type}`,
+          };
+        default:
+          return assertNever(terminal);
       }
-      return {
-        isError: true,
-        output,
-        usage: parseUsageFromSessionFile(state.sessionFile),
-        model: undefined,
-        errorMessage:
-          terminal.message ?? `interactive sub-agent ${terminal.type}`,
-      };
     }
     // No terminal event yet — if the pane has died, give it a few grace ticks for a final flush.
     let alive = true;

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -21,6 +21,9 @@ import {
   deleteInteractiveStatesFile,
   ensureArtifactDir,
   eventLogEndOffset,
+  isArtifactOutputSettled,
+  isCompletionEvent,
+  isTurnTerminal,
   lastEvent,
   listArtifacts,
   listOutputTurns,
@@ -1041,5 +1044,67 @@ describe("persisted interactive state helpers", () => {
 
   it("deleteInteractiveStatesFile is a no-op when the file is absent", () => {
     expect(() => deleteInteractiveStatesFile(root)).not.toThrow();
+  });
+});
+
+describe("SubagentEvent classification matrix", () => {
+  const baseTs = 1000;
+  const events = {
+    started: { ts: baseTs, type: "started", status: "running" },
+    tool_activity: { ts: baseTs, type: "tool_activity", status: "running" },
+    done: { ts: baseTs, type: "done", status: "done" },
+    error: { ts: baseTs, type: "error", status: "error" },
+    cancelled: { ts: baseTs, type: "cancelled", status: "cancelled" },
+    turn_started: {
+      version: 2,
+      eventId: "e-turn",
+      turnId: "t-turn",
+      ts: baseTs,
+      type: "turn_started",
+      status: "running",
+    },
+    completion: {
+      version: 2,
+      eventId: "e-completion",
+      turnId: "t-completion",
+      ts: baseTs,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "explicit",
+    },
+    process_exited: {
+      version: 2,
+      eventId: "e-exit",
+      turnId: "t-exit",
+      ts: baseTs,
+      type: "process_exited",
+      status: "done",
+      exitCode: 0,
+    },
+  } satisfies Record<SubagentEvent["type"], SubagentEvent>;
+
+  const expected = {
+    started: { terminal: false, completion: false, settled: false },
+    tool_activity: { terminal: false, completion: false, settled: false },
+    done: { terminal: true, completion: true, settled: true },
+    error: { terminal: true, completion: true, settled: true },
+    cancelled: { terminal: true, completion: true, settled: true },
+    turn_started: { terminal: false, completion: false, settled: false },
+    completion: { terminal: true, completion: true, settled: true },
+    process_exited: { terminal: false, completion: false, settled: true },
+  } satisfies Record<
+    SubagentEvent["type"],
+    { terminal: boolean; completion: boolean; settled: boolean }
+  >;
+
+  it("classifies every event discriminant", () => {
+    for (const type of Object.keys(events) as Array<SubagentEvent["type"]>) {
+      const event = events[type];
+      const result = expected[type];
+      expect(isTurnTerminal(event)).toBe(result.terminal);
+      expect(isCompletionEvent(event)).toBe(result.completion);
+      expect(isArtifactOutputSettled(event)).toBe(result.settled);
+    }
   });
 });

--- a/tests/subagent-notify.test.ts
+++ b/tests/subagent-notify.test.ts
@@ -1334,7 +1334,11 @@ describe("read_subagent_artifact (output reporting)", () => {
     return mkdtempSync(join(tmpdir(), "pi-subagentura-read-out-"));
   }
 
-  function makeArtifactWithDone(id: string, parentDir: string) {
+  function makeArtifactWithDone(
+    id: string,
+    parentDir: string,
+    appendLegacyDone = true,
+  ) {
     const dir = join(parentDir, id);
     const state: import("../src/interactive-tmux").InteractiveSubagentState = {
       id,
@@ -1353,7 +1357,9 @@ describe("read_subagent_artifact (output reporting)", () => {
     };
     const art = artifactPath(parentDir, id);
     appendEvent(art, { ts: 1, type: "started", status: "running" });
-    appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+    if (appendLegacyDone) {
+      appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+    }
     return { state, art, dir };
   }
 
@@ -1407,6 +1413,80 @@ describe("read_subagent_artifact (output reporting)", () => {
       expect(text).toContain("last event: done @ 2");
       expect(text).not.toContain("not written yet");
       expect(result.details.output).toBeNull();
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a protocol-v2 completion as exited when output.md is missing", async () => {
+    const id = "ab12cd38";
+    const parent = tmp();
+    try {
+      const { state, art } = makeArtifactWithDone(id, parent, false);
+      appendCompletionEvent(art, {
+        turnId: "turn-without-output",
+        eventId: "completion-without-output",
+        outcome: "done",
+        source: "agent_settled",
+        ts: 2,
+      });
+      const mod =
+        await importFresh<typeof import("../src/subagent")>("../src/subagent");
+      mod.interactiveSubagentRegistry.set(id, state);
+      const readTool = makeReadTool(mod);
+
+      const result = await readTool.execute(
+        "call-v2-no-output",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
+      const text = result.content[0].text;
+
+      expect(text).toContain(
+        "Output: (sub-agent exited without writing output.md",
+      );
+      expect(text).toContain("last event: completion @ 2");
+      expect(text).not.toContain("not written yet");
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a protocol-v2 process exit as exited when output.md is missing", async () => {
+    const id = "ab12cd39";
+    const parent = tmp();
+    try {
+      const { state, art } = makeArtifactWithDone(id, parent, false);
+      appendEvent(art, {
+        version: 2,
+        eventId: "process-exit-without-output",
+        turnId: "turn-process-exit",
+        ts: 2,
+        type: "process_exited",
+        status: "done",
+        exitCode: 0,
+      });
+      const mod =
+        await importFresh<typeof import("../src/subagent")>("../src/subagent");
+      mod.interactiveSubagentRegistry.set(id, state);
+      const readTool = makeReadTool(mod);
+
+      const result = await readTool.execute(
+        "call-v2-process-exit-no-output",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
+      const text = result.content[0].text;
+
+      expect(text).toContain(
+        "Output: (sub-agent exited without writing output.md",
+      );
+      expect(text).toContain("last event: process_exited @ 2");
+      expect(text).not.toContain("not written yet");
     } finally {
       rmSync(parent, { recursive: true, force: true });
     }

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -23,8 +23,15 @@ import {
   type WorkflowProgress,
 } from "../src/workflow";
 import type { SubagentResult } from "../src/helpers";
+import {
+  appendCompletionEvent,
+  appendEvent,
+  artifactPath,
+  writeOutput,
+} from "../src/artifact";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -67,6 +74,10 @@ function echoRunner(): WorkflowAgentRunner {
 }
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
+
+function fakeState(dir: string) {
+  return { id: "abcd1234", artifactDir: dir, model: "test/model" } as any;
+}
 
 describe("parseWorkflow", () => {
   it("extracts a pure-literal meta and the body", () => {
@@ -821,10 +832,6 @@ it("throws when all 100 job slots are full and none can be evicted", () => {
 });
 
 describe("awaitInteractiveResult", () => {
-  function fakeState(dir: string) {
-    return { id: "abcd1234", artifactDir: dir, model: "test/model" } as any;
-  }
-
   it("resolves with output.md when a done event is present", async () => {
     const dir = mkdtempSync(join(tmpdir(), "wf-int-"));
     writeFileSync(join(dir, "output.md"), "final answer");
@@ -838,6 +845,225 @@ describe("awaitInteractiveResult", () => {
     const res = await awaitInteractiveResult(fakeState(dir), undefined, 5);
     expect(res.isError).toBe(false);
     expect(res.output).toBe("final answer");
+  });
+
+  it("does not reuse a legacy completion from a previous turn", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-stale-"));
+    writeFileSync(join(dir, "output.md"), "stale answer");
+    writeFileSync(
+      join(dir, "events.ndjson"),
+      [
+        { ts: 1, type: "done", status: "done" },
+        {
+          version: 2,
+          eventId: "turn-start-current",
+          turnId: "turn-current",
+          ts: 2,
+          type: "turn_started",
+          status: "running",
+        },
+      ]
+        .map((event) => JSON.stringify(event))
+        .join("\n") + "\n",
+    );
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 0);
+
+    const result = await awaitInteractiveResult(
+      fakeState(dir),
+      controller.signal,
+      1,
+    );
+
+    expect(result.isError).toBe(true);
+    if (!result.isError) throw new Error("expected aborted result");
+    expect(result.errorMessage).toBe("aborted");
+    expect(result.output).not.toBe("stale answer");
+  });
+
+  it("ignores a late v2 completion for a different turn", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-late-"));
+    writeFileSync(join(dir, "output.md"), "late stale answer");
+    writeFileSync(
+      join(dir, "events.ndjson"),
+      [
+        {
+          version: 2,
+          eventId: "turn-start-current",
+          turnId: "turn-current",
+          ts: 2,
+          type: "turn_started",
+          status: "running",
+        },
+        {
+          version: 2,
+          eventId: "completion-old",
+          turnId: "turn-old",
+          ts: 3,
+          type: "completion",
+          status: "done",
+          outcome: "done",
+          source: "agent_settled",
+        },
+      ]
+        .map((event) => JSON.stringify(event))
+        .join("\n") + "\n",
+    );
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 0);
+
+    const result = await awaitInteractiveResult(
+      fakeState(dir),
+      controller.signal,
+      1,
+    );
+
+    expect(result.isError).toBe(true);
+    if (!result.isError) throw new Error("expected aborted result");
+    expect(result.errorMessage).toBe("aborted");
+    expect(result.output).not.toBe("late stale answer");
+  });
+
+  it("accepts a matching current-turn v2 completion", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-current-"));
+    const art = artifactPath(dir, "artifact");
+    appendEvent(art, {
+      version: 2,
+      eventId: "turn-start-current",
+      turnId: "turn-current",
+      ts: 2,
+      type: "turn_started",
+      status: "running",
+    });
+    writeOutput(art, "current answer");
+    appendCompletionEvent(art, {
+      turnId: "turn-current",
+      eventId: "completion-current",
+      outcome: "done",
+      source: "agent_settled",
+    });
+
+    const result = await awaitInteractiveResult(
+      fakeState(art.dir),
+      undefined,
+      1,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.output).toBe("current answer");
+  });
+
+  it("resolves a protocol-v2 completion from its immutable snapshot", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-"));
+    const outputDir = join(dir, "outputs");
+    const outputPath = join(outputDir, "event-v2.md");
+    const output = Buffer.from("v2 final answer");
+    mkdirSync(outputDir);
+    writeFileSync(join(dir, "output.md"), "stale staging output");
+    writeFileSync(outputPath, output);
+    writeFileSync(
+      join(dir, "events.ndjson"),
+      JSON.stringify({
+        version: 2,
+        eventId: "event-v2",
+        turnId: "turn-v2",
+        ts: 2,
+        type: "completion",
+        status: "done",
+        outcome: "done",
+        source: "explicit",
+        output: {
+          path: outputPath,
+          bytes: output.byteLength,
+          sha256: createHash("sha256").update(output).digest("hex"),
+        },
+      }) + "\n",
+    );
+
+    const res = await awaitInteractiveResult(fakeState(dir), undefined, 5);
+
+    expect(res.isError).toBe(false);
+    expect(res.output).toBe("v2 final answer");
+  });
+
+  it("does not fall back to mutable output for a rejected v2 snapshot", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-"));
+    writeFileSync(join(dir, "output.md"), "untrusted staging output");
+    writeFileSync(
+      join(dir, "events.ndjson"),
+      JSON.stringify({
+        version: 2,
+        eventId: "event-v2-oversized",
+        turnId: "turn-v2-oversized",
+        ts: 2,
+        type: "completion",
+        status: "done",
+        outcome: "done",
+        source: "explicit",
+        outputError: {
+          code: "output_too_large",
+          bytes: 1_048_577,
+          maxBytes: 1_048_576,
+        },
+      }) + "\n",
+    );
+
+    const res = await awaitInteractiveResult(fakeState(dir), undefined, 5);
+
+    expect(res.isError).toBe(false);
+    expect(res.output).toBe("(no output)");
+  });
+
+  it("returns an error result for a protocol-v2 error completion", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-"));
+    writeFileSync(join(dir, "output.md"), "partial");
+    writeFileSync(
+      join(dir, "events.ndjson"),
+      JSON.stringify({
+        version: 2,
+        eventId: "event-v2-error",
+        turnId: "turn-v2-error",
+        ts: 2,
+        type: "completion",
+        status: "error",
+        outcome: "error",
+        source: "explicit",
+        errorMessage: "v2 kaboom",
+      }) + "\n",
+    );
+
+    const res = await awaitInteractiveResult(fakeState(dir), undefined, 5);
+
+    expect(res).toMatchObject({
+      isError: true,
+      errorMessage: "v2 kaboom",
+    });
+  });
+
+  it("returns an error result for a protocol-v2 cancelled completion", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-"));
+    writeFileSync(join(dir, "output.md"), "partial");
+    writeFileSync(
+      join(dir, "events.ndjson"),
+      JSON.stringify({
+        version: 2,
+        eventId: "event-v2-cancelled",
+        turnId: "turn-v2-cancelled",
+        ts: 2,
+        type: "completion",
+        status: "cancelled",
+        outcome: "cancelled",
+        source: "parent",
+        message: "stopped by parent",
+      }) + "\n",
+    );
+
+    const res = await awaitInteractiveResult(fakeState(dir), undefined, 5);
+
+    expect(res).toMatchObject({
+      isError: true,
+      errorMessage: "stopped by parent",
+    });
   });
 
   it("returns an error result on an error event", async () => {
@@ -975,6 +1201,125 @@ describe("abort signal propagation", () => {
     expect(r.result).toEqual([null, null]);
     expect(r.errorCount).toBe(2);
   });
+
+  it("counts non-abort thrown agent failures once", async () => {
+    const runAgent: WorkflowAgentRunner = async () => {
+      throw new Error("boom");
+    };
+    const progress: WorkflowProgress[] = [];
+    const r = await runWorkflow(
+      meta +
+        `const r = await parallel([() => agent("a"), () => agent("b")]); return r;`,
+      {
+        runAgent,
+        onProgress: (event) => progress.push({ ...event }),
+      },
+    );
+
+    expect(r.result).toEqual([null, null]);
+    expect(r.agentsSpawned).toBe(2);
+    expect(r.errorCount).toBe(2);
+    expect(progress[progress.length - 1].runningCount).toBe(0);
+  });
+
+  it("aggregates valid v2 artifact results through parallel", async () => {
+    const root = mkdtempSync(join(tmpdir(), "wf-v2-runner-"));
+    const outcomes = ["done", "error", "cancelled"] as const;
+    let callIndex = 0;
+    const observed = new Map<string, SubagentResult>();
+    const runAgent: WorkflowAgentRunner = async ({ prompt }) => {
+      const index = callIndex++;
+      const art = artifactPath(root, `agent-${index}`);
+      writeOutput(art, `answer-${prompt}`);
+      appendCompletionEvent(art, {
+        turnId: `turn-${index}`,
+        eventId: `event-${index}`,
+        outcome: outcomes[index],
+        source: outcomes[index] === "cancelled" ? "parent" : "agent_settled",
+      });
+      const result = await awaitInteractiveResult(
+        fakeState(art.dir),
+        undefined,
+        1,
+      );
+      observed.set(prompt, result);
+      return result;
+    };
+    const progress: WorkflowProgress[] = [];
+    const meta = `export const meta = { name: "parallel-agg", description: "d" };\n`;
+
+    try {
+      const r = await runWorkflow(
+        meta +
+          `const r = await parallel([() => agent("a"), () => agent("b"), () => agent("c")]); return r;`,
+        {
+          runAgent,
+          processConcurrency: 3,
+          onProgress: (p) => progress.push({ ...p }),
+        },
+      );
+
+      expect(r.agentsSpawned).toBe(3);
+      expect(r.errorCount).toBe(2);
+      expect(r.result).toEqual(["answer-a", null, null]);
+      const observedByPrompt = [...observed.entries()].sort(([a], [b]) =>
+        a.localeCompare(b),
+      );
+      expect(
+        observedByPrompt.map(([prompt, result]) => [prompt, result.output]),
+      ).toEqual([
+        ["a", "answer-a"],
+        ["b", "answer-b"],
+        ["c", "answer-c"],
+      ]);
+      expect(
+        observedByPrompt.map(([prompt, result]) => [prompt, result.isError]),
+      ).toEqual([
+        ["a", false],
+        ["b", true],
+        ["c", true],
+      ]);
+      expect(progress[progress.length - 1].runningCount).toBe(0);
+      expect(progress.filter((p) => p.kind === "agent_done")).toHaveLength(3);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("parallel workflow error/cancelled outcomes clear runningCount", async () => {
+    const runAgent: WorkflowAgentRunner = async () => ({
+      isError: true,
+      output: "",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 1,
+      },
+      model: undefined,
+      errorMessage: "cancelled",
+    });
+
+    const progress: WorkflowProgress[] = [];
+    const meta = `export const meta = { name: "parallel-ec", description: "d" };\n`;
+    const r = await runWorkflow(
+      meta +
+        `const r = await parallel([() => agent("a"), () => agent("b")]); return r;`,
+      {
+        runAgent,
+        onProgress: (p) => progress.push({ ...p }),
+      },
+    );
+
+    expect(r.agentsSpawned).toBe(2);
+    expect(r.errorCount).toBe(2);
+    expect(r.result).toEqual([null, null]);
+
+    const lastProgress = progress[progress.length - 1];
+    expect(lastProgress.runningCount).toBe(0);
+  });
 });
 
 describe("renderProgress", () => {
@@ -1063,18 +1408,6 @@ describe("renderProgress", () => {
     const result = renderProgress(p);
     expect(result).toContain("→ done scout @gpt-4");
     expect(result).toContain("⚠ 1 error(s)");
-  });
-
-  it("falls back to just the head line for unknown kinds", () => {
-    const p = {
-      kind: "unknown" as const,
-      agentsSpawned: 0,
-      errorCount: 0,
-      tokensSpent: 0,
-      runningCount: 0,
-    };
-    const result = renderProgress(p as unknown as WorkflowProgress);
-    expect(result).toBe("● workflow — 0 agent(s), 0 tokens");
   });
 
   it("omits running count when runningCount is 0", () => {
@@ -1889,5 +2222,56 @@ describe("registerWorkflowTool", () => {
     expect(onComplete).toHaveBeenCalledTimes(
       MAX_WORKFLOW_NOTIFICATION_ATTEMPTS,
     );
+  });
+});
+
+describe("WorkflowProgress classification matrix", () => {
+  const samples = {
+    phase: {
+      kind: "phase",
+      phase: "test",
+      agentsSpawned: 1,
+      errorCount: 0,
+      tokensSpent: 100,
+      runningCount: 0,
+    },
+    log: {
+      kind: "log",
+      message: "test",
+      agentsSpawned: 1,
+      errorCount: 0,
+      tokensSpent: 100,
+      runningCount: 0,
+    },
+    agent_start: {
+      kind: "agent_start",
+      label: "test",
+      agentsSpawned: 1,
+      errorCount: 0,
+      tokensSpent: 100,
+      runningCount: 0,
+    },
+    agent_done: {
+      kind: "agent_done",
+      label: "test",
+      agentsSpawned: 1,
+      errorCount: 0,
+      tokensSpent: 100,
+      runningCount: 0,
+    },
+  } satisfies Record<WorkflowProgress["kind"], WorkflowProgress>;
+
+  it("renders every progress discriminant", () => {
+    const expected = {
+      phase: "◆ phase: test",
+      log: "test",
+      agent_start: "→ started test",
+      agent_done: "→ done test",
+    } satisfies Record<WorkflowProgress["kind"], string>;
+    for (const kind of Object.keys(samples) as Array<
+      WorkflowProgress["kind"]
+    >) {
+      expect(renderProgress(samples[kind])).toContain(expected[kind]);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- teach process-backed workflow agents to resolve protocol-v2 `completion` events from immutable output snapshots
- select completions by the latest physical `turn_started` event so stale or cross-turn terminals cannot resolve a workflow agent
- make artifact, lifecycle, mux, and workflow-progress handling exhaustive over repo-owned discriminated unions
- normalize notification delivery from narrowed completion events and count thrown workflow-agent failures exactly once
- retain protocol-v1 compatibility and pane-death grace behavior

## Regression coverage

- protocol-v2 done/error/cancelled artifact outcomes through `awaitInteractiveResult()`
- parallel workflow aggregation with immutable v2 snapshots and final `runningCount === 0`
- stale legacy terminals and late completions from another turn
- oversized/rejected v2 snapshots never falling back to mutable `output.md`
- thrown agent failures incrementing `errorCount`
- exhaustive artifact/progress classification matrices

## Verification

- `npm run typecheck`
- `npm test` — 40 files, 945 tests passed
- `npm run format:check`
- `git diff --check`
- `npm run pack:check`
