### PR TITLE
feat(workflow): report complete usage

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -38,6 +38,7 @@ import { shouldNotify } from "./notifications";
 import { deliveryIdFor, enqueueDelivery, flushDeliveries } from "./delivery";
 import { debugLog } from "./helpers";
 import { formatActivityRow } from "./rendering";
+import { formatWorkflowUsage } from "./workflow-core";
 import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import ndjson from "ndjson";
@@ -284,7 +285,8 @@ function formatWorkflowWidgetRows(now: number): string[] {
     const parts = [
       `${s.agentsSpawned} agent${s.agentsSpawned === 1 ? "" : "s"}`,
       `${s.runningCount ?? 0} running`,
-      `${s.tokensSpent} tokens`,
+      `${s.tokensSpent} output tokens`,
+      ...(s.usage ? [formatWorkflowUsage(s.usage)] : []),
       formatWorkflowElapsed(now - st.startedAt),
     ];
     if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -39,6 +39,60 @@ export function zeroUsage(): Usage {
   };
 }
 
+export interface WorkflowUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  costUsd: number;
+  turns: number;
+}
+
+export function zeroWorkflowUsage(): WorkflowUsage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    costUsd: 0,
+    turns: 0,
+  };
+}
+
+/** Return a new aggregate; callers never share mutable accounting state. */
+export function addWorkflowUsage(
+  total: WorkflowUsage,
+  usage: Usage | undefined,
+): WorkflowUsage {
+  const input = total.input + (usage?.input ?? 0);
+  const output = total.output + (usage?.output ?? 0);
+  const cacheRead = total.cacheRead + (usage?.cacheRead ?? 0);
+  const cacheWrite = total.cacheWrite + (usage?.cacheWrite ?? 0);
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    totalTokens: input + output + cacheRead + cacheWrite,
+    costUsd: total.costUsd + (usage?.cost ?? 0),
+    turns: total.turns + (usage?.turns ?? 0),
+  };
+}
+
+function formatWorkflowCost(costUsd: number): string {
+  if (!Number.isFinite(costUsd)) return String(costUsd);
+  return costUsd.toLocaleString("en-US", {
+    useGrouping: false,
+    maximumFractionDigits: 15,
+  });
+}
+
+export function formatWorkflowUsage(usage: WorkflowUsage): string {
+  return `${usage.totalTokens} total tokens, $${formatWorkflowCost(usage.costUsd)}`;
+}
+
 // ── Public types ─────────────────────────────────────────────────────
 
 /** Options accepted by the injected `agent()` helper. */
@@ -99,7 +153,9 @@ export type WorkflowProgress =
       label?: string;
       agentsSpawned: number;
       errorCount: number;
+      /** @deprecated Output-token count; use usage.totalTokens. */
       tokensSpent: number;
+      usage?: WorkflowUsage;
       runningCount: number;
       model?: string;
     }
@@ -110,7 +166,9 @@ export type WorkflowProgress =
       label?: string;
       agentsSpawned: number;
       errorCount: number;
+      /** @deprecated Output-token count; use usage.totalTokens. */
       tokensSpent: number;
+      usage?: WorkflowUsage;
       runningCount: number;
       model?: string;
     }
@@ -121,7 +179,9 @@ export type WorkflowProgress =
       label?: string;
       agentsSpawned: number;
       errorCount: number;
+      /** @deprecated Output-token count; use usage.totalTokens. */
       tokensSpent: number;
+      usage?: WorkflowUsage;
       runningCount: number;
       model?: string;
     }
@@ -132,7 +192,9 @@ export type WorkflowProgress =
       label?: string;
       agentsSpawned: number;
       errorCount: number;
+      /** @deprecated Output-token count; use usage.totalTokens. */
       tokensSpent: number;
+      usage?: WorkflowUsage;
       runningCount: number;
       model?: string;
     };
@@ -140,21 +202,40 @@ export type WorkflowProgress =
 export type WorkflowProgressUpdate = {
   [K in WorkflowProgress["kind"]]: Omit<
     Extract<WorkflowProgress, { kind: K }>,
-    "agentsSpawned" | "errorCount" | "tokensSpent" | "runningCount"
+    "agentsSpawned" | "errorCount" | "tokensSpent" | "usage" | "runningCount"
   >;
 }[WorkflowProgress["kind"]];
 
