### PR TITLE
fix: make subagent cancellation transitive

### DIFF
--- a/ORCHESTRATOR_SYSTEM_PROMPT.md
+++ b/ORCHESTRATOR_SYSTEM_PROMPT.md
@@ -21,13 +21,17 @@ Use subagents to widen investigation, reduce context pressure, or get independen
 
 ## Async defaults
 
-For multiple children or longer tasks:
+`subagent_isolated` and `subagent_with_context` default to `async: true`. Fan-out (e.g. one reviewer per PR or file) and long-running tasks must run in the background so the parent turn stays responsive and can be interrupted — never launch multiple children synchronously.
 
-- Launch with `async: true`.
+- Leave `async` at its default when spawning more than one child or any longer task. Pass `async: false` only for a single short sub-agent whose result you need inline before continuing.
 - Prefer `notifyOnComplete: "inject"` so the parent is resumed with the result.
 - Use `notifyOnComplete: "notify"` only for explicit background/UI-only work.
 - Do not poll by default. Poll or collect only if the user asks, a task appears stuck, or cancellation/follow-up is needed.
 - When child results arrive, synthesize them; do not dump raw reports unless that is the most useful output.
+
+## Bounded nesting
+
+Async keeps the parent responsive but does not stop a child from spawning its own children. Nested orchestration depth is capped (`SUBAGENTURA_MAX_ORCHESTRATION_DEPTH`, default 3); an over-deep spawn is refused and that sub-agent must complete the task itself. Give scouts and reviewers leaf tasks: instruct them to do the work directly and not to delegate further.
 
 ## Verification rule
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "src/child-protocol.ts",
     "src/delivery.ts",
     "src/helpers.ts",
+    "src/orchestration-context.ts",
     "src/pi-sdk-compat.ts",
     "src/tools/in-process.ts",
     "src/tools/interactive.ts",

