### PR TITLE
fix: preserve async sub-agent footer status

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -36,7 +36,7 @@ import {
 } from "./interactive-tmux";
 import { shouldNotify } from "./notifications";
 import { deliveryIdFor, enqueueDelivery, flushDeliveries } from "./delivery";
-import { debugLog } from "./helpers";
+import { debugLog, jobRegistry } from "./helpers";
 import { formatActivityRow } from "./rendering";
 import { formatWorkflowUsage } from "./workflow-core";
 import { closeSync, openSync, readSync, statSync } from "node:fs";
@@ -54,6 +54,32 @@ const WORKFLOW_WIDGET_KEY = "subagentura-workflow-activity";
 /** Maximum widget rows before truncation with "… and N more". */
 const MAX_WIDGET_ROWS = 10;
 const MAX_WORKFLOW_WIDGET_ROWS = 5;
+
+function getRunningSubagentCount(): number {
+  const inProcessCount = [...jobRegistry.values()].filter(
+    (job) => job.status === "running",
+  ).length;
+  const interactiveCount = [...interactiveSubagentRegistry.values()].filter(
+    (state) => state.status === "running" || state.status === "idle",
+  ).length;
+  return inProcessCount + interactiveCount;
+}
+
+export function updateRunningSubagentFooter(
+  ui: Pick<ExtensionUIContext, "setStatus">,
+): void {
+  const runningCount = getRunningSubagentCount();
+  try {
+    ui.setStatus(
+      FOOTER_KEY,
+      runningCount > 0
+        ? `⚡ ${runningCount} sub-agent${runningCount > 1 ? "s" : ""} running`
+        : undefined,
+    );
+  } catch {
+    /* ui stale */
+  }
+}
 
 /** Derive delivery status from an already narrowed completion event. */
 function deliveryStatusFromEvent(ev: CompletionEvent): CompletionOutcome {
@@ -121,7 +147,6 @@ async function runPollArtifactChanges(pi: ExtensionAPI): Promise<void> {
     ) {
       return;
     }
-    let runningCount = 0;
     const widgetRows: string[] = [];
     const ui = g2.__piSubagenturaUi as ExtensionUIContext | undefined;
     for (const [state, paneAlive] of liveness) {
@@ -212,21 +237,9 @@ async function runPollArtifactChanges(pi: ExtensionAPI): Promise<void> {
         });
       }
 
-      // Only count sub-agents that are actively processing a turn as "running".
-
-      // "exited" is terminal (pane dead) — the sub-agent is done; hide it from the
-
-      // running count and widget even though the for-loop keeps tail-reading its
-
-      // session log (for the user-role revival case in processSessionLogEntry).
-
-      // "idle" is between turns (REPL open, pane alive) — still a live sub-agent
-
-      // awaiting follow-up, so it stays in the count.
-
+      // Keep live interactive sub-agents in the activity widget. Exited panes are
+      // still tail-read above so a later user-role entry can revive them.
       if (state.status === "running" || state.status === "idle") {
-        runningCount++;
-
         widgetRows.push(formatActivityRow(state));
       }
     }
