### PR TITLE
feat: add cancellation context snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ The guidance gives the parent agent reasonable default behavior when the user as
 
 The defaults prefer async `subagent_isolated` for fresh scouts/reviewers, `subagent_with_context` for oracle checks, injected completions instead of polling, and one writer at a time for implementation. For cheap fanout, they suggest validating model availability before using optional model overrides.
 
+## Cancellation context snapshots (opt-in)
+
+Cancellation snapshots are **disabled by default**. To enable bounded snapshots before parent-initiated cancellation, set:
+
+```bash
+SUBAGENT_CANCEL_SNAPSHOT=full pi
+```
+
+In-process sub-agents write a private atomic JSON snapshot of the canonical active branch plus bounded partial streaming state. Interactive/process sub-agents write a private manifest that points to their already-persisted Pi session JSONL and artifact files; the transcript is not duplicated. Cancellation results expose receipt paths and errors, never snapshot contents.
+
+Optional configuration:
+
+- `SUBAGENT_CANCEL_SNAPSHOT_DIR` — override the private snapshot root. The directory and files are created with `0700`/`0600` permissions.
+- `SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES` — maximum raw in-process snapshot size. The default is `1048576` bytes (1 MiB); accepted values range from `4096` bytes to `16777216` bytes (16 MiB). Invalid values use the default. Oversized snapshots preserve as much context as fits and record explicit truncation/error metadata.
+
+Snapshots use schema version 1, temp-file + rename writes, deterministic per-session/job paths, and idempotent receipts so overlapping cancellation and shutdown paths do not duplicate files. They may contain sensitive prompts, tool arguments, and model output; keep the snapshot directory private and do not commit it.
+
 ## Tools
 
 ### `subagent_with_context`

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "src/workflow-tool.ts",
     "src/abortable-wait.ts",
     "src/cancel-all-flows.ts",
-    "src/cancel-all-flows-registration.ts"
+    "src/cancel-all-flows-registration.ts",
+    "src/cancellation-snapshots.ts"
   ],
   "engines": {
     "node": ">=18.0.0"

--- a/src/cancel-all-flows-registration.ts
+++ b/src/cancel-all-flows-registration.ts
@@ -7,6 +7,19 @@
 import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { cancelAllFlows } from "./cancel-all-flows";
 
+function snapshotSummary(
+  result: Awaited<ReturnType<typeof cancelAllFlows>>,
+): string {
+  const receipts = result.snapshots ?? [];
+  if (receipts.length === 0) return "";
+  return receipts
+    .map((receipt) => {
+      const suffix = receipt.path ?? receipt.error ?? "no receipt path";
+      return `Snapshot ${receipt.status}: ${suffix}`;
+    })
+    .join("\n");
+}
+
 export function registerCancelAllFlows(pi: ExtensionAPI): void {
   // ── ctrl+alt+x shortcut ────────────────────────────────────────────
   if (typeof pi.registerShortcut === "function") {
@@ -31,7 +44,13 @@ export function registerCancelAllFlows(pi: ExtensionAPI): void {
         if (parts.length === 0) {
           ctx.ui.notify("No active flows to cancel.", "info");
         } else {
-          ctx.ui.notify(`Cancelled: ${parts.join(", ")}`, "warning");
+          const message = [
+            `Cancelled: ${parts.join(", ")}`,
+            snapshotSummary(result),
+          ]
+            .filter(Boolean)
+            .join("\n");
+          ctx.ui.notify(message, "warning");
         }
       },
     });
@@ -60,7 +79,13 @@ export function registerCancelAllFlows(pi: ExtensionAPI): void {
         if (parts.length === 0) {
           ctx.ui.notify("No active flows to cancel.", "info");
         } else {
-          ctx.ui.notify(`Cancelled: ${parts.join(", ")}`, "warning");
+          const message = [
+            `Cancelled: ${parts.join(", ")}`,
+            snapshotSummary(result),
+          ]
+            .filter(Boolean)
+            .join("\n");
+          ctx.ui.notify(message, "warning");
         }
       },
     });

--- a/src/cancel-all-flows.ts
+++ b/src/cancel-all-flows.ts
@@ -8,19 +8,24 @@
  * Preserves idle interactive panes (they consume no tokens).
  * Preserves done/error/cancelled jobs and workflows.
  */
-
 import { jobRegistry, scheduleJobCleanup } from "./helpers";
 import {
   cancelInteractiveSubagent,
   interactiveSubagentRegistry,
 } from "./interactive-tmux";
 import { workflowJobRegistry } from "./workflow-jobs";