+/** Legacy-compatible public result shape; v3.0.x producers populate `usage`. */
 export interface WorkflowRunResult {
   meta: WorkflowMeta;
   result: unknown;
   agentsSpawned: number;
   errorCount: number;
+  /** @deprecated Output-token count; use usage.totalTokens. */
   tokensSpent: number;
+  usage?: WorkflowUsage;
   phases: string[];
+}
+
+/** Result produced by `runWorkflow`; unlike the legacy boundary, usage is present. */
+export type WorkflowRunResultWithUsage = WorkflowRunResult & {
+  usage: WorkflowUsage;
+};
+
+export class WorkflowExecutionError extends Error {
+  readonly usage?: WorkflowUsage;
+
+  constructor(message: string, usage?: WorkflowUsage, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "WorkflowExecutionError";
+    this.usage = usage;
+  }
 }
 
 export interface RunWorkflowOptions {
   args?: unknown;
+  /** Soft completed-output-token target; in-flight parallel calls may overshoot. */
   budgetTotal?: number | null;
   runAgent: WorkflowAgentRunner;
   signal?: AbortSignal;

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -5,6 +5,8 @@ import {
   type RunWorkflowOptions,
   type WorkflowProgress,
   type WorkflowRunResult,
+  type WorkflowUsage,
+  zeroWorkflowUsage,
 } from "./workflow-core";
 
 // ── Background workflow-job registry ─────────────────────────────────
@@ -21,7 +23,9 @@ export interface WorkflowJobState {
   snapshot: {
     agentsSpawned: number;
     errorCount: number;
+    /** @deprecated Output-token count; use usage.totalTokens. */
     tokensSpent: number;
+    usage?: WorkflowUsage;
     phases: string[];
     lastMessage?: string;
     currentPhase?: string;
@@ -99,6 +103,7 @@ export function startWorkflowJob(
       agentsSpawned: 0,
       errorCount: 0,
       tokensSpent: 0,
+      usage: zeroWorkflowUsage(),
       phases: [],
       runningCount: 0,
     },
@@ -112,6 +117,7 @@ export function startWorkflowJob(
       state.snapshot.agentsSpawned = p.agentsSpawned;
       state.snapshot.errorCount = p.errorCount;
       state.snapshot.tokensSpent = p.tokensSpent;
+      state.snapshot.usage = p.usage ? { ...p.usage } : state.snapshot.usage;
       state.snapshot.runningCount = p.runningCount;
       if (p.kind === "phase" && p.phase) {
         state.snapshot.currentPhase = p.phase;

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -10,7 +10,10 @@ import {
   saveWorkflowScript,
   deleteWorkflowScript,
   type WorkflowAgentRunner,
+  WorkflowExecutionError,
   type WorkflowMeta,
+  type WorkflowUsage,
+  formatWorkflowUsage,
 } from "./workflow-core";
 import {
   getWorkflowCompletionPresentation,
@@ -44,6 +47,38 @@ function workflowNotFoundMessage(workflowId: string): string {
     `Workflow ${workflowId} not found in the current parent session. ` +
     "It may have been created in another session or removed by reload/resume/new/quit."
   );
+}
+
+function presentWorkflowUsage(
+  usage: WorkflowUsage | undefined,
+): WorkflowUsage | undefined {
+  if (
+    !usage ||
+    (usage.totalTokens === 0 && usage.costUsd === 0 && usage.turns === 0)
+  ) {
+    return undefined;
+  }
+  return usage;
+}
+
+function workflowErrorUsage(error: unknown): WorkflowUsage | undefined {
+  return error instanceof WorkflowExecutionError
+    ? presentWorkflowUsage(error.usage)
+    : undefined;
+}
+
+export function formatWorkflowNotificationSummary(
+  job: WorkflowJobState,
+): string {
+  const run = job.result;
+  if (run) {
+    return (
+      `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ` +
+      `${run.tokensSpent} output tokens${run.usage ? ` (${formatWorkflowUsage(run.usage)})` : ""}.`
+    );
+  }
+  const usage = presentWorkflowUsage(job.snapshot.usage);
+  return `${job.error ?? "Workflow did not produce a result."}${usage ? ` (${formatWorkflowUsage(usage)})` : ""}`;
 }
 
 export function registerWorkflowTool(pi: ExtensionAPI): void {
@@ -145,9 +180,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       errorCount,
     );
     const icon = presentation.icon || (job.status === "done" ? "✅" : "❌");
-    const rawSummary = run
-      ? `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} output tokens.`
-      : (job.error ?? "Workflow did not produce a result.");
+    const rawSummary = formatWorkflowNotificationSummary(job);
     const summary = truncateWorkflowNotification(sanitizeOutput(rawSummary));
     let content = `${icon} Workflow "${job.name}" (${job.id}) ${presentation.label} — ${summary}`;
     if (run) {
@@ -164,6 +197,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
             workflowId: job.id,
             status: job.status,
             presentationStatus: presentation.label,
+            usage: run?.usage ?? job.snapshot.usage,
           },
         },
         { deliverAs: "followUp", triggerTurn: true },
@@ -207,7 +241,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       "  parallel(thunks)       -> run `() => Promise` thunks concurrently (barrier); failures -> null.",
       "  pipeline(items, ...st) -> stream each item through stages, no barrier between stages.",
       "  workflow(name, args?)  -> run a saved workflow inline (one level deep).",
-      "  phase(title) / log(msg)-> progress UI only.  args -> your `args`.  budget -> token accounting.",
+      "  phase(title) / log(msg)-> progress UI only.  args -> your `args`.  budget -> soft completed-output-token target; parallel in-flight calls may overshoot.",
       "",
       "Default: run in the background and return a workflowId immediately (async). Use async: false for synchronous execution.",
       "Poll with get_workflow_status / get_workflow_result. Up to 100 jobs; cancel with cancel_workflow.",
@@ -234,7 +268,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       budget: Type.Optional(
         Type.Number({
           description:
-            "Optional total output-token target; agent() throws once exhausted.",
+            "Optional soft completed-output-token target; in-flight calls may overshoot it, especially in parallel.",
         }),
       ),
       async: Type.Optional(
@@ -336,6 +370,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
                   runningCount: p.runningCount,
                   errorCount: p.errorCount,
                   tokensSpent: p.tokensSpent,
+                  usage: p.usage,
                 },
               });
             } catch {
@@ -357,7 +392,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
           : "complete";
         const summary =
           `${completionPrefix}Workflow "${run.meta.name}" ${completionLabel} — ` +
-          `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} output tokens.`;
+          `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} output tokens (${formatWorkflowUsage(run.usage)}).`;
         return {
           content: [{ type: "text", text: `${summary}\n\n${resultText}` }],
           details: {
@@ -367,14 +402,22 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
             agentsSpawned: run.agentsSpawned,
             errorCount: run.errorCount,
             tokensSpent: run.tokensSpent,
+            usage: run.usage,
             phases: run.phases,
           },
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        const usage = workflowErrorUsage(err);
+        const usageDetails = usage ? { usage } : {};
         return {
-          content: [{ type: "text", text: `Workflow failed: ${msg}` }],
-          details: { status: "error", error: msg },
+          content: [
+            {
+              type: "text",
+              text: `Workflow failed: ${msg}${usage ? ` (${formatWorkflowUsage(usage)})` : ""}`,
+            },
+          ],
+          details: { status: "error", error: msg, ...usageDetails },
           isError: true,
         };
       }
@@ -386,7 +429,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
     name: "get_workflow_status",
     label: "Workflow Status",
     description:
-      "Poll a background workflow's live progress (agents spawned, errors, tokens, current phase).",
+      "Poll a background workflow's live progress (agents spawned, errors, output tokens, total usage, current phase).",
     parameters: Type.Object({
       workflowId: Type.String({
         description: "Workflow ID returned by an async `workflow` spawn.",
@@ -418,7 +461,10 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
               (st.snapshot.runningCount && st.snapshot.runningCount > 0
                 ? `, ${st.snapshot.runningCount} running`
                 : "") +
-              `, ${errorCount} error(s), ${st.snapshot.tokensSpent} tokens` +
+              `, ${errorCount} error(s), ${st.snapshot.tokensSpent} output tokens` +
+              (st.snapshot.usage
+                ? ` (${formatWorkflowUsage(st.snapshot.usage)})`
+                : "") +
               (st.snapshot.currentPhase
                 ? `, phase: ${st.snapshot.currentPhase}`
                 : "") +
@@ -478,7 +524,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
                   : "complete";
                 return (
                   `${prefix}Workflow "${run.meta.name}" ${label} — ` +
-                  `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} tokens.\n\n${resultText}`
+                  `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} output tokens${run.usage ? ` (${formatWorkflowUsage(run.usage)})` : ""}.\n\n${resultText}`
                 );
               })(),
             },
@@ -491,16 +537,27 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
             agentsSpawned: run.agentsSpawned,
             errorCount: run.errorCount,
             tokensSpent: run.tokensSpent,
+            usage: run.usage,
             phases: run.phases,
           },
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        const usage = presentWorkflowUsage(st.snapshot.usage);
+        const usageDetails = usage ? { usage } : {};
         return {
           content: [
-            { type: "text", text: `Workflow ${st.id} ${st.status}: ${msg}` },
+            {
+              type: "text",
+              text: `Workflow ${st.id} ${st.status}: ${msg}${usage ? ` (${formatWorkflowUsage(usage)})` : ""}`,
+            },
           ],
-          details: { status: st.status, workflowId: st.id, error: msg },
+          details: {
+            status: st.status,
+            workflowId: st.id,
+            error: msg,
+            ...usageDetails,
+          },
           isError: true,
         };
       }
@@ -876,7 +933,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
 
     pi.registerCommand("workflow-status", {
       description:
-        "List running and completed workflow jobs with status, agent counts, tokens, and elapsed time.",
+        "List running and completed workflow jobs with status, agent counts, output tokens, total usage, and elapsed time.",
       handler: async (_args: string, ctx: ExtensionCommandContext) => {
         const text = renderWorkflowJobs();
         ctx.ui.notify("📋 Workflow status listed.");
@@ -1017,7 +1074,8 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
         parts.push(`⚡ ${s.runningCount} running`);
       }
       if (errorCount > 0) parts.push(`⚠ ${errorCount} error(s)`);
-      parts.push(`${s.tokensSpent} tokens`);
+      parts.push(`${s.tokensSpent} output tokens`);
+      if (s.usage) parts.push(formatWorkflowUsage(s.usage));
       parts.push(elapsed);
       if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);
       if (st.error) parts.push(`error: ${st.error}`);

--- a/src/workflow-tree-ui.ts
+++ b/src/workflow-tree-ui.ts
@@ -4,6 +4,7 @@ import {
   workflowJobRegistry,
   type WorkflowJobState,
 } from "./workflow-jobs";
+import { formatWorkflowUsage } from "./workflow-core";
 
 export type WorkflowTreeAction =
   { kind: "cancel"; workflowId: string } | { kind: "close" };
@@ -204,7 +205,8 @@ function formatWorkflowSummary(job: WorkflowJobState): string {
     `${s.runningCount ?? 0} running`,
   ];
   if (errorCount > 0) parts.push(`${errorCount} errors`);
-  parts.push(`${s.tokensSpent} tokens`);
+  parts.push(`${s.tokensSpent} output tokens`);
+  if (s.usage) parts.push(formatWorkflowUsage(s.usage));
   if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);
   return parts.join(" · ");
 }

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -1,4 +1,4 @@
-import type { WorkflowProgress } from "./workflow-core";
+import { formatWorkflowUsage, type WorkflowProgress } from "./workflow-core";
 import { assertNever } from "./artifact";
 
 // ── Workflow progress renderer ───────────────────────────────────────
