### PR TITLE
feat(workflow): improve orchestration authoring

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -15,6 +15,28 @@ accidental Node globals and disables string code generation, but it is not a
 security boundary; do not feed arbitrary user-supplied JavaScript to the
 workflow tool.
 
+## Authoring contract
+
+Submit raw JavaScript without markdown fences. The first statement should be a
+pure-literal `export const meta = { name, description, phases? }`; do not use
+TypeScript, imports, `require`, filesystem APIs, `Date.now()`, `Math.random()`,
+or argless `new Date()`. For editor support, reference the published ambient
+declarations at `pi-subagentura/workflow`.
+
+Use workflows only when work decomposes into independent agents or streaming
+stages. The VM globals are `agent`, `parallel`, `pipeline`, `workflow`, `phase`,
+`log`, `args`, immutable `cwd` (the parent execution directory), `budget`,
+`console`, and guarded `Date`/`Math`. `parallel()` takes thunks; `pipeline()`
+moves each item through all stages independently without a between-stage
+barrier. Use unique short labels, include enough context and relevant paths in
+every agent prompt, handle `null` failures, and add a final synthesis agent when
+one coherent result is required.
+
+Call `phase()` at real work-group transitions. Calls to `agent()` inherit the
+current phase unless `phase` is set explicitly. With `schema`, use the plain
+supported JSON Schema subset. In-process agents use native structured output;
+process agents use textual JSON extraction and validation as a fallback.
+
 ## Inventory
 
 | File                     | Size    | Purpose                                                  |
@@ -192,7 +214,11 @@ This avoided the "JSON-encoding of large file map fails" failure mode in `packag
 
 ### 5. The runtime does not inject Node APIs
 
-The sandbox exposes only: `agent`, `parallel`, `pipeline`, `phase`, `log`, `workflow`, `args`, `budget`, `console`. No `fs`, no `path`, no `process`. Calling `mkdirSync` or `readFileSync` in the script body throws `ReferenceError`. String code generation is disabled, but this VM is still a determinism aid rather than a security boundary. All file I/O must happen in sub-agents via tools.
+The sandbox exposes only the documented workflow helpers plus immutable `cwd`,
+`console`, and guarded `Date`/`Math`. No `fs`, no `path`, no `process`. Calling
+`mkdirSync` or `readFileSync` in the script body throws `ReferenceError`. String
+code generation is disabled, but this VM is still a determinism aid rather than
+a security boundary. All file I/O must happen in sub-agents via tools.
 
 ### 6. `additionalProperties: false` rejects unknown keys
 
@@ -283,18 +309,23 @@ updates as workflow log events when the underlying runner exposes them.
 Run `/workflow-tree` to open an overlay over the current session. It supports:
 
 - `↑↓` / `j` / `k` to select a workflow
-- `enter` / `→` to expand or collapse phase/latest-event details
+- `enter` / `→` to expand or collapse phase, latest-event, and per-agent rows
 - `←` to collapse
 - `c` to cancel the selected running workflow
 - `q` / `esc` to close
 
-The overlay is keyboard-driven. Mouse-clickable controls directly on widget rows are still deferred because widgets are intentionally passive status surfaces.
+Each workflow snapshot retains the latest 50 agent-attempt records; the overlay
+displays the latest 20 and reports how many older records were omitted. These
+records show phase, label, model, and status, not full tool-call history.
+
+The overlay is keyboard-driven. Mouse-clickable controls directly on widget rows
+are still deferred because widgets are intentionally passive status surfaces.
 
 #### 4. Remaining gaps
 
 - Workflow widget rows are summaries, not mouse-clickable controls.
 - Progress event coalescing/rate limiting is still basic.
-- The overlay shows workflow-level phase/latest-event details, not full per-agent tool-call history.
+- Per-agent rows do not include full tool-call history.
 
 ### Process isolation
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -40,6 +40,28 @@ workflow({
 });
 ```
 
+## Authoring guidance
+
+Write raw JavaScript without fences. Start with a pure-literal
+`export const meta = { name, description, phases? }` statement; do not use
+TypeScript, imports, `require`, filesystem APIs, `Date.now()`, `Math.random()`,
+or argless `new Date()`. Ambient authoring types are published at
+`pi-subagentura/workflow`. The runtime exposes `agent`, `parallel`, `pipeline`,
+`workflow`, `phase`, `log`, `args`, immutable parent `cwd`, `budget`, `console`,
+and guarded `Date`/`Math`.
+
+Use a workflow only for decomposable multi-agent work. Pass thunks to
+`parallel()`; `pipeline()` streams each item through every stage independently.
+Call `phase()` at real group transitions: later agents inherit that phase unless
+their options explicitly override it. Give agents unique short labels and enough
+context and paths to work independently, handle `null` failures, and use a final
+synthesis agent when the result must be coherent.
+
+Schemas must use the runtime's plain JSON Schema subset. In-process agents use
+native structured output; process-isolated agents fall back to textual JSON
+extraction and validation. Workflow snapshots retain the latest 50 per-agent
+records, while `/workflow-tree` displays the latest 20 and reports omissions.
+
 ## Planning workflows
 
 ### `ralplan-consensus.mjs`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
+        "acorn": "^8.14.0",
         "is-path-inside": "^4.0.0",
         "ndjson": "^2.0.0"
       },
@@ -3676,6 +3677,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "author": "lmn451",
   "license": "MIT",
   "main": "src/subagent.ts",
