### PR TITLE
fix: show workflow agents in supervisor

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -36,7 +36,7 @@ import {
 } from "./interactive-tmux";
 import { shouldNotify } from "./notifications";
 import { deliveryIdFor, enqueueDelivery, flushDeliveries } from "./delivery";
-import { debugLog, jobRegistry } from "./helpers";
+import { debugLog, inProcessJobBelongsToOwner, jobRegistry } from "./helpers";
 import { coarseElapsedMs, formatActivityRow } from "./rendering";
 import { formatWorkflowUsage } from "./workflow-core";
 import { closeSync, openSync, readSync, statSync } from "node:fs";
@@ -48,13 +48,10 @@ import {
   workflowJobBelongsToOwner,
   workflowJobRegistry,
 } from "./workflow-jobs";
-import type {
-  ActiveSessionContextToken,
-  SessionContextRef,
-} from "./session-context";
 import {
   getSessionContextStack,
-  parentSessionBelongsToOwner,
+  interactiveStateBelongsToOwner,
+  type ActiveSessionContextToken,
   resolveLiveSessionContext,
 } from "./session-context";
 // ── Footer / Widget Status Keys ────────────────────────────────────────
@@ -77,15 +74,49 @@ const footerStatusesByUi = new WeakMap<
   Map<string, string | undefined>
 >();
 
-function getRunningSubagentCount(): number {
+/**
+ * Owners whose sub-agents belong on the surfaces bound to `ui`.
+ *
+ * The footer and the activity widget are keyed per-ui, and nested sessions share
+ * one `ExtensionUIContext`. Repainting a shared surface from a single owner's
+ * point of view would erase its sibling context's rows (and undercount its
+ * agents) on every other poll tick, so both surfaces project the union over every
+ * live context bound to this ui. `[undefined]` means "unscoped": count everything.
+ */
+function ownersPaintingInto(
+  ui: StatusUi,
+  owner: ActiveSessionContextToken | undefined,
+): (ActiveSessionContextToken | undefined)[] {
+  if (!owner) return [undefined];
+  const bound = getSessionContextStack()
+    .filter((context) => context.ui === ui)
+    .map((context) => ({ id: context.id, generation: context.generation }));
+  // A ui the context stack does not know (e.g. a tool ctx captured before
+  // session_start bound it) can only speak for the owner that was handed in.
+  return bound.length > 0 ? bound : [owner];
+}
+
+function belongsToAnyOwner(
+  state: InteractiveSubagentState,
+  owners: (ActiveSessionContextToken | undefined)[],
+): boolean {
+  return owners.some((owner) => interactiveStateBelongsToOwner(state, owner));
+}
+
+function getRunningSubagentCount(
+  owners: (ActiveSessionContextToken | undefined)[],
+): number {
   const inProcessCount = [...jobRegistry.values()].filter(
-    (job) => job.status === "running",
+    (job) =>
+      job.status === "running" &&
+      owners.some((owner) => inProcessJobBelongsToOwner(job, owner)),
   ).length;
   const interactiveCount = [...interactiveSubagentRegistry.values()].filter(
     (state) =>
-      state.status === "running" ||
-      state.status === "idle" ||
-      state.status === "unknown",
+      (state.status === "running" ||
+        state.status === "idle" ||
+        state.status === "unknown") &&
+      belongsToAnyOwner(state, owners),
   ).length;
   return inProcessCount + interactiveCount;
 }
@@ -110,8 +141,27 @@ function updateFooterStatus(
   }
 }
 