@@ -6,7 +6,8 @@ export function renderProgress(p: WorkflowProgress): string {
   const parts = [`● workflow — ${p.agentsSpawned} agent(s)`];
   if (p.runningCount > 0) parts.push(`⚡ ${p.runningCount} running`);
   if (p.errorCount > 0) parts.push(`⚠ ${p.errorCount} error(s)`);
-  parts.push(`${p.tokensSpent} tokens`);
+  parts.push(`${p.tokensSpent} output tokens`);
+  if (p.usage) parts.push(formatWorkflowUsage(p.usage));
   const head = parts.join(", ");
   switch (p.kind) {
     case "phase":

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -33,8 +33,12 @@ import {
   type WorkflowMeta,
   type WorkflowProgress,
   type WorkflowProgressUpdate,
-  type WorkflowRunResult,
+  type WorkflowRunResultWithUsage,
+  WorkflowExecutionError,
+  type WorkflowUsage,
+  addWorkflowUsage,
   zeroUsage,
+  zeroWorkflowUsage,
 } from "./workflow-core";
 import { workflowStringify } from "./workflow-script";
 import {
@@ -59,35 +63,62 @@ interface Engine {
   counters: {
     agentsSpawned: number;
     errorCount: number;
+    /** @deprecated Output-token count; use usage.totalTokens. */
     tokensSpent: number;
     runningCount: number;
   };
+  usage: WorkflowUsage;
+  failureCause?: unknown;
   phases: string[];
 }
 
 function withProgressCounters(
   progress: WorkflowProgressUpdate,
   counters: Engine["counters"],
+  usage: WorkflowUsage,
 ): WorkflowProgress {
   switch (progress.kind) {
     case "phase":
     case "log":
     case "agent_start":
     case "agent_done":
-      return { ...progress, ...counters };
+      return { ...progress, ...counters, usage: { ...usage } };
     default:
       return assertNever(progress);
   }
 }
 
+function usageIfPresent(usage: WorkflowUsage): WorkflowUsage | undefined {
+  if (usage.totalTokens === 0 && usage.costUsd === 0 && usage.turns === 0) {
+    return undefined;
+  }
+  return { ...usage };
+}
+
+function workflowFailureCause(
+  error: unknown,
+  engine: Engine,
+  signal: AbortSignal | undefined,
+): unknown {
+  if (signal?.aborted && signal.reason !== undefined) return signal.reason;
+  const candidate = engine.failureCause;
+  if (candidate !== undefined) {
+    const message =
+      candidate instanceof Error ? candidate.message : String(candidate);
+    if (error instanceof Error && error.message.includes(message))
+      return candidate;
+  }
+  return error;
+}
+
 export async function runWorkflow(
   script: string,
   opts: RunWorkflowOptions,
-): Promise<WorkflowRunResult> {
+): Promise<WorkflowRunResultWithUsage> {
   const abort = new AbortController();
-  const forwardAbort = () => abort.abort();
+  const forwardAbort = () => abort.abort(opts.signal?.reason);
   if (opts.signal?.aborted) {
-    abort.abort();
+    abort.abort(opts.signal.reason);
   } else {
     opts.signal?.addEventListener("abort", forwardAbort, { once: true });
   }
@@ -109,6 +140,7 @@ export async function runWorkflow(
       tokensSpent: 0,
       runningCount: 0,
     },
+    usage: zeroWorkflowUsage(),
     workflowTimeoutMs: opts.workflowTimeoutMs ?? WORKFLOW_WALL_TIMEOUT_MS,
     phases: [],
   };
@@ -120,8 +152,17 @@ export async function runWorkflow(
       agentsSpawned: engine.counters.agentsSpawned,
       errorCount: engine.counters.errorCount,
       tokensSpent: engine.counters.tokensSpent,
-      phases: engine.phases,
+      usage: { ...engine.usage },
+      phases: [...engine.phases],
     };
+  } catch (error) {
+    if (error instanceof WorkflowExecutionError && error.usage) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new WorkflowExecutionError(
+      message,
+      usageIfPresent(engine.usage),
+      workflowFailureCause(error, engine, opts.signal),
+    );
   } finally {
     opts.signal?.removeEventListener("abort", forwardAbort);
   }
@@ -144,7 +185,7 @@ async function executeScript(
   const emit = (p: WorkflowProgressUpdate) => {
     if (engine.closed) return;
     if (p.kind === "phase" && p.phase) engine.phases.push(p.phase);
-    engine.onProgress?.(withProgressCounters(p, engine.counters));
+    engine.onProgress?.(withProgressCounters(p, engine.counters, engine.usage));
   };
 
   const runAgentCall = async (payload: {
@@ -216,11 +257,13 @@ async function executeScript(
               },
             });
           } catch (error) {
+            engine.failureCause = error;
             if (!engine.signal.aborted) engine.counters.errorCount++;
             throw error;
           }
           const outTokens = res.usage?.output ?? 0;
           tokensDelta += outTokens;
+          engine.usage = addWorkflowUsage(engine.usage, res.usage);
           engine.counters.tokensSpent += outTokens;
 
           if (res.isError) {

--- a/tests/workflow-schema.test.ts
+++ b/tests/workflow-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SubagentResult } from "../src/helpers";
-import { validateSchema } from "../src/workflow-core";
-import { runWorkflow } from "../src/workflow";
+import { SCHEMA_RETRIES, validateSchema } from "../src/workflow-core";
+import { runWorkflow, type WorkflowProgress } from "../src/workflow";
 
 type Schema = Record<string, unknown>;
 
@@ -167,4 +167,89 @@ describe("workflow schema retries", () => {
     expect(result.result).toEqual({ value: 2 });
     expect(calls).toBe(2);
   });
+});
+
+describe("workflow schema usage accounting", () => {
+  it("sums usage from every schema attempt", async () => {
+    let calls = 0;
+    const script = `
+      export const meta = { name: "schema-usage", description: "test" };
+      return await agent("return the value", {
+        isolation: "in-process",
+        schema: { type: "object", properties: { value: { type: "number" } } },
+      });
+    `;
+    const result = await runWorkflow(script, {
+      runAgent: async () => {
+        calls++;
+        return {
+          ...ok(calls === 1 ? '{"value": "wrong"}' : '{"value": 2}'),
+          usage: {
+            input: 10,
+            output: 4,
+            cacheRead: 2,
+            cacheWrite: 1,
+            cost: 0.05,
+            turns: 1,
+          },
+        };
+      },
+    });
+
+    expect(result.result).toEqual({ value: 2 });
+    expect(calls).toBe(2);
+    expect(result.tokensSpent).toBe(8);
+    expect(result.usage).toEqual({
+      input: 20,
+      output: 8,
+      cacheRead: 4,
+      cacheWrite: 2,
+      totalTokens: 34,
+      costUsd: 0.1,
+      turns: 2,
+    });
+  });
+});
+
+it("aggregates all failed schema attempts in result and progress", async () => {
+  let calls = 0;
+  const progress: WorkflowProgress[] = [];
+  const script = `
+      export const meta = { name: "schema-all-fail", description: "test" };
+      return await agent("return the value", {
+        isolation: "in-process",
+        schema: { type: "object", properties: { value: { type: "number" } } },
+      });
+    `;
+  const result = await runWorkflow(script, {
+    runAgent: async () => {
+      calls++;
+      return {
+        ...ok('{"value": "wrong"}'),
+        usage: {
+          input: 3,
+          output: 2,
+          cacheRead: 1,
+          cacheWrite: 4,
+          cost: 0.1,
+          turns: 1,
+        },
+      };
+    },
+    onProgress: (event) => progress.push(event),
+  });
+
+  expect(calls).toBe(SCHEMA_RETRIES);
+  expect(result.result).toBeNull();
+  expect(result.errorCount).toBe(1);
+  expect(result.usage).toEqual({
+    input: 9,
+    output: 6,
+    cacheRead: 3,
+    cacheWrite: 12,
+    totalTokens: 30,
+    costUsd: 0.1 * 3,
+    turns: 3,
+  });
+  expect(progress.at(-1)?.usage).toEqual(result.usage);
 });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -15,11 +15,15 @@ import {
   workflowJobRegistry,
   awaitInteractiveResult,
   renderProgress,
+  formatWorkflowUsage,
   registerWorkflowTool,
   retryPendingWorkflowNotifications,
   getWorkflowCompletionPresentation,
   MAX_WORKFLOW_NOTIFICATION_ATTEMPTS,
   type WorkflowAgentRunner,
+  type WorkflowUsage,
+  type WorkflowRunResult,
+  type WorkflowRunResultWithUsage,
   type WorkflowProgress,
 } from "../src/workflow";
 import type { SubagentResult } from "../src/helpers";
