### PR TITLE
fix(poller): avoid blocking pane liveness probes

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -27,7 +27,7 @@ import {
   deriveInteractiveSubagentStatusFromLifecycle,
   foldInteractiveLifecycle,
   interactiveSubagentRegistry,
-  isPaneAlive,
+  isPaneAliveAsync,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import { shouldNotify } from "./notifications";
@@ -49,6 +49,8 @@ const WORKFLOW_WIDGET_KEY = "subagentura-workflow-activity";
 /** Maximum widget rows before truncation with "… and N more". */
 const MAX_WIDGET_ROWS = 10;
 const MAX_WORKFLOW_WIDGET_ROWS = 5;
+
+let pollInFlight: Promise<void> | undefined;
 // ── Poller ─────────────────────────────────────────────────────────────
 
 /**
@@ -58,21 +60,52 @@ const MAX_WORKFLOW_WIDGET_ROWS = 5;
  * Backwards-compatible with sub-agents that finished during parent downtime:
  * we walk the artifact log in physical byte order and advance eventByteCursor.
  */
-export function pollArtifactChanges(pi: ExtensionAPI): void {
+export function pollArtifactChanges(pi: ExtensionAPI): Promise<void> {
+  if (pollInFlight) return pollInFlight;
+  const poll = runPollArtifactChanges(pi);
+  pollInFlight = poll;
+  return poll.finally(() => {
+    if (pollInFlight === poll) pollInFlight = undefined;
+  });
+}
+
+async function runPollArtifactChanges(pi: ExtensionAPI): Promise<void> {
   // Top-level defensive try/catch: the poller runs from a setInterval, so any uncaught throw here
   // would crash the parent pi process. Better to swallow and let the next tick (with a refreshed
   // pi ctx) try again. A stale extension context after session replacement is the most likely cause.
   try {
     const g2 = typeof global !== "undefined" ? global : globalThis;
+    const initialPiRef = g2.__piSubagenturaPiRef as ExtensionAPI | undefined;
     const interactivePi =
       (g2.__piSubagenturaPiRef as ExtensionAPI | undefined) ?? pi;
     if (!interactivePi) return;
 
+    const states = [...interactiveSubagentRegistry.values()];
+    const liveness = await Promise.all(
+      states.map(async (state) => {
+        try {
+          return [state, await isPaneAliveAsync(state)] as const;
+        } catch (err) {
+          debugLog("error", "poller_liveness_error", {
+            stateId: state.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return [state, false] as const;
+        }
+      }),
+    );
+    const currentPiRef = g2.__piSubagenturaPiRef as ExtensionAPI | undefined;
+    if (
+      (initialPiRef !== undefined && currentPiRef === undefined) ||
+      (currentPiRef !== undefined && currentPiRef !== interactivePi)
+    ) {
+      return;
+    }
     let runningCount = 0;
     const widgetRows: string[] = [];
     const ui = g2.__piSubagenturaUi as ExtensionUIContext | undefined;
-
-    for (const state of interactiveSubagentRegistry.values()) {
+    for (const [state, paneAlive] of liveness) {
+      if (interactiveSubagentRegistry.get(state.id) !== state) continue;
       // Cancelled is terminal. Unknown means pane liveness is unavailable, so keep polling
       // the artifact log: a later done/error event must still reach the parent.
       // 'exited' is intentionally not skipped: a follow-up user entry can revive it to "running".
@@ -80,7 +113,6 @@ export function pollArtifactChanges(pi: ExtensionAPI): void {
         dirname(state.artifactDir),
         basename(state.artifactDir),
       );
-      const paneAlive = isPaneAlive(state);
       // Tail-read the child's session log and synthesize tool_activity events.
       // TUI-widget only — the LLM never sees them.
       tailReadSessionLog(state, art);

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -612,6 +612,13 @@ export function isPaneAlive(state: InteractiveSubagentState): boolean {
   return getMuxForState(state).isPaneAlive(state.paneId, state.muxSession);
 }
 
+/** Probe pane liveness without blocking the parent event loop. */
+export function isPaneAliveAsync(
+  state: InteractiveSubagentState,
+): Promise<boolean> {
+  return getMuxForState(state).isPaneAliveAsync(state.paneId, state.muxSession);
+}
+
 /**
  * Send a command (text + Enter) to a pane, using the mux that created it.
  * Mux-agnostic — replaces `sendCommandToTmuxPane(paneId, command)`.

--- a/src/multiplexer-tmux.ts
+++ b/src/multiplexer-tmux.ts
@@ -22,7 +22,7 @@
  * runs on every backend.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import type { Multiplexer } from "./multiplexer";
 import { commandExists, execMuxOrThrow, shellEscape } from "./multiplexer";
 
@@ -325,6 +325,24 @@ export class TmuxMultiplexer implements Multiplexer {
     } catch {
       return false;
     }
+  }
+
+  isPaneAliveAsync(paneId: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      try {
+        execFile(
+          "tmux",
+          withTmuxSocket(["display-message", "-p", "-t", paneId, "#{pane_id}"]),
+          { timeout: 5000 },
+          (error) => {
+            resolve(!error);
+          },
+        );
+      } catch {
+        // A synchronous child-process setup failure is also a dead pane.
+        resolve(false);
+      }
+    });
   }
 
   sendKeys(paneId: string, text: string): void {

--- a/src/multiplexer-zellij.ts
+++ b/src/multiplexer-zellij.ts
@@ -27,7 +27,7 @@
  *      targets it via `--session <name>`.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import type { Multiplexer } from "./multiplexer";
 import { commandExists, execMuxOrThrow, shellEscape } from "./multiplexer";
 
@@ -254,6 +254,41 @@ export class ZellijMultiplexer implements Multiplexer {
     return this.listPanes(session).some(
       (p) => String(p.id) === target && p.exited !== true,
     );
+  }
+
+  isPaneAliveAsync(paneId: string, session?: string): Promise<boolean> {
+    const target = normalizePaneId(paneId);
+    return new Promise((resolve) => {
+      try {
+        execFile(
+          "zellij",
+          [...this.sessionFlag(session), "action", "list-panes", "--json"],
+          { encoding: "utf8", timeout: 5000 },
+          (error, stdout) => {
+            if (error) {
+              resolve(false);
+              return;
+            }
+            try {
+              const parsed = JSON.parse(stdout);
+              const panes = Array.isArray(parsed) ? parsed : [];
+              resolve(
+                panes.some(
+                  (pane: { id?: unknown; exited?: boolean }) =>
+                    String(pane.id) === target && pane.exited !== true,
+                ),
+              );
+            } catch {
+              // Malformed backend output is a failed liveness probe.
+              resolve(false);
+            }
+          },
+        );
+      } catch {
+        // A synchronous child-process setup failure is also a failed probe.
+        resolve(false);
+      }
+    });
   }
 
   /**

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -102,6 +102,13 @@ export interface Multiplexer {
   isPaneAlive(paneId: string, session?: string): boolean;
 
   /**
+   * Asynchronously probe pane liveness without blocking the parent event loop.
+   * Used by the recurring artifact poller; implementations must resolve false
+   * on backend errors rather than throwing.
+   */
+  isPaneAliveAsync(paneId: string, session?: string): Promise<boolean>;
+
+  /**
    * Send literal text to the pane's shell input buffer, character-by-character.
    * Does NOT submit (no Enter). Callers that want to submit pair this with
    * a second call to `sendEnter`.

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -74,7 +74,11 @@ export function registerSessionHandlers(pi: ExtensionAPI): void {
   // every running interactive sub-agent and fires pointer notifications for new events.
   // The poller survives parent restarts through persisted artifacts and byte cursors.
   if (!g2.__piSubagenturaInteractivePollerHandle) {
-    const handle = setInterval(() => pollArtifactChanges(pi), 5000);
+    const handle = setInterval(() => {
+      void pollArtifactChanges(pi).catch((err) => {
+        console.error("[subagentura] artifact poll failed", err);
+      });
+    }, 5000);
     // Don't pin the event loop on a long-lived parent. unref() lets the process exit
     // cleanly when nothing else is keeping it alive (no other ref'd handles).
     handle.unref?.();

--- a/tests/artifact-delivery.integration.test.ts
+++ b/tests/artifact-delivery.integration.test.ts
@@ -293,7 +293,7 @@ describe("artifact protocol v2 delivery", () => {
     ).toHaveLength(1);
   });
 
-  it("preserves and batches multiple immutable completions from one poll", () => {
+  it("preserves and batches multiple immutable completions from one poll", async () => {
     const art = makeArtifact();
     const state = makeState(art.dir);
     state.notifyOnComplete = "inject";
@@ -302,12 +302,15 @@ describe("artifact protocol v2 delivery", () => {
     interactiveSubagentRegistry.set(state.id, state);
     (globalThis as any).__piSubagenturaInteractiveRegistry =
       interactiveSubagentRegistry;
-    __setTmuxMultiplexer({ isPaneAlive: () => true } as any);
+    __setTmuxMultiplexer({
+      isPaneAlive: () => true,
+      isPaneAliveAsync: async () => true,
+    } as any);
     const first = appendDeterministicTurn(art, 1, "first immutable result");
     const second = appendDeterministicTurn(art, 2, "second immutable result");
     const sendMessage = vi.fn();
 
-    pollArtifactChanges({ sendMessage } as any);
+    await pollArtifactChanges({ sendMessage } as any);
 
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(sendMessage.mock.calls[0][0].details.deliveryIds).toHaveLength(2);

--- a/tests/multiplexer-tmux.test.ts
+++ b/tests/multiplexer-tmux.test.ts
@@ -388,6 +388,27 @@ describe("multiplexer-tmux", () => {
     expect(new TmuxMultiplexer().isPaneAlive("%99")).toBe(false);
   });
 
+  it("isPaneAliveAsync uses execFile rather than execFileSync", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => {
+        throw new Error("sync liveness probe must not run");
+      },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(null, "#{pane_id}\n"),
+    }));
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    await expect(new TmuxMultiplexer().isPaneAliveAsync("%42")).resolves.toBe(
+      true,
+    );
+  });
+
   it("isPaneAlive uses correct tmux args: display-message -p -t paneId #{pane_id}", async () => {
     process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
     const calls: string[][] = [];

--- a/tests/multiplexer-zellij.test.ts
+++ b/tests/multiplexer-zellij.test.ts
@@ -308,6 +308,27 @@ describe("multiplexer-zellij", () => {
     expect(mux.isPaneAlive("42")).toBe(false);
   });
 
+  it("isPaneAliveAsync uses execFile rather than execFileSync", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => {
+        throw new Error("sync liveness probe must not run");
+      },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(null, JSON.stringify([{ id: 42 }])),
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    await expect(new ZellijMultiplexer().isPaneAliveAsync("42")).resolves.toBe(
+      true,
+    );
+  });
+
   /* ------------------------------------------------------------------ */
   /*  sendKeys + sendEnter                                               */
   /* ------------------------------------------------------------------ */

--- a/tests/pi-session-delivery.integration.test.ts
+++ b/tests/pi-session-delivery.integration.test.ts
@@ -405,6 +405,7 @@ describe("Pi session delivery integration", () => {
     };
     interactiveSubagentRegistry.set(state.id, state);
     __setTmuxMultiplexer({
+      isPaneAliveAsync: async () => true,
       isPaneAlive: () => true,
     } as any);
     writeOutput(art, "immutable artifact result");
@@ -414,7 +415,7 @@ describe("Pi session delivery integration", () => {
       source: "explicit",
     });
 
-    pollArtifactChanges((globalThis as any).__piSubagenturaPiRef);
+    await pollArtifactChanges((globalThis as any).__piSubagenturaPiRef);
     await vi.waitFor(() => expect(harness.contexts).toHaveLength(1));
     expect(harness.contexts[0].messages.at(-1)).toMatchObject({ role: "user" });
     harness.completeNext();
@@ -698,7 +699,7 @@ describe("persisted delivery Pi session integration", () => {
       deliveryId,
     );
 
-    pollArtifactChanges((globalThis as any).__piSubagenturaPiRef);
+    await pollArtifactChanges((globalThis as any).__piSubagenturaPiRef);
 
     expect(harness.contexts).toHaveLength(0);
     expect(interactiveSubagentRegistry.get(art.id)?.pendingDeliveries).toEqual(
@@ -712,7 +713,7 @@ describe("persisted delivery Pi session integration", () => {
       expect.objectContaining({ state: "queued" }),
     ]);
 
-    pollArtifactChanges((globalThis as any).__piSubagenturaPiRef);
+    await pollArtifactChanges((globalThis as any).__piSubagenturaPiRef);
 
     await vi.waitFor(() => expect(harness.contexts).toHaveLength(1));
     expect(harness.contexts[0].messages.at(-1)).toMatchObject({ role: "user" });

--- a/tests/subagent-auto-done.test.ts
+++ b/tests/subagent-auto-done.test.ts
@@ -116,6 +116,12 @@ describe("no parent-side timeout completion synthesis", () => {
         if (args[0] === "display-message") return Buffer.from("%99");
         return "";
       },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => callback(null, "#99"),
     }));
     root = makeTmp();
     const g = globalThis as any;
@@ -137,7 +143,7 @@ describe("no parent-side timeout completion synthesis", () => {
     mod.interactiveSubagentRegistry.set(state.id, state);
 
     const sendMessage = vi.fn();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     const art = artifactPath(dirname(artifactDir), state.id);
     const events = readEvents(art);
@@ -154,7 +160,7 @@ describe("no parent-side timeout completion synthesis", () => {
       "Review complete. The findings file `/tmp/review-sec.md` contains 0 critical vulns.";
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(dirname(artifactDir), state.id);
     const events = readEvents(art);
@@ -169,7 +175,7 @@ describe("no parent-side timeout completion synthesis", () => {
     const { state } = makeState({ outputContent: null });
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(dirname(state.artifactDir), state.id);
     const events = readEvents(art);
@@ -185,7 +191,7 @@ describe("no parent-side timeout completion synthesis", () => {
     state.lastStopReason = "toolUse" as unknown as "stop";
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(dirname(artifactDir), state.id);
     const events = readEvents(art);
@@ -205,7 +211,7 @@ describe("no parent-side timeout completion synthesis", () => {
       state.lastStopReason = reason;
       mod.interactiveSubagentRegistry.set(state.id, state);
 
-      mod.pollArtifactChanges({} as any);
+      await mod.pollArtifactChanges({} as any);
 
       const art = artifactPath(dirname(artifactDir), state.id);
       const events = readEvents(art);
@@ -223,7 +229,7 @@ describe("no parent-side timeout completion synthesis", () => {
     state.lastStopReasonAt = Date.now() - 1_000; // legacy timestamp must not matter
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(dirname(artifactDir), state.id);
     const events = readEvents(art);
@@ -249,7 +255,7 @@ describe("no parent-side timeout completion synthesis", () => {
       exitCode: 0,
     });
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const events = readEvents(art);
 
@@ -370,7 +376,7 @@ describe("no parent-side timeout completion synthesis", () => {
 
     const sendMessage = vi.fn();
 
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     const events = readEvents(art);
 
@@ -405,9 +411,9 @@ describe("no parent-side timeout completion synthesis", () => {
     const { state, artifactDir } = makeState({ outputContent: "result" });
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    mod.pollArtifactChanges({} as any);
-    mod.pollArtifactChanges({} as any);
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(dirname(artifactDir), state.id);
     const events = readEvents(art);
@@ -422,7 +428,7 @@ describe("no parent-side timeout completion synthesis", () => {
     mod.interactiveSubagentRegistry.set(state.id, state);
 
     const sendMessage = vi.fn();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).not.toHaveBeenCalled();
 
     const art = artifactPath(dirname(artifactDir), state.id);
@@ -433,7 +439,7 @@ describe("no parent-side timeout completion synthesis", () => {
       exitCode: 0,
     });
 
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     expect(state.pendingDeliveries).toHaveLength(1);
   });
 
@@ -443,7 +449,7 @@ describe("no parent-side timeout completion synthesis", () => {
     const { state, artifactDir } = makeState({ outputContent: "result" });
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.autoDoneForTurnAt).toBeUndefined();
 
     const userMsg = {
@@ -456,7 +462,7 @@ describe("no parent-side timeout completion synthesis", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.autoDoneForTurnAt).toBeUndefined();
   });
 
@@ -466,7 +472,7 @@ describe("no parent-side timeout completion synthesis", () => {
     const { state, artifactDir } = makeState({ outputContent: "result" });
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     // Simulate a terminal previous turn. The user has now sent a follow-up;
     // we want to verify the user-role revival clears "exited" too.
     state.status = "exited";
@@ -481,7 +487,7 @@ describe("no parent-side timeout completion synthesis", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     // Status revived so child lifecycle events for the next turn are observed.
     expect(state.status).toBe("running");
   });
@@ -501,7 +507,7 @@ describe("no parent-side timeout completion synthesis", () => {
     appendEvent(art, { ts: 1, type: "started", status: "running" });
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
     state.status = "idle";
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.status).toBe("idle");
 
     const userMsg = {
@@ -514,7 +520,7 @@ describe("no parent-side timeout completion synthesis", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(userMsg) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.status).toBe("running");
   });
 
@@ -536,7 +542,7 @@ describe("no parent-side timeout completion synthesis", () => {
       "Done. Wrote the result.",
     );
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     expect(state.lastStopReason).toBe("stop");
     expect(state.lastStopReasonAt).toBe(ts);
@@ -560,7 +566,7 @@ describe("no parent-side timeout completion synthesis", () => {
       "I hit the token limit.",
     );
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     expect(state.lastStopReason).toBe("length");
     expect(state.lastStopText).toBeUndefined();
@@ -592,7 +598,7 @@ describe("no parent-side timeout completion synthesis", () => {
       { flag: "a" },
     );
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     // All three per-turn fields must be cleared, matching the reset of
     // autoDoneForTurnAt on the same code path.
@@ -612,7 +618,7 @@ describe("no parent-side timeout completion synthesis", () => {
     const ts = Date.now() - 11_000;
     writeAssistantTurn(state.sessionFile, ts, "stop", longText);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const events = readEvents(
       artifactPath(dirname(state.artifactDir), state.id),
@@ -630,7 +636,7 @@ describe("no parent-side timeout completion synthesis", () => {
     const ts = Date.now() - 11_000;
     writeAssistantTurn(state.sessionFile, ts, "stop", shortText);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const events = readEvents(
       artifactPath(dirname(state.artifactDir), state.id),
@@ -648,7 +654,7 @@ describe("no parent-side timeout completion synthesis", () => {
     const ts = Date.now() - 11_000;
     writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     // Legacy state remains untouched; protocol-v2 delivery receipts own deduplication.
     const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
@@ -665,7 +671,7 @@ describe("no parent-side timeout completion synthesis", () => {
     const ts = Date.now() - 11_000;
     writeAssistantTurn(state.sessionFile, ts, "stop", "Done.");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     // Legacy state remains untouched in notify mode too.
     const after = mod.interactiveSubagentRegistry.get(state.id) as typeof state;
@@ -719,7 +725,7 @@ describe("no parent-side timeout completion synthesis", () => {
     );
 
     const sendMessage = vi.fn();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     expect(state.lastStopReason).toBe("stop");
     expect(state.lastStopReasonAt).toBe(stopTs);
@@ -768,7 +774,7 @@ describe("no parent-side timeout completion synthesis", () => {
       }) + "\n",
     );
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(dirname(artifactDir), state.id);
     const events = readEvents(art);
@@ -859,7 +865,7 @@ describe("no parent-side timeout completion synthesis", () => {
       artifactDir: replayArtifactDir,
     });
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     // Session text alone must not create a completion event.
     const eventsFile = join(replayArtifactDir, "events.ndjson");

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -84,8 +84,116 @@ describe("pollArtifactChanges", () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps the event loop responsive while async liveness is pending", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const { state, artifactDir } = makeState();
+    mkdirSync(artifactDir, { recursive: true });
+    let resolveProbe!: (alive: boolean) => void;
+    let probeStarted = false;
+    let settled = false;
+    const probe = new Promise<boolean>((resolve) => {
+      resolveProbe = resolve;
+    });
+    multiplexer.__setTmuxMultiplexer({
+      isPaneAlive: () => {
+        throw new Error("sync liveness probe must not run");
+      },
+      isPaneAliveAsync: () => {
+        probeStarted = true;
+        return probe;
+      },
+    } as any);
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    const polling = mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    void Promise.resolve(polling).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(probeStarted).toBe(true);
+    expect(settled).toBe(false);
+    let timerRan = false;
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        timerRan = true;
+        resolve();
+      }, 0);
+    });
+    expect(timerRan).toBe(true);
+    expect(settled).toBe(false);
+    resolveProbe(true);
+    await polling;
+    expect(settled).toBe(true);
+    multiplexer.__setTmuxMultiplexer(undefined);
+  });
+
+  it("drops a pending poll when shutdown clears the registry", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const { state, artifactDir } = makeState();
+    mkdirSync(artifactDir, { recursive: true });
+    appendEvent(artifactPath(join(artifactDir, ".."), state.id), {
+      ts: 1,
+      type: "done",
+      status: "done",
+      exitCode: 0,
+    });
+    let resolveProbe!: (alive: boolean) => void;
+    const probe = new Promise<boolean>((resolve) => {
+      resolveProbe = resolve;
+    });
+    multiplexer.__setTmuxMultiplexer({
+      isPaneAlive: () => {
+        throw new Error("sync liveness probe must not run");
+      },
+      isPaneAliveAsync: () => probe,
+    } as any);
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    const sendMessage = vi.fn();
+    const polling = mod.pollArtifactChanges({ sendMessage } as any);
+    await Promise.resolve();
+    mod.interactiveSubagentRegistry.clear();
+    resolveProbe(true);
+    await polling;
+    expect(state.eventByteCursor).toBeUndefined();
+    expect(sendMessage).not.toHaveBeenCalled();
+    multiplexer.__setTmuxMultiplexer(undefined);
+  });
+
+  it("does not overlap pending poll ticks", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const { state, artifactDir } = makeState();
+    mkdirSync(artifactDir, { recursive: true });
+    let probeCalls = 0;
+    let resolveProbe!: (alive: boolean) => void;
+    const probe = new Promise<boolean>((resolve) => {
+      resolveProbe = resolve;
+    });
+    multiplexer.__setTmuxMultiplexer({
+      isPaneAlive: () => {
+        throw new Error("sync liveness probe must not run");
+      },
+      isPaneAliveAsync: () => {
+        probeCalls++;
+        return probe;
+      },
+    } as any);
+    mod.interactiveSubagentRegistry.set(state.id, state);
+    const first = mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    const second = mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await Promise.resolve();
+    expect(probeCalls).toBe(1);
+    resolveProbe(true);
+    await Promise.all([first, second]);
+    multiplexer.__setTmuxMultiplexer(undefined);
   });
 
   it("paints workflow footer and widget for running workflows", async () => {
@@ -114,7 +222,7 @@ describe("pollArtifactChanges", () => {
     const setWidget = vi.fn();
     (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
 
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     expect(setStatus).toHaveBeenCalledWith(
       "subagentura-workflows",
@@ -142,12 +250,12 @@ describe("pollArtifactChanges", () => {
       artifactDir: undefined,
     } as any);
 
-    expect(() =>
+    await expect(
       mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
 
     const logFile = join(
       logDir,
@@ -220,8 +328,8 @@ describe("pollArtifactChanges", () => {
 
     (globalThis as any).__piSubagenturaParentStreaming = false;
     const sendMessage = vi.fn();
-    mod.pollArtifactChanges({ sendMessage } as any);
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).not.toHaveBeenCalled();
     expect(state.pendingDeliveries).toEqual([]);
     expect(state.deliveryReceipts).toHaveLength(1);
@@ -277,7 +385,7 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     // Only done fires. started is silent (widget shows it).
     expect(sendMessage).toHaveBeenCalledTimes(1);
@@ -307,7 +415,7 @@ describe("pollArtifactChanges", () => {
     });
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     // Both are silent (started → TUI widget row; tool_activity → TUI widget only).
     expect(sendMessage).not.toHaveBeenCalled();
@@ -330,7 +438,7 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 3, type: "cancelled", status: "cancelled" });
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(sendMessage.mock.calls[0][0].content).toContain("error");
@@ -347,13 +455,13 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     // Only done fires (started is silent).
     expect(sendMessage).toHaveBeenCalledTimes(1);
 
     // Second poll: no new events, no new notifications.
     sendMessage.mockClear();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
@@ -372,7 +480,7 @@ describe("pollArtifactChanges", () => {
     state.eventByteCursor = readEventRecords(art)[0].endOffset;
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     // Should deliver done + cancelled, not started.
     expect(sendMessage).toHaveBeenCalledOnce();
@@ -390,6 +498,12 @@ describe("pollArtifactChanges", () => {
         if (args[0] === "display-message") return Buffer.from("#99");
         return "";
       },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => callback(null, "#99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -399,7 +513,7 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 1, type: "started", status: "running" });
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.status).toBe("idle");
     // exitCode is NOT set on idle — child is still around.
     expect(state.exitCode).toBeUndefined();
@@ -412,6 +526,12 @@ describe("pollArtifactChanges", () => {
       execFileSync: () => {
         throw new Error("can't find pane: %99");
       },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => callback(new Error("can't find pane: %99")),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -421,7 +541,7 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 1, type: "started", status: "running" });
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.status).toBe("exited");
     expect(state.exitCode).toBe(0);
   });
@@ -434,7 +554,7 @@ describe("pollArtifactChanges", () => {
     const art = artifactPath(join(artifactDir, ".."), state.id);
     appendEvent(art, { ts: 1, type: "cancelled", status: "cancelled" });
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.status).toBe("cancelled");
   });
 
@@ -448,7 +568,7 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).toHaveBeenCalledOnce();
   });
 
@@ -466,6 +586,18 @@ describe("pollArtifactChanges", () => {
         }
         return "";
       },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => {
+        paneProbeCount++;
+        callback(
+          paneProbeCount === 1 ? new Error("pane not ready yet") : null,
+          "#99",
+        );
+      },
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -475,11 +607,11 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 1, type: "started", status: "running" });
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
     expect(state.status).toBe("unknown");
 
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage.mock.calls[0][0].content).toContain("done");
@@ -507,7 +639,7 @@ describe("pollArtifactChanges", () => {
     appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 }); // follow-up turn
 
     const sendMessage = installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     // The new done event (ts=3) is delivered as a pointer notification.
     expect(sendMessage).toHaveBeenCalledTimes(1);
@@ -536,7 +668,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendMessage.mock.calls[0][0].content).not.toContain(
@@ -563,7 +695,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       // Legacy completions are pointer-only even when the delivery mode is inject.
       expect(sendMessage).toHaveBeenCalledTimes(1);
@@ -584,7 +716,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendUserMessage).not.toHaveBeenCalled();
@@ -603,7 +735,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendMessage.mock.calls[0][1]).toMatchObject({
@@ -627,7 +759,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendMessage.mock.calls[0][1]).toEqual({
@@ -655,7 +787,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendMessage.mock.calls[0][1]).toMatchObject({
@@ -678,14 +810,14 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendUserMessage).not.toHaveBeenCalled();
 
       // Second poll: no new events (cursor advanced), inject is gated by state.injected.
       sendMessage.mockClear();
       sendUserMessage.mockClear();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
       expect(sendMessage).not.toHaveBeenCalled();
       expect(sendUserMessage).not.toHaveBeenCalled();
     });
@@ -711,7 +843,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendMessage.mock.calls[0][0].content).not.toContain("answer v1");
       expect(sendMessage.mock.calls[0][0].content).toContain("Output:");
@@ -723,7 +855,7 @@ describe("pollArtifactChanges", () => {
 
       sendMessage.mockClear();
       sendUserMessage.mockClear();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(sendMessage.mock.calls[0][0].content).not.toContain("answer v2");
@@ -743,7 +875,7 @@ describe("pollArtifactChanges", () => {
 
       const sendMessage = installDeliverySpies();
       const sendUserMessage = vi.fn();
-      mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
+      await mod.pollArtifactChanges({ sendMessage, sendUserMessage } as any);
 
       expect(sendUserMessage).not.toHaveBeenCalled();
       expect(sendMessage).toHaveBeenCalledOnce();
@@ -771,7 +903,7 @@ describe("pollArtifactChanges", () => {
       appendEvent(art, { ts: 1, type: "started", status: "running" });
       appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
       writeOutput(art, "answer v1");
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -779,7 +911,7 @@ describe("pollArtifactChanges", () => {
       // Turn 2.
       appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 });
       writeOutput(art, "answer v2");
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -808,7 +940,7 @@ describe("pollArtifactChanges", () => {
       appendEvent(art, { ts: 1, type: "started", status: "running" });
       appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
       writeOutput(art, "answer v1");
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -835,7 +967,7 @@ describe("pollArtifactChanges", () => {
       appendEvent(art, { ts: 1, type: "started", status: "running" });
       appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
       writeOutput(art, "answer v1");
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -844,7 +976,7 @@ describe("pollArtifactChanges", () => {
       // Follow-up turn: the child overwrites output.md but its done event has NOT landed yet
       // (last event is still the turn-1 done@ts2). A poll lands in this window.
       writeOutput(art, "answer v2 in progress");
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -854,7 +986,7 @@ describe("pollArtifactChanges", () => {
       // A second legacy completion remains pointer-only.
       appendEvent(art, { ts: 3, type: "done", status: "done", exitCode: 0 });
       writeOutput(art, "answer v2 final");
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -884,6 +1016,16 @@ describe("pollArtifactChanges", () => {
           }
           return "";
         },
+        execFile: (
+          _file: string,
+          args: string[],
+          _options: object,
+          callback: (error: Error | null, stdout?: string) => void,
+        ) =>
+          callback(
+            args[3] === "%exited-pane" ? new Error("pane dead") : null,
+            "#99",
+          ),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -931,7 +1073,7 @@ describe("pollArtifactChanges", () => {
       const setWidget = vi.fn();
       (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
 
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -962,6 +1104,12 @@ describe("pollArtifactChanges", () => {
           if (args[0] === "-lc") return Buffer.from("");
           throw new Error("pane dead");
         },
+        execFile: (
+          _file: string,
+          _args: string[],
+          _options: object,
+          callback: (error: Error | null, stdout?: string) => void,
+        ) => callback(new Error("pane dead")),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -987,7 +1135,7 @@ describe("pollArtifactChanges", () => {
       const setWidget = vi.fn();
       (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
 
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -1011,6 +1159,12 @@ describe("pollArtifactChanges", () => {
           if (args[0] === "display-message") return Buffer.from("#99");
           return "";
         },
+        execFile: (
+          _file: string,
+          _args: string[],
+          _options: object,
+          callback: (error: Error | null, stdout?: string) => void,
+        ) => callback(null, "#99"),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1026,7 +1180,7 @@ describe("pollArtifactChanges", () => {
       const setWidget = vi.fn();
       (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
 
-      mod.pollArtifactChanges({
+      await mod.pollArtifactChanges({
         sendMessage: vi.fn(),
         sendUserMessage: vi.fn(),
       } as any);
@@ -1103,7 +1257,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
     installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeDefined();
@@ -1130,7 +1284,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     (globalThis as any).__piSubagenturaSessionManager = {
       getEntries: () => entries,
     };
-    mod.pollArtifactChanges({
+    await mod.pollArtifactChanges({
       sendMessage: vi.fn((message) => {
         entries.push({ type: "custom_message", details: message.details });
       }),
@@ -1147,6 +1301,12 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
         if (args[0] === "display-message") return Buffer.from("#99");
         return "";
       },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => callback(null, "#99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1156,7 +1316,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     appendEvent(art, { ts: 1, type: "started", status: "running" });
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeDefined();
@@ -1170,6 +1330,12 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
         if (args[0] === "display-message") return Buffer.from("#99");
         return "";
       },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => callback(null, "#99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1189,7 +1355,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     });
 
     installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     expect(state.status).toBe("idle");
     expect(loadInteractiveStates(cwd)?.states[id]).toBeDefined();
@@ -1218,7 +1384,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
       exitCode: 1,
     });
 
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     expect(state.status).toBe("exited");
     expect(loadInteractiveStates(cwd)?.states[id]).toBeUndefined();
@@ -1238,7 +1404,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     });
 
     installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeDefined();
@@ -1256,7 +1422,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     appendEvent(art, { ts: 1, type: "cancelled", status: "cancelled" });
 
     installDeliverySpies();
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeDefined();
@@ -1288,7 +1454,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
       setStatus: vi.fn(),
       setWidget: vi.fn(),
     };
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeDefined();
@@ -1297,6 +1463,16 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
   });
 
   it("does NOT remove the state.json entry on tool_activity events (only terminals)", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => callback(null, "#99"),
+    }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const { cwd, id, state } = makePersistedState();
@@ -1310,7 +1486,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
       summary: "ls",
     });
 
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     const loaded = loadInteractiveStates(cwd);
     expect(loaded?.states[id]).toBeDefined();
@@ -1339,9 +1515,9 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     const art = artifactPath("/tmp", id);
     appendEvent(art, { ts: 1, type: "done", status: "done", exitCode: 0 });
 
-    expect(() =>
+    await expect(
       mod.pollArtifactChanges({ sendMessage: vi.fn() } as any),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
   });
 
   it("advances eventByteCursor before removing the state entry", async () => {
@@ -1353,7 +1529,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     appendEvent(art, { ts: 1, type: "started", status: "running" });
     appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
 
-    mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
 
     expect(state.eventByteCursor).toBe(eventLogEndOffset(art));
   });

--- a/tests/subagent-session-log.test.ts
+++ b/tests/subagent-session-log.test.ts
@@ -75,6 +75,12 @@ describe("session-log tail-read", () => {
         if (args[0] === "display-message") return Buffer.from("#99");
         return "";
       },
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout?: string) => void,
+      ) => callback(null, "#99"),
     }));
   });
 
@@ -121,7 +127,7 @@ describe("session-log tail-read", () => {
     writeFileSync(sessionFile, JSON.stringify(entry) + "\n");
 
     const sendMessage = vi.fn();
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     // Should not have notified the LLM (tool_activity is silent).
     expect(sendMessage).not.toHaveBeenCalled();
@@ -176,7 +182,7 @@ describe("session-log tail-read", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(join(artifactDir, ".."), state.id);
     const events = readEvents(art);
@@ -225,7 +231,7 @@ describe("session-log tail-read", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(join(artifactDir, ".."), state.id);
     const events = readEvents(art);
@@ -256,7 +262,7 @@ describe("session-log tail-read", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(join(artifactDir, ".."), state.id);
     const events = readEvents(art);
@@ -289,11 +295,11 @@ describe("session-log tail-read", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     const after1 = state.lastDeliveredSessionByte;
     expect(after1).toBeGreaterThan(0);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.lastDeliveredSessionByte).toBe(after1); // unchanged
 
     const art = artifactPath(join(artifactDir, ".."), state.id);
@@ -339,13 +345,13 @@ describe("session-log tail-read", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(e1) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     // Append second line.
     const { appendFileSync } = await import("node:fs");
     appendFileSync(state.sessionFile, JSON.stringify(e2) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(join(artifactDir, ".."), state.id);
     const events = readEvents(art);
@@ -381,7 +387,7 @@ describe("session-log tail-read", () => {
     const partial = '{ "type": "mess';
     writeFileSync(state.sessionFile, complete + partial);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(join(artifactDir, ".."), state.id);
     const events = readEvents(art);
@@ -422,7 +428,7 @@ describe("session-log tail-read", () => {
     writeFileSync(state.sessionFile, complete + partial);
     // First poll: ndjson parser buffers the partial internally. The cursor sweeps to the end of
     // the read window so the next tick only reads NEW bytes (not the buffered partial).
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.lastDeliveredSessionByte).toBe(
       Buffer.byteLength(complete + partial, "utf8"),
     );
@@ -434,7 +440,7 @@ describe("session-log tail-read", () => {
       'age","message":{"role":"assistant","content":[{"type":"toolCall","id":"t2","name":"bash","arguments":{"command":"ls"}}]}}\n';
     appendFileSync(state.sessionFile, appended);
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.lastDeliveredSessionByte).toBe(
       Buffer.byteLength(complete + partial, "utf8") +
         Buffer.byteLength(appended, "utf8"),
@@ -453,7 +459,7 @@ describe("session-log tail-read", () => {
     });
     mod.interactiveSubagentRegistry.set(state.id, state);
 
-    expect(() => mod.pollArtifactChanges({} as any)).not.toThrow();
+    await expect(mod.pollArtifactChanges({} as any)).resolves.toBeUndefined();
     expect(state.lastDeliveredSessionByte).toBeUndefined();
   });
 
@@ -480,7 +486,7 @@ describe("session-log tail-read", () => {
     };
     writeFileSync(state.sessionFile, JSON.stringify(entry) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     expect(state.lastToolName).toBe("bash");
     expect(state.lastToolSummary).toBe("rg TODO src/");
@@ -514,7 +520,7 @@ describe("session-log tail-read", () => {
     const setWidget = vi.fn();
     (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     // Footer status shows count.
     expect(setStatus).toHaveBeenCalledWith(
@@ -540,7 +546,7 @@ describe("session-log tail-read", () => {
     const setWidget = vi.fn();
     (globalThis as any).__piSubagenturaUi = { setStatus, setWidget };
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     expect(setStatus).toHaveBeenCalledWith("subagentura-running", undefined);
     expect(setWidget).toHaveBeenCalledWith("subagentura-activity", undefined, {
@@ -571,7 +577,7 @@ describe("session-log tail-read", () => {
       setStatus: vi.fn(),
       setWidget: vi.fn(),
     };
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(notify).toHaveBeenCalledWith(
@@ -615,7 +621,7 @@ describe("session-log tail-read", () => {
       setStatus: vi.fn(),
       setWidget: vi.fn(),
     };
-    mod.pollArtifactChanges({ sendMessage } as any);
+    await mod.pollArtifactChanges({ sendMessage } as any);
 
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -638,11 +644,11 @@ describe("session-log tail-read", () => {
     mod.interactiveSubagentRegistry.set(state.id, state);
     // write 1KB of content, poll to advance cursor
     writeFileSync(state.sessionFile, "x".repeat(1024) + "\n");
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.lastDeliveredSessionByte).toBe(1025);
     // truncate to 0, then write new content
     writeFileSync(state.sessionFile, "new\n");
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     // cursor should have been reset, so it now points past the new content
     expect(state.lastDeliveredSessionByte).toBe(4);
   });
@@ -653,11 +659,11 @@ describe("session-log tail-read", () => {
     mod.interactiveSubagentRegistry.set(state.id, state);
     // write 1KB of content, poll to advance cursor
     writeFileSync(state.sessionFile, "x".repeat(1024) + "\n");
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.lastDeliveredSessionByte).toBe(1025);
     // truncate to 0, then write new content
     writeFileSync(state.sessionFile, "new\n");
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     // cursor should have been reset, so it now points past the new content
     expect(state.lastDeliveredSessionByte).toBe(4);
   });
@@ -695,7 +701,7 @@ describe("session-log tail-read", () => {
     writeFileSync(state.sessionFile, line + "\n");
 
     // First poll: ndjson reads up to 1 MiB (the defensive cap), buffers the rest internally.
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     const afterFirst = state.lastDeliveredSessionByte ?? 0;
     expect(afterFirst).toBe(1 * 1024 * 1024); // defensive cap was hit
 
@@ -708,7 +714,7 @@ describe("session-log tail-read", () => {
     // Second poll: cursor at 1 MiB, file has another ~0.5 MiB left. The ndjson parser combines the
     // buffered partial with the new bytes and emits the completed line. The cursor advances to the end
     // of the file. The OLD code would have re-read the same 1 MiB over and over and never advanced.
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     expect(state.lastDeliveredSessionByte).toBeGreaterThan(afterFirst);
     const activityAfterSecond = readEvents(art).filter(
       (e) => e.type === "tool_activity",
@@ -736,7 +742,7 @@ describe("session-log tail-read", () => {
       },
     };
     appendFileSync(state.sessionFile, JSON.stringify(nextEntry) + "\n");
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     const activity = readEvents(art).filter((e) => e.type === "tool_activity");
     expect(activity).toHaveLength(2);
     expect(activity[1]).toMatchObject({ tool: "read", summary: "/tmp/x" });
@@ -768,7 +774,7 @@ describe("session-log tail-read", () => {
       state.sessionFile,
       "x".repeat(1024) + "\n" + JSON.stringify(initialEntry) + "\n",
     );
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
     const cursorBeforeTruncation = state.lastDeliveredSessionByte;
     expect(cursorBeforeTruncation).toBeGreaterThan(1024);
 
@@ -792,7 +798,7 @@ describe("session-log tail-read", () => {
       },
     };
     writeFileSync(state.sessionFile, JSON.stringify(newEntry) + "\n");
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     // Cursor was reset to 0, then advanced to the end of the new content.
     const newSize = Buffer.byteLength(JSON.stringify(newEntry) + "\n", "utf8");
@@ -855,7 +861,7 @@ describe("session-log tail-read", () => {
         JSON.stringify(entry2) +
         "\n",
     );
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const art = artifactPath(join(artifactDir, ".."), state.id);
     const activity = readEvents(art).filter((e) => e.type === "tool_activity");
@@ -909,7 +915,7 @@ describe("session-log tail-read", () => {
     writeFileSync(a.state.sessionFile, JSON.stringify(entryA) + "\n");
     writeFileSync(b.state.sessionFile, JSON.stringify(entryB) + "\n");
 
-    mod.pollArtifactChanges({} as any);
+    await mod.pollArtifactChanges({} as any);
 
     const artA = artifactPath(join(a.artifactDir, ".."), a.state.id);
     const artB = artifactPath(join(b.artifactDir, ".."), b.state.id);

--- a/tests/subagent-shutdown.test.ts
+++ b/tests/subagent-shutdown.test.ts
@@ -28,6 +28,7 @@ import { appendEvent, artifactPath } from "../src/artifact";
 import { jobRegistry } from "../src/helpers";
 import { workflowJobRegistry } from "../src/workflow";
 import registerExtension, { pollArtifactChanges } from "../src/subagent";
+import { __setTmuxMultiplexer } from "../src/multiplexer";
 
 // ── Fixtures ──────────────────────────────────────────────────────────
 
@@ -103,6 +104,10 @@ describe("session_shutdown handler", () => {
     g.__piSubagenturaPiRef = undefined;
     jobRegistry.clear();
     workflowJobRegistry.clear();
+    __setTmuxMultiplexer({
+      isPaneAlive: () => true,
+      isPaneAliveAsync: async () => true,
+    } as any);
 
     // Stub the global timers. setInterval returns a fake handle with a
     // vi.fn() unref method; clearInterval is a no-op spy.
@@ -297,7 +302,7 @@ describe("session_shutdown handler", () => {
     };
   }
 
-  it("AC-A1: setInterval tick after session_shutdown delivers zero notifications (race-reproducing)", () => {
+  it("AC-A1: setInterval tick after session_shutdown delivers zero notifications (race-reproducing)", async () => {
     // Empty tmp artifact dir; no events written.
 
     tmpRoot = mkdtempSync(join(tmpdir(), "pi-shutdown-a1-"));
@@ -331,6 +336,7 @@ describe("session_shutdown handler", () => {
     // 1. Pre-shutdown tick: no artifact events, no notification.
 
     tick();
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(api.sendMessage).toHaveBeenCalledTimes(0);
 
@@ -355,11 +361,12 @@ describe("session_shutdown handler", () => {
     //    must deliver zero notifications because the registry is empty.
 
     tick();
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(api.sendMessage).toHaveBeenCalledTimes(0);
   });
 
-  it("AC-A2: setInterval tick after shutdown does not re-deliver a done event already in the artifact", () => {
+  it("AC-A2: setInterval tick after shutdown does not re-deliver a done event already in the artifact", async () => {
     tmpRoot = mkdtempSync(join(tmpdir(), "pi-shutdown-a2-"));
 
     const artifactDir = join(tmpRoot, "run-1");
@@ -375,6 +382,10 @@ describe("session_shutdown handler", () => {
     appendEvent(art, { ts: doneTs, type: "done", status: "done", exitCode: 0 });
 
     interactiveTmux.interactiveSubagentRegistry.set(running.id, running);
+    __setTmuxMultiplexer({
+      isPaneAlive: () => true,
+      isPaneAliveAsync: async () => true,
+    } as any);
 
     const { api, shutdownHandler } = setupExtension();
 
@@ -394,7 +405,8 @@ describe("session_shutdown handler", () => {
 
     // delivered. Exactly one notification.
 
-    tick();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await pollArtifactChanges(api as any);
 
     expect(api.sendMessage).toHaveBeenCalledTimes(1);
     expect(notify).toHaveBeenCalledOnce();
@@ -410,9 +422,11 @@ describe("session_shutdown handler", () => {
     // notification count stays at 1 — no duplicate delivered.
 
     tick();
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(api.sendMessage).toHaveBeenCalledTimes(1);
     expect(notify).toHaveBeenCalledOnce();
+    __setTmuxMultiplexer(undefined);
   });
 
   afterEach(() => {

--- a/tests/subagent-stale-ctx.test.ts
+++ b/tests/subagent-stale-ctx.test.ts
@@ -113,7 +113,9 @@ describe("pollArtifactChanges stale-ctx defenses", () => {
     });
 
     // The call must NOT throw — that's the entire point of the fix.
-    expect(() => mod.pollArtifactChanges(brokenPi as any)).not.toThrow();
+    await expect(
+      mod.pollArtifactChanges(brokenPi as any),
+    ).resolves.toBeUndefined();
 
     expect(brokenPi.sendMessage).toHaveBeenCalledTimes(1);
     expect(state.pendingDeliveries?.[0].state).toBe("queued");
@@ -147,7 +149,9 @@ describe("pollArtifactChanges stale-ctx defenses", () => {
     });
 
     // The call must NOT throw.
-    expect(() => mod.pollArtifactChanges(brokenPi as any)).not.toThrow();
+    await expect(
+      mod.pollArtifactChanges(brokenPi as any),
+    ).resolves.toBeUndefined();
 
     // sendMessage was attempted (we know it threw).
     expect(brokenPi.sendMessage).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- replace synchronous tmux/zellij pane-liveness subprocesses in the recurring artifact poller with asynchronous probes
- run pane probes concurrently while preventing overlapping poll ticks
- discard stale poll continuations after registry clear, shutdown, reload, or parent-session replacement
- keep existing synchronous mux helpers for non-poller compatibility

## Regression evidence

Before the implementation, deterministic focused tests failed because the poller never started the injected async probe and both mux backends lacked `isPaneAliveAsync`.

After the implementation, tests prove:

- a zero-delay timer runs while liveness remains pending
- the recurring poller never invokes the synchronous probe
- tmux and zellij use callback-based `execFile`
- overlapping ticks share one in-flight poll
- shutdown/registry replacement prevents stale processing or delivery

## Verification

- `npm run typecheck`
- `npm test` — 40 files, 937 tests passed
- `npm run format:check`
- `git diff --check`
- `npm run pack:check`
