### PR TITLE
Fix architecture isolation regressions in state persistence and completion delivery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,9 +14,9 @@ Reference docs for the pi-subagentura project.
 | [workflows.md](./workflows.md)                             | Workflow scripts shipped in the repo (consensus pipelines + converters) |
 | [interactive-tmux-review.md](./interactive-tmux-review.md) | Code review of `src/interactive-tmux.ts` via GLM-5.2                    |
 
-## Workflow scripts at the repo root
+## Workflow scripts in `examples/workflows/`
 
-These are `.mjs` workflow files invoked via the `workflow` tool:
+These are `.mjs` workflow files under `examples/workflows/` invoked via the `workflow` tool:
 
 ```
 skill-to-workflow.mjs       (12 KB)  Generic: Pi skill → workflow script

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -136,7 +136,7 @@ All bundled examples normalize both forms, and the behavior tests exercise each 
 
 ### 2. JSON-stringified payloads for large content
 
-Schema validation breaks on multi-KB string fields. The workflow runtime's `validateSchema` (in `src/workflow-core.ts`) only handles a small subset: `type`, `enum`, `properties`, `required`, `items`, `minItems`, `maxItems`. Anything >10KB inline is risky. Wrap large structured data in a single string field:
+Schema validation breaks on multi-KB string fields. The workflow runtime's `validateSchema` (in `src/workflow-core.ts`) handles a small subset: `type`, `enum`, `properties`, `required`, `additionalProperties: false`, `items`, `minItems`, and `maxItems`. Anything >10KB inline is risky. Wrap large structured data in a single string field:
 
 ```js
 // BAD — critic.md at 22KB breaks validation
@@ -194,9 +194,9 @@ This avoided the "JSON-encoding of large file map fails" failure mode in `packag
 
 The sandbox exposes only: `agent`, `parallel`, `pipeline`, `phase`, `log`, `workflow`, `args`, `budget`, `console`. No `fs`, no `path`, no `process`. Calling `mkdirSync` or `readFileSync` in the script body throws `ReferenceError`. String code generation is disabled, but this VM is still a determinism aid rather than a security boundary. All file I/O must happen in sub-agents via tools.
 
-### 6. `additionalProperties` is silently ignored
+### 6. `additionalProperties: false` rejects unknown keys
 
-The `validateSchema` function in `src/workflow-core.ts` does not check `additionalProperties`. If you write a schema like `{ type: "object", required: ["SKILL.md"], additionalProperties: { type: "string" } }`, the agent may produce objects with extra keys, and they won't be validated. Either enumerate all properties explicitly, or use a single string field (see point 2).
+The `validateSchema` function in `src/workflow-core.ts` enforces `additionalProperties: false` for object schemas. Any output key not listed in `properties` produces a validation error. Use it when an agent result must not contain undeclared keys; otherwise, extra keys are allowed.
 
 ## Round-trip: package ↔ skill ↔ workflow
 
@@ -227,7 +227,6 @@ Pi package source
 
 - Expand converter tests to cover malformed agent output and partial writes.
 - Consider whether the examples should also be installable as named presets.
-- Investigate whether `validateSchema` should support `additionalProperties` natively.
 
 ## Workflow visibility and scaling
 

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -887,7 +887,7 @@ export function readEventBatch(
   }
   if (
     endOffset === offset &&
-    content.byteLength === MAX_EVENT_BATCH_BYTES &&
+    content.byteLength > 0 &&
     offset + content.byteLength < size
   ) {
     endOffset = offset + content.byteLength;

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -245,6 +245,7 @@ export interface EventRecord {
 }
 
 export const MAX_EVENT_BATCH_BYTES = 256 * 1024;
+export const MAX_EVENT_RECORD_BYTES = 4 * MAX_EVENT_BATCH_BYTES;
 export const MAX_EVENT_ID_LENGTH = 128;
 export const MAX_TURN_ID_LENGTH = 256;
 export const MAX_EVENT_TEXT_LENGTH = 2_000;
@@ -821,10 +822,25 @@ export function readEventBatch(
     return { records: [], endOffset: fromOffset };
   }
   const offset = Math.max(0, Math.min(fromOffset, size));
-  const content = Buffer.alloc(Math.min(MAX_EVENT_BATCH_BYTES, size - offset));
+  let content = Buffer.alloc(Math.min(MAX_EVENT_BATCH_BYTES, size - offset));
   try {
-    if (content.byteLength > 0)
+    if (content.byteLength > 0) {
       readSync(fd, content, 0, content.length, offset);
+      while (
+        content.indexOf(0x0a) < 0 &&
+        offset + content.byteLength < size &&
+        content.byteLength < MAX_EVENT_RECORD_BYTES
+      ) {
+        const remaining = Math.min(
+          MAX_EVENT_BATCH_BYTES,
+          size - offset - content.byteLength,
+          MAX_EVENT_RECORD_BYTES - content.byteLength,
+        );
+        const next = Buffer.alloc(remaining);
+        readSync(fd, next, 0, next.length, offset + content.byteLength);
+        content = Buffer.concat([content, next]);
+      }
+    }
   } finally {
     closeSync(fd);
   }
@@ -1572,20 +1588,65 @@ export function saveInteractiveStates(
   if (!current || current.schemaVersion !== CURRENT_STATE_SCHEMA_VERSION) {
     throw new Error(`unsupported schemaVersion: ${payload.schemaVersion}`);
   }
+  withInteractiveStateLock(cwd, () => {
+    const existing = loadInteractiveStates(cwd);
+    writeInteractiveStatesUnlocked(cwd, {
+      ...current,
+      states: { ...(existing?.states ?? {}), ...current.states },
+    });
+  });
+}
+
+const STATE_LOCK_TIMEOUT_MS = 2_000;
+const STATE_LOCK_STALE_MS = 30_000;
+
+function withInteractiveStateLock<T>(cwd: string, action: () => T): T {
+  const piDir = join(cwd, ".pi");
+  const lock = join(piDir, "subagentura-state.lock");
+  mkdirSync(piDir, { recursive: true, mode: 0o700 });
+  const deadline = Date.now() + STATE_LOCK_TIMEOUT_MS;
+  let fd: number | undefined;
+  while (fd === undefined) {
+    try {
+      fd = openSync(lock, "wx", 0o600);
+    } catch (error: any) {
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lock).mtimeMs > STATE_LOCK_STALE_MS) {
+          unlinkSync(lock);
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`timed out acquiring interactive state lock: ${lock}`);
+      }
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+  }
+  try {
+    return action();
+  } finally {
+    closeSync(fd);
+    try {
+      unlinkSync(lock);
+    } catch {
+      /* another recovery path may already have removed a stale lock */
+    }
+  }
+}
+
+function writeInteractiveStatesUnlocked(
+  cwd: string,
+  payload: InteractiveSubagentStateFile,
+): void {
   const file = stateFilePath(cwd);
-
-  mkdirSync(join(cwd, ".pi"), { recursive: true, mode: 0o700 });
-
-  const tmp = file + ".tmp";
-
-  writeFileSync(tmp, JSON.stringify(current, null, 2), { mode: 0o600 });
-
+  const tmp = `${file}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 });
   renameSync(tmp, file);
 }