-export function updateRunningSubagentFooter(ui: StatusUi): void {
-  const runningCount = getRunningSubagentCount();
+/**
+ * Repaint the "N sub-agents active" footer, scoped to `owner` when supplied.
+ *
+ * Liveness is decided here rather than at the call sites: callers pass the raw
+ * active token, so a token whose lifecycle already ended reads as "this session
+ * owns nothing" (count 0) instead of silently falling back to a cross-session
+ * global count.
+ */
+export function updateRunningSubagentFooter(
+  ui: StatusUi,
+  owner?: ActiveSessionContextToken,
+): void {
+  const ownerContext = resolveLiveSessionContext(owner);
+  // A live context that has not bound its sessionManager yet (pre-session_start)
+  // cannot map any parentSessionId back to itself, so scoping would report 0 for
+  // agents it really owns. Stay unscoped until the binding exists.
+  const scopedOwner = ownerContext?.sessionManager ? owner : undefined;
+  const runningCount =
+    owner !== undefined && !ownerContext
+      ? 0
+      : getRunningSubagentCount(ownersPaintingInto(ui, scopedOwner));
   const statusText =
     runningCount > 0
       ? `⚡ ${runningCount} sub-agent${runningCount > 1 ? "s" : ""} active`
@@ -155,42 +205,30 @@ function updateWidgetRows(
   }
 }
 
-/** Project current live rows after owner-scoped liveness processing completes. */
+/**
+ * Project current live rows after owner-scoped liveness processing completes.
+ *
+ * Ownership is answered by exactly one predicate — `interactiveStateBelongsToOwner`
+ * — shared with the poller's own state filter, the footer count, delivery, and the
+ * supervisor. The previous ui-identity + `parentSessionId` check was a second,
+ * weaker ownership key that workflow children (which deliberately carry no
+ * `parentSessionId`) could never satisfy, so they were invisible here.
+ */
 function projectActivityWidgetRows(
   ui: ExtensionUIContext | undefined,
   owner: ActiveSessionContextToken | undefined,
   now: number,
 ): string[] {
   if (!ui) return [];
-  const contexts = getSessionContextStack();
+  const owners = ownersPaintingInto(ui, owner);
   const states = [...interactiveSubagentRegistry.values()].filter(
     (state) =>
       (state.status === "running" ||
         state.status === "idle" ||
         state.status === "unknown") &&
-      stateBelongsToUi(state, ui, owner, contexts),
+      belongsToAnyOwner(state, owners),
   );
   return states.map((state) => formatActivityRow(state, now));
-}
-
-function stateBelongsToUi(
-  state: InteractiveSubagentState,
-  ui: ExtensionUIContext,
-  owner: ActiveSessionContextToken | undefined,
-  contexts: SessionContextRef[],
-): boolean {
-  if (!owner) return true;
-  return contexts.some((context) => {
-    if (context.ui !== ui) return false;
-    let sessionId: string | undefined;
-    try {
-      sessionId = context.sessionManager?.getSessionId?.();
-    } catch {
-      /* A stale session manager cannot establish widget ownership. */
-      return false;
-    }
-    return sessionId !== undefined && state.parentSessionId === sessionId;
-  });
 }
 
 /** Derive delivery status from an already narrowed completion event. */
@@ -268,7 +306,7 @@ async function runPollArtifactChanges(
     if (!interactivePi) return;
 
     const states = [...interactiveSubagentRegistry.values()].filter((state) =>
-      parentSessionBelongsToOwner(state.parentSessionId, owner),
+      interactiveStateBelongsToOwner(state, owner),
     );
     const liveness = await Promise.all(
       states.map(async (state) => {
@@ -320,6 +358,7 @@ async function runPollArtifactChanges(
         if ("version" in ev && ev.version === 2 && ev.type === "turn_started") {
           state.activeTurnId = ev.turnId;
         }
+        if (state.completionOwner === "workflow") continue;
         if (!shouldNotify(ev) || !isCompletionEvent(ev)) continue;
         const v2 = ev.type === "completion" ? ev : undefined;
         const mode = state.notifyOnComplete ?? "inject";
@@ -353,6 +392,7 @@ async function runPollArtifactChanges(
         });
       }
       for (const issue of batch.issues) {
+        if (state.completionOwner === "workflow") continue;
         const mode = state.notifyOnComplete ?? "inject";
         const triggerTurn =
           mode === "inject"
@@ -443,7 +483,7 @@ async function runPollArtifactChanges(
 
     // Paint footer + widget. Both are TUI surfaces that never reach the LLM.
     if (ui) {
-      updateRunningSubagentFooter(ui);
+      updateRunningSubagentFooter(ui, owner);
       updateWidgetRows(ui, WIDGET_KEY, widgetRows);
       // Workflow TUI footer + widget: show running async workflows.
       try {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -23,7 +23,7 @@ import {
 import type { InteractiveSubagentState } from "./interactive-tmux";
 import { notifyCompletionDelivery, sanitizeOutput } from "./notifications";
 import {
-  parentSessionBelongsToOwner,
+  interactiveStateBelongsToOwner,
   resolveLiveSessionContext,
   type ActiveSessionContextToken,
 } from "./session-context";
@@ -334,7 +334,8 @@ export function flushDeliveries(
     content: string;
   }> = [];
   for (const state of g.__piSubagenturaInteractiveRegistry?.values?.() ?? []) {
-    if (!parentSessionBelongsToOwner(state.parentSessionId, owner)) continue;
+    if (!interactiveStateBelongsToOwner(state, owner)) continue;
+    if (state.completionOwner === "workflow") continue;
     for (const intent of state.pendingDeliveries ?? []) {
       if (intent.state === "dispatchAttempted") continue;
       llm.push({ state, intent, content: formatIntent(intent, owner) });
@@ -445,7 +446,7 @@ export function reconcileAllDeliveryReceipts(
     : g.__piSubagenturaSessionManager?.getEntries?.();
   if (!Array.isArray(entries)) return;
   for (const state of g.__piSubagenturaInteractiveRegistry?.values?.() ?? []) {
-    if (!parentSessionBelongsToOwner(state.parentSessionId, owner)) continue;
+    if (!interactiveStateBelongsToOwner(state, owner)) continue;
     reconcileDeliveryReceipts(state, entries);
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -205,6 +205,10 @@ export interface JobState {
   parentJobId?: string;
   /** Orchestration depth of this job. Root parent's direct children are 1. */
   depth?: number;
+  /** Workflow owner for live supervisor presentation. */
+  workflowId?: string;
+  /** Workflow-managed jobs never independently notify the parent. */
+  completionOwner?: "standalone" | "workflow";
   /** Recorded when a cancel path fires, for observability and result shaping. */
   cancellation?: CancellationInfo & { at: number };
 }

--- a/src/interactive-supervisor-registration.ts
+++ b/src/interactive-supervisor-registration.ts
@@ -5,7 +5,9 @@ import {
   compareByStartedAt,
   INTERACTIVE_SUPERVISOR_SHORTCUT,
   type AsyncSupervisorItem,
+  type InProcessSupervisorItem,
   type InteractiveSupervisorItem,
+  type WorkflowSupervisorItem,
   showInteractiveSupervisor,
 } from "./interactive-supervisor-ui";
 import {
@@ -43,9 +45,10 @@ import {
   normalizeCancelledWorkflowState,
   workflowJobsForOwner,
 } from "./workflow-jobs";
-import type {
-  ActiveSessionContextToken,
-  SessionContextRef,
+import {
+  interactiveStateBelongsToOwner,
+  type ActiveSessionContextToken,
+  type SessionContextRef,
 } from "./session-context";
 
 const SUPERVISOR_CAPTURE_MAX_BYTES = 16 * 1024;
@@ -72,15 +75,16 @@ function isInteractiveStateActionable(
 
 export function directSupervisorItems(
   sessionId?: string,
+  owner?: ActiveSessionContextToken,
 ): InteractiveSupervisorItem[] {
   return [...interactiveSubagentRegistry.values()]
-    .filter(
-      (state) => sessionId === undefined || state.parentSessionId === sessionId,
-    )
+    .filter((state) => interactiveStateBelongsToOwner(state, owner, sessionId))
     .sort(compareByStartedAt)
     .map((state) => ({
       kind: "interactive",
       state,
+      // Workflow indentation is decided by buildAsyncSupervisorItems, which is the
+      // only place that knows whether the owning workflow row is actually present.
       depth: 0,
       actionable: isInteractiveStateActionable(state),
       origin: {
@@ -98,13 +102,7 @@ export function buildAsyncSupervisorItems(
     .filter((job) => inProcessJobBelongsToOwner(job, owner))
     .sort(compareByStartedAt);
   const visibleJobs = new Map(processJobs.map((job) => [job.id, job]));
-  const processItems: AsyncSupervisorItem[] = processJobs.map((job) => ({
-    kind: "in-process",
-    job,
-    depth: inProcessSupervisorDepth(job, visibleJobs),
-    actionable: job.status === "running",
-  }));
-  const workflowItems: AsyncSupervisorItem[] = workflowJobsForOwner(owner)
+  const workflowItems: WorkflowSupervisorItem[] = workflowJobsForOwner(owner)
     .sort(compareByStartedAt)
     .map((job) => ({
       kind: "workflow",
@@ -112,10 +110,104 @@ export function buildAsyncSupervisorItems(
       depth: 0,
       actionable: job.status === "running",
     }));
-  const normalizedInteractive: AsyncSupervisorItem[] = interactiveItems.map(
-    (item) => ({ ...item, kind: "interactive" }),
+  const workflowIds = new Set(workflowItems.map((item) => item.job.id));
+  /**
+   * Only a child whose workflow row is present may be indented. Teardown deletes
+   * the workflow job synchronously while its children take a microtask or more to
+   * unwind, and during that window an indented row would render under no parent.
+   */
+  const inVisibleWorkflow = (
+    workflowId: string | undefined,
+  ): workflowId is string =>
+    workflowId !== undefined && workflowIds.has(workflowId);
+  const processItems: InProcessSupervisorItem[] = processJobs.map((job) => ({
+    kind: "in-process",
+    job,
+    depth: inVisibleWorkflow(job.workflowId)
+      ? 1
+      : inProcessSupervisorDepth(job, visibleJobs),
+    actionable: job.status === "running",
+    reasons: job.status === "running" ? undefined : [job.status],
+  }));
+  const normalizedInteractive: InteractiveSupervisorItem[] =
+    interactiveItems.map((item) => ({
+      ...item,
+      kind: "interactive",
+      depth: item.state.workflowId
+        ? inVisibleWorkflow(item.state.workflowId)
+          ? Math.max(1, item.depth)
+          : 0
+        : item.depth,
+    }));
+  const processByWorkflow = new Map<string, GroupableSupervisorItem[]>();
+  const interactiveByWorkflow = new Map<string, GroupableSupervisorItem[]>();
+  const standalone: GroupableSupervisorItem[] = [];
+  for (const item of processItems) {
+    const workflowId = item.job.workflowId;
+    if (inVisibleWorkflow(workflowId))
+      addWorkflowChild(processByWorkflow, workflowId, item);
+    else standalone.push(item);
+  }
+  for (const item of normalizedInteractive) {
+    const workflowId = item.state.workflowId;
+    if (inVisibleWorkflow(workflowId))
+      addWorkflowChild(interactiveByWorkflow, workflowId, item);
+    else standalone.push(item);
+  }
+  const grouped: AsyncSupervisorItem[] = [];
+  for (const root of workflowItems) {
+    grouped.push(root);
+    const children = [
+      ...(processByWorkflow.get(root.job.id) ?? []),
+      ...(interactiveByWorkflow.get(root.job.id) ?? []),
+    ].sort(compareSupervisorItems);
+    grouped.push(...children);
+  }
+  standalone.sort(compareSupervisorItems);
+  return [...grouped, ...standalone];
+}
+
+/** Items that can sit under a workflow root; workflow rows are always roots. */
+type GroupableSupervisorItem =
+  InProcessSupervisorItem | InteractiveSupervisorItem;
+
+function addWorkflowChild(
+  groups: Map<string, GroupableSupervisorItem[]>,
+  workflowId: string,
+  item: GroupableSupervisorItem,
+): void {
+  const children = groups.get(workflowId) ?? [];
+  children.push(item);
+  groups.set(workflowId, children);
+}
+
+/**
+ * Order in-process rows before interactive rows, then by age — the same relative
+ * order the supervisor listed before workflow grouping existed, when the return
+ * value was `[...processItems, ...workflowItems, ...normalizedInteractive]`.
+ */
+function compareSupervisorItems(
+  left: GroupableSupervisorItem,
+  right: GroupableSupervisorItem,
+): number {
+  const isInteractive = (
+    item: GroupableSupervisorItem,
+  ): item is InteractiveSupervisorItem => item.kind !== "in-process";
+  const kindRank = (item: GroupableSupervisorItem): number =>
+    item.kind === "in-process" ? 0 : 1;
+  const leftStartedAt = isInteractive(left)
+    ? left.state.startedAt
+    : left.job.startedAt;
+  const rightStartedAt = isInteractive(right)
+    ? right.state.startedAt
+    : right.job.startedAt;
+  const leftId = isInteractive(left) ? left.state.id : left.job.id;
+  const rightId = isInteractive(right) ? right.state.id : right.job.id;
+  return (
+    kindRank(left) - kindRank(right) ||
+    leftStartedAt - rightStartedAt ||
+    leftId.localeCompare(rightId)
   );
-  return [...processItems, ...workflowItems, ...normalizedInteractive];
 }
 
 function inProcessSupervisorDepth(
@@ -211,6 +303,7 @@ function parseStartedAt(value: string): number {
 
 async function loadSupervisorProjection(
   sessionId: string | undefined,
+  owner: ActiveSessionContextToken | undefined,
 ): Promise<SupervisorProjection | undefined> {
   const rootId = process.env.PI_SUBAGENTURA_ROOT_ID ?? sessionId;
   if (!rootId) return undefined;
@@ -282,8 +375,7 @@ async function loadSupervisorProjection(
     ];
   });
   for (const state of interactiveSubagentRegistry.values()) {
-    if (sessionId !== undefined && state.parentSessionId !== sessionId)
-      continue;
+    if (!interactiveStateBelongsToOwner(state, owner, sessionId)) continue;
     if (!seen.has(state.id)) {
       items.push({
         state,
@@ -358,16 +450,17 @@ export function registerInteractiveSupervisor(
     const sessionId = ctx.sessionManager?.getSessionId?.();
     const activeOwner = owner();
     let refreshError: string | undefined;
-    let projection = await loadSupervisorProjection(sessionId).catch(
-      (error: unknown) => {
-        refreshError = errorMessage(error);
-        return undefined;
-      },
-    );
+    let projection = await loadSupervisorProjection(
+      sessionId,
+      activeOwner,
+    ).catch((error: unknown) => {
+      refreshError = errorMessage(error);
+      return undefined;
+    });
     await showInteractiveSupervisor(ctx.ui, {
       items: () =>
         buildAsyncSupervisorItems(
-          projection?.items ?? directSupervisorItems(sessionId),
+          projection?.items ?? directSupervisorItems(sessionId, activeOwner),
           activeOwner,
         ),
       status: () => supervisorStatusLines(projection, refreshError),
@@ -375,7 +468,7 @@ export function registerInteractiveSupervisor(
         // A swallowed failure used to freeze the snapshot indefinitely with no
         // indication; the error now reaches the overlay footer.
         try {
-          projection = await loadSupervisorProjection(sessionId);
+          projection = await loadSupervisorProjection(sessionId, activeOwner);
           refreshError = undefined;
         } catch (error) {
           refreshError = errorMessage(error);

--- a/src/interactive-supervisor-registration.ts
+++ b/src/interactive-supervisor-registration.ts
@@ -508,7 +508,7 @@ export function registerInteractiveSupervisor(
       },
       cancelInProcess: (job) => {
         if (!cancelInProcessFromSupervisor(job, sessionId)) return false;
-        updateRunningSubagentFooter(ctx.ui);
+        updateRunningSubagentFooter(ctx.ui, owner());
         return true;
       },
       cancelWorkflow: (job) => {
@@ -521,7 +521,7 @@ export function registerInteractiveSupervisor(
       cancel: (id) => {
         const direct = cancelInteractiveSubagent(id);
         if (direct) {
-          updateRunningSubagentFooter(ctx.ui);
+          updateRunningSubagentFooter(ctx.ui, owner());
           return direct;
         }
         const item = projection?.items.find(
@@ -529,7 +529,7 @@ export function registerInteractiveSupervisor(
         );
         if (!item?.actionable) return undefined;
         cancelInteractiveDescendantByState(item.state);
-        updateRunningSubagentFooter(ctx.ui);
+        updateRunningSubagentFooter(ctx.ui, owner());
         return item.state;
       },
       cancelSubtree: async (state) => {
@@ -552,7 +552,7 @@ export function registerInteractiveSupervisor(
         if (!confirmed) return;
         if (!snapshotRoot) {
           cancelInteractiveSubagent(state.id);
-          updateRunningSubagentFooter(ctx.ui);
+          updateRunningSubagentFooter(ctx.ui, owner());
           return;
         }
         const result = await cancelLineageSubtreeBestEffort(snapshotRoot, {
@@ -579,7 +579,7 @@ export function registerInteractiveSupervisor(
             }
           },
         });
-        updateRunningSubagentFooter(ctx.ui);
+        updateRunningSubagentFooter(ctx.ui, owner());
         ctx.ui.notify(
           formatSubtreeCancellation(result),
           result.failed.length > 0 ||

--- a/src/interactive-supervisor-ui.ts
+++ b/src/interactive-supervisor-ui.ts
@@ -642,7 +642,10 @@ function formatAsyncSupervisorSummary(
     const phase = job.snapshot.currentPhase
       ? ` · phase: ${job.snapshot.currentPhase}`
       : "";
-    return `[workflow] ${statusIcon(job.status)} ${job.status} ${job.name} (${job.id}) · ${elapsed} · ${job.snapshot.agentsSpawned} agents · ${job.snapshot.runningCount ?? 0} running${phase}`;
+    // A blocking sync workflow is holding the parent turn open — worth telling
+    // apart from a background one before the user reaches for the cancel key.
+    const label = job.executionMode === "sync" ? "workflow:sync" : "workflow";
+    return `[${label}] ${statusIcon(job.status)} ${job.status} ${job.name} (${job.id}) · ${elapsed} · ${job.snapshot.agentsSpawned} agents · ${job.snapshot.runningCount ?? 0} running${phase}`;
   }
   const source = item.origin?.source ?? "registry";
   return `[${source}] ${formatSupervisorSummary(item.state, now)}`;

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -23,6 +23,7 @@
  * of the codebase compiles unchanged.
  */
 
+import type { ActiveSessionContextToken } from "./session-context";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { randomBytes } from "node:crypto";
 import {
@@ -181,6 +182,12 @@ export interface InteractiveSubagentState {
    * session_start. Optional for tests that don't care about reload semantics.
    */
   parentSessionId?: string;
+  /** Live supervisor owner; intentionally not persisted for workflow children. */
+  supervisorOwner?: ActiveSessionContextToken;
+  /** Workflow that owns this child, when completion is aggregated by the workflow. */
+  workflowId?: string;
+  /** Completion is delivered standalone or consumed by a workflow aggregate. */
+  completionOwner?: "standalone" | "workflow";
   model?: string;
   startedAt: number;
   /**
@@ -451,6 +458,12 @@ export function launchInteractiveSubagent(params: {
    * skipped (used by tests that don't care about reload).
    */
   parentSessionId?: string;
+  /** Live supervisor owner independent of persistence and delivery policy. */
+  supervisorOwner?: ActiveSessionContextToken;
+  /** Workflow owner for grouping and cancellation. */
+  workflowId?: string;
+  /** Workflow-managed completions are consumed by the workflow runner. */
+  completionOwner?: "standalone" | "workflow";
   /**
    * The parent session's working directory, used for the state file location.
    * If omitted, falls back to `cwd` (backward-compatible for tests).
@@ -731,6 +744,9 @@ export function launchInteractiveSubagent(params: {
     notifyOnComplete: params.notifyOnComplete ?? "inject",
     triggerTurnOnComplete: params.triggerTurnOnComplete,
     parentSessionId: params.parentSessionId,
+    supervisorOwner: params.supervisorOwner,
+    workflowId: params.workflowId,
+    completionOwner: params.completionOwner,
     eventByteCursor: 0,
     pendingDeliveries: [],
     deliveryReceipts: [],
@@ -937,6 +953,33 @@ export function cancelInteractiveSubagent(
     mux.killPane(state.paneId, state.muxSession);
   }
   return state;
+}
+
+/**
+ * Close a workflow-managed child after its result has been aggregated.
+ *
+ * Deregistration is unconditional, even when pane teardown fails. A workflow child
+ * is in-memory only and its completion is consumed by the workflow runner, so a
+ * retained entry would strand a permanently "running" supervisor row that no poll
+ * tick can ever finish — and whose only user affordance (the supervisor's cancel
+ * key) would write a false `.cancelled` marker. Returns the pane-cleanup error
+ * message, if any, so the caller can surface a leaked pane to the user.
+ */
+export function disposeWorkflowInteractiveSubagent(
+  state: InteractiveSubagentState,
+): string | undefined {
+  if (interactiveSubagentRegistry.get(state.id) === state) {
+    interactiveSubagentRegistry.delete(state.id);
+  }
+  try {
+    const mux = getMuxForState(state);
+    if (mux.getPaneLiveness(state.paneId, state.muxSession) !== "dead") {
+      mux.killPane(state.paneId, state.muxSession);
+    }
+    return undefined;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
 }
 
 function appendCancellation(

--- a/src/session-context.ts
+++ b/src/session-context.ts
@@ -190,3 +190,23 @@ export function parentSessionBelongsToOwner(
   const ownerSessionId = sessionIdForContextToken(owner);
   return ownerSessionId !== undefined && parentSessionId === ownerSessionId;
 }
+
+export interface InteractiveSupervisorOwnerState {
+  parentSessionId?: string;
+  supervisorOwner?: ActiveSessionContextToken;
+}
+
+export function interactiveStateBelongsToOwner(
+  state: InteractiveSupervisorOwnerState,
+  owner: ActiveSessionContextToken | undefined,
+  sessionId?: string,
+): boolean {
+  if (state.supervisorOwner) {
+    return owner
+      ? state.supervisorOwner.id === owner.id &&
+          state.supervisorOwner.generation === owner.generation
+      : sessionId === undefined;
+  }
+  if (owner) return parentSessionBelongsToOwner(state.parentSessionId, owner);
+  return sessionId === undefined || state.parentSessionId === sessionId;
+}

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -22,6 +22,7 @@ import {
   advanceSessionContextGeneration,
   createSessionContextRef,
   getSessionContextStack,
+  interactiveStateBelongsToOwner,
   registerSessionContext,
   removeSessionContext,
   setActiveSessionRefs,
@@ -320,8 +321,11 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
         );
         const ownedStates = [...interactiveSubagentRegistry.values()].filter(
           (state) =>
-            state.parentSessionId !== undefined &&
-            ownedSessionIds.has(state.parentSessionId),
+            shutdownOwners.some((owner) =>
+              interactiveStateBelongsToOwner(state, owner.token),
+            ) ||
+            (state.parentSessionId !== undefined &&
+              ownedSessionIds.has(state.parentSessionId)),
         );
         const ownedJobs = shutdownOwners.flatMap((owner) =>
           [...jobRegistry.entries()]
@@ -366,7 +370,8 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
         for (const state of ownedStates) {
           interactiveSubagentRegistry.delete(state.id);
           if (
-            !preserveInteractivePanes &&
+            (!preserveInteractivePanes ||
+              state.completionOwner === "workflow") &&
             (state.status === "running" ||
               state.status === "idle" ||
               state.status === "unknown")
@@ -431,16 +436,15 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
         event?.reason === "reload" ||
         event?.reason === "resume" ||
         event?.reason === "quit";
-      if (!preserveInteractivePanes) {
-        // Kill the panes using the already-snapshotted states.
-        // cancelInteractiveSubagentByState is used (not the id-based variant)
-        // because the registry was already cleared above.
-        for (const state of runningStates) {
-          try {
-            cancelInteractiveSubagentByState(state);
-          } catch {
-            /* best effort */
-          }
+      // Workflow children are in-memory only and must not survive a parent
+      // reload/quit even when standalone interactive panes are preserved.
+      for (const state of runningStates) {
+        if (preserveInteractivePanes && state.completionOwner !== "workflow")
+          continue;
+        try {
+          cancelInteractiveSubagentByState(state);
+        } catch {
+          /* best effort */
         }
       }
 

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -79,7 +79,7 @@ type InProcessSubagentDetails =
   | { status: "cancelled" | "not_found"; jobId?: string };
 
 function updateRunningFooter(ctx: RunningFooterContext): void {
-  updateRunningSubagentFooter(ctx.ui);
+  updateRunningSubagentFooter(ctx.ui, getActiveSessionContextToken());
 }
 
 const ZERO_USAGE: Usage = {

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -206,38 +206,51 @@ function settleAsyncJob(
   jobId: string,
   jobState: JobState,
   result: SubagentResult,
-  ctx: RunningFooterContext,
+  ctx: RunningFooterContext | undefined,
 ): void {
   if (jobState.status === "cancelled") return;
   if (result.cancelled) {
     jobState.status = "cancelled";
     jobState.result = result;
     scheduleJobCleanup(jobId, true);
-    updateRunningFooter(ctx);
+    if (ctx) updateRunningFooter(ctx);
     return;
   }
   jobState.status = result.isError ? "error" : "done";
   jobState.result = result;
   scheduleJobCleanup(jobId, false, jobState.maxAge);
 
+  // A workflow aggregate consumes its children's results itself; the child must
+  // never independently notify or inject into the parent session.
   const shouldDeliver =
+    jobState.completionOwner !== "workflow" &&
     jobState.notifyOnComplete &&
     !jobState.notificationDelivered &&
     !jobState.resultRetrieved &&
     (jobState.activeResultWaits ?? 0) === 0;
   if (shouldDeliver) {
     deliverNotification(jobState, result);
-  } else if (jobState.notifyOnComplete && !jobState.notificationDelivered) {
+  } else if (
+    jobState.completionOwner !== "workflow" &&
+    jobState.notifyOnComplete &&
+    !jobState.notificationDelivered
+  ) {
     notifyInProcessCompletionWithoutDelivery(jobState, result);
   }
 
-  updateRunningFooter(ctx);
+  if (ctx) updateRunningFooter(ctx);
 }
 
-function attachAsyncJobSettlement(
+/**
+ * Write the terminal status/result onto an async job when its promise settles.
+ *
+ * `ctx` is optional so non-tool spawn paths (workflow children) can reuse the
+ * same settlement without owning a footer surface — the poller repaints anyway.
+ */
+export function attachAsyncJobSettlement(
   jobId: string,
   jobState: JobState,
-  ctx: RunningFooterContext,
+  ctx?: RunningFooterContext,
 ): void {
   const settledPromise = jobState.promise.catch(createAsyncJobErrorResult);
   jobState.promise = settledPromise;

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -38,6 +38,7 @@ import {
 } from "../notifications";
 import { InteractiveParams } from "../schemas";
 import { updateRunningSubagentFooter } from "../artifact-poller";
+import { getActiveSessionContextToken } from "../session-context";
 
 const SUBAGENT_ID_INVALID_CHAR_RE = /[^a-f0-9]/;
 function isValidSubagentId(id: string): boolean {
@@ -177,7 +178,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
           parentSessionId: ctx.sessionManager.getSessionId(),
           thinkingLevel: params.thinkingLevel,
         });
-        updateRunningSubagentFooter(ctx.ui);
+        updateRunningSubagentFooter(ctx.ui, getActiveSessionContextToken());
 
         const displayMode = state.windowName
           ? "background (new window/tab)"
@@ -274,7 +275,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<any> {
       pruneDeadInteractiveSubagents();
-      updateRunningSubagentFooter(ctx.ui);
+      updateRunningSubagentFooter(ctx.ui, getActiveSessionContextToken());
       const states = params.jobId
         ? [interactiveSubagentRegistry.get(params.jobId)].filter(
             (s): s is InteractiveSubagentState => Boolean(s),
@@ -338,7 +339,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
           isError: true,
         };
       }
-      updateRunningSubagentFooter(ctx.ui);
+      updateRunningSubagentFooter(ctx.ui, getActiveSessionContextToken());
       const snapshotText = state.cancellationSnapshot?.path
         ? ` Snapshot ${state.cancellationSnapshot.status}: ${state.cancellationSnapshot.path}`
         : state.cancellationSnapshot?.error
@@ -706,7 +707,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
 
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx): Promise<any> {
       pruneDeadInteractiveSubagents();
-      updateRunningSubagentFooter(ctx.ui);
+      updateRunningSubagentFooter(ctx.ui, getActiveSessionContextToken());
       const states = [...interactiveSubagentRegistry.values()];
       const summary = states.map((s) => {
         const art = getArtifactForState(s);

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -159,14 +159,23 @@ async function runTrackedWorkflowAgent(
   }
 }
 
-/** Start a workflow running in the background. Returns the job id immediately. */
+export type StartWorkflowJobOptions = Omit<
+  RunWorkflowOptions,
+  "signal" | "onProgress" | "onCancellationSnapshot"
+>;
+
+/**
+ * Start a workflow running in the background. Returns the job id immediately.
+ *
+ * `opts` may be a builder so callers that need the job id while constructing the
+ * options (e.g. to tag spawned children with their owning `workflowId`) receive it
+ * before `runWorkflow` can invoke `runAgent`.
+ */
 export function startWorkflowJob(
   name: string,
   script: string,
-  opts: Omit<
-    RunWorkflowOptions,
-    "signal" | "onProgress" | "onCancellationSnapshot"
-  >,
+  optsOrBuilder:
+    StartWorkflowJobOptions | ((workflowId: string) => StartWorkflowJobOptions),
   startedAt?: number,
   onComplete?: (job: WorkflowJobState) => boolean | void,
   owner: ActiveSessionContextToken | undefined = getActiveSessionContextToken(),
@@ -194,6 +203,8 @@ export function startWorkflowJob(
   }
 
   const id = `wf_${randomBytes(5).toString("hex")}`;
+  const opts =
+    typeof optsOrBuilder === "function" ? optsOrBuilder(id) : optsOrBuilder;
   const abort = new AbortController();
   const state: WorkflowJobState = {
     id,

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -13,6 +13,7 @@ import {
   type WorkflowAgentRecord,
   type WorkflowProgress,
   type WorkflowRunResult,
+  type WorkflowRunResultWithUsage,
   type WorkflowUsage,
   MAX_WORKFLOW_AGENT_RECORDS,
   zeroWorkflowUsage,
@@ -26,8 +27,14 @@ export interface WorkflowJobState {
   id: string;
   name: string;
   status: WorkflowJobStatus;
+  executionMode?: "async" | "sync";
   startedAt: number;
-  promise: Promise<WorkflowRunResult>;
+  /**
+   * Settles with the runner's own result shape, where `usage` is always present.
+   * Widening to {@link WorkflowRunResult} here would force every consumer to
+   * tolerate a usage-less summary that `runWorkflow` never produces.
+   */
+  promise: Promise<WorkflowRunResultWithUsage>;
   abort: AbortController;
   snapshot: {
     agentsSpawned: number;
@@ -162,7 +169,8 @@ async function runTrackedWorkflowAgent(
 export type StartWorkflowJobOptions = Omit<
   RunWorkflowOptions,
   "signal" | "onProgress" | "onCancellationSnapshot"
->;
+> &
+  Pick<RunWorkflowOptions, "signal" | "onProgress">;
 
 /**
  * Start a workflow running in the background. Returns the job id immediately.
@@ -179,9 +187,17 @@ export function startWorkflowJob(
   startedAt?: number,
   onComplete?: (job: WorkflowJobState) => boolean | void,
   owner: ActiveSessionContextToken | undefined = getActiveSessionContextToken(),
+  executionMode: "async" | "sync" = "async",
 ): WorkflowJobState {
   const parentSessionOwner = owner;
-  while (workflowJobRegistry.size >= MAX_WORKFLOW_JOBS) {
+  // A blocking sync workflow ran unconditionally before it was tracked here.
+  // Subjecting it to the cap would turn an always-succeeding call into a new
+  // user-visible failure, so sync jobs are exempt — they are also removed from
+  // the registry as soon as they settle, so they cannot accumulate.
+  while (
+    executionMode === "async" &&
+    workflowJobRegistry.size >= MAX_WORKFLOW_JOBS
+  ) {
     // Evict the oldest terminal job; if none, throw — the caller must cancel one first.
     let evicted = false;
     for (const [id, st] of workflowJobRegistry) {
@@ -206,12 +222,17 @@ export function startWorkflowJob(
   const opts =
     typeof optsOrBuilder === "function" ? optsOrBuilder(id) : optsOrBuilder;
   const abort = new AbortController();
+  const externalSignal = opts.signal;
+  const forwardAbort = () => abort.abort(externalSignal?.reason);
+  if (externalSignal?.aborted) abort.abort(externalSignal.reason);
+  else externalSignal?.addEventListener("abort", forwardAbort, { once: true });
   const state: WorkflowJobState = {
     id,
     name,
     status: "running",
+    executionMode,
     startedAt: startedAt ?? Date.now(),
-    promise: undefined as unknown as Promise<WorkflowRunResult>,
+    promise: undefined as unknown as Promise<WorkflowRunResultWithUsage>,
     abort,
     snapshot: {
       agentsSpawned: 0,
@@ -254,6 +275,7 @@ export function startWorkflowJob(
       if (p.kind === "agent_start" || p.kind === "agent_done") {
         recordWorkflowAgentProgress(state.snapshot, p);
       }
+      opts.onProgress?.(p);
     },
     onCancellationSnapshot: (receipt) => {
       (state.cancellationSnapshots ??= []).push(receipt);
@@ -273,6 +295,15 @@ export function startWorkflowJob(
       if (state.status === "cancelled") normalizeCancelledWorkflowState(state);
       invokeCompletionHook(state);
       throw err;
+    })
+    .finally(() => {
+      externalSignal?.removeEventListener("abort", forwardAbort);
+      // A sync workflow returns its result inline. Retaining the terminal job
+      // would let get_workflow_result re-serve that result and would leave a dead
+      // `done` row in the supervisor for work the caller already collected.
+      if (executionMode === "sync" && workflowJobRegistry.get(id) === state) {
+        workflowJobRegistry.delete(id);
+      }
     });
   // Don't crash the process on an unobserved rejection before get_workflow_result is called.
   state.promise.catch(() => {});

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -36,11 +36,7 @@ import {
   type WorkflowJobState,
 } from "./workflow-jobs";
 import { renderProgress } from "./workflow-ui";
-import {
-  awaitInteractiveResult,
-  runWorkflow,
-  stringify,
-} from "./workflow-worker";
+import { awaitInteractiveResult, stringify } from "./workflow-worker";
 import { sanitizeOutput } from "./notifications";
 import { showWorkflowTree } from "./workflow-tree-ui";
 import {
@@ -161,7 +157,7 @@ export function registerWorkflowTool(
   // Build the real spawn function from the tool ctx. Switches backend on `isolation`.
   function makeRunAgent(
     ctx: any,
-    ownedWorkflowId: string | undefined,
+    ownedWorkflowId: string,
     supervisorOwner: ActiveSessionContextToken | undefined,
   ): WorkflowAgentRunner {
     return async ({
@@ -502,7 +498,7 @@ export function registerWorkflowTool(
       }
 
       const workflowOwner = owner();
-      const baseOpts = (workflowId: string | undefined) => ({
+      const baseOpts = (workflowId: string) => ({
         args: params.args,
         cwd: ctx.cwd,
         budgetTotal: params.budget ?? null,
@@ -533,6 +529,7 @@ export function registerWorkflowTool(
             jobStartedAt,
             notifyWorkflowCompletion,
             workflowOwner,
+            "async",
           );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -556,30 +553,39 @@ export function registerWorkflowTool(
       }
 
       // ── Synchronous (block-and-stream) path ──
-      // Not tracked in workflowJobRegistry, so its children have no workflow row
-      // to group under and stay flush-left in the supervisor.
       try {
-        const run = await runWorkflow(script, {
-          ...baseOpts(undefined),
-          signal,
-          onProgress: (p) => {
-            try {
-              onUpdate?.({
-                content: [{ type: "text", text: renderProgress(p) }],
-                details: {
-                  status: "running",
-                  agentsSpawned: p.agentsSpawned,
-                  runningCount: p.runningCount,
-                  errorCount: p.errorCount,
-                  tokensSpent: p.tokensSpent,
-                  usage: p.usage,
-                },
-              });
-            } catch {
-              /* onUpdate is best-effort */
-            }
-          },
-        });
+        const meta = parseWorkflow(script).meta;
+        const syncProgress = (p: WorkflowProgress) => {
+          try {
+            onUpdate?.({
+              content: [{ type: "text", text: renderProgress(p) }],
+              details: {
+                status: "running",
+                agentsSpawned: p.agentsSpawned,
+                runningCount: p.runningCount,
+                errorCount: p.errorCount,
+                tokensSpent: p.tokensSpent,
+                usage: p.usage,
+              },
+            });
+          } catch {
+            /* onUpdate is best-effort */
+          }
+        };
+        const job = startWorkflowJob(
+          meta.name,
+          script,
+          (workflowId) => ({
+            ...baseOpts(workflowId),
+            signal,
+            onProgress: syncProgress,
+          }),
+          Date.now(),
+          undefined,
+          workflowOwner,
+          "sync",
+        );
+        const run = await job.promise;
         const resultText =
           typeof run.result === "string" ? run.result : stringify(run.result);
         const presentation = getWorkflowCompletionPresentation(

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -1,7 +1,15 @@
 import { Type } from "typebox";
 import { abortableWait } from "./abortable-wait";
-import { startSubagentJob, debugLog } from "./helpers";
-import { launchInteractiveSubagent } from "./interactive-tmux";
+import {
+  debugLog,
+  jobRegistry,
+  startSubagentJob,
+  type JobState,
+} from "./helpers";
+import {
+  disposeWorkflowInteractiveSubagent,
+  launchInteractiveSubagent,
+} from "./interactive-tmux";
 import {
   MAX_ITEMS_PER_CALL,
   INTERACTIVE_POLL_MS,
@@ -14,6 +22,7 @@ import {
   type WorkflowAgentRunner,
   WorkflowExecutionError,
   type WorkflowMeta,
+  type WorkflowProgress,
   type WorkflowRunResult,
   type WorkflowUsage,
   formatWorkflowUsage,
@@ -47,9 +56,11 @@ import { cancellationSnapshotsEnabled } from "./cancellation-snapshots";
 import { getOrchestrationContext } from "./orchestration-context";
 import {
   getActiveSessionContextToken,
+  isSessionContextTokenLive,
   type ActiveSessionContextToken,
   type SessionContextRef,
 } from "./session-context";
+import { attachAsyncJobSettlement } from "./tools/in-process";
 
 const WORKFLOW_SESSION_SCOPE_MESSAGE =
   "Workflow jobs are scoped to the current parent session and do not survive reload/resume/new/quit.";
@@ -62,6 +73,32 @@ function workflowNotFoundMessage(workflowId: string): string {
 }
 
 const CANCELLATION_RECEIPT_GRACE_MS = INTERACTIVE_POLL_MS + 250;
+
+/** Tear down a prepared workflow child that must never be started. */
+function discardWorkflowChildSpawn(
+  abort: AbortController,
+  prepared: {
+    session: { abort: () => Promise<unknown> };
+    disposeBeforeStart?: () => void;
+  },
+): void {
+  prepared.disposeBeforeStart?.();
+  try {
+    abort.abort({
+      source: "session_shutdown" as const,
+      reason: "parent session shut down before workflow child registration",
+    });
+  } catch {
+    /* controller may already be aborted */
+  }
+  try {
+    void Promise.resolve(prepared.session.abort()).catch(() => {
+      /* child session may already be disposed */
+    });
+  } catch {
+    /* child session may already be disposed */
+  }
+}
 
 async function waitForCancellationReceipts(
   state: WorkflowJobState,
@@ -122,7 +159,11 @@ export function registerWorkflowTool(
       ? { id: sessionContext.id, generation: sessionContext.generation }
       : getActiveSessionContextToken();
   // Build the real spawn function from the tool ctx. Switches backend on `isolation`.
-  function makeRunAgent(ctx: any): WorkflowAgentRunner {
+  function makeRunAgent(
+    ctx: any,
+    ownedWorkflowId: string | undefined,
+    supervisorOwner: ActiveSessionContextToken | undefined,
+  ): WorkflowAgentRunner {
     return async ({
       prompt,
       persona,
@@ -135,8 +176,6 @@ export function registerWorkflowTool(
       onProgress,
       onCancellationSnapshot,
     }) => {
-      // Track last update time per agent label to throttle mid-agent previews
-
       let lastUpdateTs = 0;
       const THROTTLE_MS = 2000;
 
@@ -150,8 +189,9 @@ export function registerWorkflowTool(
 
       const tryProcess = isolation !== "in-process";
       if (tryProcess) {
+        let state: ReturnType<typeof launchInteractiveSubagent> | undefined;
         try {
-          const state = launchInteractiveSubagent({
+          state = launchInteractiveSubagent({
             name: (label || "wf-agent").slice(0, 40),
             task: prompt,
             persona,
@@ -160,16 +200,11 @@ export function registerWorkflowTool(
             contextText: null,
             background: true,
             thinkingLevel,
+            supervisorOwner,
+            workflowId: ownedWorkflowId,
+            completionOwner: "workflow",
           });
-          const result = await awaitInteractiveResult(
-            state,
-            signal,
-            undefined,
-            onCancellationSnapshot,
-          );
-          return result;
         } catch (err) {
-          // tmux/zellij unavailable — fall back to in-process, with visible warning.
           const msg = err instanceof Error ? err.message : String(err);
           debugLog("warn", "isolation_process_fallback", { reason: msg });
           onProgress?.({
@@ -177,17 +212,53 @@ export function registerWorkflowTool(
             message: `⚠ isolation:process unavailable — ${msg}. Falling back to in-process.`,
             label,
           });
-          // fall through to in-process path below
+        }
+        if (state) {
+          try {
+            return await awaitInteractiveResult(
+              state,
+              signal,
+              undefined,
+              onCancellationSnapshot,
+            );
+          } finally {
+            const paneError = disposeWorkflowInteractiveSubagent(state);
+            if (paneError) {
+              debugLog("warn", "workflow_child_pane_cleanup_failed", {
+                subagentId: state.id,
+                paneId: state.paneId,
+                error: paneError,
+              });
+              onProgress?.({
+                kind: "log",
+                message: `⚠ pane ${state.paneId} could not be closed — ${paneError}. Close it manually.`,
+                label,
+              });
+            }
+          }
         }
       }
-      // In-process path: explicit isolation:"in-process" or fallback from failed process isolation
-      const { jobPromise, start } = await startSubagentJob({
+
+      // A child whose deliveryOwner carries no session-context identity matches
+      // no owner-scoped sweep: it is invisible in the supervisor and the footer,
+      // and session_shutdown's jobRegistry drain skips it outright. Prefer the
+      // live active token, and leave the child unregistered rather than create
+      // an unreachable registry row.
+      const childOwner = supervisorOwner ?? getActiveSessionContextToken();
+
+      // Own the child's session so an ancestor abort cascades to it, and so the
+      // session_shutdown drain can reach it through jobRegistry.
+      const abort = new AbortController();
+      const forwardAbort = () => abort.abort(signal?.reason);
+      if (signal?.aborted) abort.abort(signal.reason);
+      else signal?.addEventListener("abort", forwardAbort, { once: true });
+      const prepared = await startSubagentJob({
         task: prompt,
         persona,
         modelOverride: model,
         cwd: ctx.cwd,
         contextText: null,
-        signal,
+        signal: abort.signal,
         onUpdate: (partial) => {
           const status = partial.details?.subagentStatus;
           if (status?.activeTool) {
@@ -209,8 +280,57 @@ export function registerWorkflowTool(
           ? { workflowStructuredOutputSchema: schema }
           : {}),
       });
-      start?.();
-      return jobPromise;
+      // The parent session can shut down while startSubagentJob is awaited above.
+      // session_shutdown drains jobRegistry, so registering now would re-insert
+      // into an already-drained registry and start a model turn that no abort path
+      // can reach (the PR #59 shutdown-escape hole).
+      if (childOwner && !isSessionContextTokenLive(childOwner)) {
+        signal?.removeEventListener("abort", forwardAbort);
+        discardWorkflowChildSpawn(abort, prepared);
+        throw new Error(
+          "Workflow agent cancelled: parent session shut down before the child was registered.",
+        );
+      }
+
+      const childJob: JobState = {
+        id: prepared.jobId,
+        status: "running",
+        liveStatus: prepared.liveStatus,
+        session: prepared.session,
+        startedAt: Date.now(),
+        cwd: ctx.cwd,
+        promise: prepared.jobPromise,
+        modelLabel: prepared.modelLabel,
+        thinkingLevel: prepared.thinkingLevel,
+        abort,
+        workflowId: ownedWorkflowId,
+        completionOwner: "workflow",
+        deliveryOwner: {
+          pi,
+          sessionContextId: childOwner?.id,
+          sessionContextGeneration: childOwner?.generation,
+        },
+      };
+      if (childOwner) {
+        jobRegistry.set(childJob.id, childJob);
+        // Without settlement the row would stay "running" forever: cancellable in
+        // the supervisor after it finished, double-counted against its own
+        // workflow in the footer, and given a false cancellation record on quit.
+        attachAsyncJobSettlement(childJob.id, childJob);
+      } else {
+        debugLog("warn", "workflow_child_unregistered", {
+          jobId: childJob.id,
+          workflowId: ownedWorkflowId,
+          reason: "no live session context to own the child",
+        });
+      }
+      prepared.start?.();
+      try {
+        return await prepared.jobPromise;
+      } finally {
+        signal?.removeEventListener("abort", forwardAbort);
+        jobRegistry.delete(childJob.id);
+      }
     };
   }
 
@@ -381,14 +501,14 @@ export function registerWorkflowTool(
         };
       }
 
-      const runAgent = makeRunAgent(ctx);
-      const baseOpts = {
+      const workflowOwner = owner();
+      const baseOpts = (workflowId: string | undefined) => ({
         args: params.args,
         cwd: ctx.cwd,
         budgetTotal: params.budget ?? null,
-        runAgent,
+        runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
         loadWorkflow: (n: string) => loadWorkflowScript(n),
-      };
+      });
 
       // ── Async (background) path — default ──
       if (params.async !== false) {
@@ -412,7 +532,7 @@ export function registerWorkflowTool(
             baseOpts,
             jobStartedAt,
             notifyWorkflowCompletion,
-            owner(),
+            workflowOwner,
           );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -436,9 +556,11 @@ export function registerWorkflowTool(
       }
 
       // ── Synchronous (block-and-stream) path ──
+      // Not tracked in workflowJobRegistry, so its children have no workflow row
+      // to group under and stay flush-left in the supervisor.
       try {
         const run = await runWorkflow(script, {
-          ...baseOpts,
+          ...baseOpts(undefined),
           signal,
           onProgress: (p) => {
             try {
@@ -886,19 +1008,20 @@ export function registerWorkflowTool(
       const script = loadWorkflowScript(name);
       if (!script) throw new Error(`No saved workflow named "${name}".`);
       const meta = parseWorkflow(script).meta;
+      const workflowOwner = owner();
       const job = startWorkflowJob(
         meta.name,
         script,
-        {
+        (workflowId) => ({
           args: argsValue,
           cwd: ctx.cwd,
           budgetTotal: null,
-          runAgent: makeRunAgent(ctx),
+          runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
           loadWorkflow: (n: string) => loadWorkflowScript(n),
-        },
+        }),
         Date.now(),
         notifyWorkflowCompletion,
-        owner(),
+        workflowOwner,
       );
       return { job, meta };
     };

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -421,6 +421,7 @@ export function registerWorkflowTool(
       "Orchestrate decomposable multi-agent work with trusted raw JavaScript workflows.",
     promptGuidelines: [
       "Use workflows only for decomposable multi-agent work; handle simple or sequential tasks directly.",
+      "Omit async for the default background behavior; use async: false only when synchronous execution is required.",
       "Pass raw JavaScript with no markdown fences. Include a top-level pure-literal `export const meta = { name, description, phases? }`.",
       "Do not use TypeScript, imports, require, fs, or other Node APIs. Date.now(), Math.random(), and argless new Date() are unavailable.",
       "Available globals are agent, parallel, pipeline, workflow, phase, log, args, immutable cwd, budget, console, guarded Date, and guarded Math.",

--- a/tests/artifact-delivery.integration.test.ts
+++ b/tests/artifact-delivery.integration.test.ts
@@ -393,6 +393,56 @@ describe("artifact protocol v2 delivery", () => {
     ]);
   });
 
+  it("does not independently deliver workflow-owned completions", async () => {
+    const art = makeArtifact();
+    const state = makeState(art.dir);
+    state.completionOwner = "workflow";
+    state.notifyOnComplete = "inject";
+    state.eventByteCursor = 0;
+    interactiveSubagentRegistry.set(state.id, state);
+    (globalThis as any).__piSubagenturaInteractiveRegistry =
+      interactiveSubagentRegistry;
+    __setTmuxMultiplexer({
+      isPaneAlive: () => true,
+      isPaneAliveAsync: async () => true,
+    } as any);
+    appendDeterministicTurn(art, 1, "workflow-owned result");
+    const sendMessage = vi.fn();
+    await pollArtifactChanges({ sendMessage } as any);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(state.pendingDeliveries).toEqual([]);
+    expect(state.eventByteCursor).toBeGreaterThan(0);
+  });
+
+  it("polls workflow-owned children under their live supervisor owner", async () => {
+    const art = makeArtifact();
+    const owner = { id: 411, generation: 1 };
+    const sendMessage = vi.fn();
+    registerSessionContext({
+      ...owner,
+      pi: { sendMessage } as any,
+      sessionManager: { getSessionId: () => "workflow-parent" },
+    });
+    const state = {
+      ...makeState(art.dir),
+      parentSessionId: undefined,
+      supervisorOwner: owner,
+      completionOwner: "standalone" as const,
+      eventByteCursor: 0,
+    };
+    (globalThis as any).__piSubagenturaInteractiveRegistry =
+      interactiveSubagentRegistry;
+    interactiveSubagentRegistry.set(state.id, state);
+    __setTmuxMultiplexer({
+      isPaneAlive: () => true,
+      isPaneAliveAsync: async () => true,
+    } as any);
+    appendDeterministicTurn(art, 1, "owner-visible result");
+    await pollArtifactChanges({ sendMessage } as any, owner);
+    expect(state.eventByteCursor).toBeGreaterThan(0);
+    expect(sendMessage).toHaveBeenCalledOnce();
+  });
+
   it("queues an explicit omission message for oversized completion output", async () => {
     const art = makeArtifact();
     const state = makeState(art.dir);

--- a/tests/child-recursion.test.ts
+++ b/tests/child-recursion.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/interactive-lineage";
 import {
   cancelInteractiveDescendantByState,
+  disposeWorkflowInteractiveSubagent,
   interactiveSubagentRegistry,
   type InteractiveSubagentState,
 } from "../src/interactive-tmux";
@@ -134,5 +135,83 @@ describe("recursive interactive children", () => {
       '"outcome":"cancelled"',
     );
     expect(killPane).toHaveBeenCalledWith("%42", "recursive-test");
+  });
+
+  it("disposes a completed workflow child without recording cancellation", () => {
+    const artifactDir = join(tempDir(), "workflow-artifact");
+    mkdirSync(artifactDir, { recursive: true });
+    const killPane = vi.fn();
+    __setTmuxMultiplexer({
+      getPaneLiveness: vi.fn(() => "alive"),
+      killPane,
+    } as never);
+    const state: InteractiveSubagentState = {
+      id: "workflow-child",
+      name: "workflow-child",
+      task: "managed work",
+      paneId: "%43",
+      mux: "tmux",
+      muxSession: "workflow-test",
+      sessionFile: "/sessions/workflow-child.jsonl",
+      cwd: "/workspace/workflow-child",
+      supervisorOwner: { id: 7, generation: 2 },
+      workflowId: "wf-test",
+      completionOwner: "workflow",
+      startedAt: Date.now(),
+      status: "idle",
+      attachCommand: "attach",
+      selectPaneCommand: "focus",
+      launchScriptFile: "/launch/workflow-child.sh",
+      artifactDir,
+    };
+    interactiveSubagentRegistry.set(state.id, state);
+
+    expect(disposeWorkflowInteractiveSubagent(state)).toBeUndefined();
+
+    expect(interactiveSubagentRegistry.has(state.id)).toBe(false);
+    expect(killPane).toHaveBeenCalledWith("%43", "workflow-test");
+    expect(existsSync(join(artifactDir, ".cancelled"))).toBe(false);
+    expect(existsSync(join(artifactDir, "events.ndjson"))).toBe(false);
+  });
+
+  it("deregisters a workflow child even when pane teardown fails", () => {
+    const artifactDir = join(tempDir(), "workflow-artifact-kill-fails");
+    mkdirSync(artifactDir, { recursive: true });
+    const killPane = vi.fn(() => {
+      throw new Error("mux unavailable");
+    });
+    __setTmuxMultiplexer({
+      getPaneLiveness: vi.fn(() => "alive"),
+      killPane,
+    } as never);
+    const state: InteractiveSubagentState = {
+      id: "workflow-child-kill-fails",
+      name: "workflow-child",
+      task: "managed work",
+      paneId: "%44",
+      mux: "tmux",
+      muxSession: "workflow-test",
+      sessionFile: "/sessions/workflow-child.jsonl",
+      cwd: "/workspace/workflow-child",
+      supervisorOwner: { id: 7, generation: 2 },
+      workflowId: "wf-test",
+      completionOwner: "workflow",
+      startedAt: Date.now(),
+      status: "idle",
+      attachCommand: "attach",
+      selectPaneCommand: "focus",
+      launchScriptFile: "/launch/workflow-child.sh",
+      artifactDir,
+    };
+    interactiveSubagentRegistry.set(state.id, state);
+
+    // A retained entry would strand a permanently "running" supervisor row that
+    // nothing can ever finish, and whose only affordance writes a false
+    // `.cancelled` marker. The leaked pane is reported to the caller instead.
+    expect(disposeWorkflowInteractiveSubagent(state)).toBe("mux unavailable");
+
+    expect(interactiveSubagentRegistry.has(state.id)).toBe(false);
+    expect(killPane).toHaveBeenCalledTimes(1);
+    expect(existsSync(join(artifactDir, ".cancelled"))).toBe(false);
   });
 });

--- a/tests/interactive-supervisor.test.ts
+++ b/tests/interactive-supervisor.test.ts
@@ -433,8 +433,8 @@ describe("interactive supervisor", () => {
     );
 
     expect(items.map((item) => item.kind)).toEqual([
-      "in-process",
       "workflow",
+      "in-process",
       "interactive",
     ]);
     expect(
@@ -459,6 +459,192 @@ describe("interactive supervisor", () => {
         ownerSessionId: "owned-parent-session",
       },
     });
+  });
+
+  it("groups workflow children after their matching workflow root", () => {
+    const owner = { id: 7, generation: 2 };
+    const workflowA = workflowJob("wf-a", {
+      name: "alpha",
+      parentSessionOwner: owner,
+      startedAt: 10,
+    });
+    const workflowB = workflowJob("wf-b", {
+      name: "beta",
+      parentSessionOwner: owner,
+      startedAt: 20,
+    });
+    workflowJobRegistry.set(workflowA.id, workflowA);
+    workflowJobRegistry.set(workflowB.id, workflowB);
+
+    const processA = inProcessJob("process-a", {
+      startedAt: 11,
+      workflowId: workflowA.id,
+      deliveryOwner: {
+        pi: {} as never,
+        sessionContextId: owner.id,
+        sessionContextGeneration: owner.generation,
+      },
+    });
+    const processB = inProcessJob("process-b", {
+      startedAt: 21,
+      workflowId: workflowB.id,
+      deliveryOwner: {
+        pi: {} as never,
+        sessionContextId: owner.id,
+        sessionContextGeneration: owner.generation,
+      },
+    });
+    const standalone = inProcessJob("standalone", {
+      startedAt: 100,
+      deliveryOwner: {
+        pi: {} as never,
+        sessionContextId: owner.id,
+        sessionContextGeneration: owner.generation,
+      },
+    });
+    jobRegistry.set(processA.id, processA);
+    jobRegistry.set(processB.id, processB);
+    jobRegistry.set(standalone.id, standalone);
+
+    const interactiveA = state("interactive-a", {
+      startedAt: 12,
+      workflowId: workflowA.id,
+      supervisorOwner: owner,
+    });
+    const interactiveB = state("interactive-b", {
+      startedAt: 22,
+      workflowId: workflowB.id,
+      supervisorOwner: owner,
+    });
+    const standaloneInteractive = state("standalone-interactive", {
+      startedAt: 101,
+      supervisorOwner: owner,
+    });
+    for (const item of [interactiveA, interactiveB, standaloneInteractive]) {
+      interactiveSubagentRegistry.set(item.id, item);
+    }
+
+    const items = buildAsyncSupervisorItems(
+      directSupervisorItems(undefined, owner),
+      owner,
+    );
+    expect(
+      items.map((item) =>
+        item.kind === "workflow"
+          ? item.job.id
+          : item.kind === "in-process"
+            ? item.job.id
+            : item.state.id,
+      ),
+    ).toEqual([
+      "wf-a",
+      "process-a",
+      "interactive-a",
+      "wf-b",
+      "process-b",
+      "interactive-b",
+      "standalone",
+      "standalone-interactive",
+    ]);
+  });
+
+  it("shows owner-scoped workflow interactive children", () => {
+    const owner = { id: 7, generation: 2 };
+    const workflow = workflowJob("owned-workflow", {
+      parentSessionOwner: owner,
+    });
+    workflowJobRegistry.set(workflow.id, workflow);
+    const child = state("workflow-child", {
+      supervisorOwner: owner,
+      workflowId: workflow.id,
+      completionOwner: "workflow",
+    });
+    interactiveSubagentRegistry.set(child.id, child);
+    const items = buildAsyncSupervisorItems(
+      directSupervisorItems(undefined, owner),
+      owner,
+    );
+    const visibleChild = items.find(
+      (item) => item.kind === "interactive" && item.state.id === child.id,
+    );
+    expect(visibleChild).toMatchObject({
+      kind: "interactive",
+      depth: 1,
+      actionable: true,
+    });
+    expect(child.parentSessionId).toBeUndefined();
+  });
+
+  it("flattens orphaned workflow children whose workflow row is gone", () => {
+    const owner = { id: 7, generation: 2 };
+    // cleanupWorkflowJobsForOwner deletes the workflow job synchronously while its
+    // children take a microtask or more to unwind. During that window the children
+    // have no parent row above them and must not render indented.
+    const orphanInteractive = state("orphan-interactive", {
+      supervisorOwner: owner,
+      workflowId: "wf-already-gone",
+      completionOwner: "workflow",
+    });
+    interactiveSubagentRegistry.set(orphanInteractive.id, orphanInteractive);
+    const orphanProcess = inProcessJob("orphan-process", {
+      workflowId: "wf-already-gone",
+      completionOwner: "workflow",
+      deliveryOwner: {
+        pi: {} as never,
+        sessionContextId: owner.id,
+        sessionContextGeneration: owner.generation,
+      },
+    });
+    jobRegistry.set(orphanProcess.id, orphanProcess);
+
+    const items = buildAsyncSupervisorItems(
+      directSupervisorItems(undefined, owner),
+      owner,
+    );
+
+    expect(
+      items.map((item) => [
+        item.kind === "in-process" || item.kind === "workflow"
+          ? item.job.id
+          : item.state.id,
+        item.depth,
+      ]),
+    ).toEqual([
+      ["orphan-process", 0],
+      ["orphan-interactive", 0],
+    ]);
+  });
+
+  it("keeps in-process rows ahead of interactive rows within a group", () => {
+    // Grouping moved workflow roots to the front of the list, but the relative
+    // order of non-workflow rows is unchanged from the pre-grouping return value
+    // `[...processItems, ...workflowItems, ...normalizedInteractive]`: in-process
+    // first, then interactive, each by ascending startedAt.
+    const owner = { id: 7, generation: 2 };
+    const youngProcess = inProcessJob("process-young", {
+      startedAt: 500,
+      deliveryOwner: {
+        pi: {} as never,
+        sessionContextId: owner.id,
+        sessionContextGeneration: owner.generation,
+      },
+    });
+    jobRegistry.set(youngProcess.id, youngProcess);
+    const oldInteractive = state("interactive-old", {
+      startedAt: 1,
+      supervisorOwner: owner,
+    });
+    interactiveSubagentRegistry.set(oldInteractive.id, oldInteractive);
+
+    const items = buildAsyncSupervisorItems(
+      directSupervisorItems(undefined, owner),
+      owner,
+    );
+
+    expect(items.map((item) => item.kind)).toEqual([
+      "in-process",
+      "interactive",
+    ]);
   });
 
   it("navigates, expands, refreshes, and closes without cancelling", () => {
@@ -1459,6 +1645,17 @@ describe("interactive supervisor", () => {
     } as never);
 
     const { confirm, notify } = await harness.open((component) => {
+      for (let index = 0; index < 3; index++) component.handleInput("k");
+      for (let index = 0; index < 3; index++) {
+        const selected = component
+          .render(200)
+          .find((line) => line.includes("▶"));
+        if (selected?.includes("agent-parent")) break;
+        component.handleInput("j");
+      }
+      expect(
+        component.render(200).find((line) => line.includes("▶")),
+      ).toContain("agent-parent");
       component.handleInput("X");
     });
 

--- a/tests/interactive-tmux.test.ts
+++ b/tests/interactive-tmux.test.ts
@@ -178,6 +178,9 @@ describe("interactive-tmux", () => {
     expect(statSync(join(state.artifactDir, "cli.mjs")).mode & 0o777).toBe(
       0o700,
     );
+
+    // Omitting parentSessionId keeps workflow-style children out of rehydrate state.
+    expect(existsSync(join(tmp, ".pi", "subagentura-state.json"))).toBe(false);
   });
 
   it("writes a lineage manifest before exposure and propagates child identity", async () => {

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -529,6 +529,19 @@ describe("session handler lifecycle callbacks", () => {
     expect(globalState.__piSubagenturaInteractivePollerHandle).toBeDefined();
   });
 
+  it("does not fall back to global footer counts for a stale owner", () => {
+    const ui = { setStatus: vi.fn() };
+    jobRegistry.set("foreign-job", {
+      id: "foreign-job",
+      status: "running",
+      session: { abort: vi.fn() },
+    } as any);
+
+    updateRunningSubagentFooter(ui as any, { id: 999, generation: 1 });
+
+    expect(ui.setStatus).toHaveBeenCalledWith("subagentura-running", undefined);
+  });
+
   it("polls every live owner from the single global interval", async () => {
     const parent = registerHandlers();
     const child = registerHandlers();

--- a/tests/subagent-interactive-default.test.ts
+++ b/tests/subagent-interactive-default.test.ts
@@ -101,9 +101,21 @@ describe("subagent_interactive tool lifecycle", () => {
     return _api;
   }
 
+  /** Bind ui + sessionManager onto the registered session context. */
+  function startSession(ctx: ReturnType<typeof mockCtx>): void {
+    const handler = (api.on as any).mock.calls.find(
+      ([event]: [string]) => event === "session_start",
+    )?.[1] as Function;
+    handler({ reason: "new" }, ctx);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     interactiveSubagentRegistry.clear();
+    const g = globalThis as any;
+    const stack = g.__piSubagenturaSessionContextStack;
+    if (Array.isArray(stack)) stack.length = 0;
+    g.__piSubagenturaInteractivePollerHandle = undefined;
     api = setupExtension() as any;
     mockLaunchInteractiveSubagent.mockReset();
     mockCancelInteractiveSubagent.mockReset();
@@ -116,6 +128,13 @@ describe("subagent_interactive tool lifecycle", () => {
 
   afterEach(() => {
     interactiveSubagentRegistry.clear();
+    const g = globalThis as any;
+    if (g.__piSubagenturaInteractivePollerHandle) {
+      clearInterval(g.__piSubagenturaInteractivePollerHandle);
+      g.__piSubagenturaInteractivePollerHandle = undefined;
+    }
+    const stack = g.__piSubagenturaSessionContextStack;
+    if (Array.isArray(stack)) stack.length = 0;
     vi.clearAllMocks();
     if (savedTmux === undefined) delete process.env.TMUX;
     else process.env.TMUX = savedTmux;
@@ -284,7 +303,11 @@ describe("subagent_interactive tool lifecycle", () => {
   it("updates the running footer immediately after launch", async () => {
     const toolDef = getInteractiveToolDef(api);
     const ctx = mockCtx();
-    const state = mockInteractiveState();
+    startSession(ctx);
+    const state = {
+      ...mockInteractiveState(),
+      parentSessionId: "test-session-id",
+    };
     mockLaunchInteractiveSubagent.mockImplementationOnce(() => {
       interactiveSubagentRegistry.set(state.id, state as any);
       return state;
@@ -301,6 +324,70 @@ describe("subagent_interactive tool lifecycle", () => {
     expect(ctx.ui.setStatus).toHaveBeenCalledWith(
       "subagentura-running",
       "⚡ 1 sub-agent active",
+    );
+  });
+
+  it("counts only this session's agents once the session context is bound", async () => {
+    // The reachable production path: the tool passes the raw active token and
+    // updateRunningSubagentFooter owns the scoping decision.
+    const toolDef = getInteractiveToolDef(api);
+    const ctx = mockCtx();
+    startSession(ctx);
+    const mine = {
+      ...mockInteractiveState(),
+      parentSessionId: "test-session-id",
+    };
+    const foreign = {
+      ...mockInteractiveState(),
+      id: "def67890",
+      parentSessionId: "another-session-id",
+    };
+    interactiveSubagentRegistry.set(foreign.id, foreign as any);
+    mockLaunchInteractiveSubagent.mockImplementationOnce(() => {
+      interactiveSubagentRegistry.set(mine.id, mine as any);
+      return mine;
+    });
+
+    await toolDef.execute(
+      "call-footer-scoped",
+      { task: "research X" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent active",
+    );
+  });
+
+  it("reports no agents when the active session context is already stale", async () => {
+    // A stale token must read as "this session owns nothing", never fall back to
+    // a cross-session global count.
+    const toolDef = getInteractiveToolDef(api);
+    const ctx = mockCtx();
+    startSession(ctx);
+    const foreign = {
+      ...mockInteractiveState(),
+      id: "def67890",
+      parentSessionId: "another-session-id",
+    };
+    interactiveSubagentRegistry.set(foreign.id, foreign as any);
+    const stack = (globalThis as any).__piSubagenturaSessionContextStack ?? [];
+    for (const context of stack) context.generation += 1;
+
+    await toolDef.execute(
+      "call-footer-stale",
+      { task: "research X" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(
+      "subagentura-running",
+      undefined,
     );
   });
 

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -312,6 +312,64 @@ describe("pollArtifactChanges", () => {
     );
   });
 
+  it("shows workflow children on the owning session's widget and footer", async () => {
+    // Workflow children are launched without a parentSessionId, so scoping either
+    // surface on (ui identity + parentSessionId) makes them structurally
+    // unrepresentable: visible in the supervisor, missing from the widget, and
+    // undercounted in the footer. Ownership must come from supervisorOwner.
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const uiA = { notify: vi.fn(), setStatus: vi.fn(), setWidget: vi.fn() };
+    const uiB = { notify: vi.fn(), setStatus: vi.fn(), setWidget: vi.fn() };
+    const ownerA = { id: 601, generation: 1 };
+    const ownerB = { id: 602, generation: 1 };
+    registerSessionContext({
+      ...ownerA,
+      pi: { sendMessage: vi.fn() } as any,
+      ui: uiA as any,
+      sessionManager: { getSessionId: () => "session-a" },
+    });
+    registerSessionContext({
+      ...ownerB,
+      pi: { sendMessage: vi.fn() } as any,
+      ui: uiB as any,
+      sessionManager: { getSessionId: () => "session-b" },
+    });
+
+    const child = makeState();
+    child.state.name = "wf-child";
+    child.state.supervisorOwner = ownerA;
+    child.state.workflowId = "wf-1";
+    child.state.completionOwner = "workflow";
+    child.state.parentSessionId = undefined;
+    mod.interactiveSubagentRegistry.set(child.id, child.state);
+
+    // A sibling session's plain agent must be neither listed nor counted for A.
+    const sibling = makeState();
+    sibling.state.name = "sibling";
+    sibling.state.parentSessionId = "session-b";
+    mod.interactiveSubagentRegistry.set(sibling.id, sibling.state);
+
+    multiplexer.__setTmuxMultiplexer({
+      isPaneAliveAsync: async () => true,
+    } as any);
+
+    await mod.pollArtifactChanges({} as any, ownerA);
+
+    const rows = uiA.setWidget.mock.calls
+      .filter(([key]) => key === "subagentura-activity")
+      .at(-1)?.[1] as string[] | undefined;
+    expect(rows).toEqual(
+      expect.arrayContaining([expect.stringContaining("wf-child")]),
+    );
+    expect(rows).toHaveLength(1);
+    expect(uiA.setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent active",
+    );
+  });
+
   it("keeps activity rows isolated between distinct UIs", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");

--- a/tests/subagent-shutdown.test.ts
+++ b/tests/subagent-shutdown.test.ts
@@ -351,6 +351,35 @@ describe("session_shutdown handler", () => {
     },
   );
 
+  it.each(["reload", "resume", "quit"])(
+    "still kills workflow-owned panes for preserving reason %s",
+    (reason) => {
+      // Workflow children are in-memory only: their workflowId, supervisorOwner
+      // and pending result live nowhere on disk, so rehydrate can never revive
+      // them. Preserving their panes would leak an orphan the user has no handle
+      // on, while a standalone pane is still rehydratable.
+      const workflowChild = makeState("wf-child", "running");
+      workflowChild.completionOwner = "workflow";
+      workflowChild.workflowId = "wf-1";
+      const standalone = makeState("standalone", "running");
+      interactiveTmux.interactiveSubagentRegistry.set(
+        workflowChild.id,
+        workflowChild,
+      );
+      interactiveTmux.interactiveSubagentRegistry.set(
+        standalone.id,
+        standalone,
+      );
+
+      const { shutdownHandler } = setupExtension();
+      shutdownHandler!({ reason });
+
+      expect(cancelByStateSpy).toHaveBeenCalledTimes(1);
+      expect(cancelByStateSpy).toHaveBeenCalledWith(workflowChild);
+      expect(interactiveTmux.interactiveSubagentRegistry.size).toBe(0);
+    },
+  );
+
   it("clears interactiveSubagentRegistry in session_shutdown", () => {
     // Pre-populate with both running and non-running states. The cancel
     // loop is mocked, so it does NOT remove entries — the explicit

--- a/tests/workflow-supervisor.integration.test.ts
+++ b/tests/workflow-supervisor.integration.test.ts
@@ -1,0 +1,601 @@
+/**
+ * End-to-end coverage for workflow-owned children as seen by the parent session's
+ * live surfaces: the supervisor overlay, the activity widget, the running-agents
+ * footer, the job registries, and `session_shutdown`.
+ *
+ * Only the two process boundaries are stubbed — `launchInteractiveSubagent` (which
+ * would spawn a real tmux pane) and `startSubagentJob` (which would open a real
+ * model session). Everything in between is the real code path: `registerWorkflowTool`
+ * → `startWorkflowJob` → `runWorkflow` in a real Worker → `runAgent` →
+ * `disposeWorkflowInteractiveSubagent`, plus the real poller, the real session
+ * context stack and the real `session_shutdown` handler.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SubagentResult } from "../src/helpers";
+
+const { mockAwaitInteractiveResult, mockLaunch, mockStartSubagentJob } =
+  vi.hoisted(() => ({
+    mockAwaitInteractiveResult: vi.fn(),
+    mockLaunch: vi.fn(),
+    mockStartSubagentJob: vi.fn(),
+  }));
+
+vi.mock("../src/interactive-tmux", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/interactive-tmux")>();
+  return { ...actual, launchInteractiveSubagent: mockLaunch };
+});
+
+vi.mock("../src/workflow-worker", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/workflow-worker")>();
+  return { ...actual, awaitInteractiveResult: mockAwaitInteractiveResult };
+});
+
+vi.mock("../src/helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/helpers")>();
+  return { ...actual, startSubagentJob: mockStartSubagentJob };
+});
+
+import { pollArtifactChanges } from "../src/artifact-poller";
+import { jobRegistry } from "../src/helpers";
+import {
+  buildAsyncSupervisorItems,
+  directSupervisorItems,
+} from "../src/interactive-supervisor-registration";
+import type { AsyncSupervisorItem } from "../src/interactive-supervisor-ui";
+import {
+  interactiveSubagentRegistry,
+  type InteractiveSubagentState,
+} from "../src/interactive-tmux";
+import { __resetMuxInstances, __setTmuxMultiplexer } from "../src/multiplexer";
+import {
+  advanceSessionContextGeneration,
+  getSessionContextStack,
+  registerSessionContext,
+  removeSessionContext,
+  setActiveSessionRefs,
+  type SessionContextRef,
+} from "../src/session-context";
+import {
+  MAX_WORKFLOW_JOBS,
+  workflowJobRegistry,
+  type WorkflowJobState,
+} from "../src/workflow-jobs";
+import { registerWorkflowTool } from "../src/workflow-tool";
+
+const ACTIVITY_WIDGET_KEY = "subagentura-activity";
+const RUNNING_FOOTER_KEY = "subagentura-running";
+
+const tempDirs: string[] = [];
+let releaseAgent!: (result: SubagentResult) => void;
+let killPane: ReturnType<typeof vi.fn>;
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "workflow-supervisor-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function subagentResult(output: string): SubagentResult {
+  return {
+    isError: false,
+    output,
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    },
+    model: "test/model",
+  };
+}
+
+function fakeUi() {
+  return {
+    notify: vi.fn(),
+    setStatus: vi.fn(),
+    setWidget: vi.fn(),
+  };
+}
+
+/** Register a live session context the way `registerSessionHandlers` does. */
+function liveSessionContext(options: {
+  id: number;
+  sessionId: string;
+  ui?: ReturnType<typeof fakeUi>;
+}): { context: SessionContextRef; ui: ReturnType<typeof fakeUi> } {
+  const ui = options.ui ?? fakeUi();
+  const context: SessionContextRef = {
+    id: options.id,
+    generation: 1,
+    lifecycle: "started",
+    pi: { sendMessage: vi.fn() } as never,
+    ui: ui as never,
+    sessionManager: {
+      getSessionId: () => options.sessionId,
+      getEntries: () => [],
+    },
+  };
+  registerSessionContext(context);
+  setActiveSessionRefs(context);
+  return { context, ui };
+}
+
+function ownerOf(context: SessionContextRef) {
+  return { id: context.id, generation: context.generation };
+}
+
+/** [id, depth] pairs, the two things the grouped supervisor list is about. */
+function rowShape(items: AsyncSupervisorItem[]): [string, number][] {
+  return items.map((item) => [
+    item.kind === "in-process" || item.kind === "workflow"
+      ? item.job.id
+      : item.state.id,
+    item.depth,
+  ]);
+}
+
+function lastWidgetRows(
+  ui: ReturnType<typeof fakeUi>,
+): string[] | undefined | "never-painted" {
+  const calls = ui.setWidget.mock.calls.filter(
+    ([key]) => key === ACTIVITY_WIDGET_KEY,
+  );
+  if (calls.length === 0) return "never-painted";
+  return calls.at(-1)?.[1] as string[] | undefined;
+}
+
+function lastFooter(
+  ui: ReturnType<typeof fakeUi>,
+): string | undefined | "never-painted" {
+  const calls = ui.setStatus.mock.calls.filter(
+    ([key]) => key === RUNNING_FOOTER_KEY,
+  );
+  if (calls.length === 0) return "never-painted";
+  return calls.at(-1)?.[1] as string | undefined;
+}
+
+function plainInteractiveState(
+  id: string,
+  parentSessionId: string,
+): InteractiveSubagentState {
+  return {
+    id,
+    name: id,
+    task: "unrelated work",
+    paneId: `%${id}`,
+    mux: "tmux",
+    sessionFile: `/tmp/${id}.jsonl`,
+    cwd: "/tmp",
+    parentSessionId,
+    startedAt: Date.now(),
+    status: "running",
+    attachCommand: "attach",
+    selectPaneCommand: "focus",
+    launchScriptFile: `/tmp/${id}.sh`,
+    artifactDir: tempDir(),
+  };
+}
+
+function workflowTool(pi: { registerTool: ReturnType<typeof vi.fn> }): any {
+  const tools: any[] = [];
+  (pi.registerTool as any).mockImplementation((tool: any) => tools.push(tool));
+  return () => tools.find((tool) => tool.name === "workflow");
+}
+
+function makePi() {
+  const pi = {
+    registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+    sendMessage: vi.fn(),
+  };
+  const findTool = workflowTool(pi as never);
+  return { pi, findTool };
+}
+
+const SINGLE_AGENT_SCRIPT = (name: string) =>
+  `export const meta = { name: "${name}", description: "d" };\n` +
+  'return await agent("inspect", { label: "reviewer" });';
+
+beforeEach(() => {
+  getSessionContextStack().length = 0;
+  setActiveSessionRefs(undefined);
+  jobRegistry.clear();
+  workflowJobRegistry.clear();
+  interactiveSubagentRegistry.clear();
+  killPane = vi.fn();
+  __setTmuxMultiplexer({
+    getPaneLiveness: vi.fn(() => "alive"),
+    getPaneLivenessAsync: vi.fn(async () => "alive"),
+    killPane,
+  } as never);
+  mockAwaitInteractiveResult.mockImplementation(
+    () =>
+      new Promise<SubagentResult>((resolve) => {
+        releaseAgent = resolve;
+      }),
+  );
+  mockStartSubagentJob.mockRejectedValue(
+    new Error("unexpected in-process fallback"),
+  );
+  mockLaunch.mockImplementation((params) => {
+    const state = {
+      id: "workflow-child",
+      name: params.name,
+      task: params.task,
+      paneId: "%42",
+      mux: "tmux",
+      sessionFile: "/tmp/workflow-child.jsonl",
+      cwd: params.cwd,
+      startedAt: Date.now(),
+      status: "running",
+      attachCommand: "attach",
+      selectPaneCommand: "focus",
+      launchScriptFile: "/tmp/workflow-child.sh",
+      artifactDir: tempDir(),
+      supervisorOwner: params.supervisorOwner,
+      workflowId: params.workflowId,
+      completionOwner: params.completionOwner,
+    };
+    interactiveSubagentRegistry.set(state.id, state as never);
+    return state;
+  });
+});
+
+afterEach(() => {
+  interactiveSubagentRegistry.clear();
+  workflowJobRegistry.clear();
+  jobRegistry.clear();
+  getSessionContextStack().length = 0;
+  setActiveSessionRefs(undefined);
+  __resetMuxInstances();
+  vi.clearAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("workflow supervisor integration", () => {
+  it("shows a live process child under its tracked sync workflow", async () => {
+    const { context } = liveSessionContext({ id: 7, sessionId: "session-a" });
+    const owner = ownerOf(context);
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never, context);
+
+    const execution = findTool().execute(
+      "call-sync",
+      { script: SINGLE_AGENT_SCRIPT("sync-visible"), async: false },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+
+    await vi.waitFor(() => expect(mockLaunch).toHaveBeenCalledOnce());
+    const workflow = [...workflowJobRegistry.values()].find(
+      (job) => job.name === "sync-visible",
+    );
+    expect(workflow).toBeDefined();
+    expect(workflow?.executionMode).toBe("sync");
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        background: true,
+        completionOwner: "workflow",
+        supervisorOwner: owner,
+        workflowId: workflow?.id,
+      }),
+    );
+    // Workflow children are never persisted, so they carry no parentSessionId —
+    // the reason ownership must be answered by supervisorOwner everywhere.
+    expect(mockLaunch.mock.calls[0]?.[0]?.parentSessionId).toBeUndefined();
+
+    const items = buildAsyncSupervisorItems(
+      directSupervisorItems(undefined, owner),
+      owner,
+    );
+    expect(rowShape(items)).toEqual([
+      [workflow!.id, 0],
+      ["workflow-child", 1],
+    ]);
+
+    releaseAgent(subagentResult("reviewed"));
+    const result = await execution;
+
+    expect(result.details.status).toBe("done");
+    // The real dispose ran: registry entry gone, pane killed, and no `.cancelled`
+    // marker written for an agent that completed normally.
+    expect(interactiveSubagentRegistry.has("workflow-child")).toBe(false);
+    expect(killPane).toHaveBeenCalledWith("%42", undefined);
+    // A sync workflow returned its result inline, so it must not linger where
+    // get_workflow_result could re-serve it or the supervisor could show it.
+    expect(workflowJobRegistry.has(workflow!.id)).toBe(false);
+  });
+
+  it("counts and lists a workflow child on the owning session's footer and widget", async () => {
+    // The merge-defect guard. The base branch scoped both surfaces on
+    // (ui identity + state.parentSessionId), a key workflow children structurally
+    // cannot satisfy: a textually clean merge left them visible in the supervisor
+    // but missing from the widget and undercounted in the footer.
+    const a = liveSessionContext({ id: 7, sessionId: "session-a" });
+    const b = liveSessionContext({ id: 8, sessionId: "session-b" });
+    const ownerA = ownerOf(a.context);
+    setActiveSessionRefs(a.context);
+
+    // A sibling session's plain agent must NOT be counted or listed for A.
+    const sibling = plainInteractiveState("sibling-agent", "session-b");
+    interactiveSubagentRegistry.set(sibling.id, sibling);
+
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never, a.context);
+    const execution = findTool().execute(
+      "call-widget",
+      { script: SINGLE_AGENT_SCRIPT("widget-visible"), async: false },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+    await vi.waitFor(() => expect(mockLaunch).toHaveBeenCalledOnce());
+
+    await pollArtifactChanges(a.context.pi, ownerA);
+
+    const rows = lastWidgetRows(a.ui);
+    expect(Array.isArray(rows) ? rows : rows).toHaveLength(1);
+    // The activity row renders the child's display name ("reviewer" is the
+    // workflow agent label passed through to launchInteractiveSubagent).
+    expect((rows as string[]).join("\n")).toContain("reviewer");
+    expect((rows as string[]).join("\n")).not.toContain("sibling-agent");
+    expect(lastFooter(a.ui)).toBe("⚡ 1 sub-agent active");
+    // B's surfaces are untouched by A's tick.
+    expect(lastWidgetRows(b.ui)).toBe("never-painted");
+
+    releaseAgent(subagentResult("reviewed"));
+    await execution;
+  });
+
+  it("registers, settles, and deregisters an in-process fallback child", async () => {
+    const { context } = liveSessionContext({ id: 7, sessionId: "session-a" });
+    const owner = ownerOf(context);
+    const start = vi.fn();
+    let releaseChild!: (result: SubagentResult) => void;
+    mockLaunch.mockImplementationOnce(() => {
+      throw new Error("mux unavailable");
+    });
+    mockStartSubagentJob.mockResolvedValueOnce({
+      jobId: "fallback-child",
+      jobPromise: new Promise<SubagentResult>((resolve) => {
+        releaseChild = resolve;
+      }),
+      liveStatus: { turn: 0, output: "", usage: {} },
+      session: { abort: vi.fn() },
+      modelLabel: "test/model",
+      thinkingLevel: "medium",
+      start,
+    });
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never, context);
+
+    const execution = findTool().execute(
+      "call-fallback",
+      { script: SINGLE_AGENT_SCRIPT("fallback"), async: false },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+    const childJob = jobRegistry.get("fallback-child");
+    expect(childJob).toBeDefined();
+    expect(childJob?.status).toBe("running");
+    expect(childJob?.completionOwner).toBe("workflow");
+    expect(childJob?.abort).toBeInstanceOf(AbortController);
+    // Reachable by every owner-scoped sweep, including session_shutdown's drain.
+    expect(childJob?.deliveryOwner).toMatchObject({
+      sessionContextId: owner.id,
+      sessionContextGeneration: owner.generation,
+    });
+    const workflow = [...workflowJobRegistry.values()].find(
+      (job) => job.name === "fallback",
+    );
+    const items = buildAsyncSupervisorItems(
+      directSupervisorItems(undefined, owner),
+      owner,
+    );
+    expect(rowShape(items)).toEqual([
+      [workflow!.id, 0],
+      ["fallback-child", 1],
+    ]);
+
+    releaseChild(subagentResult("fallback complete"));
+    const result = await execution;
+
+    expect(result.details.status).toBe("done");
+    expect(result.content[0]?.text).toContain("fallback complete");
+    // Settlement wrote a terminal status, so the row is never actionable-forever,
+    // never double-counted against its own workflow, and never picked up by
+    // session_shutdown's "status === running" cancellation-record loop.
+    expect(childJob?.status).toBe("done");
+    expect(childJob?.result?.output).toBe("fallback complete");
+    expect(jobRegistry.has("fallback-child")).toBe(false);
+  });
+
+  it("does not start an in-process child whose parent shut down mid-spawn", async () => {
+    const { context } = liveSessionContext({ id: 7, sessionId: "session-a" });
+    const start = vi.fn();
+    const disposeBeforeStart = vi.fn();
+    const sessionAbort = vi.fn();
+    let releaseSpawn!: (prepared: unknown) => void;
+    mockLaunch.mockImplementationOnce(() => {
+      throw new Error("mux unavailable");
+    });
+    mockStartSubagentJob.mockReturnValueOnce(
+      new Promise((resolve) => {
+        releaseSpawn = resolve;
+      }),
+    );
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never, context);
+
+    const execution = findTool().execute(
+      "call-escape",
+      { script: SINGLE_AGENT_SCRIPT("escape"), async: false },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+    await vi.waitFor(() => expect(mockStartSubagentJob).toHaveBeenCalledOnce());
+
+    // The parent session shuts down while startSubagentJob is still pending.
+    advanceSessionContextGeneration(context.id);
+    removeSessionContext(context.id);
+    releaseSpawn({
+      jobId: "escaped-child",
+      jobPromise: new Promise(() => {}),
+      liveStatus: { turn: 0, output: "", usage: {} },
+      session: { abort: sessionAbort },
+      modelLabel: "test/model",
+      start,
+      disposeBeforeStart,
+    });
+
+    const result = await execution;
+
+    expect(start).not.toHaveBeenCalled();
+    expect(disposeBeforeStart).toHaveBeenCalledOnce();
+    expect(sessionAbort).toHaveBeenCalledOnce();
+    expect(jobRegistry.has("escaped-child")).toBe(false);
+    expect(result.details.status).toBe("error");
+  });
+
+  it("leaves an unownable in-process child out of the registry", async () => {
+    // No session context at all: a deliveryOwner without a sessionContextId
+    // matches no owner-scoped sweep, so registering would create a row that is
+    // invisible in the supervisor AND skipped by session_shutdown's drain.
+    const start = vi.fn();
+    let releaseChild!: (result: SubagentResult) => void;
+    mockLaunch.mockImplementationOnce(() => {
+      throw new Error("mux unavailable");
+    });
+    mockStartSubagentJob.mockResolvedValueOnce({
+      jobId: "unowned-child",
+      jobPromise: new Promise<SubagentResult>((resolve) => {
+        releaseChild = resolve;
+      }),
+      liveStatus: { turn: 0, output: "", usage: {} },
+      session: { abort: vi.fn() },
+      modelLabel: "test/model",
+      start,
+    });
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never);
+
+    const execution = findTool().execute(
+      "call-unowned",
+      { script: SINGLE_AGENT_SCRIPT("unowned"), async: false },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+
+    // Inspected while the child is live, which is the only window in which an
+    // unreachable row would be observable.
+    expect(jobRegistry.size).toBe(0);
+
+    releaseChild(subagentResult("unowned complete"));
+    const result = await execution;
+
+    expect(result.details.status).toBe("done");
+    expect(result.content[0]?.text).toContain("unowned complete");
+    expect(jobRegistry.size).toBe(0);
+  });
+
+  it("deregisters a live interactive child when the workflow fails", async () => {
+    const { context } = liveSessionContext({ id: 7, sessionId: "session-a" });
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never, context);
+
+    const execution = findTool().execute(
+      "call-failure",
+      {
+        script:
+          'export const meta = { name: "failing", description: "d" };\n' +
+          'await agent("inspect", { label: "reviewer" });\n' +
+          'throw new Error("script blew up");',
+        async: false,
+      },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+    await vi.waitFor(() => expect(mockLaunch).toHaveBeenCalledOnce());
+    expect(interactiveSubagentRegistry.has("workflow-child")).toBe(true);
+
+    releaseAgent(subagentResult("reviewed"));
+    const result = await execution;
+
+    expect(result.isError).toBe(true);
+    expect(interactiveSubagentRegistry.has("workflow-child")).toBe(false);
+    expect(killPane).toHaveBeenCalledWith("%42", undefined);
+  });
+
+  it("runs a sync workflow even when the async job cap is saturated", async () => {
+    const { context } = liveSessionContext({ id: 7, sessionId: "session-a" });
+    const owner = ownerOf(context);
+    for (let index = 0; index < MAX_WORKFLOW_JOBS; index++) {
+      const id = `saturating-${index}`;
+      workflowJobRegistry.set(id, {
+        id,
+        name: id,
+        status: "running",
+        startedAt: Date.now(),
+        promise: new Promise(() => {}),
+        abort: new AbortController(),
+        parentSessionOwner: owner,
+        snapshot: {
+          agentsSpawned: 0,
+          errorCount: 0,
+          tokensSpent: 0,
+          phases: [],
+        },
+      } as unknown as WorkflowJobState);
+    }
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never, context);
+
+    // The async path still refuses — the cap is what protects the registry.
+    const refused = await findTool().execute(
+      "call-async-capped",
+      { script: SINGLE_AGENT_SCRIPT("async-capped") },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+    expect(refused.isError).toBe(true);
+    expect(refused.content[0]?.text).toContain("workflow jobs already running");
+
+    // The blocking sync path must not acquire a new failure mode from being
+    // tracked: it always ran before, so it still runs now.
+    const execution = findTool().execute(
+      "call-sync-capped",
+      { script: SINGLE_AGENT_SCRIPT("sync-capped"), async: false },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+    await vi.waitFor(() => expect(mockLaunch).toHaveBeenCalledOnce());
+    releaseAgent(subagentResult("reviewed"));
+    const result = await execution;
+
+    expect(result.details.status).toBe("done");
+    expect(
+      [...workflowJobRegistry.values()].some(
+        (job) => job.name === "sync-capped",
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1950,6 +1950,147 @@ describe("registerWorkflowTool", () => {
     expect(result.content[0].text).toContain("/tmp/tool-context");
   });
 
+  it("tracks an explicit synchronous workflow while it is running", async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: vi.fn((def: any) => tools.push(def)),
+      registerCommand: vi.fn(),
+    };
+    registerWorkflowTool(pi as any);
+    const workflowTool = tools.find((tool) => tool.name === "workflow")!;
+    const execution = workflowTool.execute(
+      "",
+      {
+        script:
+          `export const meta = { name: "sync-visible", description: "d" };\n` +
+          `return "done";`,
+        async: false,
+      },
+      undefined,
+      undefined,
+      { cwd: "/tmp/tool-context", modelRegistry: {} },
+    );
+    const job = [...workflowJobRegistry.values()].at(-1)!;
+    expect(job).toBeDefined();
+    expect(job.executionMode).toBe("sync");
+    expect(job.status).toBe("running");
+    expect(job.name).toBe("sync-visible");
+    const result = await execution;
+    expect(result.details.status).toBe("done");
+
+    // A sync workflow already returned its result inline. Retaining the terminal
+    // job would let get_workflow_result re-serve it and would leave a dead `done`
+    // row in the supervisor for work the caller has already collected.
+    expect(workflowJobRegistry.has(job.id)).toBe(false);
+    const reserved = await tools
+      .find((tool) => tool.name === "get_workflow_result")!
+      .execute("", { workflowId: job.id }, undefined, undefined, {
+        cwd: "/tmp/tool-context",
+      });
+    expect(reserved.isError).toBe(true);
+  });
+
+  it("runs a blocking synchronous workflow even at the async job cap", async () => {
+    // Routing sync through startWorkflowJob must not hand a previously
+    // always-succeeding blocking call a brand-new user-visible failure mode.
+    const filled: string[] = [];
+    try {
+      for (let index = 0; index < MAX_WORKFLOW_JOBS; index++) {
+        const id = `sync-cap-filler-${index}`;
+        workflowJobRegistry.set(id, {
+          id,
+          name: id,
+          status: "running",
+          startedAt: Date.now(),
+          promise: undefined as any,
+          abort: new AbortController(),
+          snapshot: {
+            agentsSpawned: 0,
+            errorCount: 0,
+            tokensSpent: 0,
+            phases: [],
+          },
+        } as any);
+        filled.push(id);
+      }
+      const script =
+        `export const meta = { name: "sync-at-cap", description: "d" };\n` +
+        `return "done";`;
+
+      expect(() =>
+        startWorkflowJob("async-at-cap", script, { runAgent: echoRunner() }),
+      ).toThrow(/workflow jobs already running/);
+
+      const job = startWorkflowJob(
+        "sync-at-cap",
+        script,
+        { runAgent: echoRunner() },
+        undefined,
+        undefined,
+        undefined,
+        "sync",
+      );
+      await expect(job.promise).resolves.toMatchObject({ result: "done" });
+      expect(workflowJobRegistry.has(job.id)).toBe(false);
+    } finally {
+      for (const id of filled) workflowJobRegistry.delete(id);
+    }
+  });
+
+  it("keeps workflows asynchronous when async is omitted", async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: vi.fn((def: any) => tools.push(def)),
+      registerCommand: vi.fn(),
+    };
+    registerWorkflowTool(pi as any);
+    const workflowTool = tools.find((tool) => tool.name === "workflow")!;
+    const started = await workflowTool.execute(
+      "",
+      {
+        script:
+          `export const meta = { name: "async-default", description: "d" };\n` +
+          `return "done";`,
+      },
+      undefined,
+      undefined,
+      { cwd: "/tmp/tool-context", modelRegistry: {} },
+    );
+    const job = workflowJobRegistry.get(started.details.workflowId)!;
+    expect(started.details.status).toBe("started");
+    expect(job.executionMode).toBe("async");
+    await job.promise;
+  });
+
+  it("cancels a tracked synchronous workflow through its signal", async () => {
+    const controller = new AbortController();
+    const job = startWorkflowJob(
+      "sync-cancel",
+      `export const meta = { name: "sync-cancel", description: "d" };\n` +
+        `return await agent("wait");`,
+      {
+        signal: controller.signal,
+        runAgent: ({ signal }) =>
+          new Promise<SubagentResult>((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => reject(new Error("agent aborted")),
+              { once: true },
+            );
+          }),
+      },
+      undefined,
+      undefined,
+      undefined,
+      "sync",
+    );
+    controller.abort("test cancellation");
+    await expect(job.promise).rejects.toThrow("Workflow aborted.");
+    expect(job.executionMode).toBe("sync");
+    expect(job.status).toBe("cancelled");
+    expect(job.completionNotification).toBeUndefined();
+  });
+
   it("rejects workflow execution from in-process orchestration contexts", async () => {
     const tools: any[] = [];
     const pi = {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1909,6 +1909,7 @@ describe("registerWorkflowTool", () => {
     expect(wf.promptSnippet).toContain("decomposable multi-agent work");
     const guidance = wf.promptGuidelines.join("\n");
     expect(guidance).toContain("raw JavaScript");
+    expect(guidance).toContain("Omit async");
     expect(guidance).toContain("top-level");
     expect(guidance).not.toContain("first statement");
     expect(guidance).toContain("immutable cwd");


### PR DESCRIPTION
## Summary

- track synchronous workflows in the workflow job registry and preserve async-by-default behavior
- attach immutable session/workflow ownership to process and in-process workflow children, grouping them directly below their workflow in the supervisor
- scope polling, footer counts, and delivery to the owning session while suppressing standalone child completion delivery and persistence
- clean up workflow-owned panes on completion/shutdown without recording false cancellations, retaining failed disposals for retry
- add regression coverage for sync visibility, owner isolation, grouping, process fallback, delivery suppression, cancellation, disposal, and non-persistence

## Validation

- `npm run typecheck`
- `npm test` — 55 files, 1218 tests passed
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`