@@ -258,16 +271,7 @@ async function runPollArtifactChanges(pi: ExtensionAPI): Promise<void> {
 
     // Paint footer + widget. Both are TUI-only — never reach the LLM.
     if (ui) {
-      try {
-        ui.setStatus(
-          FOOTER_KEY,
-          runningCount > 0
-            ? `⚡ ${runningCount} sub-agent${runningCount > 1 ? "s" : ""} running`
-            : undefined,
-        );
-      } catch {
-        /* ui stale */
-      }
+      updateRunningSubagentFooter(ui);
       try {
         ui.setWidget(
           WIDGET_KEY,

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -13,7 +13,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { FOOTER_KEY } from "../artifact-poller";
+import { updateRunningSubagentFooter } from "../artifact-poller";
 import { cleanupOldArtifacts, type CleanupResult } from "../artifact";
 import {
   buildLiveUpdate,
@@ -70,23 +70,8 @@ type InProcessSubagentDetails =
     }
   | { status: "cancelled" | "not_found"; jobId?: string };
 
-function getRunningJobCount(): number {
-  return [...jobRegistry.values()].filter((job) => job.status === "running")
-    .length;
-}
-
 function updateRunningFooter(ctx: RunningFooterContext): void {
-  const runningCount = getRunningJobCount();
-  try {
-    ctx.ui.setStatus(
-      FOOTER_KEY,
-      runningCount > 0
-        ? `⚡ ${runningCount} sub-agent${runningCount > 1 ? "s" : ""} running`
-        : undefined,
-    );
-  } catch {
-    /* ctx stale */
-  }
+  updateRunningSubagentFooter(ctx.ui);
 }
 
 function createAsyncJobErrorResult(error: unknown): SubagentResult {

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -68,6 +68,7 @@ describe("pollArtifactChanges", () => {
   beforeEach(() => {
     const g = globalThis as any;
     g.__piSubagenturaInteractiveRegistry?.clear?.();
+    g.__piSubagenturaRegistry?.clear?.();
     g.__piSubagenturaWorkflowJobs?.clear?.();
     g.__piSubagenturaPiRef = undefined;
     g.__piSubagenturaUi = undefined;
@@ -76,6 +77,7 @@ describe("pollArtifactChanges", () => {
 
   afterEach(() => {
     (globalThis as any).__piSubagenturaParentStreaming = false;
+    (globalThis as any).__piSubagenturaRegistry?.clear?.();
     delete process.env.SUBAGENT_DEBUG_LOG_DIR;
     vi.doUnmock("node:child_process");
   });
@@ -86,6 +88,24 @@ describe("pollArtifactChanges", () => {
     const sendMessage = installDeliverySpies();
     await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps running in-process jobs in the shared footer", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    mod.jobRegistry.set("async-1", { status: "running" } as any);
+    const setStatus = vi.fn();
+    (globalThis as any).__piSubagenturaUi = {
+      setStatus,
+      setWidget: vi.fn(),
+    };
+
+    await mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
+
+    expect(setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent running",
+    );
   });
 
   it("keeps the event loop responsive while async liveness is pending", async () => {
@@ -1152,7 +1172,7 @@ describe("pollArtifactChanges", () => {
       delete (globalThis as any).__piSubagenturaUi;
     });
 
-    it("AC-B3: all-running registry shows correct count (regression guard)", async () => {
+    it("AC-B3: combines interactive and in-process footer counts", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
         execFileSync: (_file: string, args: string[]) => {
@@ -1168,6 +1188,7 @@ describe("pollArtifactChanges", () => {
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
+      mod.jobRegistry.set("async-1", { status: "running" } as any);
 
       const a = makeState().state;
       a.id = "a";
@@ -1187,7 +1208,7 @@ describe("pollArtifactChanges", () => {
 
       expect(setStatus).toHaveBeenCalledWith(
         "subagentura-running",
-        "⚡ 2 sub-agents running",
+        "⚡ 3 sub-agents running",
       );
       const widgetArgs = setWidget.mock.calls[0];
       expect(widgetArgs[1].length).toBe(2);


### PR DESCRIPTION
## Summary

- derive the running sub-agent footer from both the in-process and interactive registries
- use one shared footer updater from async job start/settlement and artifact polling
- add regressions for in-process-only and combined in-process/interactive counts

## Root cause

Both execution paths write to the same `subagentura-running` status key, but each previously derived its value from only one registry:

- `src/tools/in-process.ts` counted running entries in `jobRegistry`
- `src/artifact-poller.ts` counted live entries in `interactiveSubagentRegistry`

A poll tick after an async in-process job started therefore repainted the shared key with the interactive-only count. With no interactive agents, that value was `undefined`, so the footer disappeared while the async job was still running. The inverse write order could also under-report live interactive agents when an in-process job started or settled.

## Solutions considered

| Option | Advantages | Trade-offs |
|---|---|---|
| Separate status keys | No writer collision; simple ownership | Splits the footer into two entries and loses the aggregate count |
| Make the poller the sole writer | Strong single-writer model | Start/settlement updates wait for the next poll and depend on poller lifecycle |
| Dedicated footer coordinator module | Clean separation and room for future UI behavior | More structure and wiring than this focused fix needs |
| Global aggregate counter | Constant-time updates | Can drift after errors, reloads, cancellations, or missed cleanup paths |
| Duplicate combined counting in both writers | Small patch with immediate updates | Duplicates filtering/formatting and can diverge later |
| **Shared registry-derived updater (chosen)** | Immediate updates, one rule, no mutable counter, minimal change | Scans both bounded registries on each repaint |

The chosen updater counts each running in-process job once and each live (`running` or `idle`) interactive sub-agent once, then both writers use the same formatter and status update path. The activity widget remains interactive-only.

## Tests

- `npm run typecheck`
- `npm test` (1047 tests)
- `npm run format:check`
- `npm run pack:check`
