### PR TITLE
Add only-interactive mode for interactive-only extension registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.2.0] - 2026-07-31
 
+### Added
+
+- Only-interactive mode: `pi --only-interactive` (or `PI_SUBAGENTURA_ONLY_INTERACTIVE=1`) registers only the six attachable child-session tools plus `list_available_models` and `cleanup_subagent_artifacts`, dropping the in-process and workflow tools and their slash commands. Session handlers, the artifact poller, rehydration, `/cancel-all-flows`, and `ctrl+alt+x` stay active.
+- `ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md`: `--orchestrator` injects this reduced prompt in only-interactive mode so the parent is never told to call a tool that mode omits.
+
 ### Fixed
 
 - Concurrent parent sessions now keep in-process jobs, interactive sub-agents, delivery queues, streaming state, supervisor actions, and shutdown cleanup isolated by exact session generation.
+
+## [3.1.0] - 2026-07-26
 
 ### Added
 

--- a/ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md
+++ b/ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md
@@ -1,0 +1,146 @@
+# Orchestrator System Prompt (only-interactive mode)
+
+This session runs pi-subagentura in only-interactive mode. Delegation happens
+through one mechanism: `subagent_interactive`, which starts a real child Pi
+process in a tmux or Zellij pane that the user can watch and attach to.
+In-process delegation and script-driven multi-agent orchestration are **not
+registered** in this mode. Never claim to use a tool that is not listed below.
+
+## Available tools
+
+| Tool                                | Use                                                            |
+| ----------------------------------- | -------------------------------------------------------------- |
+| `subagent_interactive`              | Start an attachable child Pi session for one task              |
+| `get_interactive_subagent_status`   | Inspect live status of child sessions                          |
+| `send_interactive_subagent_message` | Send a follow-up turn to a child, preserving its context       |
+| `cancel_interactive_subagent`       | Kill a child pane                                              |
+| `list_subagent_artifacts`           | List durable child artifacts                                   |
+| `read_subagent_artifact`            | Read a child's lifecycle events and output snapshots           |
+| `cleanup_subagent_artifacts`        | Remove expired artifact directories and stale registry entries |
+| `list_available_models`             | Confirm a model id exists before passing `model`               |
+
+The user can stop every running child at once with `/cancel-all-flows` or
+`ctrl+alt+x`.
+
+## Parent responsibility
+
+You remain the single coordinator. You decide when to delegate, define each
+child task, keep write access controlled, synthesize results, verify important
+claims, and give the user a short final answer.
+
+Delegate to widen investigation, reduce context pressure, or get independent
+review — not because a tool exists.
+
+## Default behavior
+
+- Handle small or obvious tasks directly.
+- Inspect the repo/diff yourself before delegating so child tasks are precise.
+- Use `subagent_interactive` for scouts, reviewers, planners, and any
+  long-running or human-watchable investigation.
+- Run at most one writer against the active worktree at a time.
+- Make reviewers and scouts read-only.
+- Ask the user before ambiguous, architectural, security-sensitive, destructive,
+  or irreversible decisions.
+- Only set a child `model` after confirming it exists with
+  `list_available_models`; otherwise inherit the parent model.
+
+## Child sessions are always asynchronous
+
+`subagent_interactive` returns as soon as the pane is spawned, so the parent turn
+stays responsive and interruptible. Fan-out (e.g. one reviewer per file) is
+therefore safe, but every child costs a pane and a process — keep concurrency to
+what the user can actually follow.
+
+- `notifyOnComplete: "inject"` resumes the parent with the child's full output.
+- `notifyOnComplete: "notify"` (default) persists a pointer-only completion;
+  read the referenced artifact when you need the content.
+- `triggerTurnOnComplete: false` records completion without waking the parent.
+- `background: false` splits the pane side by side when the user wants to watch
+  in real time; the default detached window keeps the layout clean.
+- Do not poll. Call `get_interactive_subagent_status` only if the user asks, a
+  child appears stuck, or you need to cancel or follow up.
+- Use `send_interactive_subagent_message` for true follow-ups: it preserves the
+  child's model context instead of starting a fresh session.
+- Synthesize child results; do not dump raw reports unless that is the most
+  useful output.
+
+## Bounded nesting
+
+A child can spawn its own children. Nested orchestration depth is capped
+(`SUBAGENTURA_MAX_ORCHESTRATION_DEPTH`, default 3); an over-deep spawn is
+refused and that sub-agent must finish the task itself. Give scouts and
+reviewers leaf tasks: instruct them to do the work directly and not delegate
+further.
+
+## Verification rule
+
+Before reporting a behavioral bug, require evidence: a failing test, repro
+command, actual-vs-expected output, or direct observation. If evidence is
+missing, say: "I could not verify this claim."
+
+When child reports conflict, resolve it in the parent by checking files/tests
+yourself, or state the uncertainty.
+
+## Routing patterns
+
+- **Small task:** do it directly; optionally use one child for a focused second
+  opinion.
+- **Review repo/codebase:** inspect dependencies and structure first, then start
+  2-4 read-only children with distinct angles.
+- **Review diff/changes:** inspect the diff first, then start read-only children
+  for correctness/regressions, tests/validation, and simplicity.
+- **Plan work:** scout relevant files if unclear, then produce a concrete plan.
+  Ask before implementing if choices are high-stakes or ambiguous.
+- **Second opinion:** start one child with `includeContext: true` so it can
+  challenge the assumptions and drift in this conversation. It must not edit.
+- **Implement and review:** one child implements; read-only children review; one
+  child applies accepted fixes if authorized. Stop after 3 review rounds or when
+  only optional feedback remains.
+
+## Child task templates
+
+Give every child a narrow scope, explicit edit permission, files/diff/commands
+to inspect, and expected output format. Pass the role as `persona` and the work
+as `task`.
+
+### Scout
+
+```text
+You are a scouting subagent. Use targeted search and selective reading. Do not edit files. Return only what the parent needs: relevant entry points, key files/types/functions, data flow, constraints, likely change locations, risks, and open questions. Cite exact file paths and line ranges where possible. Do not guess.
+```
+
+### Planner
+
+```text
+You are a planning subagent. Convert the request and code context into a concrete implementation plan. Do not edit files. Name exact files when possible. Prefer small ordered steps with acceptance criteria and validation commands. Surface ambiguity instead of guessing.
+```
+
+### Worker
+
+```text
+You are the single implementation writer. Make narrow, coherent edits for the approved task only. Follow existing project conventions. If an unapproved product, architecture, security, destructive, or scope decision is required, stop and report instead of guessing. Validate with appropriate checks. Return changed files, commands run, results, risks, and next steps.
+```
+
+### Reviewer
+
+```text
+You are a disciplined review subagent. Inspect the actual repo, instructions, and current diff/files directly. Do not edit files. Report only evidence-backed findings with file paths and line references. For behavioral bug claims, verify with a repro/test or explicitly say: "I could not verify this claim." Separate blockers from optional improvements. If there are no material findings, say so plainly.
+```
+
+### Oracle
+
+Start with `includeContext: true` when prior conversation and decisions matter:
+
+```text
+You are an oracle subagent. Use the inherited conversation to reconstruct decisions, constraints, assumptions, and open questions. Challenge the current approach for contradictions, drift, missing constraints, and unsafe assumptions. Do not edit files. Recommend the safest next move and identify any user decisions needed.
+```
+
+## Parent final response
+
+Keep final responses short:
+
+- what was delegated, if anything;
+- what changed or was learned;
+- validation commands/results;
+- decisions needed, only if blocked;
+- one clear next step.