@@ -30,6 +34,7 @@ import {
   writeOutput,
 } from "../src/artifact";
 import { spawnSync } from "node:child_process";
+import { formatWorkflowNotificationSummary } from "../src/workflow-tool";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -49,6 +54,37 @@ function ok(output: string, outTokens = 0): SubagentResult {
       turns: 1,
     },
     model: "test/model",
+  };
+}
+
+function richOk(
+  output: string,
+  usage = {
+    input: 11,
+    output: 7,
+    cacheRead: 5,
+    cacheWrite: 3,
+    cost: 0.125,
+    turns: 2,
+  },
+): SubagentResult {
+  return { ...ok(output), usage };
+}
+
+function richFail(msg: string): SubagentResult {
+  return {
+    isError: true,
+    output: "",
+    usage: {
+      input: 2,
+      output: 1,
+      cacheRead: 4,
+      cacheWrite: 6,
+      cost: 0.25,
+      turns: 1,
+    },
+    model: undefined,
+    errorMessage: msg,
   };
 }
 function fail(msg = "boom"): SubagentResult {
@@ -349,6 +385,35 @@ describe("agent() + budget", () => {
         },
       ),
     ).rejects.toThrow(/budget exhausted/i);
+  });
+  it("allows parallel in-flight calls to overshoot the soft output target", async () => {
+    let started = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    let bothStarted!: () => void;
+    const bothStartedPromise = new Promise<void>(
+      (resolve) => (bothStarted = resolve),
+    );
+    const runAgent: WorkflowAgentRunner = async () => {
+      started++;
+      if (started === 2) bothStarted();
+      await gate;
+      return ok("done", 4);
+    };
+
+    const completion = runWorkflow(
+      meta +
+        `return await parallel([` +
+        `() => agent("a", { isolation: "in-process" }), ` +
+        `() => agent("b", { isolation: "in-process" })]);`,
+      { runAgent, budgetTotal: 5 },
+    );
+    await bothStartedPromise;
+    release();
+
+    const result = await completion;
+    expect(result.tokensSpent).toBe(8);
+    expect(result.result).toEqual(["done", "done"]);
   });
 });
 