+  "exports": {
+    ".": "./src/subagent.ts",
+    "./workflow": {
+      "types": "./types/workflow.d.ts"
+    }
+  },
   "type": "module",
   "keywords": [
     "pi-package",
@@ -38,6 +44,7 @@
     "examples/workflows/README.md",
     "examples/workflows/*.mjs",
     "skills/ralplan",
+    "types/workflow.d.ts",
     "src/ndjson.d.ts",
     "src/notifications.ts",
     "src/rendering.ts",
@@ -64,6 +71,7 @@
     "src/workflow-script.mjs",
     "src/workflow-script.d.mts",
     "src/workflow-worker.ts",
+    "src/workflow-structured-output.ts",
     "src/workflow-worker-thread.mjs",
     "src/workflow-jobs.ts",
     "src/workflow-ui.ts",
@@ -126,6 +134,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
+    "acorn": "^8.14.0",
     "is-path-inside": "^4.0.0",
     "ndjson": "^2.0.0"
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,6 +31,10 @@ import {
   createCompatibleSessionRuntime,
 } from "./pi-sdk-compat";
 import {
+  createWorkflowStructuredOutputTool,
+  type WorkflowStructuredOutputCapture,
+} from "./workflow-structured-output";
+import {
   snapshotInProcessSession,
   type CancellationSnapshotReceipt,
   type CancellationSnapshotSource,
@@ -123,6 +127,7 @@ export type SubagentResult =
       usage: Usage;
       model?: string;
       thinkingLevel?: ThinkingLevel;
+      workflowStructuredOutput?: WorkflowStructuredOutputCapture;
     }
   | {
       isError: true;
@@ -131,6 +136,7 @@ export type SubagentResult =
       model?: undefined;
       thinkingLevel?: ThinkingLevel;
       errorMessage: string;
+      workflowStructuredOutput?: WorkflowStructuredOutputCapture;
     };
 
 export interface SubagentLiveStatus {
@@ -367,6 +373,8 @@ export interface StartSubagentJobParams {
   maxAge?: number;
   /** Parent session's model registry for resolving extension-added models (e.g. minimax) */
   parentModelRegistry?: ModelRegistry;
+  /** Optional JSON Schema delivered via a workflow structured-output tool in in-process mode. */
+  workflowStructuredOutputSchema?: unknown;
   onCancellationSnapshot?: (receipt: CancellationSnapshotReceipt) => void;
   cancellationSource?: CancellationSnapshotSource;
   /** Thinking/reasoning level. Pass through to createAgentSession. */
@@ -407,6 +415,7 @@ export async function startSubagentJob(
     onUpdate,
     defaultModel,
     parentModelRegistry,
+    workflowStructuredOutputSchema,
     onCancellationSnapshot,
     cancellationSource,
     thinkingLevel,
@@ -504,11 +513,22 @@ export async function startSubagentJob(
     model: modelLabel ?? "default",
     cwd,
   });
+  const {
+    tool: workflowStructuredOutputTool,
+    capture: workflowStructuredOutput,
+  } =
+    workflowStructuredOutputSchema === undefined
+      ? { tool: undefined, capture: undefined }
+      : createWorkflowStructuredOutputTool(workflowStructuredOutputSchema);
+
   const sessionOptions = buildSessionOptions(sessionRuntime, {
     sessionManager: SessionManager.inMemory(),
     model: targetModel,
     cwd,
     ...(thinkingLevel ? { thinkingLevel } : {}),
+    ...(workflowStructuredOutputTool
+      ? { customTools: [workflowStructuredOutputTool] }
+      : {}),
   });
   const session = (
     await createAgentSession(
@@ -636,10 +656,31 @@ export async function startSubagentJob(
     promptPreview: finalPrompt.slice(0, 500),
   });
 
+  const attachWorkflowStructuredOutput = <T extends SubagentResult>(
+    result: T,
+  ): T =>
+    workflowStructuredOutput === undefined
+      ? result
+      : ({ ...result, workflowStructuredOutput } as T);
+
   // Launch the prompt in a promise chain (NOT awaited — returns immediately).
   // The jobPromise represents the full lifecycle: prompt → extraction → cleanup.
+  let result: SubagentResult = {
+    isError: true,
+    output: "(no output)",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 0,
+    },
+    model: undefined,
+    thinkingLevel: effectiveThinkingLevel,
+    errorMessage: "No subagent result captured.",
+  };
   const jobPromise = (async (): Promise<SubagentResult> => {
-    let result!: SubagentResult;
     try {
       debugLog("info", "prompt_start", { jobId });
       await session.prompt(finalPrompt);
@@ -697,16 +738,16 @@ export async function startSubagentJob(
       }
 
       if (session.agent.state.errorMessage) {
-        result = {
+        result = attachWorkflowStructuredOutput({
           isError: true,
           output: finalOutput || "(no output)",
           usage,
           model: undefined,
           thinkingLevel: effectiveThinkingLevel,
           errorMessage: session.agent.state.errorMessage,
-        };
+        });
       } else {
-        result = {
+        result = attachWorkflowStructuredOutput({
           isError: false,
           output: finalOutput || "(no output)",
           usage,
@@ -714,7 +755,7 @@ export async function startSubagentJob(
             ? `${session.model.provider}/${session.model.id}`
             : undefined,
           thinkingLevel: effectiveThinkingLevel,
-        };
+        });
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -725,7 +766,7 @@ export async function startSubagentJob(
         stack: stack ?? null,
         errorName: err instanceof Error ? err.name : typeof err,
       });
-      result = {
+      result = attachWorkflowStructuredOutput({
         output: `Sub-agent crashed: ${msg}`,
         usage: {
           input: 0,
@@ -739,7 +780,7 @@ export async function startSubagentJob(
         thinkingLevel: effectiveThinkingLevel,
         isError: true,
         errorMessage: msg,
-      };
+      });
     } finally {
       debugLog("info", "job_complete", {
         jobId,

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -110,22 +110,23 @@ export interface WorkflowAgentOpts {
   /** Thinking/reasoning level for the sub-agent. Clamped to model capabilities. */
   thinkingLevel?: ThinkingLevel;
 }
-
 export type WorkflowAgentProgress =
   | {
       kind: "phase";
       phase: string;
       message?: string;
       label?: string;
+      agentId?: number;
     }
   | {
       kind: "log";
       message: string;
       phase?: string;
       label?: string;
+      agentId?: number;
     };
 
-/** Injectable spawn function — the real one wraps startSubagentJob / launchInteractiveSubagent. */
+/** Injectable spawn function — wraps in-process or process-backed agents. */
 export type WorkflowAgentRunner = (req: {
   prompt: string;
   persona?: string;
@@ -133,7 +134,8 @@ export type WorkflowAgentRunner = (req: {
   signal?: AbortSignal;
   isolation?: string;
   label?: string;
-  /** Thinking/reasoning level for the sub-agent. */
+  schema?: unknown;
+  /** Thinking/reasoning for the sub-agent. */
   thinkingLevel?: ThinkingLevel;
   /**
    * Optional callback for emitting progress events from inside the runner.
@@ -159,6 +161,7 @@ export type WorkflowProgress =
       phase: string;
       message?: string;
       label?: string;
+      agentId?: number;
       agentsSpawned: number;
       errorCount: number;
       /** @deprecated Output-token count; use usage.totalTokens. */
@@ -172,6 +175,7 @@ export type WorkflowProgress =
       phase?: string;
       message: string;
       label?: string;
+      agentId?: number;
       agentsSpawned: number;
       errorCount: number;
       /** @deprecated Output-token count; use usage.totalTokens. */
@@ -185,6 +189,7 @@ export type WorkflowProgress =
       phase?: string;
       message?: string;
       label?: string;
+      agentId?: number;
       agentsSpawned: number;
       errorCount: number;
       /** @deprecated Output-token count; use usage.totalTokens. */
@@ -198,6 +203,8 @@ export type WorkflowProgress =
       phase?: string;
       message?: string;
       label?: string;
+      status?: "done" | "error";
+      agentId?: number;
       agentsSpawned: number;
       errorCount: number;
       /** @deprecated Output-token count; use usage.totalTokens. */
@@ -206,6 +213,16 @@ export type WorkflowProgress =
       runningCount: number;
       model?: string;
     };
+
+export interface WorkflowAgentRecord {
+  agentId: number;
+  phase?: string;
+  label?: string;
+  model?: string;
+  status: "running" | "done" | "error";
+}
+
+export const MAX_WORKFLOW_AGENT_RECORDS = 50;
 
 export type WorkflowProgressUpdate = {
   [K in WorkflowProgress["kind"]]: Omit<
@@ -243,6 +260,8 @@ export class WorkflowExecutionError extends Error {
 
 export interface RunWorkflowOptions {
   args?: unknown;
+  /** Parent execution directory exposed to workflow scripts as immutable `cwd`. */
+  cwd?: string;
   /** Soft completed-output-token target; in-flight parallel calls may overshoot. */
   budgetTotal?: number | null;
   runAgent: WorkflowAgentRunner;

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -4,9 +4,11 @@ import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
 import { runWorkflow } from "./workflow-worker";
 import {
   type RunWorkflowOptions,
+  type WorkflowAgentRecord,
   type WorkflowProgress,
   type WorkflowRunResult,
   type WorkflowUsage,
+  MAX_WORKFLOW_AGENT_RECORDS,
   zeroWorkflowUsage,
 } from "./workflow-core";
 
@@ -30,6 +32,8 @@ export interface WorkflowJobState {
     phases: string[];
     lastMessage?: string;
     currentPhase?: string;
+    agentRecords?: WorkflowAgentRecord[];
+    agentRecordsOmitted?: number;
     runningCount?: number;
   };
   result?: WorkflowRunResult;
@@ -111,6 +115,8 @@ export function startWorkflowJob(
       tokensSpent: 0,
       usage: zeroWorkflowUsage(),
       phases: [],
+      agentRecords: [],
+      agentRecordsOmitted: 0,
       runningCount: 0,
     },
     completionNotification: onComplete,
@@ -136,6 +142,9 @@ export function startWorkflowJob(
         state.snapshot.lastMessage = `→ started${formatWorkflowAgentTag(p)}`;
       } else if (p.kind === "agent_done") {
         state.snapshot.lastMessage = `→ done${formatWorkflowAgentTag(p)}`;
+      }
+      if (p.kind === "agent_start" || p.kind === "agent_done") {
+        recordWorkflowAgentProgress(state.snapshot, p);
       }
     },
     onCancellationSnapshot: (receipt) => {
@@ -229,6 +238,42 @@ export function getRunningWorkflowCount(): number {
     if (st.status === "running") count++;
   }
   return count;
+}
+
+function recordWorkflowAgentProgress(
+  snapshot: WorkflowJobState["snapshot"],
+  progress: Extract<WorkflowProgress, { kind: "agent_start" | "agent_done" }>,
+): void {
+  if (typeof progress.agentId !== "number") return;
+  const records = (snapshot.agentRecords ??= []);
+  if (progress.kind === "agent_start") {
+    records.push({
+      agentId: progress.agentId,
+      phase: progress.phase,
+      label: progress.label,
+      model: progress.model,
+      status: "running",
+    });
+  } else {
+    const record = records.find(
+      (candidate) => candidate.agentId === progress.agentId,
+    );
+    if (record) {
+      record.status = progress.status ?? "done";
+    } else {
+      records.push({
+        agentId: progress.agentId,
+        phase: progress.phase,
+        label: progress.label,
+        model: progress.model,
+        status: progress.status ?? "done",
+      });
+    }
+  }
+  while (records.length > MAX_WORKFLOW_AGENT_RECORDS) {
+    records.shift();
+    snapshot.agentRecordsOmitted = (snapshot.agentRecordsOmitted ?? 0) + 1;
+  }
 }
 
 function formatWorkflowAgentTag(p: WorkflowProgress): string {

--- a/src/workflow-script.mjs
+++ b/src/workflow-script.mjs
@@ -1,58 +1,30 @@
-import { runInNewContext } from "node:vm";
+import { parse } from "acorn";
+
+const META_EXPORT_NAME = "meta";
+const RESERVE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
 /** Split a workflow script into its static `meta` literal and executable body. */
-const META_EVAL_TIMEOUT_MS = 100;
-
 export function parseWorkflow(script) {
-  const tokens = scanTopLevelTokens(script);
-  let metaTokenIndex = -1;
-  let braceStart = -1;
-
-  for (let i = 0; i < tokens.length - 4; i++) {
-    if (
-      tokens[i].value === "export" &&
-      tokens[i + 1].value === "const" &&
-      tokens[i + 2].value === "meta" &&
-      tokens[i + 3].value === "="
-    ) {
-      metaTokenIndex = i;
-      braceStart = tokens[i + 4].value === "{" ? tokens[i + 4].start : -1;
-      break;
-    }
-  }
-  if (metaTokenIndex === -1) {
+  const ast = parseWorkflowAst(script);
+  const metaExport = findMetaExport(ast.body);
+  if (metaExport === null) {
     throw new Error(
       "Workflow script must declare `export const meta = { name, description }` as a pure literal.",
     );
   }
-  if (braceStart === -1) {
-    throw new Error(
-      "`export const meta` must be assigned an object literal `{ ... }`.",
-    );
-  }
 
-  const braceEnd = matchBrace(script, braceStart);
-  const metaText = script.slice(braceStart, braceEnd + 1);
   let meta;
   try {
-    const sandbox = Object.assign(Object.create(null), {
-      Date: makeGuardedDate(),
-      Math: makeGuardedMath(),
-    });
-    meta = runInNewContext(`(${metaText})`, sandbox, {
-      timeout: META_EVAL_TIMEOUT_MS,
-      microtaskMode: "afterEvaluate",
-      contextCodeGeneration: { strings: false, wasm: false },
-    });
+    meta = parseMetaLiteral(metaExport.init, "meta");
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `Workflow \`meta\` must be a pure literal (no variables/calls). Eval failed: ${msg}`,
-    );
+    const message = err instanceof Error ? `: ${err.message}` : "";
+    throw new Error(`Workflow \`meta\` must be a pure literal${message}`);
   }
-  if (!meta || typeof meta !== "object") {
-    throw new Error("Workflow `meta` did not evaluate to an object.");
+
+  if (meta == null || typeof meta !== "object" || Array.isArray(meta)) {
+    throw new Error("Workflow `meta` did not evaluate to an object literal.");
   }
+
   if (typeof meta.name !== "string" || !meta.name) {
     throw new Error("Workflow `meta.name` must be a non-empty string.");
   }
@@ -60,319 +32,243 @@ export function parseWorkflow(script) {
     throw new Error("Workflow `meta.description` must be a non-empty string.");
   }
 
-  let metaEnd = braceEnd + 1;
-  if (script[metaEnd] === ";") metaEnd++;
-  const body = stripWorkflowExports(script, tokens, metaTokenIndex, metaEnd);
+  const body = stripWorkflowExports(script, ast.body, metaExport.node);
   return { meta, body };
 }
 
-const CONTROL_HEADER_KEYWORDS = new Set([
-  "if",
-  "while",
-  "for",
-  "with",
-  "switch",
-  "catch",
-]);
-
-function scanTopLevelTokens(src) {
-  const tokens = [];
-  let braceDepth = 0;
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let previousToken = "";
-  const parenContexts = [];
-  let i = 0;
-
-  while (i < src.length) {
-    const c = src[i];
-    if (/\s/.test(c)) {
-      i++;
-      continue;
-    }
-    if (c === '"' || c === "'") {
-      i = skipString(src, i);
-      previousToken = "string";
-      continue;
-    }
-    if (c === "`") {
-      i = skipTemplate(src, i);
-      previousToken = "template";
-      continue;
-    }
-    if (c === "/" && src[i + 1] === "/") {
-      i = skipLineComment(src, i);
-      continue;
-    }
-    if (c === "/" && src[i + 1] === "*") {
-      i = skipBlockComment(src, i);
-      continue;
-    }
-    if (c === "/" && isRegexStart(previousToken)) {
-      i = skipRegex(src, i);
-      previousToken = "regex";
-      continue;
-    }
-
-    const identifier = readIdentifier(src, i);
-    if (identifier) {
-      if (braceDepth === 0 && parenDepth === 0 && bracketDepth === 0) {
-        tokens.push(identifier);
-      }
-      previousToken = identifier.value;
-      i = identifier.end;
-      continue;
-    }
-
-    const token = { value: c, start: i, end: i + 1 };
-    if (braceDepth === 0 && parenDepth === 0 && bracketDepth === 0) {
-      tokens.push(token);
-    }
-    const nextPreviousToken = punctuatorToken(c, previousToken, parenContexts);
-    if (c === "{") braceDepth++;
-    else if (c === "}") braceDepth--;
-    else if (c === "(") parenDepth++;
-    else if (c === ")") parenDepth--;
-    else if (c === "[") bracketDepth++;
-    else if (c === "]") bracketDepth--;
-    previousToken = nextPreviousToken;
-    i++;
-  }
-  return tokens;
+function parseWorkflowAst(script) {
+  return parse(script, {
+    sourceType: "module",
+    ecmaVersion: "latest",
+    allowHashBang: true,
+    allowReturnOutsideFunction: true,
+    ranges: true,
+  });
 }
 
-function stripWorkflowExports(src, tokens, metaTokenIndex, metaEnd) {
-  const ranges = [{ start: tokens[metaTokenIndex].start, end: metaEnd }];
-  for (let i = 0; i < tokens.length; i++) {
-    if (i === metaTokenIndex || tokens[i].value !== "export") continue;
-    let end = tokens[i].end;
-    if (tokens[i + 1]?.value === "default") end = tokens[i + 1].end;
-    ranges.push({ start: tokens[i].start, end });
+function findMetaExport(body) {
+  for (const node of body) {
+    if (!isMetaExport(node)) continue;
+    const decl = node.declaration.declarations[0];
+    return { node, init: decl.init };
   }
-  ranges.sort((a, b) => a.start - b.start);
-  let body = "";
-  let cursor = 0;
-  for (const range of ranges) {
-    body += src.slice(cursor, range.start);
-    cursor = range.end;
-  }
-  return body + src.slice(cursor);
+  return null;
 }
 
-function readIdentifier(src, start) {
-  if (!/[A-Za-z_$]/.test(src[start])) return null;
-  let end = start + 1;
-  while (end < src.length && /[A-Za-z0-9_$]/.test(src[end])) end++;
-  return { value: src.slice(start, end), start, end };
-}
-
-function punctuatorToken(token, previousToken, parenContexts) {
-  if (token === "(") {
-    parenContexts.push(CONTROL_HEADER_KEYWORDS.has(previousToken));
-  } else if (token === ")") {
-    return parenContexts.pop() ? "control-close" : token;
+function isMetaExport(node) {
+  if (
+    node.type !== "ExportNamedDeclaration" ||
+    !node.declaration ||
+    node.declaration.type !== "VariableDeclaration" ||
+    node.declaration.kind !== "const"
+  ) {
+    return false;
   }
-  return token;
-}
 
-function isRegexStart(previousToken) {
+  if (node.declaration.declarations.length !== 1) return false;
+
+  const decl = node.declaration.declarations[0];
   return (
-    !previousToken ||
-    new Set([
-      "(",
-      "control-close",
-      "=",
-      "[",
-      "{",
-      ",",
-      ":",
-      ";",
-      "!",
-      "?",
-      "+",
-      "-",
-      "*",
-      "%",
-      "&",
-      "|",
-      "~",
-      ">",
-      "return",
-      "throw",
-      "case",
-      "delete",
-      "void",
-      "typeof",
-      "new",
-      "in",
-      "instanceof",
-      "else",
-      "do",
-    ]).has(previousToken)
+    decl.id?.type === "Identifier" &&
+    decl.id.name === META_EXPORT_NAME &&
+    !!decl.init
   );
 }
 
-function matchBrace(src, openIdx) {
-  let depth = 0;
-  let i = openIdx;
-  let previousToken = "";
-  const parenContexts = [];
-  while (i < src.length) {
-    const c = src[i];
-    if (c === '"' || c === "'") {
-      i = skipString(src, i);
-      previousToken = "string";
-      continue;
+function parseMetaLiteral(node, path) {
+  if (node.type === "Literal") {
+    if (node.value instanceof RegExp) {
+      throw new Error(`${path}: regex values are not allowed`);
     }
-    if (c === "`") {
-      i = skipTemplate(src, i);
-      previousToken = "template";
-      continue;
+    if (typeof node.value === "bigint") {
+      throw new Error(`${path}: bigint values are not allowed`);
     }
-    if (c === "/" && src[i + 1] === "/") {
-      i = skipLineComment(src, i);
-      continue;
-    }
-    if (c === "/" && src[i + 1] === "*") {
-      i = skipBlockComment(src, i);
-      continue;
-    }
-    if (c === "/" && isRegexStart(previousToken)) {
-      i = skipRegex(src, i);
-      previousToken = "regex";
-      continue;
-    }
-    const identifier = readIdentifier(src, i);
-    if (identifier) {
-      previousToken = identifier.value;
-      i = identifier.end;
-      continue;
-    }
-    const nextPreviousToken = punctuatorToken(c, previousToken, parenContexts);
-    if (c === "{") depth++;
-    else if (c === "}") {
-      depth--;
-      if (depth === 0) return i;
-    }
-    previousToken = nextPreviousToken;
-    i++;
+    return node.value;
   }
-  throw new Error("Unbalanced braces in `export const meta` literal.");
-}
 
-function skipTemplate(src, start) {
-  let i = start + 1;
-  while (i < src.length) {
-    if (src[i] === "\\") {
-      i += 2;
-      continue;
-    }
-    if (src[i] === "`") return i + 1;
-    if (src[i] === "$" && src[i + 1] === "{") {
-      i = skipTemplateExpression(src, i + 2);
-      continue;
-    }
-    i++;
+  if (node.type === "ObjectExpression") {
+    return parseObjectLiteral(node, path);
   }
-  return src.length;
-}
 
-function skipTemplateExpression(src, start) {
-  let depth = 1;
-  let i = start;
-  let previousToken = "";
-  const parenContexts = [];
-  while (i < src.length) {
-    const c = src[i];
-    if (/\s/.test(c)) {
-      i++;
-      continue;
-    }
-    if (c === '"' || c === "'") {
-      i = skipString(src, i);
-      previousToken = "string";
-      continue;
-    }
-    if (c === "`") {
-      i = skipTemplate(src, i);
-      previousToken = "template";
-      continue;
-    }
-    if (c === "/" && src[i + 1] === "/") {
-      i = skipLineComment(src, i);
-      continue;
-    }
-    if (c === "/" && src[i + 1] === "*") {
-      i = skipBlockComment(src, i);
-      continue;
-    }
-    if (c === "/" && isRegexStart(previousToken)) {
-      i = skipRegex(src, i);
-      previousToken = "regex";
-      continue;
-    }
-    const identifier = readIdentifier(src, i);
-    if (identifier) {
-      previousToken = identifier.value;
-      i = identifier.end;
-      continue;
-    }
-    const nextPreviousToken = punctuatorToken(c, previousToken, parenContexts);
-    if (c === "{") depth++;
-    else if (c === "}") {
-      depth--;
-      if (depth === 0) return i + 1;
-    }
-    previousToken = nextPreviousToken;
-    i++;
+  if (node.type === "ArrayExpression") {
+    return parseArrayLiteral(node, path);
   }
-  return src.length;
+
+  if (node.type === "UnaryExpression") {
+    if (node.operator !== "-" && node.operator !== "+") {
+      throw new Error(`${path}: unsupported unary operator ${node.operator}`);
+    }
+    if (
+      node.argument.type !== "Literal" ||
+      typeof node.argument.value !== "number"
+    ) {
+      throw new Error(
+        `${path}: unary expressions are only allowed for numbers`,
+      );
+    }
+    const value = node.argument.value;
+    return node.operator === "-" ? -value : value;
+  }
+
+  if (node.type === "TemplateLiteral") {
+    if (node.expressions.length > 0) {
+      throw new Error(`${path}: template literals must be static`);
+    }
+    if (node.quasis.length !== 1) {
+      throw new Error(`${path}: invalid template literal`);
+    }
+    const template = node.quasis[0];
+    return template.value.cooked ?? template.value.raw;
+  }
+
+  if (node.type === "BinaryExpression") {
+    if (node.operator !== "+") {
+      throw new Error(`${path}: unsupported operator ${node.operator}`);
+    }
+    const left = parseMetaLiteral(node.left, `${path}.left`);
+    const right = parseMetaLiteral(node.right, `${path}.right`);
+    if (!isMetadataPrimitive(left) || !isMetadataPrimitive(right)) {
+      throw new Error(
+        `${path}: binary expressions can only combine primitive literals`,
+      );
+    }
+    return left + right;
+  }
+
+  throw new Error(`${path}: unsupported expression (${node.type})`);
 }
 
-function skipLineComment(src, start) {
-  const newline = src.indexOf("\n", start + 2);
-  return newline === -1 ? src.length : newline;
+function isMetadataPrimitive(value) {
+  const type = typeof value;
+  return (
+    value === null ||
+    type === "string" ||
+    type === "number" ||
+    type === "boolean"
+  );
 }
 
-function skipBlockComment(src, start) {
-  const end = src.indexOf("*/", start + 2);
-  return end === -1 ? src.length : end + 2;
+function parseObjectLiteral(node, path) {
+  const out = {};
+  for (const property of node.properties) {
+    if (property.type !== "Property") {
+      throw new Error(`${path}: spread properties are not allowed`);
+    }
+
+    if (property.kind !== "init") {
+      throw new Error(
+        `${path}: only literal object properties are allowed, not method/getter/setter`,
+      );
+    }
+
+    if (property.shorthand) {
+      throw new Error(`${path}: shorthand properties are not allowed`);
+    }
+
+    if (property.computed) {
+      throw new Error(`${path}: computed keys are not allowed`);
+    }
+
+    if (property.method) {
+      throw new Error(`${path}: method properties are not allowed`);
+    }
+
+    if (property.key == null) {
+      throw new Error(`${path}: missing property key`);
+    }
+
+    const key = parseMetaObjectKey(property.key, path);
+    if (RESERVE_KEYS.has(key)) {
+      throw new Error(
+        `${path}: reserved key ${JSON.stringify(key)} is not allowed`,
+      );
+    }
+
+    if (!property.value) {
+      throw new Error(`${path}.${key}: object property value is missing`);
+    }
+
+    out[key] = parseMetaLiteral(property.value, `${path}.${key}`);
+  }
+
+  return out;
 }
 
-function skipRegex(src, start) {
-  let i = start + 1;
-  let inClass = false;
-  while (i < src.length) {
-    const c = src[i];
-    if (c === "\\") {
-      i += 2;
+function parseMetaObjectKey(key, path) {
+  if (key.type === "Identifier") return key.name;
+  if (key.type === "Literal") {
+    if (key.value === null) {
+      throw new Error(`${path}: null keys are not allowed`);
+    }
+    if (typeof key.value === "string" || typeof key.value === "number") {
+      return String(key.value);
+    }
+    throw new Error(`${path}: unsupported key type ${key.type}`);
+  }
+
+  throw new Error(`${path}: unsupported key type ${key.type}`);
+}
+
+function parseArrayLiteral(node, path) {
+  const out = [];
+  for (let i = 0; i < node.elements.length; i++) {
+    const item = node.elements[i];
+    if (item == null) {
+      throw new Error(`${path}[${i}]: sparse array entries are not allowed`);
+    }
+    out.push(parseMetaLiteral(item, `${path}[${i}]`));
+  }
+  return out;
+}
+
+/** Strip workflow export wrappers into executable statements and remove meta declaration. */
+function stripWorkflowExports(script, body, metaNode) {
+  const removals = [];
+
+  for (const node of body) {
+    if (node === metaNode) {
+      removals.push({
+        start: node.start,
+        end: node.end,
+        replacement: "",
+      });
       continue;
     }
-    if (c === "[") inClass = true;
-    else if (c === "]") inClass = false;
-    else if (c === "/" && !inClass) {
-      i++;
-      while (/[A-Za-z]/.test(src[i])) i++;
-      return i;
-    }
-    i++;
-  }
-  return src.length;
-}
 
-function skipString(src, start) {
-  const quote = src[start];
-  let i = start + 1;
-  while (i < src.length) {
-    const c = src[i];
-    if (c === "\\") {
-      i += 2;
+    if (
+      node.type !== "ExportNamedDeclaration" &&
+      node.type !== "ExportDefaultDeclaration" &&
+      node.type !== "ExportAllDeclaration"
+    ) {
       continue;
     }
-    if (c === quote) return i + 1;
-    i++;
+
+    if (node.declaration) {
+      removals.push({
+        start: node.start,
+        end: node.end,
+        replacement: script.slice(node.declaration.start, node.end),
+      });
+      continue;
+    }
+
+    removals.push({
+      start: node.start,
+      end: node.end,
+      replacement: "",
+    });
   }
-  return src.length;
+
+  if (!removals.length) return script;
+
+  removals.sort((a, b) => b.start - a.start);
+  let out = script;
+  for (const removal of removals) {
+    out = `${out.slice(0, removal.start)}${removal.replacement}${out.slice(
+      removal.end,
+    )}`;
+  }
+  return out;
 }
 
 export function makeGuardedDate() {

--- a/src/workflow-structured-output.ts
+++ b/src/workflow-structured-output.ts
@@ -1,0 +1,70 @@
+import { Type } from "typebox";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+
+export interface WorkflowStructuredOutputCapture {
+  called: boolean;
+  value: unknown;
+}
+
+interface WorkflowStructuredOutputToolDefinition {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  executionMode: "sequential";
+  execute(
+    _toolCallId: string,
+    params: { value: unknown },
+    _signal?: AbortSignal,
+    _onUpdate?: (partialResult: AgentToolResult<unknown>) => void,
+  ): Promise<AgentToolResult<{ value: unknown }>>;
+}
+
+export interface WorkflowStructuredOutputTool {
+  tool: WorkflowStructuredOutputToolDefinition;
+  capture: WorkflowStructuredOutputCapture;
+}
+
+function wrapSchemaWithValue(schema: unknown): unknown {
+  return Type.Object(
+    {
+      value: schema as any,
+    },
+    { required: ["value"] },
+  );
+}
+
+export function createWorkflowStructuredOutputTool(
+  schema: unknown,
+): WorkflowStructuredOutputTool {
+  const capture: WorkflowStructuredOutputCapture = {
+    called: false,
+    value: undefined,
+  };
+
+  const wrappedSchema = wrapSchemaWithValue(schema);
+
+  return {
+    capture,
+    tool: {
+      name: "structured_output",
+      label: "structured output",
+      description:
+        "Return the final structured output for workflow schema-driven calls.",
+      parameters: wrappedSchema,
+      executionMode: "sequential",
+      async execute(
+        _toolCallId: string,
+        params: { value: unknown },
+      ): Promise<AgentToolResult<{ value: unknown }>> {
+        capture.called = true;
+        capture.value = params.value;
+        return Promise.resolve({
+          content: [{ type: "text", text: "Structured output captured." }],
+          details: { value: params.value },
+          terminate: true,
+        });
+      },
+    },
+  };
+}

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -116,6 +116,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       signal,
       isolation,
       label,
+      schema,
       thinkingLevel,
       onProgress,
       onCancellationSnapshot,
@@ -190,6 +191,9 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
         onCancellationSnapshot,
         cancellationSource: "workflow",
         thinkingLevel,
+        ...(isolation === "in-process" && schema !== undefined
+          ? { workflowStructuredOutputSchema: schema }
+          : {}),
       });
       return jobPromise;
     };
@@ -266,7 +270,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       "",
       "Injected helpers/globals:",
       "  agent(prompt, opts?)   -> spawn one isolated sub-agent. opts: { schema?, label?, phase?,",
-      "                            model?, persona?, isolation?, thinkingLevel? (off|minimal|low|medium|high|xhigh|max) }. Without schema returns the final text;",
+      "                            model?, persona?, isolation?, agentType?, thinkingLevel? (off|minimal|low|medium|high|xhigh|max) }. Without schema returns the final text;",
       "                            with schema returns a value validated against the supported JSON Schema",
       "                            subset (type, enum, required/properties, additionalProperties, items,",
       "                            minItems, maxItems), or null after retries. Returns null on error",
@@ -276,13 +280,26 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       "  parallel(thunks)       -> run `() => Promise` thunks concurrently (barrier); failures -> null.",
       "  pipeline(items, ...st) -> stream each item through stages, no barrier between stages.",
       "  workflow(name, args?)  -> run a saved workflow inline (one level deep).",
-      "  phase(title) / log(msg)-> progress UI only.  args -> your `args`.  budget -> soft completed-output-token target; parallel in-flight calls may overshoot.",
+      "  phase(title) / log(msg)-> progress UI only. args -> your `args`; cwd -> immutable parent working directory; budget -> soft completed-output-token target; parallel in-flight calls may overshoot.",
       "",
       "Default: run in the background and return a workflowId immediately (async). Use async: false for synchronous execution.",
       "Poll with get_workflow_status / get_workflow_result. Up to 100 jobs; cancel with cancel_workflow.",
       "Constraints: Date.now()/Math.random()/argless new Date() throw; concurrency capped automatically;",
       `>${MAX_TOTAL_AGENTS} agents or >${MAX_ITEMS_PER_CALL} items per call throws. meta MUST be a pure literal.`,
     ].join("\n"),
+    promptSnippet:
+      "Orchestrate decomposable multi-agent work with trusted raw JavaScript workflows.",
+    promptGuidelines: [
+      "Use workflows only for decomposable multi-agent work; handle simple or sequential tasks directly.",
+      "Pass raw JavaScript with no markdown fences. The first statement must be a pure-literal `export const meta = { name, description, phases? }`.",
+      "Do not use TypeScript, imports, require, fs, or other Node APIs. Date.now(), Math.random(), and argless new Date() are unavailable.",
+      "Available globals are agent, parallel, pipeline, workflow, phase, log, args, immutable cwd, budget, console, guarded Date, and guarded Math.",
+      "Call phase(title) at real work-group transitions. Agent phase defaults to the current phase; an explicit agent phase overrides it.",
+      "parallel() takes thunks such as `() => agent(...)`; pipeline() streams each item through every stage independently, with no barrier between stages.",
+      "Give agent calls unique short labels, include enough task context and relevant paths, and treat failed agents or stages as null.",
+      "Use only the documented plain JSON Schema subset for schema outputs; in-process agents use native structured output while process agents use validated textual JSON fallback.",
+      "Filter or handle null results, then use a final synthesis agent when the workflow needs one coherent answer.",
+    ],
     parameters: Type.Object({
       script: Type.Optional(
         Type.String({
@@ -341,6 +358,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
       const runAgent = makeRunAgent(ctx);
       const baseOpts = {
         args: params.args,
+        cwd: ctx.cwd,
         budgetTotal: params.budget ?? null,
         runAgent,
         loadWorkflow: (n: string) => loadWorkflowScript(n),
@@ -839,6 +857,7 @@ export function registerWorkflowTool(pi: ExtensionAPI): void {
         script,
         {
           args: argsValue,
+          cwd: ctx.cwd,
           budgetTotal: null,
           runAgent: makeRunAgent(ctx),
           loadWorkflow: (n: string) => loadWorkflowScript(n),

--- a/src/workflow-tree-ui.ts
+++ b/src/workflow-tree-ui.ts
@@ -6,6 +6,8 @@ import {
 } from "./workflow-jobs";
 import { formatWorkflowUsage } from "./workflow-core";
 
+const MAX_WORKFLOW_TREE_AGENT_ROWS = 20;
+
 export type WorkflowTreeAction =
   { kind: "cancel"; workflowId: string } | { kind: "close" };
 
@@ -219,6 +221,32 @@ function formatWorkflowDetails(job: WorkflowJobState): WorkflowRow[] {
       depth: 1,
       selectable: false,
       text: `◆ phase: ${phase}`,
+    });
+  }
+  const records = job.snapshot.agentRecords ?? [];
+  const agentRows = records.slice(-MAX_WORKFLOW_TREE_AGENT_ROWS);
+  const omittedForUi =
+    (job.snapshot.agentRecordsOmitted ?? 0) +
+    Math.max(0, records.length - agentRows.length);
+  if (omittedForUi > 0) {
+    rows.push({
+      job,
+      depth: 1,
+      selectable: false,
+      text: `… ${omittedForUi} older agent records omitted`,
+    });
+  }
+  for (const record of agentRows) {
+    const marker =
+      record.status === "running" ? "→" : record.status === "error" ? "✗" : "✓";
+    const label = `${record.label ?? "agent"} #${record.agentId}`;
+    const model = record.model ? ` @${record.model}` : "";
+    const phase = record.phase ? ` (${record.phase})` : "";
+    rows.push({
+      job,
+      depth: 1,
+      selectable: false,
+      text: `${marker} ${record.status} ${label}${model}${phase}`,
     });
   }
   if (job.snapshot.lastMessage) {

--- a/src/workflow-worker-thread.mjs
+++ b/src/workflow-worker-thread.mjs
@@ -20,6 +20,7 @@ let workerConfig = {
   maxItemsPerCall: 4096,
   maxWorkflowDepth: 1,
   budgetTotal: null,
+  cwd: "",
 };
 let tokensSpent = 0;
 
@@ -50,6 +51,7 @@ parentPort.on("message", (msg) => {
       maxItemsPerCall: msg.maxItemsPerCall,
       maxWorkflowDepth: msg.maxWorkflowDepth,
       budgetTotal: msg.budgetTotal,
+      cwd: msg.cwd,
     };
     executeScript(msg.script, msg.args, 0)
       .then((value) => parentPort.postMessage({ type: "result", value }))
@@ -80,6 +82,8 @@ async function executeScript(script, args, depth) {
 }
 
 async function executeBody(meta, body, args, depth) {
+  let currentPhase;
+
   function checkAbort() {
     if (aborted) throw new Error("Workflow aborted.");
   }
@@ -93,7 +97,19 @@ async function executeBody(meta, body, args, depth) {
       if (workerConfig.budgetTotal != null && budgetRemaining() <= 0) {
         throw new Error("Workflow token budget exhausted.");
       }
-      const res = await rpc("agent", { prompt, opts });
+      const hasExplicitPhase = Object.prototype.hasOwnProperty.call(
+        opts,
+        "phase",
+      );
+      const resolvedPhase =
+        hasExplicitPhase && opts.phase != null
+          ? String(opts.phase)
+          : currentPhase;
+      const callOpts = { ...opts, phase: resolvedPhase };
+      const res = await rpc("agent", {
+        prompt,
+        opts: callOpts,
+      });
       tokensSpent +=
         res && typeof res.tokensDelta === "number" ? res.tokensDelta : 0;
       return res ? res.value : null;
@@ -169,6 +185,7 @@ async function executeBody(meta, body, args, depth) {
 
   function phase(title) {
     const t = String(title ?? "");
+    currentPhase = t;
     parentPort.postMessage({
       type: "progress",
       payload: { kind: "phase", phase: t },
@@ -214,6 +231,12 @@ async function executeBody(meta, body, args, depth) {
     },
     Date: makeGuardedDate(),
     Math: makeGuardedMath(),
+  });
+  Object.defineProperty(sandbox, "cwd", {
+    value: workerConfig.cwd,
+    enumerable: true,
+    writable: false,
+    configurable: false,
   });
 
   try {

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -60,6 +60,7 @@ interface Engine {
   sem: Semaphore;
   processSem: Semaphore;
   loadWorkflow?: (name: string) => string | null;
+  cwd: string;
   budgetTotal: number | null;
   workflowTimeoutMs: number;
   counters: {
@@ -69,6 +70,8 @@ interface Engine {
     tokensSpent: number;
     runningCount: number;
   };
+  nextAgentAttemptId: number;
+
   usage: WorkflowUsage;
   failureCause?: unknown;
   phases: string[];
@@ -136,6 +139,7 @@ export async function runWorkflow(
       opts.processConcurrency ?? defaultProcessConcurrency(),
     ),
     loadWorkflow: opts.loadWorkflow,
+    cwd: opts.cwd ?? process.cwd(),
     budgetTotal: opts.budgetTotal ?? null,
     counters: {
       agentsSpawned: 0,
@@ -143,6 +147,8 @@ export async function runWorkflow(
       tokensSpent: 0,
       runningCount: 0,
     },
+    nextAgentAttemptId: 0,
+
     usage: zeroWorkflowUsage(),
     workflowTimeoutMs: opts.workflowTimeoutMs ?? WORKFLOW_WALL_TIMEOUT_MS,
     phases: [],
@@ -187,31 +193,27 @@ async function executeScript(
 ): Promise<{ meta: WorkflowMeta; result: unknown }> {
   const emit = (p: WorkflowProgressUpdate) => {
     if (engine.closed) return;
-    if (p.kind === "phase" && p.phase) engine.phases.push(p.phase);
+    if (p.kind === "phase" && p.phase) {
+      engine.phases.push(p.phase);
+    }
     engine.onProgress?.(withProgressCounters(p, engine.counters, engine.usage));
   };
-
   const runAgentCall = async (payload: {
     prompt: unknown;
     opts?: WorkflowAgentOpts;
   }): Promise<{ value: unknown; tokensDelta: number }> => {
-    const prompt = payload.prompt;
-    const agentOpts = payload.opts ?? {};
-    if (engine.signal?.aborted) throw new Error("Workflow aborted.");
-    if (typeof prompt !== "string" || prompt.trim() === "") {
+    if (typeof payload.prompt !== "string" || payload.prompt.trim() === "") {
       throw new Error("agent(prompt): prompt must be a non-empty string.");
     }
-    if (
-      engine.budgetTotal != null &&
-      engine.budgetTotal - engine.counters.tokensSpent <= 0
-    ) {
-      throw new Error("Workflow token budget exhausted.");
-    }
 
+    const prompt = payload.prompt;
+    const agentOpts = payload.opts ?? {};
     const hasSchema = agentOpts.schema != null;
     const isolation = agentOpts.isolation ?? "process";
     const isProcess = isolation !== "in-process";
     const sem = isProcess ? engine.processSem : engine.sem;
+    const resolvedPhase =
+      agentOpts.phase != null ? String(agentOpts.phase) : undefined;
     await sem.acquire();
     let tokensDelta = 0;
     try {
@@ -225,17 +227,26 @@ async function executeScript(
           );
         }
         engine.counters.agentsSpawned++;
+        const agentId = ++engine.nextAgentAttemptId;
         engine.counters.runningCount++;
+        let status: "done" | "error" = "done";
         try {
-          // Emit *before* awaiting runAgent so status polling sees in-flight process agents.
           emit({
             kind: "agent_start",
             label: agentOpts.label,
-            phase: agentOpts.phase,
+            phase: resolvedPhase,
             model: agentOpts.model,
+            agentId,
           });
           const finalPrompt = hasSchema
-            ? buildSchemaPrompt(prompt, agentOpts.schema, attempt, lastErr)
+            ? isProcess
+              ? buildProcessSchemaPrompt(
+                  prompt,
+                  agentOpts.schema,
+                  attempt,
+                  lastErr,
+                )
+              : buildInProcessSchemaPrompt(prompt, attempt, lastErr)
             : prompt;
           let res: SubagentResult;
           try {
@@ -246,22 +257,25 @@ async function executeScript(
               signal: engine.signal,
               isolation,
               label: agentOpts.label,
+              ...(hasSchema && !isProcess ? { schema: agentOpts.schema } : {}),
               onCancellationSnapshot: engine.onCancellationSnapshot,
               thinkingLevel: agentOpts.thinkingLevel,
               onProgress: (ev) => {
                 if (ev.kind === "phase") {
                   if (ev.phase) {
-                    emit({
-                      ...ev,
-                      phase: agentOpts.phase ?? ev.phase,
-                    });
+                    emit({ ...ev, phase: ev.phase, agentId });
                   }
                   return;
                 }
-                emit({ ...ev, phase: agentOpts.phase });
+                emit({
+                  ...ev,
+                  phase: ev.phase ?? resolvedPhase,
+                  agentId,
+                });
               },
             });
           } catch (error) {
+            status = "error";
             engine.failureCause = error;
             if (!engine.signal.aborted) engine.counters.errorCount++;
             throw error;
@@ -270,24 +284,42 @@ async function executeScript(
           tokensDelta += outTokens;
           engine.usage = addWorkflowUsage(engine.usage, res.usage);
           engine.counters.tokensSpent += outTokens;
-
           if (res.isError) {
+            status = "error";
             engine.counters.errorCount++;
             return { value: null, tokensDelta };
           }
           if (!hasSchema) return { value: res.output, tokensDelta };
-
+          if (!isProcess && res.workflowStructuredOutput != null) {
+            const schemaCapture = res.workflowStructuredOutput;
+            if (!schemaCapture?.called) {
+              status = "error";
+              lastErr = "No structured_output call found.";
+              continue;
+            }
+            const verrs = validateSchema(schemaCapture.value, agentOpts.schema);
+            if (verrs.length === 0)
+              return { value: schemaCapture.value, tokensDelta };
+            status = "error";
+            lastErr = verrs.slice(0, 5).join("; ");
+            continue;
+          }
           const raw = extractJson(res.output);
           if (raw != null) {
             try {
               const parsed = JSON.parse(raw);
               const verrs = validateSchema(parsed, agentOpts.schema);
               if (verrs.length === 0) return { value: parsed, tokensDelta };
+              status = "error";
               lastErr = verrs.slice(0, 5).join("; ");
             } catch (e) {
-              lastErr = `JSON parse error: ${e instanceof Error ? e.message : String(e)}`;
+              status = "error";
+              lastErr = `JSON parse error: ${
+                e instanceof Error ? e.message : String(e)
+              }`;
             }
           } else {
+            status = "error";
             lastErr = "no JSON object/array found in output";
           }
         } finally {
@@ -295,12 +327,13 @@ async function executeScript(
           emit({
             kind: "agent_done",
             label: agentOpts.label,
-            phase: agentOpts.phase,
+            phase: resolvedPhase,
             model: agentOpts.model,
+            status,
+            agentId,
           });
         }
       }
-
       engine.counters.errorCount++;
       emit({
         kind: "log",
@@ -417,6 +450,7 @@ function runWorkflowWorker(
       type: "init",
       script,
       args,
+      cwd: engine.cwd,
       budgetTotal: engine.budgetTotal,
       syncTimeoutMs: WORKFLOW_SYNC_TIMEOUT_MS,
       maxItemsPerCall: MAX_ITEMS_PER_CALL,
@@ -462,7 +496,7 @@ export function stringify(x: unknown): string {
   return workflowStringify(x);
 }
 
-function buildSchemaPrompt(
+function buildProcessSchemaPrompt(
   prompt: string,
   schema: unknown,
   attempt: number,
@@ -477,6 +511,20 @@ function buildSchemaPrompt(
     `${prompt}\n\n` +
     `Respond with ONLY a single JSON value that conforms to this JSON Schema. ` +
     `No prose, no markdown fences, no commentary.\n\nJSON Schema:\n${schemaText}${retry}`
+  );
+}
+function buildInProcessSchemaPrompt(
+  prompt: string,
+  attempt: number,
+  lastErr: string,
+): string {
+  const retry =
+    attempt > 0
+      ? `\n\nYour previous response did not include a valid structured_output call (${lastErr}). Retry using a single tool call.`
+      : "";
+  return (
+    `${prompt}${retry}` +
+    `\n\nUse the structured_output tool as your ONLY final action.`
   );
 }
 

--- a/tests/published-tarball.test.ts
+++ b/tests/published-tarball.test.ts
@@ -39,6 +39,7 @@ const PKG = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
   name: string;
   version: string;
   files: string[];
+  exports: Record<string, unknown>;
 };
 const NM_SMOKE_DIR = join(
   REPO,
@@ -177,6 +178,17 @@ describe("published tarball", () => {
       "src/helpers.ts is missing from the tarball — this is the exact pi-subagentura@2.0.0 regression. " +
         "Re-add it to package.json `files`.",
     ).toContain("src/helpers.ts");
+  });
+
+  it("publishes workflow declarations through the workflow subpath", () => {
+    expect(entries).toContain("types/workflow.d.ts");
+    const packedPackage = JSON.parse(
+      readFileSync(join(pkgDir, "package.json"), "utf8"),
+    );
+    expect(packedPackage.exports).toEqual({
+      ".": "./src/subagent.ts",
+      "./workflow": { types: "./types/workflow.d.ts" },
+    });
   });
 
   it("contains the workflow guide, examples, and bundled RALPLAN skill", () => {

--- a/tests/workflow-structured-output.test.ts
+++ b/tests/workflow-structured-output.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createWorkflowStructuredOutputTool } from "../src/workflow-structured-output";
+
+describe("workflow structured output tool", () => {
+  it("captures tool output and sets terminate", async () => {
+    const tool = createWorkflowStructuredOutputTool({ type: "number" });
+
+    const result = await tool.tool.execute("call-1", { value: 42 });
+
+    expect(result.terminate).toBe(true);
+    expect(tool.capture).toEqual({ called: true, value: 42 });
+    expect(result.details).toEqual({ value: 42 });
+  });
+
+  it("builds tool parameters with a required value field", () => {
+    const schema = { type: "object", properties: { n: { type: "number" } } };
+    const tool = createWorkflowStructuredOutputTool(schema);
+
+    expect(tool.tool.parameters).toMatchObject({
+      type: "object",
+      required: ["value"],
+      properties: {
+        value: schema,
+      },
+    });
+  });
+
+  it("marks structured-output tools as sequential", () => {
+    const tool = createWorkflowStructuredOutputTool({ type: "string" });
+    expect(tool.tool.executionMode).toBe("sequential");
+  });
+});

--- a/tests/workflow-tree-ui.test.ts
+++ b/tests/workflow-tree-ui.test.ts
@@ -22,6 +22,8 @@ function makeJob(overrides: Partial<WorkflowJobState> = {}): WorkflowJobState {
       currentPhase: "Scan",
       lastMessage: "→ started scout",
       runningCount: 1,
+      agentRecords: [],
+      agentRecordsOmitted: 0,
     },
     ...overrides,
   };
@@ -52,6 +54,80 @@ describe("WorkflowTreeComponent", () => {
     const expanded = component.render(100).join("\n");
     expect(expanded).toContain("◆ phase: Scan");
     expect(expanded).toContain("→ started scout");
+  });
+
+  it("renders latest agent rows with omission count", () => {
+    workflowJobRegistry.set(
+      "wf_test",
+      makeJob({
+        snapshot: {
+          ...makeJob().snapshot,
+          phases: ["Scan"],
+          agentRecords: Array.from({ length: 50 }, (_, index) => ({
+            agentId: index + 2,
+            label: "reused",
+            model: "test/model",
+            status: "done" as const,
+          })),
+          agentRecordsOmitted: 1,
+        },
+      }),
+    );
+
+    const component = new WorkflowTreeComponent({ done: vi.fn() });
+    component.handleInput("\r");
+    const expanded = component.render(220).join("\n");
+
+    expect(expanded).toContain("… 31 older agent records omitted");
+    expect(expanded).toContain("✓ done reused #51 @test/model");
+    expect(expanded).toContain("✓ done reused #32 @test/model");
+    expect(expanded).not.toContain("reused #31");
+  });
+
+  it("shows duplicate labels with stable attempt IDs", () => {
+    workflowJobRegistry.set(
+      "wf_test",
+      makeJob({
+        snapshot: {
+          ...makeJob().snapshot,
+          phases: [],
+          agentRecords: [
+            {
+              agentId: 1,
+              label: "worker",
+              model: "m-1",
+              status: "done",
+            },
+            {
+              agentId: 2,
+              label: "worker",
+              model: "m-2",
+              status: "error",
+            },
+          ],
+          agentRecordsOmitted: 0,
+        },
+      }),
+    );
+
+    const component = new WorkflowTreeComponent({ done: vi.fn() });
+    component.handleInput("\r");
+    const expanded = component.render(220).join("\n");
+
+    expect(expanded).toContain("✓ done worker #1 @m-1");
+    expect(expanded).toContain("✗ error worker #2 @m-2");
+  });
+
+  it("handles legacy snapshots without agent records", () => {
+    const job = makeJob();
+    delete job.snapshot.agentRecords;
+    delete job.snapshot.agentRecordsOmitted;
+    workflowJobRegistry.set(job.id, job);
+    const component = new WorkflowTreeComponent({ done: vi.fn() });
+
+    component.handleInput("\r");
+
+    expect(component.render(100).join("\n")).toContain("→ started scout");
   });
 
   it("navigates, clamps, and collapses selected workflows", () => {

--- a/tests/workflow-types.test-d.ts
+++ b/tests/workflow-types.test-d.ts
@@ -1,0 +1,54 @@
+import type {
+  WorkflowAgentOptions,
+  WorkflowJSONSchema,
+  WorkflowMeta,
+} from "pi-subagentura/workflow";
+
+const meta: WorkflowMeta = {
+  name: "typed-workflow",
+  description: "Exercises the published workflow globals.",
+  phases: [{ title: "Scan", detail: "Inspect inputs" }],
+};
+
+const schema: WorkflowJSONSchema = {
+  type: "object",
+  properties: { ok: { type: "boolean" } },
+  required: ["ok"],
+  additionalProperties: false,
+};
+
+const options = {
+  schema,
+  label: "scan",
+  phase: "Scan",
+  model: "provider/model",
+  persona: "Careful reviewer",
+  isolation: "in-process",
+  agentType: "reviewer",
+  thinkingLevel: "high",
+} satisfies WorkflowAgentOptions;
+
+async function authorWorkflow(): Promise<unknown> {
+  phase(meta.phases?.[0]?.title ?? "Scan");
+  log({ cwd, args, remaining: budget.remaining() });
+
+  const text = await agent("Inspect the repository", { label: "inspect" });
+  const structured = await agent<{ ok: boolean }>("Return status", options);
+  const parallelResults = await parallel([
+    () => agent("Task A"),
+    () => agent("Task B"),
+  ]);
+  const piped = await pipeline(
+    [1, 2],
+    (value) => value * 2,
+    (value, item, index) => ({ value, item, index }),
+  );
+  const nested = await workflow("child", { parentCwd: cwd });
+
+  return { text, structured, parallelResults, piped, nested };
+}
+
+// @ts-expect-error cwd is an immutable workflow global.
+cwd = "/different";
+
+void authorWorkflow;

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,30 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  parseWorkflow,
-  runWorkflow,
-  extractJson,
-  validateSchema,
   MAX_ITEMS_PER_CALL,
-  saveWorkflowScript,
-  loadWorkflowScript,
-  listSavedWorkflows,
-  sanitizeWorkflowName,
+  MAX_WORKFLOW_AGENT_RECORDS,
+  SCHEMA_RETRIES,
   MAX_WORKFLOW_JOBS,
-  startWorkflowJob,
-  deleteWorkflowScript,
-  workflowJobRegistry,
-  awaitInteractiveResult,
-  renderProgress,
-  formatWorkflowUsage,
-  registerWorkflowTool,
-  retryPendingWorkflowNotifications,
-  getWorkflowCompletionPresentation,
   MAX_WORKFLOW_NOTIFICATION_ATTEMPTS,
+  awaitInteractiveResult,
+  deleteWorkflowScript,
+  extractJson,
+  formatWorkflowUsage,
+  getWorkflowCompletionPresentation,
+  listSavedWorkflows,
+  loadWorkflowScript,
+  parseWorkflow,
+  registerWorkflowTool,
+  renderProgress,
+  retryPendingWorkflowNotifications,
+  runWorkflow,
+  saveWorkflowScript,
+  sanitizeWorkflowName,
+  startWorkflowJob,
   type WorkflowAgentRunner,
-  type WorkflowUsage,
+  type WorkflowProgress,
   type WorkflowRunResult,
   type WorkflowRunResultWithUsage,
-  type WorkflowProgress,
+  type WorkflowUsage,
+  validateSchema,
+  workflowJobRegistry,
 } from "../src/workflow";
 import type { SubagentResult } from "../src/helpers";
 import {
@@ -33,7 +35,6 @@ import {
   artifactPath,
   writeOutput,
 } from "../src/artifact";
-import { spawnSync } from "node:child_process";
 import { formatWorkflowNotificationSummary } from "../src/workflow-tool";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -128,34 +129,119 @@ describe("parseWorkflow", () => {
 
   it("handles braces and semicolons inside meta string values", () => {
     const { meta, body } = parseWorkflow(
-      `export const meta = { name: "f", description: "uses { and } and ; chars" };\nlog("hi");`,
+      `export const meta = { name: "f", description: "uses { and } and ; chars" };\nlog(\"hi\");`,
     );
     expect(meta.description).toBe("uses { and } and ; chars");
     expect(body).toContain('log("hi");');
   });
 
-  it("worker parser handles escaped quotes before braces in meta string values", async () => {
-    const script = String.raw`export const meta = { name: "f", description: "escaped quote: \" } still inside string" };
-return 42;`;
+  it("preserves nested literals, static templates, and negative numbers", () => {
+    const { meta } = parseWorkflow(
+      "export const meta = {\n" +
+        '  name: "flow",\n' +
+        "  description: `literal template`,\n" +
+        "  phases: [{ title: `phase-template` }],\n" +
+        "  retries: [1, -2, { values: [3, 4] }],\n" +
+        "};\nreturn 0;",
+    );
+    expect(meta).toEqual({
+      name: "flow",
+      description: "literal template",
+      phases: [{ title: "phase-template" }],
+      retries: [1, -2, { values: [3, 4] }],
+    });
+  });
 
-    const r = await runWorkflow(script, { runAgent: echoRunner() });
+  it("finds metadata after helper declarations", () => {
+    const script = [
+      "const helper = 2;",
+      "function helperFn() { return helper + 1; }",
+      'export const meta = { name: "helpers", description: "after" };',
+      "return helperFn();",
+    ].join("\n");
+    const { meta, body } = parseWorkflow(script);
+    expect(meta).toEqual({ name: "helpers", description: "after" });
+    expect(body).toContain("function helperFn()");
+  });
 
-    expect(r.meta.description).toBe('escaped quote: " } still inside string');
-    expect(r.result).toBe(42);
+  it("rejects member expressions in metadata values", () => {
+    expect(() =>
+      parseWorkflow(
+        `export const meta = { name: base.name, description: \"d\" };`,
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects call expressions in metadata", () => {
+    expect(() =>
+      parseWorkflow(
+        `export const meta = { name: String(\"flow\"), description: \"d\" };`,
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects interpolated template literals in metadata", () => {
+    expect(() =>
+      parseWorkflow(
+        'export const meta = { name: `interpolated ${"x"}`, description: "d" };',
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects spread properties in metadata", () => {
+    expect(() =>
+      parseWorkflow(
+        `export const meta = { name: \"x\", description: \"d\", ...{ whenToUse: \"x\" } };`,
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects computed keys in metadata objects", () => {
+    expect(() =>
+      parseWorkflow(
+        `const key = \"name\";\nexport const meta = { [key]: \"x\", description: \"d\" };`,
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects shorthand keys in metadata objects", () => {
+    expect(() =>
+      parseWorkflow(
+        `const n = \"x\";\nexport const meta = { n, description: \"d\" };`,
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects methods and accessors in metadata objects", () => {
+    expect(() =>
+      parseWorkflow(
+        `export const meta = { get name() { return \"x\"; }, description: \"d\" };`,
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects sparse arrays in metadata", () => {
+    expect(() =>
+      parseWorkflow(
+        `export const meta = { name: \"x\", description: \"d\", phases: [{ title: \"ok\" }, , { title: \"more\" }] };`,
+      ),
+    ).toThrow(/pure literal/i);
+  });
+
+  it("rejects reserved keys in metadata", () => {
+    expect(() =>
+      parseWorkflow(
+        `export const meta = { name: \"x\", description: \"d\", __proto__: {} };`,
+      ),
+    ).toThrow(/pure literal/i);
   });
 
   it("rejects a meta literal that references a helper (not pure)", () => {
     expect(() =>
-      parseWorkflow(`export const meta = { name: agent, description: "x" };\n`),
-    ).toThrow(/pure literal/i);
-  });
-
-  it("rejects constructor-chain code generation in meta", () => {
-    expect(() =>
       parseWorkflow(
-        `export const meta = { name: "f", description: "d", leak: this.constructor.constructor("return process.version")() };\nreturn 1;`,
+        `export const meta = { name: agent, description: \"x\" };\n`,
       ),
-    ).toThrow(/pure literal|Code generation from strings disallowed/i);
+    ).toThrow(/pure literal/i);
   });
 
   it("throws when meta is missing", () => {
@@ -163,10 +249,11 @@ return 42;`;
   });
 
   it("throws when name/description are absent", () => {
-    expect(() => parseWorkflow(`export const meta = { name: "x" };\n`)).toThrow(
-      /description/,
-    );
+    expect(() =>
+      parseWorkflow(`export const meta = { name: \"x\" };\n`),
+    ).toThrow(/description/);
   });
+
   it("ignores fake metadata in comments, templates, and regex literals", () => {
     const script = [
       '// export const meta = { name: "fake", description: "fake" };',
@@ -188,7 +275,6 @@ return 42;`;
 export const meta = { name: "real", description: "real" };
 return fake;`;
     const { meta, body } = parseWorkflow(script);
-
     expect(meta).toEqual({ name: "real", description: "real" });
     expect(body).toContain("export const meta");
   });
@@ -211,30 +297,7 @@ return increment(helper);`;
 export const meta = { name: "regex-control", description: "d" };
 return helper();`;
     const result = await runWorkflow(script, { runAgent: echoRunner() });
-
     expect(result.result).toBe(1);
-  });
-
-  it("times out metadata evaluation in a child process", () => {
-    const script =
-      'export const meta = { name: "loop", description: "d", loop: (() => { while (true) {} })() };';
-    const child = spawnSync(
-      process.execPath,
-      [
-        "--input-type=module",
-        "-e",
-        `import { parseWorkflow } from ${JSON.stringify(
-          "./src/workflow-script.mjs",
-        )}; parseWorkflow(${JSON.stringify(script)});`,
-      ],
-      { encoding: "utf8", timeout: 2_000 },
-    );
-
-    expect((child.error as NodeJS.ErrnoException | undefined)?.code).not.toBe(
-      "ETIMEDOUT",
-    );
-    expect(child.status).not.toBe(0);
-    expect(`${child.stderr}${child.stdout}`).toMatch(/timed out|pure literal/i);
   });
 });
 
@@ -271,6 +334,49 @@ describe("determinism guards", () => {
     await expect(
       run(`return this.constructor.constructor("return Date.now()")();`),
     ).rejects.toThrow(/Code generation from strings disallowed|Date\.now/i);
+  });
+});
+
+describe("workflow cwd global", () => {
+  const meta = `export const meta = { name: "cwd", description: "d" };\n`;
+
+  it("exposes the parent cwd as an immutable enumerable global", async () => {
+    const parentCwd = "/tmp/workflow-parent";
+    const result = await runWorkflow(
+      meta +
+        `const before = cwd; cwd = "changed"; ` +
+        `const descriptor = Object.getOwnPropertyDescriptor(globalThis, "cwd"); ` +
+        `return { before, after: cwd, descriptor };`,
+      { runAgent: echoRunner(), cwd: parentCwd },
+    );
+
+    expect(result.result).toEqual({
+      before: parentCwd,
+      after: parentCwd,
+      descriptor: {
+        value: parentCwd,
+        enumerable: true,
+        writable: false,
+        configurable: false,
+      },
+    });
+  });
+
+  it("keeps cwd consistent in nested workflows", async () => {
+    const parentCwd = "/tmp/workflow-nested";
+    const child =
+      `export const meta = { name: "child-cwd", description: "d" };\n` +
+      `return cwd;`;
+    const result = await runWorkflow(
+      meta + `return [cwd, await workflow("child")];`,
+      {
+        runAgent: echoRunner(),
+        cwd: parentCwd,
+        loadWorkflow: () => child,
+      },
+    );
+
+    expect(result.result).toEqual([parentCwd, parentCwd]);
   });
 });
 
@@ -356,6 +462,29 @@ describe("agent() + budget", () => {
     );
 
     expect(seenIsolation).toBe("in-process");
+  });
+
+  it("inherits phases per workflow body without leaking nested phases", async () => {
+    const phases: Array<string | undefined> = [];
+    const child =
+      `export const meta = { name: "child", description: "d" };\n` +
+      `phase("Child"); return await agent("child");`;
+    const script =
+      meta +
+      `phase("Parent"); await agent("before"); ` +
+      `await workflow("child"); ` +
+      `await agent("override", { phase: "Manual" }); ` +
+      `return await agent("after");`;
+
+    await runWorkflow(script, {
+      runAgent: echoRunner(),
+      loadWorkflow: () => child,
+      onProgress: (progress) => {
+        if (progress.kind === "agent_start") phases.push(progress.phase);
+      },
+    });
+
+    expect(phases).toEqual(["Parent", "Child", "Manual", "Parent"]);
   });
 
   it("returns null and counts errors when the sub-agent errors", async () => {
@@ -519,6 +648,43 @@ describe("schema enforcement", () => {
     expect(call).toBe(2);
   });
 
+  it("uses in-process structured output capture instead of parsing text", async () => {
+    let schemaArg: unknown = undefined;
+    const runAgent: WorkflowAgentRunner = async ({ schema }) => {
+      schemaArg = schema;
+      return {
+        ...ok("noise"),
+        workflowStructuredOutput: { called: true, value: { n: 7 } },
+      };
+    };
+    const body = `return await agent("give n", { isolation: "in-process", schema: ${JSON.stringify(schema)} });`;
+    const r = await runWorkflow(meta + body, { runAgent });
+    expect(schemaArg).toEqual(schema);
+    expect(r.result).toEqual({ n: 7 });
+  });
+
+  it("retries when structured_output is not called and fails after retries", async () => {
+    let calls = 0;
+    const expectedSchema = schema;
+    let schemaArg: unknown = undefined;
+    const runAgent: WorkflowAgentRunner = async ({ schema }) => {
+      calls++;
+      expect(schema).toEqual(expectedSchema);
+      schemaArg = schema;
+      return {
+        ...ok("not json", 3),
+        workflowStructuredOutput: { called: false, value: undefined },
+      };
+    };
+    const body = `return await agent("give n", { isolation: "in-process", schema: ${JSON.stringify(schema)} });`;
+    const r = await runWorkflow(meta + body, { runAgent });
+    expect(schemaArg).toEqual(expectedSchema);
+    expect(calls).toBe(SCHEMA_RETRIES);
+    expect(r.result).toBeNull();
+    expect(r.errorCount).toBe(1);
+    expect(r.usage?.output).toBe(3 * SCHEMA_RETRIES);
+  });
+
   it("returns null and counts an error after exhausting retries", async () => {
     const runAgent: WorkflowAgentRunner = async () => ok("no json here");
     const body = `return await agent("give n", { schema: ${JSON.stringify(schema)} });`;
@@ -526,6 +692,37 @@ describe("schema enforcement", () => {
     expect(r.result).toBeNull();
     expect(r.errorCount).toBe(1);
     expect(r.agentsSpawned).toBe(3);
+  });
+
+  it("keeps process-mode schema behavior: no runner schema field, text fallback prompt", async () => {
+    let runAgentCalls = 0;
+    let schemaArg: unknown = undefined;
+    let promptPreview = "";
+    const runAgent: WorkflowAgentRunner = async ({ schema, prompt }) => {
+      schemaArg = schema;
+      if (!promptPreview) promptPreview = prompt as string;
+      const out = runAgentCalls === 0 ? ok("oops", 1) : ok('{"n": 5}', 2);
+      runAgentCalls++;
+      return out;
+    };
+    const body = `return await agent("give n", { schema: ${JSON.stringify(schema)} });`;
+    const r = await runWorkflow(meta + body, { runAgent });
+    expect(schemaArg).toBeUndefined();
+    expect(promptPreview).toContain("Respond with ONLY a single JSON value");
+    expect(r.result).toEqual({ n: 5 });
+    expect(runAgentCalls).toBe(2);
+  });
+
+  it("does not pass schema to non-schema sub-agent runs", async () => {
+    let schemaArg: unknown = undefined;
+    const runAgent: WorkflowAgentRunner = async ({ schema }) => {
+      schemaArg = schema;
+      return ok("done");
+    };
+    const body = `return await agent("just do work");`;
+    const r = await runWorkflow(meta + body, { runAgent });
+    expect(schemaArg).toBeUndefined();
+    expect(r.result).toBe("done");
   });
 });
 
@@ -709,6 +906,25 @@ describe("background workflow jobs", () => {
     expect(run.result).toBe("done");
     expect(job.status).toBe("done");
     expect(job.snapshot.agentsSpawned).toBe(1);
+  });
+
+  it("stores one bounded record per agent attempt", async () => {
+    const count = MAX_WORKFLOW_AGENT_RECORDS + 1;
+    const script =
+      `export const meta = { name: "records", description: "d" };\n` +
+      `return await parallel(Array.from({ length: ${count} }, (_, index) => ` +
+      `() => agent(String(index), { label: "worker" })));`;
+    const job = startWorkflowJob("records", script, { runAgent: echoRunner() });
+
+    await job.promise;
+
+    expect(job.snapshot.agentRecords).toHaveLength(MAX_WORKFLOW_AGENT_RECORDS);
+    expect(job.snapshot.agentRecordsOmitted).toBe(1);
+    expect(job.snapshot.agentRecords?.[0]?.agentId).toBe(2);
+    expect(job.snapshot.agentRecords?.at(-1)?.agentId).toBe(count);
+    expect(
+      job.snapshot.agentRecords?.every((record) => record.status === "done"),
+    ).toBe(true);
   });
 
   it("calls the completion hook after all agents finish", async () => {
@@ -1594,8 +1810,7 @@ describe("registerWorkflowTool", () => {
   });
 
   it("workflow tool has the expected description and parameters", () => {
-    const tools: Array<{ name: string; description: string; parameters: any }> =
-      [];
+    const tools: any[] = [];
     const pi = {
       registerTool: vi.fn((def: any) => tools.push(def)),
       registerFlag: vi.fn(),
@@ -1606,11 +1821,48 @@ describe("registerWorkflowTool", () => {
     const wf = tools.find((t) => t.name === "workflow")!;
     expect(wf.description).toContain("agent(prompt, opts?)");
     expect(wf.description).toContain("workflow(name, args?)");
+    expect(wf.description).toContain("immutable parent working directory");
+    expect(wf.promptSnippet).toContain("decomposable multi-agent work");
+    const guidance = wf.promptGuidelines.join("\n");
+    expect(guidance).toContain("raw JavaScript");
+    expect(guidance).toContain("first statement");
+    expect(guidance).toContain("immutable cwd");
+    expect(guidance).toContain("parallel() takes thunks");
+    expect(guidance).toContain("pipeline() streams");
+    expect(guidance).toContain("unique short labels");
+    expect(guidance).toContain("plain JSON Schema");
+    expect(guidance).toContain("null results");
+    expect(guidance).toContain("final synthesis");
     expect(wf.parameters).toBeDefined();
     expect(wf.parameters.properties).toBeDefined();
     expect(Object.keys(wf.parameters.properties)).toContain("script");
     expect(Object.keys(wf.parameters.properties)).toContain("name");
     expect(Object.keys(wf.parameters.properties)).toContain("async");
+  });
+
+  it("threads the tool execution cwd into the workflow global", async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: vi.fn((def: any) => tools.push(def)),
+      registerCommand: vi.fn(),
+    };
+    registerWorkflowTool(pi as any);
+    const workflowTool = tools.find((tool) => tool.name === "workflow")!;
+    const result = await workflowTool.execute(
+      "",
+      {
+        script:
+          `export const meta = { name: "tool-cwd", description: "d" };\n` +
+          `return cwd;`,
+        async: false,
+      },
+      undefined,
+      undefined,
+      { cwd: "/tmp/tool-context", modelRegistry: {} },
+    );
+
+    expect(result.details.status).toBe("done");
+    expect(result.content[0].text).toContain("/tmp/tool-context");
   });
 
   it("does not report a completed workflow as cancelled", async () => {

--- a/types/workflow.d.ts
+++ b/types/workflow.d.ts
@@ -1,0 +1,110 @@
+export type WorkflowJSONPrimitive = string | number | boolean | null;
+
+export type WorkflowJSONValue =
+  | WorkflowJSONPrimitive
+  | { readonly [key: string]: WorkflowJSONValue }
+  | readonly WorkflowJSONValue[];
+
+export type WorkflowJSONSchemaType =
+  "object" | "array" | "string" | "number" | "integer" | "boolean" | "null";
+
+/** Plain JSON Schema subset validated by the workflow runtime. */
+export interface WorkflowJSONSchema {
+  readonly type?: WorkflowJSONSchemaType | readonly WorkflowJSONSchemaType[];
+  readonly enum?: readonly WorkflowJSONValue[];
+  readonly properties?: Readonly<Record<string, WorkflowJSONSchema>>;
+  readonly required?: readonly string[];
+  readonly additionalProperties?: boolean;
+  readonly items?: WorkflowJSONSchema;
+  readonly minItems?: number;
+  readonly maxItems?: number;
+}
+
+export interface WorkflowPhase {
+  readonly title: string;
+  readonly detail?: string;
+  readonly [key: string]: WorkflowJSONValue | undefined;
+}
+
+export interface WorkflowMeta {
+  readonly name: string;
+  readonly description: string;
+  readonly whenToUse?: string;
+  readonly phases?: readonly WorkflowPhase[];
+  readonly [key: string]:
+    WorkflowJSONValue | readonly WorkflowPhase[] | undefined;
+}
+
+export type WorkflowThinkingLevel =
+  "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+export interface WorkflowAgentOptions {
+  readonly schema?: WorkflowJSONSchema;
+  readonly label?: string;
+  readonly phase?: string;
+  readonly model?: string;
+  readonly persona?: string;
+  readonly isolation?: "process" | "in-process";
+  readonly agentType?: string;
+  readonly thinkingLevel?: WorkflowThinkingLevel;
+}
+
+export type WorkflowThunk<T> = () => T | PromiseLike<T>;
+
+export type WorkflowPipelineStage<TItem, TPrevious, TResult> = (
+  previous: TPrevious,
+  item: TItem,
+  index: number,
+) => TResult | PromiseLike<TResult>;
+
+export interface WorkflowBudget {
+  readonly total: number | null;
+  spent(): number;
+  remaining(): number;
+}
+
+declare global {
+  function agent(
+    prompt: string,
+    options?: WorkflowAgentOptions & { readonly schema?: undefined },
+  ): Promise<string | null>;
+  function agent<T extends WorkflowJSONValue = WorkflowJSONValue>(
+    prompt: string,
+    options: WorkflowAgentOptions & { readonly schema: WorkflowJSONSchema },
+  ): Promise<T | null>;
+
+  function parallel<T>(
+    thunks: readonly WorkflowThunk<T>[],
+  ): Promise<Array<Awaited<T> | null>>;
+
+  function pipeline<TItem, TResult>(
+    items: readonly TItem[],
+    stage: WorkflowPipelineStage<TItem, TItem, TResult>,
+  ): Promise<Array<Awaited<TResult> | null>>;
+  function pipeline<TItem, TResult1, TResult2>(
+    items: readonly TItem[],
+    stage1: WorkflowPipelineStage<TItem, TItem, TResult1>,
+    stage2: WorkflowPipelineStage<TItem, Awaited<TResult1>, TResult2>,
+  ): Promise<Array<Awaited<TResult2> | null>>;
+  function pipeline<TItem, TResult1, TResult2, TResult3>(
+    items: readonly TItem[],
+    stage1: WorkflowPipelineStage<TItem, TItem, TResult1>,
+    stage2: WorkflowPipelineStage<TItem, Awaited<TResult1>, TResult2>,
+    stage3: WorkflowPipelineStage<TItem, Awaited<TResult2>, TResult3>,
+  ): Promise<Array<Awaited<TResult3> | null>>;
+  function pipeline<TItem>(
+    items: readonly TItem[],
+    ...stages: Array<WorkflowPipelineStage<TItem, any, any>>
+  ): Promise<Array<any | null>>;
+
+  function workflow(
+    name: string,
+    childArgs?: WorkflowJSONValue,
+  ): Promise<unknown>;
+  function phase(title: string): void;
+  function log(message: unknown): void;
+
+  const args: WorkflowJSONValue | undefined;
+  const cwd: string;
+  const budget: WorkflowBudget;
+}


### PR DESCRIPTION
## Summary

- use Pi-native terminating `structured_output` capture for in-process workflow agents while retaining validated textual JSON fallback for process-backed agents
- enforce first-statement, pure-literal workflow metadata with Acorn AST validation
- inherit runtime phases per workflow body and show bounded per-agent attempt records in `/workflow-tree`
- publish `pi-subagentura/workflow` ambient typings and inject an immutable `cwd` workflow global
- add workflow-authoring prompt guidance and update workflow documentation/examples

## Compatibility and safety

- keeps process isolation as the default and preserves its textual schema retry path
- scopes phase inheritance to each composed workflow body
- retains at most 50 agent records per job and displays at most 20 in the tree
- validates parser, package export, tarball, and minimum Pi SDK behavior in tests

## Validation

- `npm run typecheck`
- `npm test` — 47 files, 1,070 tests passed
- `npm run format:check`
- `npm run pack:check`
- independent Spark and Big Pickle reviews: no material findings
