### PR TITLE
chore: open Pi peer compatibility range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ permissions:
 
 jobs:
   test:
-    name: Test (latest Pi)
+    name: Test (Pi ${{ matrix.pi-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pi-version: ["0.80.6", "latest"]
 
     steps:
       - name: Checkout
@@ -30,15 +34,17 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
-      - name: Install latest Pi SDK
+      - name: Install selected Pi SDK
+        env:
+          PI_VERSION: ${{ matrix.pi-version }}
         run: >-
           npm install --no-save --package-lock=false
-          '@earendil-works/pi-agent-core@latest'
-          '@earendil-works/pi-ai@latest'
-          '@earendil-works/pi-coding-agent@latest'
-          '@earendil-works/pi-tui@latest'
+          "@earendil-works/pi-agent-core@${PI_VERSION}"
+          "@earendil-works/pi-ai@${PI_VERSION}"
+          "@earendil-works/pi-coding-agent@${PI_VERSION}"
+          "@earendil-works/pi-tui@${PI_VERSION}"
 
-      - name: Verify extension loads in latest Pi
+      - name: Verify extension loads in selected Pi
         run: |
           npx --no-install pi --version
           PI_OFFLINE=1 npx --no-install pi --offline --no-session \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ A public [Pi](https://pi.dev) extension that adds in-process and attachable sub-
 
 - **npm package** `pi-subagentura` — published via OIDC trusted publishing on push of a `v*` tag.
 - **Pi extension** — single entry point: `./src/subagent.ts` (declared in `package.json#pi.extensions`).
-- **TypeScript, ESM, strict mode**, `target: ESNext`, Node ≥ 18, Pi SDK ≥ 0.80.6 and < 0.81.
+- **TypeScript, ESM, strict mode**, `target: ESNext`, Node ≥ 18, Pi SDK ≥ 0.80.6. CI verifies both the minimum and latest published Pi SDKs.
 - **Runtime deps** are minimal: `ndjson`, `is-path-inside`. Pi SDKs are peer dependencies.
 - **Tests** are `vitest` and live in `tests/` as `*.test.ts` (27 test files, ~12k lines of test code).
 - **CI** is a single GitHub Actions workflow: typecheck → tests → published-tarball smoke → pack dry-run.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Implementation details for crash-safe ordering and delivery recovery are in the
 #### Sub-agent completion protocol
 
 Every interactive child runs protocol-only Pi lifecycle hooks and therefore
-requires Pi SDK `>=0.80.6 <0.81.0`. `before_agent_start` creates a provisional
+requires Pi SDK `>=0.80.6`. `before_agent_start` creates a provisional
 turn, the first `turn_start` binds it to the persisted Pi user-entry id, tool
 hooks record activity, and `agent_settled` records the authoritative completion
 after retries, compaction, and queued continuations. When Pi accepts Enter while

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,10 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-agent-core": ">=0.80.6 <0.81.0",
-        "@earendil-works/pi-ai": ">=0.80.6 <0.81.0",
-        "@earendil-works/pi-coding-agent": ">=0.80.6 <0.81.0",
-        "@earendil-works/pi-tui": ">=0.80.6 <0.81.0",
+        "@earendil-works/pi-agent-core": ">=0.80.6",
+        "@earendil-works/pi-ai": ">=0.80.6",
+        "@earendil-works/pi-coding-agent": ">=0.80.6",
+        "@earendil-works/pi-tui": ">=0.80.6",
         "typebox": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -90,10 +90,10 @@
     "*.{ts,tsx,js,jsx,mjs,cjs,json,md,yml,yaml,css,html}": "prettier --write"
   },
   "peerDependencies": {
-    "@earendil-works/pi-agent-core": ">=0.80.6 <0.81.0",
-    "@earendil-works/pi-ai": ">=0.80.6 <0.81.0",
-    "@earendil-works/pi-coding-agent": ">=0.80.6 <0.81.0",
-    "@earendil-works/pi-tui": ">=0.80.6 <0.81.0",
+    "@earendil-works/pi-agent-core": ">=0.80.6",
+    "@earendil-works/pi-ai": ">=0.80.6",
+    "@earendil-works/pi-coding-agent": ">=0.80.6",
+    "@earendil-works/pi-tui": ">=0.80.6",
     "typebox": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove the Pi `<0.81.0` peer dependency ceiling while retaining the verified `>=0.80.6` minimum
- keep the legacy/modern SDK compatibility shim
- run CI against both Pi 0.80.6 and the latest published Pi SDK
- update compatibility documentation

## Verification
- Pi 0.80.6: typecheck and 932 tests passed
- Pi latest (0.80.10): typecheck and 932 tests passed
- `npm run format:check`
- `npm run pack:check`