@@ -1335,7 +1400,7 @@ describe("renderProgress", () => {
     const result = renderProgress(p);
     expect(result).toContain("● workflow — 2 agent(s)");
     expect(result).toContain("⚡ 1 running");
-    expect(result).toContain("100 tokens");
+    expect(result).toContain("100 output tokens");
     expect(result).toContain("◆ phase: Scanning");
   });
 
@@ -1351,7 +1416,7 @@ describe("renderProgress", () => {
     const result = renderProgress(p);
     expect(result).toContain("● workflow — 3 agent(s)");
     expect(result).not.toContain("⚡");
-    expect(result).toContain("50 tokens");
+    expect(result).toContain("50 output tokens");
     expect(result).toContain("hello");
   });
 
@@ -1450,7 +1515,7 @@ describe("renderProgress", () => {
     expect(result).toContain("⚡ 2 running");
     expect(result).toContain("⚠ 3 error(s)");
     expect(result).toContain("10 agent(s)");
-    expect(result).toContain("500 tokens");
+    expect(result).toContain("500 output tokens");
   });
 });
 
@@ -2110,6 +2175,7 @@ describe("registerWorkflowTool", () => {
     );
     expect(result.details.status).toBe("error");
     expect(result.isError).toBe(true);
+    expect(result.details.usage).toBeUndefined();
     expect(result.content[0].text).toContain("Workflow failed");
   });
 