--- a/src/cancel-all-flows.ts
+++ b/src/cancel-all-flows.ts
@@ -64,7 +64,13 @@ export async function cancelAllFlows(): Promise<CancelAllResult> {
   const jobs = [...jobRegistry.values()].filter(
     (job) => job.status === "running",
   );
+  const jobCancellation = {
+    source: "cancel_all" as const,
+    initiator: "cancel_all_flows",
+    reason: "cancel-all-flows aborted every running flow",
+  };
   for (const job of jobs) {
+    job.cancellation = { ...jobCancellation, at: Date.now() };
     job.cancellationSnapshot = snapshotInProcessSession({
       kind: "in-process",
       jobId: job.id,
@@ -74,12 +80,17 @@ export async function cancelAllFlows(): Promise<CancelAllResult> {
       activeTool: job.liveStatus?.activeTool,
       partialOutput: job.liveStatus?.output,
       source: "cancel_all",
+      initiator: jobCancellation.initiator,
+      reason: jobCancellation.reason,
     });
     addSnapshot(job.cancellationSnapshot);
   }
   for (const job of jobs) {
     try {
-      await job.session.abort();
+      // Prefer the controller so the abort handler cascades to descendants;
+      // fall back to a direct session abort for jobs spawned without one.
+      if (job.abort) job.abort.abort(jobCancellation);
+      else await job.session.abort();
     } catch {
       /* session may already be disposed */
     }

--- a/src/cancellation-snapshots.ts
+++ b/src/cancellation-snapshots.ts
@@ -63,6 +63,10 @@ export interface InProcessSnapshotInput {
   partialOutput?: string;
   startedAt?: number;
   source: CancellationSnapshotSource;
+  /** Session/tool-call id or symbolic origin that initiated the cancel. */
+  initiator?: string;
+  /** Human-readable cancellation reason. */
+  reason?: string;
 }
 
 export interface InteractiveSnapshotInput {
@@ -272,6 +276,8 @@ function buildInProcessPayload(
     errors,
     cancellation: {
       source: input.source,
+      initiator: input.initiator,
+      reason: input.reason,
       jobId: input.jobId,
       parentSessionId: input.parentSessionId,
       startedAt: input.startedAt,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,6 +35,7 @@ import {
   type CancellationSnapshotReceipt,
   type CancellationSnapshotSource,
 } from "./cancellation-snapshots";
+import { withOrchestrationContext } from "./orchestration-context";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 // ── Debug Logging ─────────────────────────────────────────────────
 
@@ -123,6 +124,8 @@ export type SubagentResult =
       usage: Usage;
       model?: string;
       thinkingLevel?: ThinkingLevel;
+      /** Set when the sub-agent was aborted before producing a final answer. */
+      cancelled?: boolean;
     }
   | {
       isError: true;
@@ -130,6 +133,8 @@ export type SubagentResult =
       usage: Usage;
       model?: undefined;
       thinkingLevel?: ThinkingLevel;
+      /** Never set on the error branch; present so the union can be probed. */
+      cancelled?: undefined;
       errorMessage: string;
     };
 
@@ -175,6 +180,26 @@ export interface JobState {
   maxAge?: number;
   /** Most recent cancellation snapshot receipt, when snapshots are enabled. */
   cancellationSnapshot?: CancellationSnapshotReceipt;
+  /**
+   * Controller wired to this job's session (async jobs only). Aborting it
+   * cancels the session AND cascades to any descendants this job owns.
+   */
+  abort?: AbortController;
+  /** Job id of the owning parent sub-agent (undefined for root-parent spawns). */
+  parentJobId?: string;
+  /** Orchestration depth of this job. Root parent's direct children are 1. */
+  depth?: number;
+  /** Recorded when a cancel path fires, for observability and result shaping. */
+  cancellation?: CancellationInfo & { at: number };
+}
+
+/** Who/why a cancellation happened — threaded to logs and snapshots. */
+export interface CancellationInfo {
+  source: CancellationSnapshotSource;
+  /** Session id, tool-call id, or symbolic origin (e.g. "user_escape"). */
+  initiator?: string;
+  /** Human-readable reason preserved in logs and the snapshot. */
+  reason?: string;
 }
 
 // ── Job Registry ────────────────────────────────────────────────────
@@ -244,6 +269,94 @@ export function pruneCompletedJobs(): number {
     }
   }
   return removed;
+}
+
+/**
+ * Recover a structured {@link CancellationInfo} from an AbortSignal.
+ *
+ * Our own cancel paths call `controller.abort(info)`, so `signal.reason` is the
+ * CancellationInfo object. When Pi core aborts a parent turn (e.g. the user
+ * pressed Escape) the reason is a DOMException/Error/string — we surface its
+ * message and fall back to the given source.
+ */
+export function readCancellationInfo(
+  signal: AbortSignal | undefined,
+  fallbackSource: CancellationSnapshotSource,
+): CancellationInfo {
+  const reason = signal?.reason;
+  if (
+    reason &&
+    typeof reason === "object" &&
+    "source" in (reason as Record<string, unknown>)
+  ) {
+    return reason as CancellationInfo;
+  }
+  const message =
+    reason instanceof Error
+      ? reason.message
+      : typeof reason === "string"
+        ? reason
+        : undefined;
+  return { source: fallbackSource, reason: message };
+}
+
+/**
+ * Abort every running async job the given owner spawned, recursively.
+ *
+ * Each async job's controller fires its own abort handler (snapshot →
+ * session.abort → cascade), so aborting a controller propagates the cancel
+ * through the whole ownership subtree. Sync jobs are not registered here; their
+ * descendants are reached from the sync job's own abort handler via {@link cascadeChildAborts}.
+ * Returns the ids that were signalled.
+ */
+export function cascadeChildAborts(
+  ownerJobId: string,
+  info: CancellationInfo,
+): string[] {
+  const signalled: string[] = [];
+  for (const [childId, child] of jobRegistry) {
+    if (child.parentJobId !== ownerJobId) continue;
+    if (child.status !== "running") continue;
+    child.cancellation = { ...info, at: Date.now() };
+    // Mark cancelled up front so late settlement cannot flip it to done/error
+    // and no completion notification fires for an aborted child.
+    child.status = "cancelled";
+    scheduleJobCleanup(childId, true);
+    signalled.push(childId);
+    if (child.abort) {
+      try {
+        child.abort.abort(info);
+      } catch {
+        /* controller may already be aborted */
+      }
+    } else {
+      child.session.abort().catch(() => {});
+      signalled.push(...cascadeChildAborts(childId, info));
+    }
+  }
+  return signalled;
+}
+
+/**
+ * Cancel a specific async job and its owned descendants. Records the
+ * cancellation metadata, then aborts the job's controller (which snapshots and
+ * tears down the session) and cascades to children.
+ */
+export function abortJobTree(jobId: string, info: CancellationInfo): string[] {
+  const job = jobRegistry.get(jobId);
+  if (!job || job.status !== "running") return [];
+  job.cancellation = { ...info, at: Date.now() };
+  const cascaded = cascadeChildAborts(jobId, info);
+  if (job.abort) {
+    try {
+      job.abort.abort(info);
+    } catch {
+      /* already aborted */
+    }
+  } else {
+    job.session.abort().catch(() => {});
+  }
+  return [jobId, ...cascaded];
 }
 
 export function scheduleJobCleanup(
@@ -371,6 +484,13 @@ export interface StartSubagentJobParams {
   cancellationSource?: CancellationSnapshotSource;
   /** Thinking/reasoning level. Pass through to createAgentSession. */
   thinkingLevel?: ThinkingLevel;
+  /**
+   * Orchestration depth of THIS job (root parent's direct child = 1). Bound
+   * into the async context so nested spawns can see their own depth.
+   */
+  depth?: number;
+  /** Top-level parent session id, propagated for observability. */
+  rootSessionId?: string;
 }
 
 export interface StartSubagentJobResult {
@@ -410,6 +530,8 @@ export async function startSubagentJob(
     onCancellationSnapshot,
     cancellationSource,
     thinkingLevel,
+    depth,
+    rootSessionId,
   } = params;
 
   // Enforce registry size cap before adding a new job
@@ -528,19 +650,37 @@ export async function startSubagentJob(
   // Wire abort signal
   if (signal) {
     handleAbort = () => {
-      debugLog("warn", "job_abort", { jobId });
-      const receipt = snapshotInProcessSession({
-        kind: "in-process",
+      const info = readCancellationInfo(signal, cancellationSource ?? "signal");
+      debugLog("warn", "job_abort", {
         jobId,
-        session,
-        cwd,
-        model: modelLabel,
-        activeTool: liveStatus.activeTool,
-        partialOutput: liveStatus.output,
-        source: cancellationSource ?? "signal",
+        source: info.source,
+        initiator: info.initiator ?? null,
+        reason: info.reason ?? null,
+        depth: depth ?? null,
+        rootSessionId: rootSessionId ?? null,
       });
-      onCancellationSnapshot?.(receipt);
+      // Only take a snapshot when a receiver was wired (workflow path). The
+      // in-process cancel sites snapshot before aborting to capture pre-abort
+      // state, so snapshotting again here would be redundant.
+      if (onCancellationSnapshot) {
+        onCancellationSnapshot(
+          snapshotInProcessSession({
+            kind: "in-process",
+            jobId,
+            session,
+            cwd,
+            model: modelLabel,
+            activeTool: liveStatus.activeTool,
+            partialOutput: liveStatus.output,
+            source: info.source,
+            initiator: info.initiator,
+            reason: info.reason,
+          }),
+        );
+      }
       session.abort().catch(() => {});
+      // Cancellation is transitive: tear down every descendant this job owns.
+      cascadeChildAborts(jobId, info);
     };
     if (signal.aborted) {
       handleAbort();
@@ -642,8 +782,41 @@ export async function startSubagentJob(
     let result!: SubagentResult;
     try {
       debugLog("info", "prompt_start", { jobId });
-      await session.prompt(finalPrompt);
+      // Bind ownership + depth so any nested sub-agent spawned during this
+      // prompt can discover its owner (for cascade) and its depth (for the cap).
+      await withOrchestrationContext(
+        { ownerJobId: jobId, depth: depth ?? 0, rootSessionId },
+        () => session.prompt(finalPrompt),
+      );
       debugLog("info", "prompt_complete", { jobId });
+
+      // Aborted before completion → return an explicit cancelled result rather
+      // than a false empty success. Pi resolves prompt() on abort (it does not
+      // throw), so without this check an aborted job looks like `done` output.
+      if (signal?.aborted) {
+        const info = readCancellationInfo(
+          signal,
+          cancellationSource ?? "signal",
+        );
+        result = {
+          isError: false,
+          cancelled: true,
+          output: `Sub-agent cancelled before completion${info.reason ? `: ${info.reason}` : ""}.`,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            cost: 0,
+            turns: 0,
+          },
+          model: session.model
+            ? `${session.model.provider}/${session.model.id}`
+            : undefined,
+          thinkingLevel: effectiveThinkingLevel,
+        };
+        return result;
+      }
 
       // Extract final assistant output
       const messages = session.agent.state.messages;

--- a/src/orchestration-context.ts
+++ b/src/orchestration-context.ts
@@ -1,0 +1,103 @@
+/**
+ * Orchestration ownership + depth context.
+ *
+ * In-process sub-agents run in the SAME process as the parent (they share the
+ * global `jobRegistry`), but a spawned child session has no idea it is a child
+ * — its tool `execute()` callbacks cannot see who launched them. That blind
+ * spot is why nested orchestration was unbounded and why cancellation could
+ * not be made transitive.
+ *
+ * We close it with an AsyncLocalStorage. When a job runs its `session.prompt()`
+ * we wrap the call in `withOrchestrationContext({ ownerJobId, depth, ... })`.
+ * Because Pi's agent loop awaits tool execution inside that same async call
+ * stack, any nested `subagent_isolated` / `subagent_with_context` call can read
+ * `getOrchestrationContext()` to learn its owner job id and its depth in the
+ * orchestration tree. This is race-free across concurrent spawns (unlike a
+ * process-global env var) because each prompt gets its own async context.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface OrchestrationContext {
+  /** Job id of the sub-agent whose prompt is currently executing. */
+  ownerJobId: string;
+  /** Orchestration depth of the CURRENT agent. Root parent = 0. */
+  depth: number;
+  /** Session id of the top-level parent, propagated for observability. */
+  rootSessionId?: string;
+}
+
+export const DEFAULT_MAX_ORCHESTRATION_DEPTH = 3;
+
+/**
+ * Maximum orchestration depth. A spawn is refused when the would-be child's
+ * depth would exceed this. Root parent spawns children at depth 1, so the
+ * default of 3 permits parent → child → grandchild and stops great-grandchild
+ * fan-out. Override with SUBAGENTURA_MAX_ORCHESTRATION_DEPTH.
+ */
+export function maxOrchestrationDepth(): number {
+  const raw = process.env.SUBAGENTURA_MAX_ORCHESTRATION_DEPTH;
+  if (!raw) return DEFAULT_MAX_ORCHESTRATION_DEPTH;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 32) {
+    return DEFAULT_MAX_ORCHESTRATION_DEPTH;
+  }
+  return parsed;
+}
+
+// Persist on the global so jiti module reloads don't fork the storage and
+// silently lose the active context mid-run (same pattern as jobRegistry).
+const g = typeof global !== "undefined" ? global : globalThis;
+declare global {
+  // eslint-disable-next-line no-var
+  var __piSubagenturaOrchestrationStore:
+    AsyncLocalStorage<OrchestrationContext> | undefined;
+}
+if (!g.__piSubagenturaOrchestrationStore) {
+  g.__piSubagenturaOrchestrationStore =
+    new AsyncLocalStorage<OrchestrationContext>();
+}
+
+const store =
+  g.__piSubagenturaOrchestrationStore as AsyncLocalStorage<OrchestrationContext>;
+
+/** Read the orchestration context of the currently executing agent, if any. */
+export function getOrchestrationContext(): OrchestrationContext | undefined {
+  return store.getStore();
+}
+
+/** Run `fn` with the given orchestration context bound for its async subtree. */
+export function withOrchestrationContext<T>(
+  ctx: OrchestrationContext,
+  fn: () => T,
+): T {
+  return store.run(ctx, fn);
+}
+
+export interface SpawnDepthDecision {
+  /** Depth the child would occupy (parent depth + 1). */
+  childDepth: number;
+  /** Owner job id of the spawning parent, if this spawn is itself nested. */
+  parentJobId?: string;
+  rootSessionId?: string;
+  /** True when the spawn must be refused because it exceeds the depth cap. */
+  exceedsLimit: boolean;
+  limit: number;
+}
+
+/**
+ * Resolve the depth a new child would occupy and whether it is allowed.
+ * Reads the ambient orchestration context (undefined at the root parent).
+ */
+export function resolveSpawnDepth(): SpawnDepthDecision {
+  const parent = getOrchestrationContext();
+  const parentDepth = parent?.depth ?? 0;
+  const childDepth = parentDepth + 1;
+  const limit = maxOrchestrationDepth();
+  return {
+    childDepth,
+    parentJobId: parent?.ownerJobId,
+    rootSessionId: parent?.rootSessionId,
+    exceedsLimit: childDepth > limit,
+    limit,
+  };
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -42,7 +42,7 @@ export const BaseParams = Type.Object({
   async: Type.Optional(
     Type.Boolean({
       description:
-        "Run subagent in background. Returns a jobId immediately instead of blocking. Async jobs inject their result by default when complete. Poll with get_subagent_status or collect with get_subagent_result only when requested or when manual follow-up is needed. The main agent continues execution immediately — it does NOT wait for async sub-agents to complete. Use only if users asks to",
+        "Run subagent in background. DEFAULT: true — fan-out and long-running work must not block the parent turn. Returns a jobId immediately instead of blocking; the main agent continues and the result is injected when complete (poll with get_subagent_status or collect with get_subagent_result for manual follow-up). Pass async: false ONLY for a single short sub-agent whose answer you need inline before continuing. Async keeps the parent responsive but does NOT by itself prevent nested fan-out — depth is capped separately.",
     }),
   ),
   notifyOnComplete: Type.Optional(

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -141,9 +141,21 @@ export function registerSessionHandlers(pi: ExtensionAPI): void {
         }
       }
 
+      let shutdownInitiator: string | undefined;
+      try {
+        shutdownInitiator = ctx?.sessionManager?.getSessionId?.();
+      } catch {
+        shutdownInitiator = undefined;
+      }
+      const shutdownCancellation = {
+        source: "session_shutdown" as const,
+        initiator: shutdownInitiator,
+        reason: `session_shutdown (${event?.reason ?? "unknown"})`,
+      };
       // Snapshot all in-process jobs before any abort can wait for idle.
       for (const job of jobRegistry.values()) {
         if (job.status !== "running") continue;
+        job.cancellation = { ...shutdownCancellation, at: Date.now() };
         job.cancellationSnapshot = snapshotInProcessSession({
           kind: "in-process",
           jobId: job.id,
@@ -153,13 +165,17 @@ export function registerSessionHandlers(pi: ExtensionAPI): void {
           activeTool: job.liveStatus?.activeTool,
           partialOutput: job.liveStatus?.output,
           source: "session_shutdown",
+          initiator: shutdownCancellation.initiator,
+          reason: shutdownCancellation.reason,
         });
       }
-      // Abort all running subagent sessions before clearing
+      // Abort all running subagent sessions before clearing. Prefer the
+      // controller so descendants are torn down too.
       for (const job of jobRegistry.values()) {
         if (job.status === "running") {
           try {
-            job.session.abort().catch(() => {});
+            if (job.abort) job.abort.abort(shutdownCancellation);
+            else job.session.abort().catch(() => {});
           } catch {
             /* session may already be disposed */
           }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import { FOOTER_KEY } from "../artifact-poller";
 import { cleanupOldArtifacts, type CleanupResult } from "../artifact";
 import {
+  abortJobTree,
   buildLiveUpdate,
   debugLog,
   formatUsage,
@@ -29,6 +30,7 @@ import {
   type SubagentResult,
   type Usage,
 } from "../helpers";
+import { resolveSpawnDepth } from "../orchestration-context";
 import { abortableWait } from "../abortable-wait";
 import { snapshotInProcessSession } from "../cancellation-snapshots";
 import {
@@ -89,6 +91,52 @@ function updateRunningFooter(ctx: RunningFooterContext): void {
   }
 }
 
+const ZERO_USAGE: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  cost: 0,
+  turns: 0,
+};
+
+interface SpawnContext {
+  sessionManager?: { getSessionId?: () => string };
+}
+
+/** Resolve depth/ownership for a new spawn, plus the root session id for logs. */
+function resolveSpawn(ctx: SpawnContext) {
+  const spawn = resolveSpawnDepth();
+  let rootSessionId = spawn.rootSessionId;
+  if (!rootSessionId) {
+    try {
+      rootSessionId = ctx.sessionManager?.getSessionId?.();
+    } catch {
+      rootSessionId = undefined;
+    }
+  }
+  return { ...spawn, rootSessionId };
+}
+
+/** Tool result returned when a spawn would exceed the orchestration depth cap. */
+function depthLimitResult(
+  limit: number,
+): AgentToolResult<InProcessSubagentDetails> {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text:
+          `Orchestration depth limit reached (max ${limit}). ` +
+          `You are a leaf worker — complete this task directly instead of ` +
+          `delegating to another sub-agent.`,
+      },
+    ],
+    details: { status: "error", usage: ZERO_USAGE },
+    isError: true,
+  } as AgentToolResult<InProcessSubagentDetails>;
+}
+
 function createAsyncJobErrorResult(error: unknown): SubagentResult {
   const message = error instanceof Error ? error.message : String(error);
   return {
@@ -114,6 +162,13 @@ function settleAsyncJob(
   ctx: RunningFooterContext,
 ): void {
   if (jobState.status === "cancelled") return;
+  if (result.cancelled) {
+    jobState.status = "cancelled";
+    jobState.result = result;
+    scheduleJobCleanup(jobId, true);
+    updateRunningFooter(ctx);
+    return;
+  }
   jobState.status = result.isError ? "error" : "done";
   jobState.result = result;
   scheduleJobCleanup(jobId, false, jobState.maxAge);
@@ -153,6 +208,8 @@ async function runSubagent(
   defaultModel: Model<any> | undefined,
   parentModelRegistry: ModelRegistry | undefined,
   thinkingLevel?: ThinkingLevel,
+  depth?: number,
+  rootSessionId?: string,
 ): Promise<SubagentResult> {
   try {
     const { jobPromise, modelWarning } = await startSubagentJob({
@@ -166,6 +223,8 @@ async function runSubagent(
       defaultModel,
       parentModelRegistry,
       thinkingLevel,
+      depth,
+      rootSessionId,
     });
     const result = await jobPromise;
     if (modelWarning && !result.isError) {
@@ -216,9 +275,10 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
       '  - task: "Continue debugging while we plan next steps", async: true, notifyOnComplete: "notify"',
       '  - task: "Summarize the key decisions made in this conversation", model: "anthropic/claude-sonnet-4-5"',
       "",
-      "For async (background) execution, the main agent continues immediately.",
-      'Async jobs inject their result by default when complete. Pass notifyOnComplete: "notify" for a UI-only hint.',
-      "Use async only if user asked to do so or is willing to continue the conversation.",
+      "Runs async (background) BY DEFAULT so the parent turn stays responsive — pass async: false only for a single short sub-agent whose result you need inline.",
+      "When fanning out multiple sub-agents (e.g. one per PR/file), leave async at its default so they run concurrently without blocking the parent.",
+      'The main agent continues immediately; async jobs inject their result by default when complete. Pass notifyOnComplete: "notify" for a UI-only hint.',
+      "Nested orchestration depth is capped (SUBAGENTURA_MAX_ORCHESTRATION_DEPTH, default 3); over-deep spawns are refused and the sub-agent should do the work itself.",
       "Use get_subagent_status to poll progress and get_subagent_result to collect output.",
       "Both modes show the user a completion notification.",
       "notifyOnComplete controls the LLM payload; triggerTurnOnComplete independently controls whether a new parent turn starts.",
@@ -226,10 +286,11 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
     parameters: BaseParams,
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const runAsync = params.async ?? true;
       debugLog("info", "tool_call", {
         toolName: "subagent_with_context",
         toolCallId: _toolCallId,
-        async: params.async ?? false,
+        async: runAsync,
         taskLength: params.task?.length ?? 0,
         persona: params.persona ?? null,
         model: params.model ?? null,
@@ -239,6 +300,9 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
         maxAge: params.maxAge ?? null,
       });
 
+      const spawn = resolveSpawn(ctx);
+      if (spawn.exceedsLimit) return depthLimitResult(spawn.limit);
+
       const branch = ctx.sessionManager.getBranch();
       const messages = branch
         .filter(
@@ -246,7 +310,7 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
         )
         .map((e) => e.message);
 
-      if (params.async === true) {
+      if (runAsync) {
         if (messages.length === 0) {
           return {
             content: [
@@ -260,6 +324,8 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
         const conversationText = serializeConversation(llmMessages);
         const targetCwd = params.cwd ?? ctx.cwd;
 
+        // Own the child's session so any ancestor abort cascades to it.
+        const abort = new AbortController();
         const {
           jobId,
           jobPromise,
@@ -274,12 +340,14 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
           modelOverride: params.model,
           cwd: targetCwd,
           contextText: conversationText,
-          signal: undefined,
+          signal: abort.signal,
           onUpdate: undefined,
           defaultModel: ctx.model,
           maxAge: params.maxAge,
           parentModelRegistry: ctx.modelRegistry,
           thinkingLevel: params.thinkingLevel,
+          depth: spawn.childDepth,
+          rootSessionId: spawn.rootSessionId,
         });
         const jobState: JobState = {
           id: jobId,
@@ -291,6 +359,9 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
           promise: jobPromise,
           modelLabel,
           thinkingLevel,
+          abort,
+          parentJobId: spawn.parentJobId,
+          depth: spawn.childDepth,
           notifyOnComplete:
             params.notifyOnComplete === "inject"
               ? "inject"
@@ -356,7 +427,16 @@ function registerSubagentWithContextTool(pi: ExtensionAPI): void {
         ctx.model,
         ctx.modelRegistry,
         params.thinkingLevel,
+        spawn.childDepth,
+        spawn.rootSessionId,
       );
+
+      if (result.cancelled) {
+        return {
+          content: [{ type: "text", text: result.output }],
+          details: { status: "cancelled" },
+        };
+      }
 
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {
@@ -409,18 +489,21 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
       '  - task: "Give me a second opinion on this approach", model: "anthropic/claude-sonnet-4-5"',
       '  - task: "Analyze this code without context contamination", async: true, notifyOnComplete: "inject"',
       "",
-      "For async (background) execution, the main agent continues immediately.",
-      "Use get_subagent_status to poll progress and get_subagent_result to collect output.",
+      "Runs async (background) BY DEFAULT so the parent turn stays responsive — pass async: false only for a single short sub-agent whose result you need inline.",
+      "When fanning out multiple sub-agents (e.g. one per PR/file), leave async at its default so they run concurrently without blocking the parent.",
+      "The main agent continues immediately. Use get_subagent_status to poll progress and get_subagent_result to collect output.",
+      "Nested orchestration depth is capped (SUBAGENTURA_MAX_ORCHESTRATION_DEPTH, default 3); over-deep spawns are refused and the sub-agent should do the work itself.",
       "Both modes show the user a completion notification.",
       "notifyOnComplete controls the LLM payload; triggerTurnOnComplete independently controls whether a new parent turn starts.",
     ].join("\n"),
     parameters: BaseParams,
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const runAsync = params.async ?? true;
       debugLog("info", "tool_call", {
         toolName: "subagent_isolated",
         toolCallId: _toolCallId,
-        async: params.async ?? false,
+        async: runAsync,
         taskLength: params.task?.length ?? 0,
         persona: params.persona ?? null,
         model: params.model ?? null,
@@ -430,8 +513,13 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
         maxAge: params.maxAge ?? null,
       });
 
-      if (params.async === true) {
+      const spawn = resolveSpawn(ctx);
+      if (spawn.exceedsLimit) return depthLimitResult(spawn.limit);
+
+      if (runAsync) {
         const targetCwd = params.cwd ?? ctx.cwd;
+        // Own the child's session so any ancestor abort cascades to it.
+        const abort = new AbortController();
         const {
           jobId,
           jobPromise,
@@ -446,12 +534,14 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
           modelOverride: params.model,
           cwd: targetCwd,
           contextText: null,
-          signal: undefined,
+          signal: abort.signal,
           onUpdate: undefined,
           defaultModel: ctx.model,
           maxAge: params.maxAge,
           parentModelRegistry: ctx.modelRegistry,
           thinkingLevel: params.thinkingLevel,
+          depth: spawn.childDepth,
+          rootSessionId: spawn.rootSessionId,
         });
         const jobState: JobState = {
           id: jobId,
@@ -463,6 +553,9 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
           promise: jobPromise,
           modelLabel,
           thinkingLevel,
+          abort,
+          parentJobId: spawn.parentJobId,
+          depth: spawn.childDepth,
           notifyOnComplete:
             params.notifyOnComplete === "inject"
               ? "inject"
@@ -516,7 +609,16 @@ function registerSubagentIsolatedTool(pi: ExtensionAPI): void {
         ctx.model,
         ctx.modelRegistry,
         params.thinkingLevel,
+        spawn.childDepth,
+        spawn.rootSessionId,
       );
+
+      if (result.cancelled) {
+        return {
+          content: [{ type: "text", text: result.output }],
+          details: { status: "cancelled" },
+        };
+      }
 
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {
@@ -814,6 +916,20 @@ function registerCancelSubagentTool(pi: ExtensionAPI): void {
         };
       }
 
+      let initiator: string | undefined;
+      try {
+        initiator = (
+          ctx as { sessionManager?: { getSessionId?: () => string } }
+        ).sessionManager?.getSessionId?.();
+      } catch {
+        initiator = undefined;
+      }
+      const info = {
+        source: "cancel_subagent" as const,
+        initiator,
+        reason: `cancel_subagent tool cancelled job ${params.jobId}`,
+      };
+      job.cancellation = { ...info, at: Date.now() };
       job.cancellationSnapshot = snapshotInProcessSession({
         kind: "in-process",
         jobId: job.id,
@@ -823,9 +939,12 @@ function registerCancelSubagentTool(pi: ExtensionAPI): void {
         activeTool: job.liveStatus.activeTool,
         partialOutput: job.liveStatus.output,
         source: "cancel_subagent",
+        initiator: info.initiator,
+        reason: info.reason,
       });
       try {
-        await job.session.abort();
+        // Aborts this job AND cascades to every descendant it owns.
+        abortJobTree(params.jobId, info);
       } catch {
         /* Session may already be disposed; abort is best-effort */
       }

--- a/tests/in-process-tools.test.ts
+++ b/tests/in-process-tools.test.ts
@@ -92,6 +92,10 @@ import {
   registerInProcessMaintenanceTools,
   registerInProcessSubagentTools,
 } from "../src/tools/in-process";
+import {
+  DEFAULT_MAX_ORCHESTRATION_DEPTH,
+  withOrchestrationContext,
+} from "../src/orchestration-context";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -283,10 +287,11 @@ describe("subagent_isolated tool", () => {
 
   it("passes null context to startSubagentJob (sync path)", async () => {
     const ctx = mockCtx();
-    // isolated tool doesn't consult getBranch at all, so no messages needed
+    // isolated tool doesn't consult getBranch at all, so no messages needed.
+    // async now defaults to true, so pass async: false to exercise the sync path.
     const result = await toolDef.execute(
       "call-1",
-      { task: "analyze code" },
+      { task: "analyze code", async: false },
       undefined,
       undefined,
       ctx,
@@ -299,6 +304,45 @@ describe("subagent_isolated tool", () => {
     // Result should come from the mocked runSubagent path
     expect(result.content[0].text).toBe("task completed");
     expect(result.details.status).toBe("done");
+  });
+
+  it("defaults to async (background) when the flag is omitted", async () => {
+    const ctx = mockCtx();
+    const result = await toolDef.execute(
+      "call-async-default",
+      { task: "analyze code" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    // Async path returns immediately with a started job, not inline output.
+    expect(result.details.status).toBe("started");
+    expect(result.content[0].text).toMatch(/^Job .* started/);
+    // The owning controller must be wired so ancestor aborts can cascade.
+    expect(mockStartSubagentJob).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: expect.any(AbortSignal), depth: 1 }),
+    );
+  });
+
+  it("refuses to spawn once the orchestration depth cap is reached", async () => {
+    const ctx = mockCtx();
+    const result = await withOrchestrationContext(
+      { ownerJobId: "deep-parent", depth: DEFAULT_MAX_ORCHESTRATION_DEPTH },
+      () =>
+        toolDef.execute(
+          "call-too-deep",
+          { task: "spawn yet another reviewer" },
+          undefined,
+          undefined,
+          ctx,
+        ),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/depth limit reached/i);
+    // No job should have been spawned.
+    expect(mockStartSubagentJob).not.toHaveBeenCalled();
   });
 
   it("registers with BaseParams schema", () => {

--- a/tests/orchestration-cancellation.test.ts
+++ b/tests/orchestration-cancellation.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MAX_ORCHESTRATION_DEPTH,
+  getOrchestrationContext,
+  maxOrchestrationDepth,
+  resolveSpawnDepth,
+  withOrchestrationContext,
+} from "../src/orchestration-context";
+import {
+  abortJobTree,
+  cascadeChildAborts,
+  jobRegistry,
+  readCancellationInfo,
+  type CancellationInfo,
+  type JobState,
+} from "../src/helpers";
+
+function fakeJob(overrides: Partial<JobState> & { id: string }): JobState {
+  return {
+    status: "running",
+    liveStatus: {
+      turn: 1,
+      output: "",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    },
+    session: { abort: vi.fn().mockResolvedValue(undefined) } as any,
+    startedAt: Date.now(),
+    promise: Promise.resolve({
+      output: "",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+      isError: false,
+    }) as any,
+    ...overrides,
+  };
+}
+
+describe("orchestration context + depth cap", () => {
+  afterEach(() => {
+    delete process.env.SUBAGENTURA_MAX_ORCHESTRATION_DEPTH;
+  });
+
+  it("root spawn has no parent and sits at depth 1", () => {
+    expect(getOrchestrationContext()).toBeUndefined();
+    const spawn = resolveSpawnDepth();
+    expect(spawn.childDepth).toBe(1);
+    expect(spawn.parentJobId).toBeUndefined();
+    expect(spawn.exceedsLimit).toBe(false);
+  });
+
+  it("nested spawn inherits owner and increments depth", () => {
+    withOrchestrationContext(
+      { ownerJobId: "job-a", depth: 1, rootSessionId: "root-1" },
+      () => {
+        const spawn = resolveSpawnDepth();
+        expect(spawn.childDepth).toBe(2);
+        expect(spawn.parentJobId).toBe("job-a");
+        expect(spawn.rootSessionId).toBe("root-1");
+        expect(spawn.exceedsLimit).toBe(false);
+      },
+    );
+  });
+
+  it("refuses a spawn that would exceed the depth cap", () => {
+    withOrchestrationContext(
+      { ownerJobId: "deep", depth: DEFAULT_MAX_ORCHESTRATION_DEPTH },
+      () => {
+        const spawn = resolveSpawnDepth();
+        expect(spawn.childDepth).toBe(DEFAULT_MAX_ORCHESTRATION_DEPTH + 1);
+        expect(spawn.exceedsLimit).toBe(true);
+      },
+    );
+  });
+
+  it("honours SUBAGENTURA_MAX_ORCHESTRATION_DEPTH override", () => {
+    process.env.SUBAGENTURA_MAX_ORCHESTRATION_DEPTH = "1";
+    expect(maxOrchestrationDepth()).toBe(1);
+    withOrchestrationContext({ ownerJobId: "x", depth: 1 }, () => {
+      expect(resolveSpawnDepth().exceedsLimit).toBe(true);
+    });
+  });
+
+  it("falls back to the default for invalid overrides", () => {
+    process.env.SUBAGENTURA_MAX_ORCHESTRATION_DEPTH = "not-a-number";
+    expect(maxOrchestrationDepth()).toBe(DEFAULT_MAX_ORCHESTRATION_DEPTH);
+  });
+});
+
+describe("readCancellationInfo", () => {
+  it("returns a structured reason verbatim", () => {
+    const info: CancellationInfo = {
+      source: "cancel_subagent",
+      initiator: "sess-1",
+      reason: "user cancelled",
+    };
+    const c = new AbortController();
+    c.abort(info);
+    expect(readCancellationInfo(c.signal, "signal")).toEqual(info);
+  });
+
+  it("surfaces an Error reason message under the fallback source", () => {
+    const c = new AbortController();
+    c.abort(new Error("boom"));
+    expect(readCancellationInfo(c.signal, "signal")).toEqual({
+      source: "signal",
+      reason: "boom",
+    });
+  });
+
+  it("uses the fallback source when there is no reason", () => {
+    expect(readCancellationInfo(undefined, "session_shutdown")).toEqual({
+      source: "session_shutdown",
+      reason: undefined,
+    });
+  });
+});
+
+describe("transitive cancellation", () => {
+  beforeEach(() => jobRegistry.clear());
+  afterEach(() => jobRegistry.clear());
+
+  const info: CancellationInfo = {
+    source: "cancel_subagent",
+    initiator: "sess-1",
+    reason: "test cancel",
+  };
+
+  it("abortJobTree aborts the target controller and marks children cancelled", () => {
+    const parentAbort = new AbortController();
+    const childAbort = new AbortController();
+    jobRegistry.set("p", fakeJob({ id: "p", abort: parentAbort }));
+    jobRegistry.set(
+      "c",
+      fakeJob({ id: "c", parentJobId: "p", abort: childAbort }),
+    );
+
+    const aborted = abortJobTree("p", info);
+
+    expect(aborted).toContain("p");
+    expect(aborted).toContain("c");
+    expect(parentAbort.signal.aborted).toBe(true);
+    expect(childAbort.signal.aborted).toBe(true);
+    // The controller reason carries the structured cancellation info.
+    expect(parentAbort.signal.reason).toEqual(info);
+    expect(jobRegistry.get("c")!.status).toBe("cancelled");
+    expect(jobRegistry.get("c")!.cancellation?.source).toBe("cancel_subagent");
+  });
+
+  it("cascades recursively through controller-less descendants", () => {
+    // Sync-spawned descendants have no controller, so cascade recurses directly.
+    jobRegistry.set("p", fakeJob({ id: "p" }));
+    jobRegistry.set("c", fakeJob({ id: "c", parentJobId: "p" }));
+    jobRegistry.set("g", fakeJob({ id: "g", parentJobId: "c" }));
+
+    const signalled = cascadeChildAborts("p", info);
+
+    expect(signalled).toEqual(expect.arrayContaining(["c", "g"]));
+    expect(jobRegistry.get("c")!.status).toBe("cancelled");
+    expect(jobRegistry.get("g")!.status).toBe("cancelled");
+    expect(jobRegistry.get("c")!.session.abort as any).toHaveBeenCalled();
+    expect(jobRegistry.get("g")!.session.abort as any).toHaveBeenCalled();
+  });
+
+  it("ignores unrelated and already-terminal jobs", () => {
+    jobRegistry.set("p", fakeJob({ id: "p" }));
+    jobRegistry.set("other", fakeJob({ id: "other" }));
+    jobRegistry.set(
+      "done",
+      fakeJob({ id: "done", parentJobId: "p", status: "done" }),
+    );
+
+    const signalled = cascadeChildAborts("p", info);
+
+    expect(signalled).toEqual([]);
+    expect(jobRegistry.get("other")!.status).toBe("running");
+    expect(jobRegistry.get("done")!.status).toBe("done");
+  });
+});


### PR DESCRIPTION
## Summary

- default in-process sub-agent calls to background execution so fan-out does not block the parent turn
- track nested in-process orchestration ownership and enforce a configurable maximum depth
- cascade cancellation through owned in-process descendants and return explicit cancelled results
- preserve cancellation initiator/reason metadata in logs and snapshots
- update orchestrator guidance and package contents for the new orchestration context module

## Validation

- `npm run typecheck`
- `npm test` — 1,059 tests passed
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`