+import {
+  snapshotInProcessSession,
+  snapshotInteractiveContext,
+  type CancellationSnapshotReceipt,
+} from "./cancellation-snapshots";
 
 export interface CancelAllResult {
   jobsAborted: number;
   workflowsAborted: number;
   interactiveKilled: number;
   interactivePreserved: number;
+  snapshots?: CancellationSnapshotReceipt[];
 }
 
 export async function cancelAllFlows(): Promise<CancelAllResult> {
@@ -29,20 +34,57 @@ export async function cancelAllFlows(): Promise<CancelAllResult> {
     workflowsAborted: 0,
     interactiveKilled: 0,
     interactivePreserved: 0,
+    snapshots: [],
+  };
+  const snapshots = result.snapshots;
+  const snapshotKeys = new Set<string>();
+  const addSnapshot = (receipt: CancellationSnapshotReceipt): void => {
+    if (snapshotKeys.has(receipt.key)) return;
+    snapshotKeys.add(receipt.key);
+    snapshots!.push(receipt);
   };
 
-  // 1. Abort all running in-process subagent jobs
-  for (const job of jobRegistry.values()) {
-    if (job.status === "running") {
-      try {
-        await job.session.abort();
-      } catch {
-        /* session may already be disposed */
-      }
-      job.status = "cancelled";
-      scheduleJobCleanup(job.id, true);
-      result.jobsAborted++;
+  // Snapshot every known child before the first potentially slow abort.
+  const interactiveStates = [...interactiveSubagentRegistry.values()];
+  for (const state of interactiveStates) {
+    if (state.status !== "running") continue;
+    state.cancellationSnapshot = snapshotInteractiveContext({
+      kind: "interactive",
+      id: state.id,
+      parentSessionId: state.parentSessionId,
+      cwd: state.cwd,
+      sessionFile: state.sessionFile,
+      artifactDir: state.artifactDir,
+      startedAt: state.startedAt,
+      source: "cancel_all",
+    });
+    addSnapshot(state.cancellationSnapshot);
+  }
+  const jobs = [...jobRegistry.values()].filter(
+    (job) => job.status === "running",
+  );
+  for (const job of jobs) {
+    job.cancellationSnapshot = snapshotInProcessSession({
+      kind: "in-process",
+      jobId: job.id,
+      session: job.session,
+      cwd: job.cwd ?? process.cwd(),
+      model: job.modelLabel,
+      activeTool: job.liveStatus?.activeTool,
+      partialOutput: job.liveStatus?.output,
+      source: "cancel_all",
+    });
+    addSnapshot(job.cancellationSnapshot);
+  }
+  for (const job of jobs) {
+    try {
+      await job.session.abort();
+    } catch {
+      /* session may already be disposed */
     }
+    job.status = "cancelled";
+    scheduleJobCleanup(job.id, true);
+    result.jobsAborted++;
   }
 
   // 2. Abort all running workflows
@@ -50,17 +92,23 @@ export async function cancelAllFlows(): Promise<CancelAllResult> {
     if (workflow.status === "running") {
       workflow.abort.abort();
       workflow.status = "cancelled";
+      for (const receipt of workflow.cancellationSnapshots ?? []) {
+        addSnapshot(receipt);
+      }
       result.workflowsAborted++;
     }
   }
 
   // 3. Kill running interactive agents; preserve idle ones
-  for (const state of interactiveSubagentRegistry.values()) {
+  for (const state of interactiveStates) {
     if (state.status === "running") {
       try {
         const cancelled = cancelInteractiveSubagent(state.id);
         if (cancelled) {
           result.interactiveKilled++;
+          if (cancelled.cancellationSnapshot) {
+            addSnapshot(cancelled.cancellationSnapshot);
+          }
         }
       } catch {
         /* best effort */

--- a/src/cancel-all-flows.ts
+++ b/src/cancel-all-flows.ts
@@ -39,6 +39,7 @@ export async function cancelAllFlows(): Promise<CancelAllResult> {
   const snapshots = result.snapshots;
   const snapshotKeys = new Set<string>();
   const addSnapshot = (receipt: CancellationSnapshotReceipt): void => {
+    if (!receipt.enabled || receipt.status === "disabled") return;
     if (snapshotKeys.has(receipt.key)) return;
     snapshotKeys.add(receipt.key);
     snapshots!.push(receipt);

--- a/src/cancellation-snapshots.ts
+++ b/src/cancellation-snapshots.ts
@@ -1,0 +1,547 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+
+export const CANCELLATION_SNAPSHOT_SCHEMA_VERSION = 1;
+export const DEFAULT_CANCEL_SNAPSHOT_MAX_BYTES = 1024 * 1024;
+export const MAX_CANCEL_SNAPSHOT_MAX_BYTES = 16 * 1024 * 1024;
+const MIN_CANCEL_SNAPSHOT_MAX_BYTES = 4 * 1024;
+const MAX_HASH_BYTES = 1024 * 1024;
+
+type SnapshotKind = "in-process" | "interactive";
+export type CancellationSnapshotSource =
+  | "signal"
+  | "cancel_subagent"
+  | "cancel_all"
+  | "workflow"
+  | "cancel_interactive_subagent"
+  | "session_shutdown";
+export type CancellationSnapshotStatus =
+  "disabled" | "written" | "truncated" | "deduplicated" | "error";
+
+export interface CancellationSnapshotReceipt {
+  schemaVersion: typeof CANCELLATION_SNAPSHOT_SCHEMA_VERSION;
+  kind: SnapshotKind;
+  status: CancellationSnapshotStatus;
+  enabled: boolean;
+  source: CancellationSnapshotSource;
+  key: string;
+  path?: string;
+  bytes?: number;
+  maxBytes?: number;
+  truncated?: boolean;
+  error?: string;
+  errors?: string[];
+}
+
+export interface InProcessSnapshotInput {
+  kind: "in-process";
+  jobId: string;
+  session: Pick<
+    AgentSession,
+    "sessionId" | "model" | "thinkingLevel" | "state" | "sessionManager"
+  >;
+  cwd: string;
+  parentSessionId?: string;
+  model?: string;
+  thinkingLevel?: string;
+  activeTool?: { name: string; args: Record<string, unknown> };
+  partialOutput?: string;
+  startedAt?: number;
+  source: CancellationSnapshotSource;
+}
+
+export interface InteractiveSnapshotInput {
+  kind: "interactive";
+  id: string;
+  parentSessionId?: string;
+  cwd: string;
+  sessionFile: string;
+  artifactDir: string;
+  startedAt?: number;
+  source: CancellationSnapshotSource;
+}
+
+interface FileMetadata {
+  path: string;
+  exists: boolean;
+  bytes?: number;
+  sha256?: string;
+  hashBytes?: number;
+  hashTruncated?: boolean;
+  error?: string;
+}
+
+function baseReceipt(
+  kind: SnapshotKind,
+  source: CancellationSnapshotSource,
+  key: string,
+): CancellationSnapshotReceipt {
+  return {
+    schemaVersion: CANCELLATION_SNAPSHOT_SCHEMA_VERSION,
+    kind,
+    status: "error",
+    enabled: true,
+    source,
+    key,
+  };
+}
+
+export function cancellationSnapshotsEnabled(): boolean {
+  return process.env.SUBAGENT_CANCEL_SNAPSHOT === "full";
+}
+
+export function cancellationSnapshotMaxBytes(): number {
+  const raw = process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES;
+  if (!raw) return DEFAULT_CANCEL_SNAPSHOT_MAX_BYTES;
+  const parsed = Number(raw);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < MIN_CANCEL_SNAPSHOT_MAX_BYTES ||
+    parsed > MAX_CANCEL_SNAPSHOT_MAX_BYTES
+  ) {
+    return DEFAULT_CANCEL_SNAPSHOT_MAX_BYTES;
+  }
+  return parsed;
+}
+
+function snapshotRoot(cwd: string): string {
+  if (process.env.SUBAGENT_CANCEL_SNAPSHOT_DIR) {
+    const configured = resolve(process.env.SUBAGENT_CANCEL_SNAPSHOT_DIR);
+    if (configured === "/") {
+      throw new Error("snapshot directory may not be filesystem root");
+    }
+    return configured;
+  }
+  const sessionRoot =
+    process.env.PI_CODING_AGENT_SESSION_DIR ??
+    join(homedir(), ".pi", "agent", "sessions");
+  const cwdHash = createHash("sha256")
+    .update(resolve(cwd))
+    .digest("hex")
+    .slice(0, 24);
+  return join(sessionRoot, "subagentura", "cancel-snapshots", cwdHash);
+}
+
+function keyFor(
+  kind: SnapshotKind,
+  id: string,
+  sessionId: string | undefined,
+): string {
+  return createHash("sha256")
+    .update(`${kind}\0${id}\0${sessionId ?? "session"}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function disabledReceipt(
+  kind: SnapshotKind,
+  source: CancellationSnapshotSource,
+  key: string,
+): CancellationSnapshotReceipt {
+  return {
+    ...baseReceipt(kind, source, key),
+    status: "disabled",
+    enabled: false,
+  };
+}
+
+function existingReceipt(
+  receipt: CancellationSnapshotReceipt,
+  path: string,
+): CancellationSnapshotReceipt | undefined {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return undefined;
+    return {
+      ...receipt,
+      status: "deduplicated",
+      path,
+      bytes: stat.size,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function atomicWrite(
+  path: string,
+  content: string,
+): { bytes: number } | { error: string } {
+  const bytes = Buffer.byteLength(content, "utf8");
+  const dir = dirname(path);
+  const temporary = `${path}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    chmodSync(dir, 0o700);
+    writeFileSync(temporary, content, { encoding: "utf8", mode: 0o600 });
+    chmodSync(temporary, 0o600);
+    renameSync(temporary, path);
+    return { bytes };
+  } catch (err) {
+    try {
+      rmSync(temporary, { force: true });
+    } catch {
+      /* cleanup is best effort; cancellation must not be blocked */
+    }
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function jsonClone(value: unknown): unknown {
+  const seen = new WeakSet<object>();
+  const encoded = JSON.stringify(value, (_key, candidate) => {
+    if (typeof candidate === "bigint") return `${candidate}n`;
+    if (typeof candidate === "function") return undefined;
+    if (!candidate || typeof candidate !== "object") return candidate;
+    if (seen.has(candidate)) throw new Error("circular value");
+    seen.add(candidate);
+    return candidate;
+  });
+  return encoded === undefined ? undefined : JSON.parse(encoded);
+}
+
+function utf8Prefix(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.byteLength <= maxBytes) return value;
+  return bytes.subarray(0, maxBytes).toString("utf8");
+}
+
+function modelId(
+  session: InProcessSnapshotInput["session"],
+): string | undefined {
+  if (!session.model) return undefined;
+  return `${session.model.provider}/${session.model.id}`;
+}
+
+function buildInProcessPayload(
+  input: InProcessSnapshotInput,
+  maxBytes: number,
+): { content: string; truncated: boolean; errors: string[] } {
+  const errors: string[] = [];
+  const branchEntries: unknown[] = [];
+  let omittedEntries = 0;
+  let branch: unknown[] = [];
+  try {
+    branch = input.session.sessionManager.getBranch();
+  } catch (err) {
+    errors.push(
+      `branch_entries_unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let streamingMessage: unknown;
+  try {
+    streamingMessage = jsonClone(input.session.state.streamingMessage);
+  } catch (err) {
+    errors.push(
+      `streaming_message_unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let activeTool: unknown = input.activeTool;
+  try {
+    activeTool = jsonClone(input.activeTool);
+  } catch (err) {
+    errors.push(
+      `active_tool_unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    activeTool = input.activeTool ? { name: input.activeTool.name } : undefined;
+  }
+
+  const sessionId = input.session.sessionId;
+  const base = {
+    schemaVersion: CANCELLATION_SNAPSHOT_SCHEMA_VERSION,
+    kind: "in-process",
+    capturedAt: new Date().toISOString(),
+    truncated: false,
+    errors,
+    cancellation: {
+      source: input.source,
+      jobId: input.jobId,
+      parentSessionId: input.parentSessionId,
+      startedAt: input.startedAt,
+      capturedAt: Date.now(),
+    },
+    session: {
+      jobId: input.jobId,
+      sessionId,
+      cwd: input.cwd,
+      model: input.model ?? modelId(input.session),
+      thinkingLevel: input.thinkingLevel ?? input.session.thinkingLevel,
+    },
+    context: {
+      branchEntries,
+      branchEntriesOmitted: 0,
+      streamingMessage,
+      partialOutput: utf8Prefix(
+        input.partialOutput ?? "",
+        Math.floor(maxBytes / 4),
+      ),
+      partialOutputTruncated:
+        (input.partialOutput?.length ?? 0) > Math.floor(maxBytes / 4),
+      activeTool,
+    },
+  };
+
+  const encode = (value: typeof base): string => JSON.stringify(value);
+  let truncated = base.context.partialOutputTruncated;
+  let content = encode(base);
+
+  if (
+    Buffer.byteLength(content, "utf8") > maxBytes &&
+    streamingMessage !== undefined
+  ) {
+    base.context.streamingMessage = undefined;
+    base.errors.push("streaming_message_omitted_for_size");
+    truncated = true;
+    content = encode(base);
+  }
+  if (
+    Buffer.byteLength(content, "utf8") > maxBytes &&
+    activeTool !== undefined
+  ) {
+    base.context.activeTool = input.activeTool
+      ? { name: input.activeTool.name, argsOmitted: true }
+      : undefined;
+    base.errors.push("active_tool_args_omitted_for_size");
+    truncated = true;
+    content = encode(base);
+  }
+  if (Buffer.byteLength(content, "utf8") > maxBytes) {
+    base.context.partialOutput = "";
+    base.context.partialOutputTruncated = true;
+    base.errors.push("partial_output_omitted_for_size");
+    truncated = true;
+    content = encode(base);
+  }
+
+  for (let i = branch.length - 1; i >= 0; i--) {
+    let entry: unknown;
+    try {
+      entry = jsonClone(branch[i]);
+    } catch (err) {
+      omittedEntries++;
+      errors.push(
+        `branch_entry_${i}_unavailable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+    const candidate = [entry, ...base.context.branchEntries];
+    const candidatePayload = {
+      ...base,
+      context: { ...base.context, branchEntries: candidate },
+    };
+    if (Buffer.byteLength(encode(candidatePayload), "utf8") <= maxBytes) {
+      base.context.branchEntries.unshift(entry);
+      content = encode(base);
+    } else {
+      omittedEntries++;
+      truncated = true;
+    }
+  }
+
+  base.context.branchEntriesOmitted = omittedEntries;
+  if (omittedEntries > 0) {
+    base.errors.push("branch_entries_omitted_for_size");
+  }
+  base.truncated = truncated || omittedEntries > 0;
+  content = encode(base);
+  if (Buffer.byteLength(content, "utf8") > maxBytes) {
+    base.context.branchEntries = [];
+    base.context.branchEntriesOmitted = branch.length;
+    base.context.streamingMessage = undefined;
+    base.context.activeTool = undefined;
+    base.context.partialOutput = "";
+    base.errors.push("context_reduced_to_metadata_for_size");
+    base.truncated = true;
+    content = encode(base);
+  }
+
+  return { content, truncated: base.truncated, errors: base.errors };
+}
+
+function safeSnapshotReceipt(
+  receipt: CancellationSnapshotReceipt,
+  content: string,
+): CancellationSnapshotReceipt {
+  const maxBytes = cancellationSnapshotMaxBytes();
+  const bytes = Buffer.byteLength(content, "utf8");
+  if (bytes > maxBytes) {
+    return {
+      ...receipt,
+      status: "error",
+      maxBytes,
+      error: `snapshot exceeded ${maxBytes} byte ceiling`,
+    };
+  }
+  const written = atomicWrite(receipt.path!, content);
+  if ("error" in written) {
+    return { ...receipt, status: "error", maxBytes, error: written.error };
+  }
+  return {
+    ...receipt,
+    status: receipt.truncated ? "truncated" : "written",
+    bytes: written.bytes,
+    maxBytes,
+    truncated: receipt.truncated,
+  };
+}
+
+export function snapshotInProcessSession(
+  input: InProcessSnapshotInput,
+): CancellationSnapshotReceipt {
+  let sessionId: string | undefined;
+  try {
+    sessionId =
+      input.session.sessionId ??
+      (typeof (input.session.sessionManager as any).getSessionId === "function"
+        ? (input.session.sessionManager as any).getSessionId()
+        : undefined);
+  } catch {
+    sessionId = undefined;
+  }
+  const key = keyFor("in-process", input.jobId, sessionId);
+  if (!cancellationSnapshotsEnabled()) {
+    return disabledReceipt("in-process", input.source, key);
+  }
+  const receipt = baseReceipt("in-process", input.source, key);
+  try {
+    const path = join(
+      snapshotRoot(input.cwd),
+      "in-process",
+      `in-process-${key}.json`,
+    );
+    receipt.path = path;
+    const existing = existingReceipt(receipt, path);
+    if (existing) return existing;
+    const maxBytes = cancellationSnapshotMaxBytes();
+    const built = buildInProcessPayload(input, maxBytes);
+    receipt.truncated = built.truncated;
+    receipt.errors =
+      built.errors.length > 0 ? built.errors.slice(0, 16) : undefined;
+    return safeSnapshotReceipt(receipt, built.content);
+  } catch (err) {
+    return {
+      ...receipt,
+      status: "error",
+      maxBytes: cancellationSnapshotMaxBytes(),
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function fileMetadata(path: string): FileMetadata {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = fstatSync(fd);
+    if (!stat.isFile())
+      return { path, exists: false, error: "not a regular file" };
+    const hash = createHash("sha256");
+    const limit = Math.min(stat.size, MAX_HASH_BYTES);
+    const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, Math.max(1, limit)));
+    let offset = 0;
+    while (offset < limit) {
+      const wanted = Math.min(buffer.byteLength, limit - offset);
+      const count = readSync(fd, buffer, 0, wanted, offset);
+      if (count <= 0) break;
+      hash.update(buffer.subarray(0, count));
+      offset += count;
+    }
+    return {
+      path,
+      exists: true,
+      bytes: stat.size,
+      sha256: hash.digest("hex"),
+      hashBytes: offset,
+      hashTruncated: stat.size > offset,
+    };
+  } catch (err) {
+    return {
+      path,
+      exists: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* metadata collection is best effort */
+      }
+    }
+  }
+}
+
+export function snapshotInteractiveContext(
+  input: InteractiveSnapshotInput,
+): CancellationSnapshotReceipt {
+  const key = keyFor("interactive", input.id, input.parentSessionId);
+  if (!cancellationSnapshotsEnabled()) {
+    return disabledReceipt("interactive", input.source, key);
+  }
+  const receipt = baseReceipt("interactive", input.source, key);
+  let root: string;
+  try {
+    root = process.env.SUBAGENT_CANCEL_SNAPSHOT_DIR
+      ? snapshotRoot(input.cwd)
+      : join(input.artifactDir, "context-snapshots");
+  } catch (err) {
+    return {
+      ...receipt,
+      status: "error",
+      maxBytes: cancellationSnapshotMaxBytes(),
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  const path = join(root, "interactive", `interactive-${key}.json`);
+  receipt.path = path;
+  const existing = existingReceipt(receipt, path);
+  if (existing) return existing;
+  try {
+    const payload = {
+      schemaVersion: CANCELLATION_SNAPSHOT_SCHEMA_VERSION,
+      kind: "interactive",
+      capturedAt: new Date().toISOString(),
+      cancellation: {
+        source: input.source,
+        id: input.id,
+        parentSessionId: input.parentSessionId,
+        startedAt: input.startedAt,
+      },
+      sessionFile: input.sessionFile,
+      artifactDir: input.artifactDir,
+      files: {
+        sessionFile: fileMetadata(input.sessionFile),
+        events: fileMetadata(join(input.artifactDir, "events.ndjson")),
+        output: fileMetadata(join(input.artifactDir, "output.md")),
+        activeTurn: fileMetadata(join(input.artifactDir, "active-turn.json")),
+      },
+    };
+    const content = JSON.stringify(payload);
+    receipt.truncated = false;
+    return safeSnapshotReceipt(receipt, content);
+  } catch (err) {
+    return {
+      ...receipt,
+      status: "error",
+      maxBytes: cancellationSnapshotMaxBytes(),
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,6 +27,11 @@ import {
   copyProviderConfig,
   createCompatibleSessionRuntime,
 } from "./pi-sdk-compat";
+import {
+  snapshotInProcessSession,
+  type CancellationSnapshotReceipt,
+  type CancellationSnapshotSource,
+} from "./cancellation-snapshots";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 // ── Debug Logging ─────────────────────────────────────────────────
 
@@ -139,6 +144,7 @@ export interface JobState {
   result?: SubagentResult;
   session: AgentSession;
   startedAt: number;
+  cwd?: string;
   promise: Promise<SubagentResult>;
   modelLabel?: string;
   /** Notification mode requested by spawner's notifyOnComplete param */
@@ -151,6 +157,8 @@ export interface JobState {
   resultRetrieved?: boolean;
   /** Optional TTL in ms for completed job retention */
   maxAge?: number;
+  /** Most recent cancellation snapshot receipt, when snapshots are enabled. */
+  cancellationSnapshot?: CancellationSnapshotReceipt;
 }
 
 // ── Job Registry ────────────────────────────────────────────────────
@@ -342,6 +350,8 @@ export interface StartSubagentJobParams {
   maxAge?: number;
   /** Parent session's model registry for resolving extension-added models (e.g. minimax) */
   parentModelRegistry?: ModelRegistry;
+  onCancellationSnapshot?: (receipt: CancellationSnapshotReceipt) => void;
+  cancellationSource?: CancellationSnapshotSource;
 }
 
 export interface StartSubagentJobResult {
@@ -376,6 +386,8 @@ export async function startSubagentJob(
     onUpdate,
     defaultModel,
     parentModelRegistry,
+    onCancellationSnapshot,
+    cancellationSource,
   } = params;
 
   // Enforce registry size cap before adding a new job
@@ -491,6 +503,17 @@ export async function startSubagentJob(
   if (signal) {
     handleAbort = () => {
       debugLog("warn", "job_abort", { jobId });
+      const receipt = snapshotInProcessSession({
+        kind: "in-process",
+        jobId,
+        session,
+        cwd,
+        model: modelLabel,
+        activeTool: liveStatus.activeTool,
+        partialOutput: liveStatus.output,
+        source: cancellationSource ?? "signal",
+      });
+      onCancellationSnapshot?.(receipt);
       session.abort().catch(() => {});
     };
     if (signal.aborted) {

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -45,6 +45,11 @@ import {
   type MuxName,
   type Multiplexer,
 } from "./multiplexer";
+import {
+  snapshotInteractiveContext,
+  type CancellationSnapshotReceipt,
+  type CancellationSnapshotSource,
+} from "./cancellation-snapshots";
 
 // Re-export the tmux-specific `readPaneExitCode` for the test suite. The
 // launch script's EXIT trap still writes the @pi-exit-code pane option
@@ -162,6 +167,8 @@ export interface InteractiveSubagentState {
    * - cancel_interactive_subagent tool sets "cancelled"
    */
   status: InteractiveSubagentStatus;
+  /** Receipt for the latest parent cancellation snapshot. */
+  cancellationSnapshot?: CancellationSnapshotReceipt;
   /** Captured child pi exit code (0 = success). Undefined while still running. */
   exitCode?: number;
   attachCommand: string;
@@ -663,9 +670,22 @@ export function sendCommandToTmuxPane(paneId: string, command: string): void {
 
 export function cancelInteractiveSubagent(
   id: string,
+  source: CancellationSnapshotSource = "cancel_interactive_subagent",
 ): InteractiveSubagentState | undefined {
   const state = interactiveSubagentRegistry.get(id);
   if (!state) return undefined;
+
+  const snapshot = snapshotInteractiveContext({
+    kind: "interactive",
+    id: state.id,
+    parentSessionId: state.parentSessionId,
+    cwd: state.cwd,
+    sessionFile: state.sessionFile,
+    artifactDir: state.artifactDir,
+    startedAt: state.startedAt,
+    source,
+  });
+  state.cancellationSnapshot = snapshot;
 
   // 1. Drop a `.cancelled` flag file in the artifact dir. The wrapper's EXIT trap
   //    checks for this before writing the `done` event; if present, it writes
@@ -675,14 +695,12 @@ export function cancelInteractiveSubagent(
   } catch {
     /* best effort — dir may not exist yet if the launch script is still warming up */
   }
-
   appendCancellation(state);
 
   // 2. Update the registry. The poller still processes the durable cancellation.
   state.status = "cancelled";
 
-  // 3. Kill the pane via the backend that created it. The wrapper's EXIT
-  //    trap fires and records the event.
+  // 3. Kill the pane via the backend that created it. The wrapper's EXIT trap fires and records the event.
   const mux = getMuxForState(state);
   if (mux.isPaneAlive(state.paneId, state.muxSession)) {
     mux.killPane(state.paneId, state.muxSession);
@@ -757,6 +775,18 @@ function appendCancellation(state: InteractiveSubagentState): void {
 export function cancelInteractiveSubagentByState(
   state: InteractiveSubagentState,
 ): void {
+  const snapshot = snapshotInteractiveContext({
+    kind: "interactive",
+    id: state.id,
+    parentSessionId: state.parentSessionId,
+    cwd: state.cwd,
+    sessionFile: state.sessionFile,
+    artifactDir: state.artifactDir,
+    startedAt: state.startedAt,
+    source: "session_shutdown",
+  });
+  state.cancellationSnapshot = snapshot;
+
   // 1. Write .cancelled flag (best-effort)
   try {
     writeFileSync(join(state.artifactDir, ".cancelled"), "", { mode: 0o600 });

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -11,6 +11,7 @@ import { pollArtifactChanges } from "./artifact-poller";
 import { flushDeliveries } from "./delivery";
 import { flushInProcessDeliveries } from "./notifications";
 import { jobRegistry } from "./helpers";
+import { snapshotInProcessSession } from "./cancellation-snapshots";
 import { rehydrateInteractiveSubagents } from "./rehydrate";
 import {
   cancelInteractiveSubagentByState,
@@ -136,6 +137,20 @@ export function registerSessionHandlers(pi: ExtensionAPI): void {
         }
       }
 
+      // Snapshot all in-process jobs before any abort can wait for idle.
+      for (const job of jobRegistry.values()) {
+        if (job.status !== "running") continue;
+        job.cancellationSnapshot = snapshotInProcessSession({
+          kind: "in-process",
+          jobId: job.id,
+          session: job.session,
+          cwd: job.cwd ?? ctx?.cwd ?? process.cwd(),
+          model: job.modelLabel,
+          activeTool: job.liveStatus?.activeTool,
+          partialOutput: job.liveStatus?.output,
+          source: "session_shutdown",
+        });
+      }
       // Abort all running subagent sessions before clearing
       for (const job of jobRegistry.values()) {
         if (job.status === "running") {

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -27,6 +27,7 @@ import {
   type Usage,
 } from "../helpers";
 import { abortableWait } from "../abortable-wait";
+import { snapshotInProcessSession } from "../cancellation-snapshots";
 import {
   completionTriggersTurn,
   deliverNotification,
@@ -42,6 +43,7 @@ import {
 } from "../schemas";
 
 interface RunningFooterContext {
+  cwd?: string;
   ui: {
     setStatus(key: string, value?: string): void;
   };
@@ -270,6 +272,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
           liveStatus,
           session,
           startedAt: Date.now(),
+          cwd: targetCwd,
           promise: jobPromise,
           modelLabel,
           notifyOnComplete:
@@ -434,6 +437,7 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
           liveStatus,
           session,
           startedAt: Date.now(),
+          cwd: targetCwd,
           promise: jobPromise,
           modelLabel,
           notifyOnComplete:
@@ -775,19 +779,32 @@ function registerCancelSubagentTool(pi: ExtensionAPI): void {
         };
       }
 
+      job.cancellationSnapshot = snapshotInProcessSession({
+        kind: "in-process",
+        jobId: job.id,
+        session: job.session,
+        cwd: ctx.cwd ?? process.cwd(),
+        model: job.modelLabel,
+        activeTool: job.liveStatus.activeTool,
+        partialOutput: job.liveStatus.output,
+        source: "cancel_subagent",
+      });
       try {
         await job.session.abort();
       } catch {
         /* Session may already be disposed; abort is best-effort */
       }
-
       job.status = "cancelled";
       scheduleJobCleanup(params.jobId, true);
       updateRunningFooter(ctx);
 
       return {
         content: [{ type: "text", text: `Job ${params.jobId} cancelled.` }],
-        details: { jobId: params.jobId, status: "cancelled" },
+        details: {
+          jobId: params.jobId,
+          status: "cancelled",
+          snapshot: job.cancellationSnapshot,
+        },
       };
     },
 

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -313,9 +313,14 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
           isError: true,
         };
       }
+      const snapshotText = state.cancellationSnapshot?.path
+        ? ` Snapshot ${state.cancellationSnapshot.status}: ${state.cancellationSnapshot.path}`
+        : state.cancellationSnapshot?.error
+          ? ` Snapshot error: ${state.cancellationSnapshot.error}`
+          : "";
       userNotification =
         `Interactive sub-agent ${params.jobId} cancelled; no separate cancellation completion was injected into the parent LLM. ` +
-        `Artifacts retained at ${state.artifactDir}.`;
+        `Artifacts retained at ${state.artifactDir}.${snapshotText}`;
       try {
         ctx.ui.notify(userNotification, "warning");
       } catch {
@@ -328,7 +333,12 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
             text:
               `Interactive sub-agent ${params.jobId} cancelled. ` +
               `No separate cancellation completion will be injected into the parent LLM. ` +
-              `Artifacts retained at ${state.artifactDir}.`,
+              `Artifacts retained at ${state.artifactDir}.` +
+              (state.cancellationSnapshot?.path
+                ? ` Snapshot ${state.cancellationSnapshot.status}: ${state.cancellationSnapshot.path}.`
+                : state.cancellationSnapshot?.error
+                  ? ` Snapshot error: ${state.cancellationSnapshot.error}.`
+                  : ""),
           },
         ],
         details: { ...state },

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -72,6 +72,9 @@ export type WorkflowAgentRunner = (req: {
     phase?: string;
     label?: string;
   }) => void;
+  onCancellationSnapshot?: (
+    receipt: import("./cancellation-snapshots").CancellationSnapshotReceipt,
+  ) => void;
 }) => Promise<SubagentResult>;
 
 export interface WorkflowMeta {
@@ -111,6 +114,9 @@ export interface RunWorkflowOptions {
   runAgent: WorkflowAgentRunner;
   signal?: AbortSignal;
   onProgress?: (p: WorkflowProgress) => void;
+  onCancellationSnapshot?: (
+    receipt: import("./cancellation-snapshots").CancellationSnapshotReceipt,
+  ) => void;
   concurrency?: number;
   processConcurrency?: number;
   /** Resolve a saved workflow script by name, for `workflow(name, args)` composition. */

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { debugLog } from "./helpers";
+import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
 import { runWorkflow } from "./workflow-worker";
 import {
   type RunWorkflowOptions,
@@ -35,6 +36,8 @@ export interface WorkflowJobState {
   completionNotificationDelivered?: boolean;
   /** Set during parent shutdown so late settlement cannot notify a replacement session. */
   suppressCompletionNotification?: boolean;
+  /** Receipts captured by nested agents during workflow cancellation. */
+  cancellationSnapshots?: CancellationSnapshotReceipt[];
   /** Set when notification attempts are exhausted. Prevents re-logging. */
   _notificationExhausted?: boolean;
   /** Synchronous reentrant guard — set while the delivery callback is in flight. */
@@ -64,7 +67,10 @@ export const MAX_WORKFLOW_NOTIFICATION_ATTEMPTS = 5;
 export function startWorkflowJob(
   name: string,
   script: string,
-  opts: Omit<RunWorkflowOptions, "signal" | "onProgress">,
+  opts: Omit<
+    RunWorkflowOptions,
+    "signal" | "onProgress" | "onCancellationSnapshot"
+  >,
   startedAt?: number,
   onComplete?: (job: WorkflowJobState) => boolean | void,
 ): WorkflowJobState {
@@ -104,6 +110,7 @@ export function startWorkflowJob(
     },
     completionNotification: onComplete,
     completionNotificationDelivered: false,
+    cancellationSnapshots: [],
   };
   state.promise = runWorkflow(script, {
     ...opts,
@@ -124,6 +131,9 @@ export function startWorkflowJob(
       } else if (p.kind === "agent_done") {
         state.snapshot.lastMessage = `→ done${formatWorkflowAgentTag(p)}`;
       }
+    },
+    onCancellationSnapshot: (receipt) => {
+      (state.cancellationSnapshots ??= []).push(receipt);
     },
   })
     .then((r) => {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -60,6 +60,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       isolation,
       label,
       onProgress,
+      onCancellationSnapshot,
     }) => {
       // Track last update time per agent label to throttle mid-agent previews
 
@@ -86,7 +87,12 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
             contextText: null,
             background: true,
           });
-          const result = await awaitInteractiveResult(state, signal);
+          const result = await awaitInteractiveResult(
+            state,
+            signal,
+            undefined,
+            onCancellationSnapshot,
+          );
           return result;
         } catch (err) {
           // tmux/zellij unavailable — fall back to in-process, with visible warning.
@@ -122,6 +128,8 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
         },
         defaultModel: ctx.model,
         parentModelRegistry: ctx.modelRegistry,
+        onCancellationSnapshot,
+        cancellationSource: "workflow",
       });
       return jobPromise;
     };
@@ -600,6 +608,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
           status: "cancelled",
           workflowId: st.id,
           cancelled: true,
+          snapshots: [...(st.cancellationSnapshots ?? [])],
         },
       };
     },

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -4,6 +4,7 @@ import { startSubagentJob, debugLog } from "./helpers";
 import { launchInteractiveSubagent } from "./interactive-tmux";
 import {
   MAX_ITEMS_PER_CALL,
+  INTERACTIVE_POLL_MS,
   MAX_TOTAL_AGENTS,
   listSavedWorkflows,
   loadWorkflowScript,
@@ -37,6 +38,7 @@ import type {
   ExtensionAPI,
   ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
+import { cancellationSnapshotsEnabled } from "./cancellation-snapshots";
 
 const WORKFLOW_SESSION_SCOPE_MESSAGE =
   "Workflow jobs are scoped to the current parent session and do not survive reload/resume/new/quit.";
@@ -46,6 +48,26 @@ function workflowNotFoundMessage(workflowId: string): string {
     `Workflow ${workflowId} not found in the current parent session. ` +
     "It may have been created in another session or removed by reload/resume/new/quit."
   );
+}
+
+const CANCELLATION_RECEIPT_GRACE_MS = INTERACTIVE_POLL_MS + 250;
+
+async function waitForCancellationReceipts(
+  state: WorkflowJobState,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const settled = state.promise.then(
+    () => undefined,
+    () => undefined,
+  );
+  const grace = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, CANCELLATION_RECEIPT_GRACE_MS);
+  });
+  try {
+    await Promise.race([settled, grace]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export function registerWorkflowTool(pi: ExtensionAPI): void {
@@ -602,6 +624,9 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       }
       st.abort.abort();
       st.status = "cancelled";
+      if (cancellationSnapshotsEnabled()) {
+        await waitForCancellationReceipts(st);
+      }
       return {
         content: [{ type: "text", text: `Workflow ${st.id} cancelled.` }],
         details: {

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -33,6 +33,7 @@ import {
   isPaneAlive,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
+import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
 
 // ── Engine (shared across nested workflows) ──────────────────────────
 
@@ -42,6 +43,7 @@ interface Engine {
   signal: AbortSignal;
   closed: boolean;
   onProgress?: (p: WorkflowProgress) => void;
+  onCancellationSnapshot?: RunWorkflowOptions["onCancellationSnapshot"];
   sem: Semaphore;
   processSem: Semaphore;
   loadWorkflow?: (name: string) => string | null;
@@ -73,6 +75,7 @@ export async function runWorkflow(
     signal: abort.signal,
     closed: false,
     onProgress: opts.onProgress,
+    onCancellationSnapshot: opts.onCancellationSnapshot,
     sem: createSemaphore(opts.concurrency ?? defaultConcurrency()),
     processSem: createSemaphore(
       opts.processConcurrency ?? defaultProcessConcurrency(),
@@ -187,6 +190,7 @@ async function executeScript(
             signal: engine.signal,
             isolation,
             label: agentOpts.label,
+            onCancellationSnapshot: engine.onCancellationSnapshot,
             onProgress: (ev) => emit({ ...ev, phase: agentOpts.phase }),
           });
           const outTokens = res.usage?.output ?? 0;
@@ -459,13 +463,17 @@ export async function awaitInteractiveResult(
   state: InteractiveSubagentState,
   signal: AbortSignal | undefined,
   pollMs = INTERACTIVE_POLL_MS,
+  onCancellationSnapshot?: (receipt: CancellationSnapshotReceipt) => void,
 ): Promise<SubagentResult> {
   const art = artifactFor(state);
   let deadTicks = 0;
   for (;;) {
     if (signal?.aborted) {
       try {
-        cancelInteractiveSubagent(state.id);
+        const cancelled = cancelInteractiveSubagent(state.id, "workflow");
+        if (cancelled?.cancellationSnapshot) {
+          onCancellationSnapshot?.(cancelled.cancellationSnapshot);
+        }
       } catch {
         /* best effort */
       }

--- a/tests/cancellation-snapshots.test.ts
+++ b/tests/cancellation-snapshots.test.ts
@@ -14,6 +14,8 @@ import { jobRegistry } from "../src/helpers";
 import { registerInProcessSubagentTools } from "../src/tools/in-process";
 import { cancelAllFlows } from "../src/cancel-all-flows";
 import { registerSessionHandlers } from "../src/session-handlers";
+import { registerWorkflowTool } from "../src/workflow-tool";
+import { workflowJobRegistry } from "../src/workflow-jobs";
 import {
   snapshotInProcessSession,
   snapshotInteractiveContext,
@@ -113,6 +115,7 @@ function setSnapshotEnv(dir: string, maxBytes?: number): void {
 
 beforeEach(() => {
   jobRegistry.clear();
+  workflowJobRegistry.clear();
 });
 
 afterEach(() => {
@@ -126,6 +129,7 @@ afterEach(() => {
     delete process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES;
   else process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES = originalEnv.maxBytes;
   vi.restoreAllMocks();
+  workflowJobRegistry.clear();
 });
 
 describe("cancellation snapshots", () => {
@@ -135,6 +139,24 @@ describe("cancellation snapshots", () => {
     const receipt = snapshotInProcessSession(inProcessInput());
     expect(receipt.status).toBe("disabled");
     expect(allFiles(root)).toHaveLength(0);
+  });
+
+  it("omits disabled receipts from cancel-all results", async () => {
+    delete process.env.SUBAGENT_CANCEL_SNAPSHOT;
+    const input = inProcessInput();
+    jobRegistry.set("job-disabled", {
+      id: "job-disabled",
+      status: "running",
+      session: { ...input.session, abort: vi.fn() },
+      liveStatus: { output: input.partialOutput, activeTool: input.activeTool },
+      cwd: input.cwd,
+      modelLabel: input.model,
+    } as any);
+
+    const result = await cancelAllFlows();
+
+    expect(result.jobsAborted).toBe(1);
+    expect(result.snapshots).toEqual([]);
   });
 
   it("writes a private full in-process snapshot with canonical context and partial state", () => {
@@ -349,6 +371,57 @@ describe("cancellation snapshots", () => {
     await Promise.resolve();
     controller.abort();
     await expect(promise).rejects.toThrow("Workflow aborted");
+  });
+
+  it("waits for asynchronous workflow snapshot receipts before returning", async () => {
+    setSnapshotEnv(mkdtempSync(join(tmpdir(), "workflow-receipt-wait-")));
+    const tools: Record<string, any> = {};
+    registerWorkflowTool({
+      registerTool: (tool: any) => {
+        tools[tool.name] = tool;
+      },
+    } as any);
+    const controller = new AbortController();
+    const receipt: CancellationSnapshotReceipt = {
+      schemaVersion: 1,
+      kind: "interactive",
+      status: "written",
+      enabled: true,
+      source: "workflow",
+      key: "async-workflow-receipt",
+      path: "/private/async-workflow-snapshot.json",
+    };
+    const state: any = {
+      id: "wf_snapshot_wait",
+      name: "snapshot-wait",
+      status: "running",
+      abort: controller,
+      cancellationSnapshots: [],
+      snapshot: { agentsSpawned: 1, runningCount: 1 },
+    };
+    state.promise = new Promise((_resolve, reject) => {
+      controller.signal.addEventListener(
+        "abort",
+        () => {
+          setTimeout(() => {
+            state.cancellationSnapshots.push(receipt);
+            reject(new Error("Workflow aborted."));
+          }, 0);
+        },
+        { once: true },
+      );
+    });
+    workflowJobRegistry.set(state.id, state);
+
+    const result = await tools.cancel_workflow.execute(
+      "cancel-call",
+      { workflowId: state.id },
+      undefined,
+      undefined,
+    );
+    await expect(state.promise).rejects.toThrow("Workflow aborted");
+
+    expect(result.details.snapshots).toContainEqual(receipt);
   });
 
   it("snapshots in-process jobs before session shutdown aborts them", async () => {

--- a/tests/cancellation-snapshots.test.ts
+++ b/tests/cancellation-snapshots.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { jobRegistry } from "../src/helpers";
+import { registerInProcessSubagentTools } from "../src/tools/in-process";
+import { cancelAllFlows } from "../src/cancel-all-flows";
+import { registerSessionHandlers } from "../src/session-handlers";
+import {
+  snapshotInProcessSession,
+  snapshotInteractiveContext,
+  type CancellationSnapshotReceipt,
+} from "../src/cancellation-snapshots";
+import type { CancellationSnapshotSource } from "../src/cancellation-snapshots";
+
+const originalEnv = {
+  mode: process.env.SUBAGENT_CANCEL_SNAPSHOT,
+  dir: process.env.SUBAGENT_CANCEL_SNAPSHOT_DIR,
+  maxBytes: process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES,
+};
+
+function fakeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: "session-1",
+    model: { provider: "test", id: "model-1" },
+    thinkingLevel: "high",
+    state: {
+      streamingMessage: {
+        role: "assistant",
+        content: [{ type: "text", text: "streaming" }],
+      },
+      pendingToolCalls: new Set<string>(["tool-1"]),
+    },
+    sessionManager: {
+      getBranch: () => [
+        {
+          type: "message",
+          id: "entry-1",
+          parentId: null,
+          timestamp: "2026-01-01T00:00:00.000Z",
+          message: { role: "user", content: [{ type: "text", text: "hello" }] },
+        },
+      ],
+    },
+    ...overrides,
+  } as any;
+}
+
+function inProcessInput(session = fakeSession()) {
+  return {
+    kind: "in-process" as const,
+    jobId: "job-1",
+    session,
+    cwd: "/tmp/project",
+    parentSessionId: "parent-1",
+    model: "test/model-1",
+    thinkingLevel: "high",
+    activeTool: { name: "bash", args: { command: "echo hi" } },
+    partialOutput: "partial output",
+    startedAt: 100,
+    source: "cancel_subagent" as const,
+  };
+}
+
+function interactiveInput(root: string) {
+  const artifactDir = join(root, "artifacts", "interactive-1");
+  const sessionFile = join(root, "child-session.jsonl");
+  const eventsFile = join(artifactDir, "events.ndjson");
+  const outputFile = join(artifactDir, "output.md");
+  const activeTurnFile = join(artifactDir, "active-turn.json");
+  mkdirSync(artifactDir, { recursive: true });
+  writeFileSync(sessionFile, '{"type":"session"}\n');
+  writeFileSync(eventsFile, '{"type":"turn_started"}\n');
+  writeFileSync(outputFile, "child output\n");
+  writeFileSync(activeTurnFile, '{"turnId":"turn-1"}\n');
+  return {
+    kind: "interactive" as const,
+    id: "interactive-1",
+    parentSessionId: "parent-1",
+    cwd: "/tmp/project",
+    sessionFile,
+    artifactDir,
+    source: "cancel_interactive_subagent" as const,
+    startedAt: 100,
+  };
+}
+
+function allFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, name.name);
+    if (name.isDirectory()) out.push(...allFiles(path));
+    else out.push(path);
+  }
+  return out;
+}
+
+function setSnapshotEnv(dir: string, maxBytes?: number): void {
+  process.env.SUBAGENT_CANCEL_SNAPSHOT = "full";
+  process.env.SUBAGENT_CANCEL_SNAPSHOT_DIR = dir;
+  if (maxBytes === undefined)
+    delete process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES;
+  else process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES = String(maxBytes);
+}
+
+beforeEach(() => {
+  jobRegistry.clear();
+});
+
+afterEach(() => {
+  if (originalEnv.mode === undefined)
+    delete process.env.SUBAGENT_CANCEL_SNAPSHOT;
+  else process.env.SUBAGENT_CANCEL_SNAPSHOT = originalEnv.mode;
+  if (originalEnv.dir === undefined)
+    delete process.env.SUBAGENT_CANCEL_SNAPSHOT_DIR;
+  else process.env.SUBAGENT_CANCEL_SNAPSHOT_DIR = originalEnv.dir;
+  if (originalEnv.maxBytes === undefined)
+    delete process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES;
+  else process.env.SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES = originalEnv.maxBytes;
+  vi.restoreAllMocks();
+});
+
+describe("cancellation snapshots", () => {
+  it("is disabled by default", () => {
+    delete process.env.SUBAGENT_CANCEL_SNAPSHOT;
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-off-"));
+    const receipt = snapshotInProcessSession(inProcessInput());
+    expect(receipt.status).toBe("disabled");
+    expect(allFiles(root)).toHaveLength(0);
+  });
+
+  it("writes a private full in-process snapshot with canonical context and partial state", () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-full-"));
+    setSnapshotEnv(root);
+    const receipt = snapshotInProcessSession(inProcessInput());
+    expect(receipt.status).toBe("written");
+    expect(receipt.path).toBeDefined();
+    const stat = statSync(receipt.path!);
+    expect(stat.mode & 0o777).toBe(0o600);
+    const payload = JSON.parse(readFileSync(receipt.path!, "utf8"));
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.kind).toBe("in-process");
+    expect(payload.context.branchEntries).toHaveLength(1);
+    expect(payload.context.streamingMessage).toBeDefined();
+    expect(payload.context.partialOutput).toBe("partial output");
+    expect(payload.context.activeTool.name).toBe("bash");
+    expect(payload.session).toMatchObject({
+      jobId: "job-1",
+      sessionId: "session-1",
+      model: "test/model-1",
+      thinkingLevel: "high",
+      cwd: "/tmp/project",
+    });
+    expect(payload.cancellation.source).toBe("cancel_subagent");
+  });
+
+  it("preserves a bounded partial snapshot and records explicit truncation metadata", () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-cap-"));
+    setSnapshotEnv(root, 16 * 1024);
+    const huge = fakeSession({
+      sessionManager: {
+        getBranch: () => [
+          {
+            type: "message",
+            id: "huge",
+            parentId: null,
+            timestamp: "2026-01-01T00:00:00.000Z",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "x".repeat(100_000) }],
+            },
+          },
+        ],
+      },
+    });
+    const receipt = snapshotInProcessSession({
+      ...inProcessInput(huge),
+      partialOutput: "y".repeat(100_000),
+    });
+    expect(["written", "truncated"]).toContain(receipt.status);
+    const payload = JSON.parse(readFileSync(receipt.path!, "utf8"));
+    expect(receipt.bytes).toBeLessThanOrEqual(16 * 1024);
+    expect(payload.truncated).toBe(true);
+    expect(payload.errors.length).toBeGreaterThan(0);
+  });
+
+  it("writes an interactive manifest with path, size, and hash metadata without copying transcript", () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-interactive-"));
+    setSnapshotEnv(join(root, "snapshots"));
+    const input = interactiveInput(root);
+    const receipt = snapshotInteractiveContext(input);
+    expect(receipt.status).toBe("written");
+    const payload = JSON.parse(readFileSync(receipt.path!, "utf8"));
+    expect(payload.kind).toBe("interactive");
+    expect(payload.files.sessionFile.bytes).toBeGreaterThan(0);
+    expect(payload.files.sessionFile.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(existsSync(join(root, "snapshots", "interactive-1.jsonl"))).toBe(
+      false,
+    );
+  });
+
+  it("never blocks cancellation when snapshot capture fails", () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-error-"));
+    setSnapshotEnv(root);
+    const receipt = snapshotInProcessSession(
+      inProcessInput({
+        sessionManager: {
+          getBranch: () => {
+            throw new Error("broken");
+          },
+        },
+      }),
+    );
+    expect(receipt.status).toBe("written");
+    expect(receipt.errors).toContain("branch_entries_unavailable: broken");
+  });
+
+  it("is idempotent for overlapping cancellation paths", () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-idempotent-"));
+    setSnapshotEnv(root);
+    const first = snapshotInProcessSession(inProcessInput());
+    const second = snapshotInProcessSession({
+      ...inProcessInput(),
+      source: "session_shutdown",
+    });
+    expect(first.path).toBe(second.path);
+    expect(second.status).toBe("deduplicated");
+    expect(allFiles(root)).toHaveLength(1);
+  });
+
+  it("captures all cancel-all snapshots before the first slow abort awaits", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-all-"));
+    setSnapshotEnv(root);
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let filesAtFirstAbort = 0;
+    const abort1 = vi.fn(async () => {
+      filesAtFirstAbort = allFiles(root).length;
+      release();
+    });
+    const abort2 = vi.fn();
+    const input = inProcessInput();
+    const makeJob = (id: string, abort: () => Promise<void> | void) => ({
+      id,
+      status: "running",
+      session: { ...input.session, abort },
+      liveStatus: { output: "partial", activeTool: input.activeTool },
+      cwd: input.cwd,
+      modelLabel: input.model,
+    });
+    jobRegistry.set("job-1", makeJob("job-1", abort1) as any);
+    jobRegistry.set("job-2", makeJob("job-2", abort2) as any);
+    const resultPromise = cancelAllFlows();
+    await pending;
+    const result = await resultPromise;
+    expect(filesAtFirstAbort).toBeGreaterThanOrEqual(2);
+    expect(abort1).toHaveBeenCalledOnce();
+    expect(abort2).toHaveBeenCalledOnce();
+    expect(result.snapshots).toHaveLength(2);
+  });
+
+  it("reports snapshot receipt details on per-ID cancellation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-per-id-"));
+    setSnapshotEnv(root);
+    const tools: Record<string, any> = {};
+    registerInProcessSubagentTools({
+      registerTool: (tool: any) => {
+        tools[tool.name] = tool;
+      },
+    } as any);
+    const abort = vi.fn();
+    const input = inProcessInput();
+    jobRegistry.set("job-1", {
+      id: "job-1",
+      status: "running",
+      session: { ...input.session, abort },
+      liveStatus: { output: input.partialOutput, activeTool: input.activeTool },
+      cwd: input.cwd,
+      modelLabel: input.model,
+    } as any);
+    const result = await tools.cancel_subagent.execute(
+      "call",
+      { jobId: "job-1" },
+      undefined,
+      undefined,
+      { cwd: input.cwd, ui: { setStatus: vi.fn() } },
+    );
+    expect(result.details.snapshot.path).toBeDefined();
+    expect(result.details.snapshot.status).toBe("written");
+    expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it("keeps explicit receipt errors out of notification content", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-notify-"));
+    setSnapshotEnv(root);
+    const receipt: CancellationSnapshotReceipt = {
+      schemaVersion: 1,
+      kind: "in-process",
+      status: "error",
+      enabled: true,
+      source: "cancel_all",
+      key: "key",
+      error: "secret-like path details",
+    };
+    expect(JSON.stringify(receipt)).toContain("error");
+    expect(JSON.stringify(receipt)).not.toContain("partial output");
+  });
+
+  it("propagates workflow cancellation callbacks to nested agents", async () => {
+    const { runWorkflow } = await import("../src/workflow-worker");
+    const controller = new AbortController();
+    const receipt = {
+      schemaVersion: 1 as const,
+      kind: "in-process" as const,
+      status: "written" as const,
+      enabled: true,
+      source: "workflow" as CancellationSnapshotSource,
+      key: "workflow-key",
+      path: "/private/workflow-snapshot.json",
+    };
+    const promise = runWorkflow(
+      'export const meta = { name: "snapshot", description: "snapshot" }; return await agent("work");',
+      {
+        signal: controller.signal,
+        runAgent: async ({ signal, onCancellationSnapshot }) => {
+          return new Promise<never>((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => {
+                onCancellationSnapshot?.(receipt);
+                reject(new Error("Workflow aborted."));
+              },
+              { once: true },
+            );
+          });
+        },
+      },
+    );
+    await Promise.resolve();
+    controller.abort();
+    await expect(promise).rejects.toThrow("Workflow aborted");
+  });
+
+  it("snapshots in-process jobs before session shutdown aborts them", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cancel-snapshot-shutdown-"));
+    setSnapshotEnv(root);
+    const handlers: Record<string, Array<(...args: any[]) => any>> = {};
+    registerSessionHandlers({
+      on: (event: string, handler: (...args: any[]) => any) => {
+        (handlers[event] ??= []).push(handler);
+      },
+    } as any);
+    const input = inProcessInput();
+    const abort = vi.fn(() => {
+      expect(allFiles(root).length).toBeGreaterThan(0);
+    });
+    jobRegistry.set("job-shutdown", {
+      id: "job-shutdown",
+      status: "running",
+      session: { ...input.session, abort },
+      liveStatus: { output: input.partialOutput, activeTool: input.activeTool },
+      cwd: input.cwd,
+      modelLabel: input.model,
+    } as any);
+    const shutdown = handlers.session_shutdown.at(-1)!;
+    await shutdown({ reason: "new" }, { cwd: root, sessionManager: {} });
+    expect(abort).toHaveBeenCalledOnce();
+    expect(jobRegistry.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add default-off `SUBAGENT_CANCEL_SNAPSHOT=full` context preservation
- atomically snapshot bounded in-process context before cancellation and write manifests for already-persisted interactive sessions
- cover Escape, per-ID, cancel-all, workflow, interactive, and shutdown cancellation paths
- surface private snapshot receipts without injecting snapshot contents

## Configuration
- `SUBAGENT_CANCEL_SNAPSHOT=full`
- optional `SUBAGENT_CANCEL_SNAPSHOT_DIR`
- optional bounded `SUBAGENT_CANCEL_SNAPSHOT_MAX_BYTES`

## Verification
- `npm run typecheck`
- `npm test` — 962 tests passed
- `npm run format:check`
- `npm run pack:check`

## Dependency
Stacked on #43 (`feat/cancellable-flows`).