--- a/ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md
+++ b/ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md
@@ -64,13 +64,12 @@ what the user can actually follow.
 - Synthesize child results; do not dump raw reports unless that is the most
   useful output.
 
-## Bounded nesting
+## Child sessions are leaf workers
 
-A child can spawn its own children. Nested orchestration depth is capped
-(`SUBAGENTURA_MAX_ORCHESTRATION_DEPTH`, default 3); an over-deep spawn is
-refused and that sub-agent must finish the task itself. Give scouts and
-reviewers leaf tasks: instruct them to do the work directly and not delegate
-further.
+Children run with `PI_SUBAGENTURA_CHILD=1`, which registers only the child
+protocol and no delegation tools. They cannot spawn another child. Give each
+child a self-contained task it can finish directly, and keep all spawning,
+follow-up, and coordination in this parent session.
 
 ## Verification rule
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ pi --orchestrator
 workflow. `/workflows` runs saved workflows, and `/workflow-tree` shows live
 phases, agents, and cancellation controls.
 
+Attach-only mode keeps the full interactive session toolchain but skips in-process
+and workflow sub-agents. Start Pi with:
+
+```text
+pi --only-interactive
+```
+
+Use this when you want only attachable child-session tools while preserving
+poller/rehydration and interactive artifact controls.
+
 ## Reusable workflows
 
 Workflow files are ordinary `.mjs` scripts with static metadata and a small set

--- a/README.md
+++ b/README.md
@@ -55,15 +55,50 @@ pi --orchestrator
 workflow. `/workflows` runs saved workflows, and `/workflow-tree` shows live
 phases, agents, and cancellation controls.
 
-Attach-only mode keeps the full interactive session toolchain but skips in-process
-and workflow sub-agents. Start Pi with:
+## Only-interactive mode
 
 ```text
 pi --only-interactive
 ```
 
-Use this when you want only attachable child-session tools while preserving
-poller/rehydration and interactive artifact controls.
+Only-interactive mode registers a reduced surface: the six attachable
+child-session tools plus model listing and artifact cleanup. Session handlers,
+the artifact poller, and rehydration stay active, so children survive reload and
+resume. Use it when you want child Pi sessions you can watch and attach to, and
+none of the in-process or workflow machinery.
+
+The mode is chosen when the extension loads — before Pi applies flag values — so
+pass `--only-interactive` on the command line or set
+`PI_SUBAGENTURA_ONLY_INTERACTIVE=1` in the environment. Combined with
+`--orchestrator` it injects `ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md`, a
+reduced prompt that mentions only the tools this mode registers.
+
+### Registered in only-interactive mode
+
+| Tool                                | Purpose                                                        |
+| ----------------------------------- | -------------------------------------------------------------- |
+| `subagent_interactive`              | Launch an attachable Pi session in tmux/Zellij                 |
+| `get_interactive_subagent_status`   | Inspect attachable child sessions                              |
+| `send_interactive_subagent_message` | Send a follow-up while preserving child context                |
+| `cancel_interactive_subagent`       | Kill an attachable child pane                                  |
+| `list_subagent_artifacts`           | List durable interactive-agent artifacts                       |
+| `read_subagent_artifact`            | Read lifecycle events and output snapshots                     |
+| `cleanup_subagent_artifacts`        | Remove expired artifact directories and stale registry entries |
+| `list_available_models`             | List configured model identifiers                              |
+
+The `/cancel-all-flows` command and its `ctrl+alt+x` shortcut stay available.
+
+### Not registered in only-interactive mode
+
+Thirteen tools are dropped: `workflow`, `save_workflow`, `list_workflows`,
+`delete_workflow`, `get_workflow_status`, `get_workflow_result`,
+`cancel_workflow`, `subagent_with_context`, `subagent_isolated`,
+`get_subagent_status`, `get_subagent_result`, `cancel_subagent`, and
+`prune_subagent_jobs`.
+
+Six slash commands go with them: `/workflow`, `/workflows`, `/list-workflows`,
+`/workflow-status`, `/workflow-tree`, and `/delete-workflow`. The Quick start
+above therefore does not apply in this mode.
 
 ## Reusable workflows
 
@@ -112,7 +147,9 @@ See the [workflow guide](./docs/workflows.md) and
 
 ## User commands
 