-// SAFETY: load-modify-write is not atomic across concurrent callers.
-// Safe today only because a pi session is single-event-loop and never
-// calls this re-entrantly. Do NOT call from parallel async paths without
-// adding a write lock.
+
 /**
  * Convenience: load (or create fresh) + add/overwrite entry by id + save.
  * Called from hot paths (spawn) where a write failure must not break the parent.
@@ -1595,33 +1656,32 @@ export function appendInteractiveState(
   entry:
     InteractiveSubagentPersistedStateV1 | InteractiveSubagentPersistedStateV2,
 ): void {
-  const current = loadInteractiveStates(cwd) ?? {
-    schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
-
-    parent: "pi",
-
-    states: {},
-  };
-
-  const art = artifactPath(
-    dirname(entry.artifactDir),
-    basename(entry.artifactDir),
-  );
-  current.states[entry.id] = {
-    ...entry,
-    eventByteCursor: "eventByteCursor" in entry ? entry.eventByteCursor : 0,
-    sessionByteCursor:
-      "sessionByteCursor" in entry ? entry.sessionByteCursor : 0,
-    pendingDeliveries:
-      "pendingDeliveries" in entry ? entry.pendingDeliveries : [],
-    deliveryReceipts: "deliveryReceipts" in entry ? entry.deliveryReceipts : [],
-    legacyCutoverOffset:
-      "legacyCutoverOffset" in entry
-        ? entry.legacyCutoverOffset
-        : eventLogEndOffset(art),
-  };
-
-  saveInteractiveStates(cwd, current);
+  withInteractiveStateLock(cwd, () => {
+    const current = loadInteractiveStates(cwd) ?? {
+      schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
+      parent: "pi",
+      states: {},
+    };
+    const art = artifactPath(
+      dirname(entry.artifactDir),
+      basename(entry.artifactDir),
+    );
+    current.states[entry.id] = {
+      ...entry,
+      eventByteCursor: "eventByteCursor" in entry ? entry.eventByteCursor : 0,
+      sessionByteCursor:
+        "sessionByteCursor" in entry ? entry.sessionByteCursor : 0,
+      pendingDeliveries:
+        "pendingDeliveries" in entry ? entry.pendingDeliveries : [],
+      deliveryReceipts:
+        "deliveryReceipts" in entry ? entry.deliveryReceipts : [],
+      legacyCutoverOffset:
+        "legacyCutoverOffset" in entry
+          ? entry.legacyCutoverOffset
+          : eventLogEndOffset(art),
+    };
+    writeInteractiveStatesUnlocked(cwd, current);
+  });
 }
 
 export function updateInteractiveState(
@@ -1629,39 +1689,35 @@ export function updateInteractiveState(
   id: string,
   update: (entry: InteractiveSubagentPersistedStateV2) => void,
 ): void {
-  const current = loadInteractiveStates(cwd);
-  const entry = current?.states[id];
-  if (!current || !entry) return;
-  update(entry);
-  saveInteractiveStates(cwd, current);
+  withInteractiveStateLock(cwd, () => {
+    const current = loadInteractiveStates(cwd);
+    const entry = current?.states[id];
+    if (!current || !entry) return;
+    update(entry);
+    writeInteractiveStatesUnlocked(cwd, current);
+  });
 }
-
-// SAFETY: load-modify-write is not atomic across concurrent callers.
-// Safe today only because a pi session is single-event-loop and never
-// calls this re-entrantly. Do NOT call from parallel async paths without
-// adding a write lock.
 /**
  * Convenience: load + drop entry by id + save. No-op if absent or file missing.
  */
 export function removeInteractiveState(cwd: string, id: string): void {
-  const current = loadInteractiveStates(cwd);
-
-  if (!current) return;
-
-  if (!(id in current.states)) return;
-
-  delete current.states[id];
-
-  saveInteractiveStates(cwd, current);
+  withInteractiveStateLock(cwd, () => {
+    const current = loadInteractiveStates(cwd);
+    if (!current || !(id in current.states)) return;
+    delete current.states[id];
+    writeInteractiveStatesUnlocked(cwd, current);
+  });
 }
 /**
  * Delete the state file outright. Used on session_shutdown(reason="new") to
  * give the next session a clean slate. No-op if the file doesn't exist.
  */
 export function deleteInteractiveStatesFile(cwd: string): void {
-  try {
-    unlinkSync(stateFilePath(cwd));
-  } catch {
-    /* best effort — file may not exist */
-  }
+  withInteractiveStateLock(cwd, () => {
+    try {
+      unlinkSync(stateFilePath(cwd));
+    } catch {
+      /* best effort — file may not exist */
+    }
+  });
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -206,7 +206,7 @@ declare global {
   var __piSubagenturaPiRef: ExtensionAPI | undefined;
   var __piSubagenturaUi: ExtensionUIContext | undefined;
   var __piSubagenturaSessionManager:
-    { getEntries?: () => unknown[] } | undefined;
+    { getEntries?: () => unknown[]; getSessionId?: () => string } | undefined;
   var __piSubagenturaInjectCount: number | undefined;
   var __piSubagenturaInteractivePollerHandle:
     ReturnType<typeof setInterval> | undefined;

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -32,6 +32,8 @@ const MAX_IN_PROCESS_FLUSH_BYTES = 64 * 1024;
 interface PendingJobCompletion {
   kind: "completion";
   deliveryId: string;
+  ownerPi: ExtensionAPI;
+  ownerSessionId?: string;
   jobState: JobState;
   result: SubagentResult;
 }
@@ -39,6 +41,8 @@ interface PendingJobCompletion {
 interface PendingJobOverflow {
   kind: "overflow";
   deliveryId: string;
+  ownerPi: ExtensionAPI;
+  ownerSessionId?: string;
   overflowPath: string;
   mode: NotifyOnComplete;
   triggerTurn: boolean;
@@ -139,6 +143,8 @@ function collapseOldestJobDelivery(queue: PendingJobDelivery[]): void {
       .update(`in-process-overflow\0${oldest.deliveryId}`)
       .digest("hex")
       .slice(0, 32),
+    ownerPi: oldest.ownerPi,
+    ownerSessionId: oldest.ownerSessionId,
     overflowPath,
     mode: "notify",
     triggerTurn: false,
@@ -271,6 +277,7 @@ export function deliverNotification(
   if (!pi) return; // extension not loaded yet
 
   const mode = jobState.notifyOnComplete ?? "inject";
+  const ownerSessionId = g2.__piSubagenturaSessionManager?.getSessionId?.();
   const deliveryId = createHash("sha256")
     .update(`${jobState.id}\0${mode}`)
     .digest("hex")
@@ -290,6 +297,8 @@ export function deliverNotification(
     queue.push({
       kind: "completion",
       deliveryId,
+      ownerPi: pi,
+      ownerSessionId,
       jobState,
       result: boundedResult,
     });
@@ -321,6 +330,7 @@ export function flushInProcessDeliveries(): void {
   const g = globalThis as any;
   const pi = g.__piSubagenturaPiRef as ExtensionAPI | undefined;
   if (!pi) return;
+  const currentSessionId = g.__piSubagenturaSessionManager?.getSessionId?.();
   const queue = pendingJobDeliveries();
   const llm: Array<{
     pending: PendingJobDelivery;
@@ -332,6 +342,14 @@ export function flushInProcessDeliveries(): void {
   let bytes = 0;
   for (let index = 0; index < queue.length;) {
     const pending = queue[index];
+    const crossedSession =
+      pending.ownerSessionId !== undefined &&
+      currentSessionId !== undefined &&
+      pending.ownerSessionId !== currentSessionId;
+    if (crossedSession) {
+      queue.splice(index, 1);
+      continue;
+    }
     if (pending.kind === "overflow") {
       const content =
         "⚠️ In-process completion delivery overflowed its bounded queue." +

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -26,6 +26,7 @@ import {
   isTurnTerminal,
   lastEvent,
   listArtifacts,
+  MAX_EVENT_RECORD_BYTES,
   listOutputTurns,
   loadInteractiveStates,
   MAX_EVENT_TEXT_LENGTH,
@@ -286,6 +287,32 @@ describe("artifact", () => {
 
     expect(events).toHaveLength(1);
     expect((events[0] as any).eventId).toBe("oversized-completion");
+  });
+
+  it("advances cursor for records larger than MAX_EVENT_RECORD_BYTES", () => {
+    const art = artifactPath(root, "ultra-oversized-event");
+    ensureArtifactDir(art);
+    const event = {
+      version: 2,
+      eventId: "ultra-oversized-completion",
+      turnId: "ultra-oversized-turn",
+      ts: 1,
+      type: "completion",
+      outcome: "done",
+      source: "agent_settled",
+      errorMessage: "x".repeat(MAX_EVENT_RECORD_BYTES + 1024),
+    };
+    writeFileSync(art.statusFile, JSON.stringify(event) + "\n");
+
+    const first = readEventBatch(art, 0);
+
+    expect(first.endOffset).toBeGreaterThan(0);
+
+    const second = readEventBatch(art, first.endOffset);
+
+    expect(second.endOffset).toBeGreaterThan(first.endOffset);
+
+    expect(readEvents(art)).toEqual([]);
   });
 
   describe("readOutput", () => {

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -267,6 +267,27 @@ describe("artifact", () => {
     expect(records).toBe(count);
   });
 
+  it("does not skip a valid event larger than the physical batch size", () => {
+    const art = artifactPath(root, "oversized-event");
+    ensureArtifactDir(art);
+    const event = {
+      version: 2,
+      eventId: "oversized-completion",
+      turnId: "oversized-turn",
+      ts: 1,
+      type: "completion",
+      outcome: "error",
+      source: "agent_settled",
+      errorMessage: "x".repeat(MAX_EVENT_BATCH_BYTES + 1024),
+    };
+    writeFileSync(art.statusFile, JSON.stringify(event) + "\n");
+
+    const events = readEvents(art);
+
+    expect(events).toHaveLength(1);
+    expect((events[0] as any).eventId).toBe("oversized-completion");
+  });
+
   describe("readOutput", () => {
     it("returns null when output.md doesn't exist", () => {
       const art = artifactPath(root, "a");
@@ -994,6 +1015,36 @@ describe("persisted interactive state helpers", () => {
     appendInteractiveState(root, updated);
 
     expect(loadInteractiveStates(root)?.states["abc12345"]?.paneId).toBe("%99");
+  });
+
+  it("preserves updates from concurrent parents using the same cwd", () => {
+    saveInteractiveStates(root, {
+      schemaVersion: 2,
+      parent: "pi",
+      states: {},
+    });
+    const firstParent = loadInteractiveStates(root)!;
+    const secondParent = loadInteractiveStates(root)!;
+    firstParent.states.aaaaaaaa = {
+      ...SAMPLE,
+      id: "aaaaaaaa",
+      artifactDir: "/tmp/artifacts/aaaaaaaa",
+      parentSessionId: "parent-a",
+    };
+    secondParent.states.bbbbbbbb = {
+      ...SAMPLE,
+      id: "bbbbbbbb",
+      artifactDir: "/tmp/artifacts/bbbbbbbb",
+      parentSessionId: "parent-b",
+    };
+
+    saveInteractiveStates(root, firstParent);
+    saveInteractiveStates(root, secondParent);
+
+    expect(Object.keys(loadInteractiveStates(root)!.states).sort()).toEqual([
+      "aaaaaaaa",
+      "bbbbbbbb",
+    ]);
   });
 
   it("removeInteractiveState drops the entry by id", () => {

--- a/tests/notifications-unit.test.ts
+++ b/tests/notifications-unit.test.ts
@@ -165,6 +165,29 @@ describe("in-process completion delivery queue", () => {
     });
     expect(job.notificationDelivered).toBe(true);
   });
+
+  it("does not deliver a queued completion into a replacement parent session", async () => {
+    const firstSessionSend = vi.fn();
+    const secondSessionSend = vi.fn();
+    (globalThis as any).__piSubagenturaPiRef = {
+      sendMessage: firstSessionSend,
+    };
+    (globalThis as any).__piSubagenturaParentStreaming = true;
+    const job = makeJobState({ notifyOnComplete: "notify" });
+
+    deliverNotification(job, SUCCESS_RESULT);
+    await Promise.resolve();
+    expect(firstSessionSend).not.toHaveBeenCalled();
+
+    (globalThis as any).__piSubagenturaPiRef = {
+      sendMessage: secondSessionSend,
+    };
+    (globalThis as any).__piSubagenturaParentStreaming = false;
+    flushInProcessDeliveries();
+
+    expect(secondSessionSend).not.toHaveBeenCalled();
+    expect(job.notificationDelivered).toBeFalsy();
+  });
 });
 
 describe("artifact notification compatibility", () => {

--- a/tests/notifications-unit.test.ts
+++ b/tests/notifications-unit.test.ts
@@ -51,6 +51,7 @@ function cleanGlobals() {
   const globalState = globalThis as any;
   globalState.__piSubagenturaPiRef = undefined;
   globalState.__piSubagenturaUi = undefined;
+  globalState.__piSubagenturaSessionManager = undefined;
   globalState.__piSubagenturaParentStreaming = false;
   globalState.__piSubagenturaPendingJobDeliveries = [];
   globalState.__piSubagenturaInProcessFlushScheduled = false;
@@ -172,6 +173,9 @@ describe("in-process completion delivery queue", () => {
     (globalThis as any).__piSubagenturaPiRef = {
       sendMessage: firstSessionSend,
     };
+    (globalThis as any).__piSubagenturaSessionManager = {
+      getSessionId: () => "parent-session-a",
+    };
     (globalThis as any).__piSubagenturaParentStreaming = true;
     const job = makeJobState({ notifyOnComplete: "notify" });
 
@@ -181,6 +185,9 @@ describe("in-process completion delivery queue", () => {
 
     (globalThis as any).__piSubagenturaPiRef = {
       sendMessage: secondSessionSend,
+    };
+    (globalThis as any).__piSubagenturaSessionManager = {
+      getSessionId: () => "parent-session-b",
     };
     (globalThis as any).__piSubagenturaParentStreaming = false;
     flushInProcessDeliveries();


### PR DESCRIPTION
## Summary
- Isolate in-process completion delivery by parent session context so queued deliveries do not cross session replacement boundaries.
- Add cross-process locking for interactive state persistence and make state updates merge-safe across concurrent writers.
- Improve event batch reader so oversized NDJSON lines are not skipped and cursors still advance deterministically.
- Add regression coverage for all three architecture defects and a guard for records larger than MAX_EVENT_RECORD_BYTES.

## Validation
- `npm run typecheck`
- `npm run test`
- `npm run format:check`
- `npm run pack:check`

## Commits
- f3a75d0 fix: avoid zero-advance on ultra-large event record
- f068fc8 fix: isolate sessions and preserve artifact state
- 0796143 test: reproduce architecture isolation defects