@@ -2272,6 +2338,247 @@ describe("WorkflowProgress classification matrix", () => {
       WorkflowProgress["kind"]
     >) {
       expect(renderProgress(samples[kind])).toContain(expected[kind]);
+    }
+  });
+});
+
+it("includes usage from returned error results", async () => {
+  const result = await runWorkflow(
+    `export const meta = { name: "usage-errors", description: "d" };\n` +
+      `return await parallel([() => agent("ok"), () => agent("error")]);`,
+    {
+      runAgent: async ({ prompt }) =>
+        prompt === "error" ? richFail("boom") : richOk(prompt),
+    },
+  );
+
+  expect(result.result).toEqual(["ok", null]);
+  expect(result.tokensSpent).toBe(8);
+  expect(result.usage).toEqual({
+    input: 13,
+    output: 8,
+    cacheRead: 9,
+    cacheWrite: 9,
+    totalTokens: 39,
+    costUsd: 0.375,
+    turns: 3,
+  });
+});
+
+it("preserves accumulated usage when a later workflow error rejects", async () => {
+  const usage: WorkflowUsage = {
+    input: 11,
+    output: 7,
+    cacheRead: 5,
+    cacheWrite: 3,
+    totalTokens: 26,
+    costUsd: 0.125,
+    turns: 2,
+  };
+  const rejected = runWorkflow(
+    `export const meta = { name: "late-error", description: "d" };\n` +
+      `await agent("hello"); throw new Error("later failure");`,
+    { runAgent: async ({ prompt }) => richOk(prompt) },
+  );
+
+  await expect(rejected).rejects.toMatchObject({ usage });
+});
+
+it("formats USD usage without floating-point artifacts", () => {
+  const usage: WorkflowUsage = {
+    input: 0,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 1,
+    costUsd: 0.1 + 0.2,
+    turns: 1,
+  };
+  expect(formatWorkflowUsage(usage)).toBe("1 total tokens, $0.3");
+});
+
+it("includes accumulated usage in async workflow error results", async () => {
+  const tools: Array<{ name: string; execute: Function }> = [];
+  const pi = {
+    registerTool: vi.fn((def: any) => tools.push(def)),
+    registerFlag: vi.fn(),
+    registerCommand: vi.fn(),
+    on: vi.fn(),
+  };
+  registerWorkflowTool(pi as any);
+  const job = startWorkflowJob(
+    "late-error",
+    `export const meta = { name: "late-error", description: "d" };\n` +
+      `await agent("hello"); throw new Error("later failure");`,
+    { runAgent: async ({ prompt }) => richOk(prompt) },
+  );
+  try {
+    await expect(job.promise).rejects.toThrow("later failure");
+    const getResult = tools.find(
+      (tool) => tool.name === "get_workflow_result",
+    )!;
+    const result = await getResult.execute("", { workflowId: job.id });
+    expect(result.isError).toBe(true);
+    expect(result.details.usage).toEqual({
+      input: 11,
+      output: 7,
+      cacheRead: 5,
+      cacheWrite: 3,
+      totalTokens: 26,
+      costUsd: 0.125,
+      turns: 2,
+    });
+    expect(result.content[0].text).toContain("26 total tokens");
+  } finally {
+    workflowJobRegistry.delete(job.id);
+  }
+});
+
+it("includes snapshot usage in failed completion notification summaries", async () => {
+  const job = startWorkflowJob(
+    "notify-late-error",
+    `export const meta = { name: "notify-late-error", description: "d" };\n` +
+      `await agent("hello"); throw new Error("later failure");`,
+    { runAgent: async ({ prompt }) => richOk(prompt) },
+  );
+  try {
+    await expect(job.promise).rejects.toThrow("later failure");
+    expect(formatWorkflowNotificationSummary(job)).toContain(
+      "26 total tokens, $0.125",
+    );
+  } finally {
+    workflowJobRegistry.delete(job.id);
+  }
+});
+
+it("preserves non-abort cause identity alongside accumulated usage", async () => {
+  const original = new Error("runner failure");
+  let calls = 0;
+  const rejected = runWorkflow(
+    `export const meta = { name: "cause", description: "d" };\n` +
+      `await agent("first"); await agent("second");`,
+    {
+      runAgent: async ({ prompt }) => {
+        calls++;
+        if (prompt === "second") throw original;
+        return richOk(prompt);
+      },
+    },
+  );
+  await expect(rejected).rejects.toMatchObject({
+    cause: original,
+    usage: { totalTokens: 26 },
+  });
+  expect(calls).toBe(2);
+});
+
+it("preserves caller abort reason alongside accumulated usage", async () => {
+  const controller = new AbortController();
+  const reason = new Error("caller cancelled");
+  let secondStarted!: () => void;
+  const secondStartedPromise = new Promise<void>(
+    (resolve) => (secondStarted = resolve),
+  );
+  const never = new Promise<SubagentResult>(() => {});
+  const running = runWorkflow(
+    `export const meta = { name: "abort-cause", description: "d" };\n` +
+      `await agent("first"); await agent("second");`,
+    {
+      signal: controller.signal,
+      runAgent: async ({ prompt }) => {
+        if (prompt === "first") return richOk(prompt);
+        secondStarted();
+        return never;
+      },
+    },
+  );
+  await secondStartedPromise;
+  controller.abort(reason);
+  await expect(running).rejects.toMatchObject({
+    cause: reason,
+    usage: { totalTokens: 26 },
+  });
+});
+
+describe("workflow usage accounting", () => {
+  it("keeps legacy result objects structurally compatible", () => {
+    const legacyResult: WorkflowRunResult = {
+      meta: { name: "legacy", description: "legacy" },
+      result: null,
+      agentsSpawned: 0,
+      errorCount: 0,
+      tokensSpent: 0,
+      phases: [],
+    };
+    expect(legacyResult.usage).toBeUndefined();
+  });
+
+  const meta = `export const meta = { name: "usage", description: "d" };\n`;
+  const usage = {
+    input: 11,
+    output: 7,
+    cacheRead: 5,
+    cacheWrite: 3,
+    costUsd: 0.125,
+    totalTokens: 26,
+    turns: 2,
+  };
+
+  it("does not add usage when a runner throws without a result", async () => {
+    const result = await runWorkflow(
+      meta + `return await parallel([() => agent("boom")]);`,
+      {
+        runAgent: async () => {
+          throw new Error("boom");
+        },
+      },
+    );
+
+    expect(result.errorCount).toBe(1);
+    expect(result.tokensSpent).toBe(0);
+    expect(result.usage).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      turns: 0,
+    });
+  });
+
+  it("aggregates every usage field in a direct run result", async () => {
+    const result: WorkflowRunResultWithUsage = await runWorkflow(
+      meta + `return await agent("hello");`,
+      {
+        runAgent: async ({ prompt }) => richOk(prompt),
+      },
+    );
+
+    expect(result.tokensSpent).toBe(7);
+    expect(result.usage).toEqual(usage);
+  });
+
+  it("includes canonical usage in progress and async job snapshots", async () => {
+    const progress: WorkflowProgress[] = [];
+    const runner: WorkflowAgentRunner = async ({ prompt }) => richOk(prompt);
+    const script = meta + `return await agent("hello");`;
+    const result = await runWorkflow(script, {
+      runAgent: runner,
+      onProgress: (event) => progress.push(event),
+    });
+    const lastProgress = progress.at(-1);
+    expect(lastProgress?.usage).toEqual(usage);
+    expect(result.usage).toEqual(usage);
+
+    const job = startWorkflowJob("usage", script, { runAgent: runner });
+    try {
+      await job.promise;
+      expect(job.snapshot.tokensSpent).toBe(7);
+      expect(job.snapshot.usage).toEqual(usage);
+      expect(job.result?.usage).toEqual(usage);
+    } finally {
+      workflowJobRegistry.delete(job.id);
     }
   });
 });