-These commands are intended for people at the Pi prompt.
+These commands are intended for people at the Pi prompt. In
+[only-interactive mode](#only-interactive-mode) only `/cancel-all-flows` is
+registered.
 
 | Command             | Purpose                                                           |
 | ------------------- | ----------------------------------------------------------------- |
@@ -127,7 +164,8 @@ These commands are intended for people at the Pi prompt.
 
 ## Agent-facing tools
 
-The extension registers 21 public tools for parent agents.
+The extension registers 21 public tools for parent agents, or the 8 listed under
+[only-interactive mode](#only-interactive-mode).
 
 | Tool                                | Purpose                                                        |
 | ----------------------------------- | -------------------------------------------------------------- |
@@ -205,6 +243,8 @@ The guidance gives the parent agent reasonable default behavior when the user as
 - “implement and review” — use one writer, parallel reviewers, and capped fix/review rounds
 
 The defaults prefer async `subagent_isolated` for fresh scouts/reviewers, `subagent_with_context` for oracle checks, injected completions instead of polling, and one writer at a time for implementation. For cheap fanout, they suggest validating model availability before using optional model overrides.
+
+In [only-interactive mode](#only-interactive-mode) the flag injects `ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md` instead, which routes every delegation through `subagent_interactive` and never names a tool that mode omits.
 
 ## Cancellation context snapshots (opt-in)
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "files": [
     "LICENSE",
     "ORCHESTRATOR_SYSTEM_PROMPT.md",
+    "ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md",
     "docs/workflows.md",
     "examples/workflows/README.md",
     "examples/workflows/*.mjs",

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -31,10 +31,9 @@ import {
 } from "./helpers";
 import { registerWorkflowTool } from "./workflow";
 import {
+  ONLY_INTERACTIVE_MAINTENANCE_TOOLS,
   registerInProcessMaintenanceTools,
   registerInProcessSubagentTools,
-  registerSubagentArtifactsCleanupTool,
-  registerSubagentModelListTool,
 } from "./tools/in-process";
 import { registerInteractiveSubagentTools } from "./tools/interactive";
 import { registerSessionHandlers } from "./session-handlers";
@@ -84,6 +83,43 @@ const ORCHESTRATOR_SYSTEM_PROMPT = readFileSync(
   "utf8",
 ).trim();
 
+/**
+ * Reduced orchestration guidance for only-interactive mode: the full prompt
+ * instructs the model to use in-process and script-orchestration tools that are
+ * not registered in that mode.
+ */
+const ONLY_INTERACTIVE_ORCHESTRATOR_SYSTEM_PROMPT = readFileSync(
+  new URL("../ORCHESTRATOR_ONLY_INTERACTIVE_SYSTEM_PROMPT.md", import.meta.url),
+  "utf8",
+).trim();
+
+/**
+ * Detects only-interactive mode from load-time signals — deliberately NOT from
+ * `pi.getFlag("only-interactive")`.
+ *
+ * `getFlag` is unusable during activation: Pi must load extensions first to
+ * learn which flags exist, and applies CLI flag values only afterwards
+ * (`resourceLoader.reload()` runs every extension factory before
+ * `applyExtensionFlagValues()` in @earendil-works/pi-coding-agent's
+ * `core/agent-session-services.js`). Until that point `getFlag` returns the
+ * default `registerFlag` seeded — i.e. `false` — so a flag read here always
+ * loses. Flags are only readable lazily, from inside an event handler; see the
+ * `before_agent_start` handler below, which is why `--orchestrator` can use
+ * `getFlag`.
+ *
+ * This mode decides *tool registration*, which happens during activation, so it
+ * reads the signals that already exist then: the env var (programmatic and test
+ * use) and raw argv (so the documented CLI flag works). `--only-interactive` is
+ * still registered via `registerFlag` so `--help` lists it and Pi's flag
+ * validation accepts it.
+ */
+function isOnlyInteractiveMode(): boolean {
+  return (
+    process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE === "1" ||
+    process.argv.includes("--only-interactive")
+  );
+}
+
 export default function (pi: ExtensionAPI) {
   if (process.env.PI_SUBAGENTURA_CHILD === "1") {
     registerChildProtocol(pi);
@@ -108,23 +144,29 @@ export default function (pi: ExtensionAPI) {
     default: false,
   });
   pi.registerFlag("only-interactive", {
-    description: "Enable only interactive sub-agent tools",
+    description:
+      "Register only attachable interactive sub-agent tools, model listing, and artifact cleanup",
     type: "boolean",
     default: false,
   });
-  const onlyInteractive = pi.getFlag("only-interactive") === true;
+  const onlyInteractive = isOnlyInteractiveMode();
   pi.on("before_agent_start", (event) => {
     if (pi.getFlag("orchestrator") !== true) return;
+    const prompt = onlyInteractive
+      ? ONLY_INTERACTIVE_ORCHESTRATOR_SYSTEM_PROMPT
+      : ORCHESTRATOR_SYSTEM_PROMPT;
     return {
-      systemPrompt: `${event.systemPrompt}\n\n${ORCHESTRATOR_SYSTEM_PROMPT}`,
+      systemPrompt: `${event.systemPrompt}\n\n${prompt}`,
     };
   });
   pi.registerMessageRenderer("subagent-notify", renderSubagentNotify);
-const sessionScope = registerSessionHandlers(pi);
+  const sessionScope = registerSessionHandlers(pi);
   registerInteractiveSubagentTools(pi, sessionScope);
   if (onlyInteractive) {
-    registerSubagentArtifactsCleanupTool(pi, sessionScope);
-    registerSubagentModelListTool(pi);
+    registerInProcessMaintenanceTools(pi, {
+      scope: sessionScope,
+      include: ONLY_INTERACTIVE_MAINTENANCE_TOOLS,
+    });
   } else {
     registerWorkflowTool(pi, sessionScope);
     registerInProcessSubagentTools(pi, sessionScope);

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -109,14 +109,19 @@ const ONLY_INTERACTIVE_ORCHESTRATOR_SYSTEM_PROMPT = readFileSync(
  *
  * This mode decides *tool registration*, which happens during activation, so it
  * reads the signals that already exist then: the env var (programmatic and test
- * use) and raw argv (so the documented CLI flag works). `--only-interactive` is
- * still registered via `registerFlag` so `--help` lists it and Pi's flag
- * validation accepts it.
+ * use) and raw argv (so the documented CLI flag works). Pi's unknown-flag
+ * parser recognizes either the exact token or `--only-interactive=<value>`;
+ * every supplied value, including `false`, enables a registered boolean.
+ * `--only-interactive` is still registered via `registerFlag` so `--help` lists
+ * it and Pi's flag validation accepts it.
  */
 function isOnlyInteractiveMode(): boolean {
   return (
     process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE === "1" ||
-    process.argv.includes("--only-interactive")
+    process.argv.some(
+      (arg) =>
+        arg === "--only-interactive" || arg.startsWith("--only-interactive="),
+    )
   );
 }
 
@@ -128,8 +133,10 @@ export default function (pi: ExtensionAPI) {
     }
     const sessionScope = registerSessionHandlers(pi);
     registerInteractiveSubagentTools(pi, sessionScope);
-    registerSubagentArtifactsCleanupTool(pi, sessionScope);
-    registerSubagentModelListTool(pi);
+    registerInProcessMaintenanceTools(pi, {
+      scope: sessionScope,
+      include: ONLY_INTERACTIVE_MAINTENANCE_TOOLS,
+    });
     registerInteractiveSupervisor(pi, sessionScope);
     return;
   }
@@ -172,7 +179,9 @@ export default function (pi: ExtensionAPI) {
     registerInProcessSubagentTools(pi, sessionScope);
     registerInProcessMaintenanceTools(pi, sessionScope);
   }
-  registerInteractiveSupervisor(pi, sessionScope);
+  if (!onlyInteractive) {
+    registerInteractiveSupervisor(pi, sessionScope);
+  }
   // ── Cancel-all-flows shortcut and command ──────────────────────
   registerCancelAllFlows(pi, sessionScope);
 }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -107,6 +107,12 @@ export default function (pi: ExtensionAPI) {
     type: "boolean",
     default: false,
   });
+  pi.registerFlag("only-interactive", {
+    description: "Enable only interactive sub-agent tools",
+    type: "boolean",
+    default: false,
+  });
+  const onlyInteractive = pi.getFlag("only-interactive") === true;
   pi.on("before_agent_start", (event) => {
     if (pi.getFlag("orchestrator") !== true) return;
     return {
@@ -114,12 +120,17 @@ export default function (pi: ExtensionAPI) {
     };
   });
   pi.registerMessageRenderer("subagent-notify", renderSubagentNotify);
-  const sessionScope = registerSessionHandlers(pi);
+const sessionScope = registerSessionHandlers(pi);
   registerInteractiveSubagentTools(pi, sessionScope);
+  if (onlyInteractive) {
+    registerSubagentArtifactsCleanupTool(pi, sessionScope);
+    registerSubagentModelListTool(pi);
+  } else {
+    registerWorkflowTool(pi, sessionScope);
+    registerInProcessSubagentTools(pi, sessionScope);
+    registerInProcessMaintenanceTools(pi, sessionScope);
+  }
   registerInteractiveSupervisor(pi, sessionScope);
-  registerWorkflowTool(pi, sessionScope);
-  registerInProcessSubagentTools(pi, sessionScope);
-  registerInProcessMaintenanceTools(pi, sessionScope);
   // ── Cancel-all-flows shortcut and command ──────────────────────
   registerCancelAllFlows(pi, sessionScope);
 }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -1200,8 +1200,7 @@ function registerCancelSubagentTool(
 
     renderResult(result, _options, theme, _context) {
       const details = result.details as
-        | (InProcessSubagentDetails & { jobId?: string })
-        | undefined;
+        (InProcessSubagentDetails & { jobId?: string }) | undefined;
       const jobId = String(details?.jobId ?? "unknown");
       const cancelled = details?.status === "cancelled";
       const firstContent = result.content?.[0];
@@ -1601,33 +1600,5 @@ export function registerInProcessMaintenanceTools(
   const include = isScope ? undefined : scopeOrOptions.include;
   for (const name of include ?? MAINTENANCE_TOOL_NAMES) {
     MAINTENANCE_REGISTRARS[name](pi, scope);
-  }
-}
-
-export type MaintenanceToolName = (typeof MAINTENANCE_TOOL_NAMES)[number];
-
-/**
- * Maintenance tools kept in only-interactive mode: model listing (children take
- * a `model`) and artifact cleanup (interactive children write artifacts).
- * `prune_subagent_jobs` is excluded because in-process jobs cannot exist there.
- */
-export const ONLY_INTERACTIVE_MAINTENANCE_TOOLS: readonly MaintenanceToolName[] =
-  ["list_available_models", "cleanup_subagent_artifacts"];
-
-const MAINTENANCE_REGISTRARS: Record<
-  MaintenanceToolName,
-  (pi: ExtensionAPI) => void
-> = {
-  list_available_models: registerListAvailableModelsTool,
-  prune_subagent_jobs: registerPruneSubagentJobsTool,
-  cleanup_subagent_artifacts: registerCleanupArtifactsTool,
-};
-
-export function registerInProcessMaintenanceTools(
-  pi: ExtensionAPI,
-  options: { include?: readonly MaintenanceToolName[] } = {},
-): void {
-  for (const name of options.include ?? MAINTENANCE_TOOL_NAMES) {
-    MAINTENANCE_REGISTRARS[name](pi);
   }
 }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -1563,3 +1563,7 @@ export function registerSubagentArtifactsCleanupTool(
 ): void {
   registerCleanupArtifactsTool(pi, scope);
 }
+
+export function registerSubagentArtifactsCleanupTool(pi: ExtensionAPI): void {
+  registerCleanupArtifactsTool(pi);
+}

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -1200,7 +1200,8 @@ function registerCancelSubagentTool(
 
     renderResult(result, _options, theme, _context) {
       const details = result.details as
-        (InProcessSubagentDetails & { jobId?: string }) | undefined;
+        | (InProcessSubagentDetails & { jobId?: string })
+        | undefined;
       const jobId = String(details?.jobId ?? "unknown");
       const cancelled = details?.status === "cancelled";
       const firstContent = result.content?.[0];
@@ -1545,28 +1546,88 @@ export function registerInProcessSubagentTools(
   registerCancelSubagentTool(pi, toolToken);
 }
 
+/**
+ * Every maintenance tool, in registration order — the single source of truth.
+ *
+ * A new maintenance tool must be added here, which forces an explicit decision
+ * about whether it belongs in `ONLY_INTERACTIVE_MAINTENANCE_TOOLS` too.
+ */
+export const MAINTENANCE_TOOL_NAMES = [
+  "list_available_models",
+  "prune_subagent_jobs",
+  "cleanup_subagent_artifacts",
+] as const;
+
+export type MaintenanceToolName = (typeof MAINTENANCE_TOOL_NAMES)[number];
+
+/**
+ * Maintenance tools kept in only-interactive mode: model listing (children take
+ * a `model`) and artifact cleanup (interactive children write artifacts).
+ * `prune_subagent_jobs` is excluded because in-process jobs cannot exist there.
+ */
+export const ONLY_INTERACTIVE_MAINTENANCE_TOOLS: readonly MaintenanceToolName[] =
+  ["list_available_models", "cleanup_subagent_artifacts"];
+
+type MaintenanceRegistrationOptions = {
+  include?: readonly MaintenanceToolName[];
+  scope?: SessionScope;
+};
+
+const MAINTENANCE_REGISTRARS: Record<
+  MaintenanceToolName,
+  (pi: ExtensionAPI, scope?: SessionScope) => void
+> = {
+  list_available_models: (pi) => registerListAvailableModelsTool(pi),
+  prune_subagent_jobs: (pi, scope) =>
+    registerPruneSubagentJobsTool(pi, scope ? { id: scope.id } : undefined),
+  cleanup_subagent_artifacts: (pi, scope) =>
+    registerCleanupArtifactsTool(pi, scope),
+};
+
 export function registerInProcessMaintenanceTools(
   pi: ExtensionAPI,
   scope?: SessionScope,
-): void {
-  registerListAvailableModelsTool(pi);
-  registerPruneSubagentJobsTool(pi, scope ? { id: scope.id } : undefined);
-  registerCleanupArtifactsTool(pi, scope);
-}
-
-export function registerSubagentModelListTool(pi: ExtensionAPI): void {
-  registerListAvailableModelsTool(pi);
-}
-export function registerSubagentArtifactsCleanupTool(
+): void;
+export function registerInProcessMaintenanceTools(
   pi: ExtensionAPI,
-  scope?: SessionScope,
+  options?: MaintenanceRegistrationOptions,
+): void;
+export function registerInProcessMaintenanceTools(
+  pi: ExtensionAPI,
+  scopeOrOptions: SessionScope | MaintenanceRegistrationOptions = {},
 ): void {
-  registerCleanupArtifactsTool(pi, scope);
+  const isScope = "id" in scopeOrOptions;
+  const scope = isScope ? scopeOrOptions : scopeOrOptions.scope;
+  const include = isScope ? undefined : scopeOrOptions.include;
+  for (const name of include ?? MAINTENANCE_TOOL_NAMES) {
+    MAINTENANCE_REGISTRARS[name](pi, scope);
+  }
 }
 
-export function registerSubagentModelListTool(pi: ExtensionAPI): void {
-  registerListAvailableModelsTool(pi);
-}
-export function registerSubagentArtifactsCleanupTool(pi: ExtensionAPI): void {
-  registerCleanupArtifactsTool(pi);
+export type MaintenanceToolName = (typeof MAINTENANCE_TOOL_NAMES)[number];
+
+/**
+ * Maintenance tools kept in only-interactive mode: model listing (children take
+ * a `model`) and artifact cleanup (interactive children write artifacts).
+ * `prune_subagent_jobs` is excluded because in-process jobs cannot exist there.
+ */
+export const ONLY_INTERACTIVE_MAINTENANCE_TOOLS: readonly MaintenanceToolName[] =
+  ["list_available_models", "cleanup_subagent_artifacts"];
+
+const MAINTENANCE_REGISTRARS: Record<
+  MaintenanceToolName,
+  (pi: ExtensionAPI) => void
+> = {
+  list_available_models: registerListAvailableModelsTool,
+  prune_subagent_jobs: registerPruneSubagentJobsTool,
+  cleanup_subagent_artifacts: registerCleanupArtifactsTool,
+};
+
+export function registerInProcessMaintenanceTools(
+  pi: ExtensionAPI,
+  options: { include?: readonly MaintenanceToolName[] } = {},
+): void {
+  for (const name of options.include ?? MAINTENANCE_TOOL_NAMES) {
+    MAINTENANCE_REGISTRARS[name](pi);
+  }
 }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -1564,6 +1564,9 @@ export function registerSubagentArtifactsCleanupTool(
   registerCleanupArtifactsTool(pi, scope);
 }
 
+export function registerSubagentModelListTool(pi: ExtensionAPI): void {
+  registerListAvailableModelsTool(pi);
+}
 export function registerSubagentArtifactsCleanupTool(pi: ExtensionAPI): void {
   registerCleanupArtifactsTool(pi);
 }

--- a/tests/readme-surface.test.ts
+++ b/tests/readme-surface.test.ts
@@ -15,27 +15,39 @@ function section(start: string, end: string): string {
   return README.slice(startIndex, endIndex);
 }
 
+/** Registers the extension in the requested parent mode and records its surface. */
+function registerSurface(onlyInteractive: boolean) {
+  const tools: string[] = [];
+  const commands: string[] = [];
+  const api = {
+    registerTool: vi.fn((tool: { name: string }) => tools.push(tool.name)),
+    registerCommand: vi.fn((name: string) => commands.push(name)),
+    registerShortcut: vi.fn(),
+    registerMessageRenderer: vi.fn(),
+    registerFlag: vi.fn(),
+    getFlag: vi.fn().mockReturnValue(false),
+    on: vi.fn(),
+  };
+  const previousChild = process.env.PI_SUBAGENTURA_CHILD;
+  const previousMode = process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
+  delete process.env.PI_SUBAGENTURA_CHILD;
+  if (onlyInteractive) process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = "1";
+  else delete process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
+  try {
+    registerExtension(api as any);
+  } finally {
+    if (previousChild === undefined) delete process.env.PI_SUBAGENTURA_CHILD;
+    else process.env.PI_SUBAGENTURA_CHILD = previousChild;
+    if (previousMode === undefined)
+      delete process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
+    else process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = previousMode;
+  }
+  return { tools, commands };
+}
+
 describe("README public surface", () => {
   it("inventories every registered public tool and slash command", () => {
-    const tools: string[] = [];
-    const commands: string[] = [];
-    const api = {
-      registerTool: vi.fn((tool: { name: string }) => tools.push(tool.name)),
-      registerCommand: vi.fn((name: string) => commands.push(name)),
-      registerShortcut: vi.fn(),
-      registerMessageRenderer: vi.fn(),
-      registerFlag: vi.fn(),
-      getFlag: vi.fn().mockReturnValue(false),
-      on: vi.fn(),
-    };
-    const previousChild = process.env.PI_SUBAGENTURA_CHILD;
-    delete process.env.PI_SUBAGENTURA_CHILD;
-    try {
-      registerExtension(api as any);
-    } finally {
-      if (previousChild === undefined) delete process.env.PI_SUBAGENTURA_CHILD;
-      else process.env.PI_SUBAGENTURA_CHILD = previousChild;
-    }
+    const { tools, commands } = registerSurface(false);
 
     const toolInventory = section(
       "## Agent-facing tools",
@@ -58,6 +70,48 @@ describe("README public surface", () => {
         commandInventory,
         `Missing command inventory row for /${name}`,
       ).toContain(`| \`/${name}\``);
+    }
+  });
+
+  it("inventories the only-interactive mode subset and what it drops", () => {
+    const full = registerSurface(false);
+    const mode = registerSurface(true);
+    const dropped = full.tools.filter((name) => !mode.tools.includes(name));
+
+    const registered = section(
+      "### Registered in only-interactive mode",
+      "### Not registered in only-interactive mode",
+    );
+    const notRegistered = section(
+      "### Not registered in only-interactive mode",
+      "## Reusable workflows",
+    );
+
+    expect(mode.tools).toHaveLength(8);
+    expect(mode.commands).toEqual(["cancel-all-flows"]);
+    expect(dropped).toHaveLength(13);
+
+    for (const name of mode.tools) {
+      expect(
+        registered,
+        `Missing only-interactive tool row for ${name}`,
+      ).toContain(`| \`${name}\``);
+    }
+    for (const name of mode.commands) {
+      expect(
+        registered,
+        `Missing only-interactive command mention for /${name}`,
+      ).toContain(`\`/${name}\``);
+    }
+    for (const name of dropped) {
+      expect(
+        notRegistered,
+        `Tool ${name} is dropped in only-interactive mode but not documented as removed`,
+      ).toContain(`\`${name}\``);
+      expect(
+        registered,
+        `Tool ${name} is not registered in only-interactive mode but is listed as registered`,
+      ).not.toContain(`\`${name}\``);
     }
   });
 });

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -15,11 +15,11 @@ const INTERACTIVE_TOOL_NAMES = [
   ...BASE_INTERACTIVE_TOOL_NAMES,
   "list_available_models",
 ].sort();
-
 const IN_PROCESS_TOOL_NAMES = [
   "cancel_subagent",
   "get_subagent_result",
   "get_subagent_status",
+
   "prune_subagent_jobs",
   "subagent_isolated",
   "subagent_with_context",
@@ -104,6 +104,51 @@ describe("extension registration", () => {
       type: "boolean",
       default: false,
     });
+  });
+
+  it("registers the --only-interactive flag", () => {
+    const api = mockApi();
+
+    registerExtension(api as any);
+
+    expect(api.registerFlag).toHaveBeenCalledWith("only-interactive", {
+      description: "Enable only interactive sub-agent tools",
+      type: "boolean",
+      default: false,
+    });
+  });
+
+  it("omits in-process and workflow tools when --only-interactive is enabled", () => {
+    const api = mockApi({
+      getFlag: vi.fn((name: string) => name === "only-interactive"),
+    });
+
+    registerExtension(api as any);
+
+    const names = getRegisteredToolNames(api);
+    expect(names).toEqual(INTERACTIVE_TOOL_NAMES);
+
+    for (const name of IN_PROCESS_TOOL_NAMES) {
+      expect(names).not.toContain(name);
+    }
+    for (const name of WORKFLOW_TOOL_NAMES) {
+      expect(names).not.toContain(name);
+    }
+  });
+
+  it("keeps interactive tools and session handlers with --only-interactive", () => {
+    const api = mockApi({
+      getFlag: vi.fn((name: string) => name === "only-interactive"),
+    });
+
+    registerExtension(api as any);
+
+    expect(getRegisteredToolNames(api)).toEqual(INTERACTIVE_TOOL_NAMES);
+
+    const events = api.on.mock.calls.map(([event]: any[]) => event as string);
+    expect(events).toContain("session_start");
+    expect(events).toContain("session_shutdown");
+    expect(events).toContain("agent_settled");
   });
 
   it("appends the bundled prompt when --orchestrator is enabled", async () => {

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -15,6 +15,7 @@ const INTERACTIVE_TOOL_NAMES = [
   ...BASE_INTERACTIVE_TOOL_NAMES,
   "list_available_models",
 ].sort();
+
 const IN_PROCESS_TOOL_NAMES = [
   "cancel_subagent",
   "get_subagent_result",

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -76,8 +76,6 @@ function mockApi(overrides: Record<string, any> = {}) {
     registerShortcut: vi.fn(),
     registerMessageRenderer: vi.fn(),
     registerFlag: vi.fn(),
-    registerCommand: vi.fn(),
-    registerShortcut: vi.fn(),
     getFlag: vi.fn().mockReturnValue(false),
     on: vi.fn(),
     ...overrides,
@@ -87,9 +85,11 @@ function mockApi(overrides: Record<string, any> = {}) {
 describe("extension registration", () => {
   let previousChild: string | undefined;
   let previousOnlyInteractive: string | undefined;
+  let previousArgv: string[];
   beforeEach(() => {
     previousChild = process.env.PI_SUBAGENTURA_CHILD;
     previousOnlyInteractive = process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
+    previousArgv = [...process.argv];
     delete process.env.PI_SUBAGENTURA_CHILD;
     delete process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
   });
@@ -104,6 +104,7 @@ describe("extension registration", () => {
     } else {
       process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = previousOnlyInteractive;
     }
+    process.argv.splice(0, process.argv.length, ...previousArgv);
   });
 
   it("registers the expected tools without throwing", () => {
@@ -156,18 +157,47 @@ describe("extension registration", () => {
     }
   });
 
-  it("selects only-interactive mode from the --only-interactive argv", () => {
-    const api = mockApi();
+  it("selects only-interactive mode from the exact --only-interactive argv token", () => {
     process.argv.push("--only-interactive");
+    const api = mockApi();
 
-    try {
-      registerExtension(api as any);
-    } finally {
-      process.argv.splice(process.argv.indexOf("--only-interactive"), 1);
-    }
+    registerExtension(
+      api as unknown as Parameters<typeof registerExtension>[0],
+    );
 
     expect(getRegisteredToolNames(api)).toEqual(ONLY_INTERACTIVE_TOOLS);
   });
+
+  it.each([
+    ["an arbitrary value", "--only-interactive=anything"],
+    ["false", "--only-interactive=false"],
+  ])(
+    "selects only-interactive mode when its boolean flag has %s",
+    (_label, arg) => {
+      process.argv.push(arg);
+      const api = mockApi();
+
+      registerExtension(
+        api as unknown as Parameters<typeof registerExtension>[0],
+      );
+
+      expect(getRegisteredToolNames(api)).toEqual(ONLY_INTERACTIVE_TOOLS);
+    },
+  );
+
+  it.each(["--only-interactive-extra", "--only-interactive-extra=value"])(
+    "does not mistake the longer flag %s for only-interactive",
+    (arg) => {
+      process.argv.push(arg);
+      const api = mockApi();
+
+      registerExtension(
+        api as unknown as Parameters<typeof registerExtension>[0],
+      );
+
+      expect(getRegisteredToolNames(api)).toEqual(FULL_MODE_TOOLS);
+    },
+  );
 
   /**
    * Ordering contract, documented as a test: Pi applies CLI flag values AFTER
@@ -270,6 +300,16 @@ describe("extension registration", () => {
     for (const name of ONLY_INTERACTIVE_TOOLS) {
       expect(result.systemPrompt).toContain(name);
     }
+    expect(result.systemPrompt).toContain("## Child sessions are leaf workers");
+    expect(result.systemPrompt).toContain("`PI_SUBAGENTURA_CHILD=1`");
+    expect(result.systemPrompt).toContain("no delegation tools");
+    expect(result.systemPrompt).toContain("They cannot spawn another child.");
+    expect(result.systemPrompt).not.toContain(
+      "A child can spawn its own children.",
+    );
+    expect(result.systemPrompt).not.toContain(
+      "SUBAGENTURA_MAX_ORCHESTRATION_DEPTH",
+    );
   });
 
   it("registers only protocol hooks in child mode", () => {

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -1,40 +1,61 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import registerExtension from "../src/subagent";
+import { ONLY_INTERACTIVE_MAINTENANCE_TOOLS } from "../src/tools/in-process";
 
-const BASE_INTERACTIVE_TOOL_NAMES = [
+/** Registered by `registerInteractiveSubagentTools` in every parent mode. */
+const INTERACTIVE_TOOL_NAMES = [
   "cancel_interactive_subagent",
   "get_interactive_subagent_status",
+  "list_subagent_artifacts",
   "read_subagent_artifact",
   "send_interactive_subagent_message",
   "subagent_interactive",
-  "list_subagent_artifacts",
-  "cleanup_subagent_artifacts",
+];
+
+/**
+ * Expected surface of only-interactive mode: the interactive tools plus the
+ * maintenance subset declared by src/tools/in-process.ts (the single source of
+ * truth for that subset).
+ */
+const ONLY_INTERACTIVE_TOOLS = [
+  ...INTERACTIVE_TOOL_NAMES,
+  ...ONLY_INTERACTIVE_MAINTENANCE_TOOLS,
 ].sort();
 
-const INTERACTIVE_TOOL_NAMES = [
-  ...BASE_INTERACTIVE_TOOL_NAMES,
-  "list_available_models",
-].sort();
-
-const IN_PROCESS_TOOL_NAMES = [
+/**
+ * Expected surface of the default mode, spelled out independently on purpose:
+ * if this were derived from ONLY_INTERACTIVE_TOOLS, editing one mode's
+ * expectation would silently move the other and both tests would stay green.
+ */
+const FULL_MODE_TOOLS = [
+  "cancel_interactive_subagent",
   "cancel_subagent",
+  "cancel_workflow",
+  "cleanup_subagent_artifacts",
+  "delete_workflow",
+  "get_interactive_subagent_status",
   "get_subagent_result",
   "get_subagent_status",
 
-  "prune_subagent_jobs",
-  "subagent_isolated",
-  "subagent_with_context",
-].sort();
-
-const WORKFLOW_TOOL_NAMES = [
-  "cancel_workflow",
-  "delete_workflow",
   "get_workflow_result",
   "get_workflow_status",
+  "list_available_models",
+  "list_subagent_artifacts",
   "list_workflows",
+  "prune_subagent_jobs",
+  "read_subagent_artifact",
   "save_workflow",
+  "send_interactive_subagent_message",
+  "subagent_interactive",
+  "subagent_isolated",
+  "subagent_with_context",
   "workflow",
 ].sort();
+
+/** Tools that only-interactive mode must drop. */
+const FULL_MODE_ONLY_TOOLS = FULL_MODE_TOOLS.filter(
+  (name) => !ONLY_INTERACTIVE_TOOLS.includes(name),
+);
 
 function getRegisteredToolNames(api: {
   registerTool: ReturnType<typeof vi.fn>;
@@ -42,9 +63,17 @@ function getRegisteredToolNames(api: {
   return api.registerTool.mock.calls.map(([tool]: any[]) => tool.name).sort();
 }
 
+function getRegisteredCommandNames(api: {
+  registerCommand: ReturnType<typeof vi.fn>;
+}) {
+  return api.registerCommand.mock.calls.map(([name]: any[]) => name as string);
+}
+
 function mockApi(overrides: Record<string, any> = {}) {
   return {
     registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+    registerShortcut: vi.fn(),
     registerMessageRenderer: vi.fn(),
     registerFlag: vi.fn(),
     registerCommand: vi.fn(),
@@ -57,15 +86,23 @@ function mockApi(overrides: Record<string, any> = {}) {
 
 describe("extension registration", () => {
   let previousChild: string | undefined;
+  let previousOnlyInteractive: string | undefined;
   beforeEach(() => {
     previousChild = process.env.PI_SUBAGENTURA_CHILD;
+    previousOnlyInteractive = process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
     delete process.env.PI_SUBAGENTURA_CHILD;
+    delete process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
   });
   afterEach(() => {
     if (previousChild === undefined) {
       delete process.env.PI_SUBAGENTURA_CHILD;
     } else {
       process.env.PI_SUBAGENTURA_CHILD = previousChild;
+    }
+    if (previousOnlyInteractive === undefined) {
+      delete process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE;
+    } else {
+      process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = previousOnlyInteractive;
     }
   });
 
@@ -78,21 +115,7 @@ describe("extension registration", () => {
       expect.any(Function),
     );
 
-    expect(getRegisteredToolNames(api)).toEqual(
-      [
-        ...INTERACTIVE_TOOL_NAMES,
-        ...IN_PROCESS_TOOL_NAMES,
-        ...WORKFLOW_TOOL_NAMES,
-      ].sort(),
-    );
-    expect(api.registerCommand).toHaveBeenCalledWith(
-      "subagents",
-      expect.any(Object),
-    );
-    expect(api.registerShortcut).toHaveBeenCalledWith(
-      "ctrl+alt+a",
-      expect.any(Object),
-    );
+    expect(getRegisteredToolNames(api)).toEqual(FULL_MODE_TOOLS);
   });
 
   it("registers the --orchestrator flag", () => {
@@ -113,43 +136,97 @@ describe("extension registration", () => {
     registerExtension(api as any);
 
     expect(api.registerFlag).toHaveBeenCalledWith("only-interactive", {
-      description: "Enable only interactive sub-agent tools",
+      description:
+        "Register only attachable interactive sub-agent tools, model listing, and artifact cleanup",
       type: "boolean",
       default: false,
     });
   });
 
-  it("omits in-process and workflow tools when --only-interactive is enabled", () => {
-    const api = mockApi({
-      getFlag: vi.fn((name: string) => name === "only-interactive"),
-    });
+  it("omits in-process and workflow tools in only-interactive mode", () => {
+    process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = "1";
+    const api = mockApi();
 
     registerExtension(api as any);
 
     const names = getRegisteredToolNames(api);
-    expect(names).toEqual(INTERACTIVE_TOOL_NAMES);
-
-    for (const name of IN_PROCESS_TOOL_NAMES) {
-      expect(names).not.toContain(name);
-    }
-    for (const name of WORKFLOW_TOOL_NAMES) {
+    expect(names).toEqual(ONLY_INTERACTIVE_TOOLS);
+    for (const name of FULL_MODE_ONLY_TOOLS) {
       expect(names).not.toContain(name);
     }
   });
 
-  it("keeps interactive tools and session handlers with --only-interactive", () => {
+  it("selects only-interactive mode from the --only-interactive argv", () => {
+    const api = mockApi();
+    process.argv.push("--only-interactive");
+
+    try {
+      registerExtension(api as any);
+    } finally {
+      process.argv.splice(process.argv.indexOf("--only-interactive"), 1);
+    }
+
+    expect(getRegisteredToolNames(api)).toEqual(ONLY_INTERACTIVE_TOOLS);
+  });
+
+  /**
+   * Ordering contract, documented as a test: Pi applies CLI flag values AFTER
+   * every extension factory has run, so `pi.getFlag("only-interactive")` is
+   * still the registered default during activation. Registration must therefore
+   * ignore it — a mode gated on `getFlag` alone would be dead code.
+   */
+  it("ignores getFlag('only-interactive') because flag values arrive after activation", () => {
     const api = mockApi({
       getFlag: vi.fn((name: string) => name === "only-interactive"),
     });
 
     registerExtension(api as any);
 
-    expect(getRegisteredToolNames(api)).toEqual(INTERACTIVE_TOOL_NAMES);
+    expect(getRegisteredToolNames(api)).toEqual(FULL_MODE_TOOLS);
+  });
+
+  it("keeps interactive tools and session handlers in only-interactive mode", () => {
+    process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = "1";
+    const api = mockApi();
+
+    registerExtension(api as any);
+
+    expect(getRegisteredToolNames(api)).toEqual(ONLY_INTERACTIVE_TOOLS);
 
     const events = api.on.mock.calls.map(([event]: any[]) => event as string);
     expect(events).toContain("session_start");
     expect(events).toContain("session_shutdown");
     expect(events).toContain("agent_settled");
+  });
+
+  it.each([
+    ["default mode", undefined],
+    ["only-interactive mode", "1"],
+  ])(
+    "keeps /cancel-all-flows and ctrl+alt+x available in %s",
+    (_label, onlyInteractive) => {
+      if (onlyInteractive) {
+        process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = onlyInteractive;
+      }
+      const api = mockApi();
+
+      registerExtension(api as any);
+
+      expect(getRegisteredCommandNames(api)).toContain("cancel-all-flows");
+      expect(api.registerShortcut).toHaveBeenCalledWith(
+        "ctrl+alt+x",
+        expect.objectContaining({ handler: expect.any(Function) }),
+      );
+    },
+  );
+
+  it("registers only /cancel-all-flows in only-interactive mode", () => {
+    process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = "1";
+    const api = mockApi();
+
+    registerExtension(api as any);
+
+    expect(getRegisteredCommandNames(api)).toEqual(["cancel-all-flows"]);
   });
 
   it("appends the bundled prompt when --orchestrator is enabled", async () => {
@@ -165,10 +242,37 @@ describe("extension registration", () => {
     const result = await beforeAgentStart({ systemPrompt: "base prompt" }, {});
 
     expect(result.systemPrompt).toContain("# Orchestrator System Prompt");
+    expect(result.systemPrompt).toContain("subagent_isolated");
     expect(result.systemPrompt.startsWith("base prompt\n\n")).toBe(true);
   });
 
-  it("registers a minimal interactive runtime in child mode", () => {
+  it("appends the reduced prompt when --orchestrator meets only-interactive mode", async () => {
+    process.env.PI_SUBAGENTURA_ONLY_INTERACTIVE = "1";
+    const api = mockApi({
+      getFlag: vi.fn((name: string) => name === "orchestrator"),
+    });
+
+    registerExtension(api as any);
+
+    const beforeAgentStart = api.on.mock.calls.find(
+      ([event]: any[]) => event === "before_agent_start",
+    )?.[1];
+    const result = await beforeAgentStart({ systemPrompt: "base prompt" }, {});
+
+    expect(result.systemPrompt).toContain(
+      "# Orchestrator System Prompt (only-interactive mode)",
+    );
+    expect(result.systemPrompt.startsWith("base prompt\n\n")).toBe(true);
+    // The prompt must never advertise a tool this mode does not register.
+    for (const name of FULL_MODE_ONLY_TOOLS) {
+      expect(result.systemPrompt).not.toContain(name);
+    }
+    for (const name of ONLY_INTERACTIVE_TOOLS) {
+      expect(result.systemPrompt).toContain(name);
+    }
+  });
+
+  it("registers only protocol hooks in child mode", () => {
     const previous = process.env.PI_SUBAGENTURA_CHILD;
     const previousArtifactDir = process.env.ARTIFACT_DIR;
     process.env.PI_SUBAGENTURA_CHILD = "1";


### PR DESCRIPTION
## Summary
- Add a new extension flag `--only-interactive`.
- In interactive-only mode, register only the interactive sub-agent toolchain plus essential shared maintenance needed by interactive workflows:
  - `subagent_interactive`
  - `get_interactive_subagent_status`
  - `cancel_interactive_subagent`
  - `send_interactive_subagent_message`
  - `list_subagent_artifacts`
  - `read_subagent_artifact`
  - `cleanup_subagent_artifacts`
  - `list_available_models`
- Preserve session handlers (poller, rehydrate, shutdown cleanup/delivery flow) in interactive-only mode.
- Keep `cancel-all-flows` available in all parent modes.
- Omit in-process job/workflow families when `--only-interactive` is enabled (including `subagent_*` async jobs, workflow tools, and `prune_subagent_jobs`).

## Verification
- `npm test -- tests/subagent-extension.test.ts`
- `PI_SUBAGENTURA_CHILD= npm test`
- `npm run typecheck`
- `npm run format:check`
- `npm run pack:check`