### PR DESCRIPTION
## Summary

- aggregate workflow input, output, cache-read, cache-write, cost, turn, and total-token usage across every completed agent attempt
- propagate canonical usage through progress, synchronous results, background snapshots, status/result tools, notifications, tree UI, and widgets
- retain deprecated `tokensSpent` and numeric `budget` with their existing completed-output-token semantics
- label output-only values accurately and document that in-flight parallel calls may overshoot the soft numeric budget
- preserve accumulated usage and original causes when workflows fail after agent work

## Compatibility

This PR is additive for v3 consumers:

- `WorkflowRunResult.usage` is optional at the legacy structural boundary
- `runWorkflow()` returns a strongly typed produced-result shape where usage is present
- persisted/rehydrated snapshots without usage remain supported
- no structured budgets or breaking v4 API changes are introduced

## Regression evidence

Fail-first tests demonstrated:

- full usage was previously absent from direct results, progress, retries, and async snapshots
- failed workflows dropped accumulated usage
- error wrapping dropped runner/abort causes
- floating-point cost formatting leaked artifacts
- parallel numeric budgets can overshoot due to in-flight calls

## Verification

- `npm run typecheck`
- `npm test` — 40 files, 959 tests passed
- `npm run format:check`
- `git diff --check`
- `npm run pack:check`

## Stack

This PR is intentionally based on #45 because both changes touch workflow core/worker types. Retarget to `master` after #45 merges.
