### PR TITLE
refactor: centralize interactive state transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "src/tools/in-process.ts",
     "src/tools/interactive.ts",
     "src/interactive-tmux.ts",
+    "src/interactive-state.ts",
     "src/interactive-supervisor-registration.ts",
     "src/interactive-supervisor-ui.ts",
     "src/interactive-lineage.ts",

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -28,10 +28,12 @@ import {
   type SubagentEvent,
 } from "./artifact";
 import {
-  deriveInteractiveSubagentStatusFromLifecycle,
-  foldInteractiveLifecycle,
+  advanceInteractiveState,
+  getInteractiveMachineState,
   interactiveSubagentRegistry,
-  getInteractivePaneLivenessAsync,
+  interactiveStatusForState,
+  isInteractiveStateActive,
+  observeInteractivePane,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import { shouldNotify } from "./notifications";
@@ -82,10 +84,7 @@ function getRunningSubagentCount(): number {
     (job) => job.status === "running",
   ).length;
   const interactiveCount = [...interactiveSubagentRegistry.values()].filter(
-    (state) =>
-      state.status === "running" ||
-      state.status === "idle" ||
-      state.status === "unknown",
+    isInteractiveStateActive,
   ).length;
   return inProcessCount + interactiveCount;
 }
@@ -165,9 +164,7 @@ function projectActivityWidgetRows(
   const contexts = getSessionContextStack();
   const states = [...interactiveSubagentRegistry.values()].filter(
     (state) =>
-      (state.status === "running" ||
-        state.status === "idle" ||
-        state.status === "unknown") &&
+      isInteractiveStateActive(state) &&
       stateBelongsToUi(state, ui, owner, contexts),
   );
   return states.map((state) => formatActivityRow(state, now));
@@ -270,16 +267,35 @@ async function runPollArtifactChanges(
     const states = [...interactiveSubagentRegistry.values()].filter((state) =>
       parentSessionBelongsToOwner(state.parentSessionId, owner),
     );
+    const pendingObservations = states.map((state) => {
+      const transition = advanceInteractiveState(state, {
+        type: "pane_observation_started",
+      });
+      const revision =
+        transition.kind === "applied"
+          ? transition.state.observationRevision
+          : getInteractiveMachineState(state).observationRevision;
+      return { state, revision } as const;
+    });
     const liveness = await Promise.all(
-      states.map(async (state) => {
+      pendingObservations.map(async ({ state, revision }) => {
         try {
-          return [state, await getInteractivePaneLivenessAsync(state)] as const;
+          return {
+            state,
+            revision,
+            liveness: await observeInteractivePane(state),
+          } as const;
         } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
           debugLog("error", "poller_liveness_error", {
             stateId: state.id,
-            error: err instanceof Error ? err.message : String(err),
+            error: reason,
           });
-          return [state, "unknown"] as const;
+          return {
+            state,
+            revision,
+            liveness: { kind: "unknown", reason } as const,
+          } as const;
         }
       }),
     );
@@ -295,11 +311,15 @@ async function runPollArtifactChanges(
     const ui =
       ownerContext?.ui ??
       (g2.__piSubagenturaUi as ExtensionUIContext | undefined);
-    for (const [state, paneLiveness] of liveness) {
+    for (const observation of liveness) {
+      const { state, revision, liveness: paneLiveness } = observation;
       if (interactiveSubagentRegistry.get(state.id) !== state) continue;
-      // Cancelled is terminal. Unknown means pane liveness is unavailable, so keep polling
-      // the artifact log: a later done/error event must still reach the parent.
-      // 'exited' is intentionally not skipped: a follow-up user entry can revive it to "running".
+      advanceInteractiveState(state, {
+        type: "pane_observed",
+        revision,
+        liveness: paneLiveness,
+      });
+      // Terminal states still consume durable records in physical byte order.
       const art = artifactPath(
         dirname(state.artifactDir),
         basename(state.artifactDir),
@@ -311,12 +331,11 @@ async function runPollArtifactChanges(
       const cursor = state.eventByteCursor ?? 0;
       const batch = readEventBatch(art, cursor);
       const records = batch.records;
-      const lifecycle = (state.lifecycle ??= {});
       let nextCursor = cursor;
       for (const record of records) {
         const ev = record.event;
         nextCursor = record.endOffset;
-        foldInteractiveLifecycle(lifecycle, ev);
+        advanceInteractiveState(state, { type: "artifact", event: ev });
         if ("version" in ev && ev.version === 2 && ev.type === "turn_started") {
           state.activeTurnId = ev.turnId;
         }
@@ -385,18 +404,7 @@ async function runPollArtifactChanges(
       }
       nextCursor = batch.endOffset;
       state.eventByteCursor = nextCursor;
-      const next = deriveInteractiveSubagentStatusFromLifecycle(
-        lifecycle,
-        paneLiveness,
-      );
-      if (next !== state.status) state.status = next;
-      if (next === "exited") {
-        if (lifecycle.processExitCode !== undefined) {
-          state.exitCode = lifecycle.processExitCode;
-        } else if (lifecycle.completionExitCode !== undefined) {
-          state.exitCode = lifecycle.completionExitCode;
-        }
-      }
+
       if (state.parentSessionId) {
         updateInteractiveState(state.cwd, state.id, (entry) => {
           entry.eventByteCursor = nextCursor;
@@ -418,11 +426,17 @@ async function runPollArtifactChanges(
     flushDeliveries(interactivePi, ui, owner);
     for (const state of states) {
       if (interactiveSubagentRegistry.get(state.id) !== state) continue;
-      const terminal =
-        state.status === "cancelled" || state.status === "exited";
-      if (terminal) destroySessionParser(state);
+      const machine = getInteractiveMachineState(state);
+      const processDeathConfirmed =
+        machine.pane.kind === "dead" ||
+        machine.lifecycle.processStatus !== undefined;
+      const status = interactiveStatusForState(state);
+      const retired =
+        status === "exited" ||
+        (status === "cancelled" && processDeathConfirmed);
+      if (retired) destroySessionParser(state);
       if (
-        terminal &&
+        retired &&
         state.parentSessionId &&
         (state.pendingDeliveries?.length ?? 0) === 0
       ) {
@@ -696,17 +710,13 @@ function processSessionLogEntry(
     state.lastStopReason = undefined;
     state.lastStopReasonAt = undefined;
     state.lastStopText = undefined;
-    if (state.lifecycle && !state.lifecycle.parentCancelled) {
-      state.lifecycle.currentTurnId = undefined;
-      state.lifecycle.completionTurnId = undefined;
-      state.lifecycle.completionOutcome = undefined;
-      state.lifecycle.completionSource = undefined;
-      state.lifecycle.completionExitCode = undefined;
-      state.lifecycle.legacyTerminal = undefined;
+    // Session replay is a compatibility signal until the durable turn_started
+    // record arrives; the kernel still owns the transition and rejects terminal
+    // process or parent-cancellation states.
+    const status = interactiveStatusForState(state);
+    if (status === "exited" || status === "idle") {
+      advanceInteractiveState(state, { type: "followup_started" });
     }
-    // A user-role entry starts a new turn regardless of how the previous turn ended.
-    if (state.status === "exited" || state.status === "idle")
-      state.status = "running";
     return;
   }
 

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -1310,6 +1310,8 @@ export interface InteractiveSubagentPersistedStateV2 extends InteractiveSubagent
   deliveryReceipts: string[];
   legacyCutoverOffset?: number;
   lifecycle?: PersistedLifecycleFold;
+  /** Once true, this mux pane identity cannot become live again. */
+  paneDeathConfirmed?: true;
 }
 
 export interface InteractiveSubagentStateFile {
@@ -1592,6 +1594,9 @@ function migrateStatePayload(
         pendingDeliveries,
         deliveryReceipts,
         legacyCutoverOffset: cursor(entry.legacyCutoverOffset, cutoverOffset),
+        ...(entry.paneDeathConfirmed === true
+          ? { paneDeathConfirmed: true as const }
+          : {}),
         ...(lifecycle ? { lifecycle } : {}),
       };
     }

--- a/src/cancel-all-flows.ts
+++ b/src/cancel-all-flows.ts
@@ -17,6 +17,7 @@ import {
 import {
   cancelInteractiveSubagent,
   interactiveSubagentRegistry,
+  interactiveStatusForState,
 } from "./interactive-tmux";
 import {
   normalizeCancelledWorkflowState,
@@ -62,7 +63,8 @@ export async function cancelAllFlows(
     (state) => parentSessionBelongsToOwner(state.parentSessionId, owner),
   );
   for (const state of interactiveStates) {
-    if (state.status !== "running" && state.status !== "unknown") continue;
+    const status = interactiveStatusForState(state);
+    if (status !== "running" && status !== "unknown") continue;
     state.cancellationSnapshot = snapshotInteractiveContext({
       kind: "interactive",
       id: state.id,
@@ -131,7 +133,8 @@ export async function cancelAllFlows(
 
   // 3. Kill active interactive agents; preserve confirmed-idle ones
   for (const state of interactiveStates) {
-    if (state.status === "running" || state.status === "unknown") {
+    const status = interactiveStatusForState(state);
+    if (status === "running" || status === "unknown") {
       try {
         const cancelled = cancelInteractiveSubagent(state.id);
         if (cancelled) {
@@ -143,7 +146,7 @@ export async function cancelAllFlows(
       } catch {
         /* best effort */
       }
-    } else if (state.status === "idle") {
+    } else if (status === "idle") {
       // Idle panes consume no tokens — preserve them
       result.interactivePreserved++;
     }

--- a/src/interactive-state.ts
+++ b/src/interactive-state.ts
@@ -1,0 +1,324 @@
+import type { PersistedLifecycleFold, SubagentEvent } from "./artifact";
+
+export type PaneLiveness =
+  | { readonly kind: "alive" }
+  | { readonly kind: "dead" }
+  | { readonly kind: "unavailable"; readonly reason?: string }
+  | { readonly kind: "unknown"; readonly reason?: string };
+
+type InteractiveMachineBase = {
+  readonly lifecycle: Readonly<PersistedLifecycleFold>;
+  readonly pane: PaneLiveness;
+  readonly observationRevision: number;
+};
+
+export type InteractiveMachineState =
+  | (InteractiveMachineBase & { readonly phase: "running" })
+  | (InteractiveMachineBase & {
+      readonly phase: "completed";
+      readonly protocol: "legacy" | "v2";
+      readonly outcome: "done" | "error";
+    })
+  | (InteractiveMachineBase & {
+      readonly phase: "cancelled";
+      readonly source: "parent" | "artifact" | "process";
+    })
+  | (InteractiveMachineBase & {
+      readonly phase: "process_exited";
+      readonly status: "done" | "error";
+      readonly exitCode?: number;
+    });
+
+export type InteractiveMachineEvent =
+  | { readonly type: "artifact"; readonly event: SubagentEvent }
+  | { readonly type: "parent_cancelled" }
+  | { readonly type: "followup_started"; readonly turnId?: string }
+  | { readonly type: "pane_observation_started" }
+  | {
+      readonly type: "pane_observed";
+      readonly revision: number;
+      readonly liveness: PaneLiveness;
+    };
+
+export type InteractiveMachineTransition =
+  | {
+      readonly kind: "applied";
+      readonly previous: InteractiveMachineState;
+      readonly state: InteractiveMachineState;
+    }
+  | { readonly kind: "unchanged"; readonly state: InteractiveMachineState }
+  | {
+      readonly kind: "stale";
+      readonly state: InteractiveMachineState;
+      readonly expectedRevision: number;
+      readonly receivedRevision: number;
+    }
+  | {
+      readonly kind: "invalid";
+      readonly state: InteractiveMachineState;
+      readonly reason: string;
+    };
+
+export type InteractiveProjectedStatus =
+  "running" | "idle" | "cancelled" | "exited" | "unknown";
+
+export interface InitialInteractiveMachineStateOptions {
+  readonly lifecycle?: Readonly<PersistedLifecycleFold>;
+  readonly pane?: PaneLiveness;
+  readonly observationRevision?: number;
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected interactive state variant: ${String(value)}`);
+}
+
+function copyLifecycle(
+  lifecycle: Readonly<PersistedLifecycleFold>,
+): PersistedLifecycleFold {
+  return { ...lifecycle };
+}
+
+function classifyMachineState(
+  lifecycle: Readonly<PersistedLifecycleFold>,
+  pane: PaneLiveness,
+  observationRevision: number,
+): InteractiveMachineState {
+  const base = { lifecycle, pane, observationRevision } as const;
+  if (lifecycle.parentCancelled) {
+    return { ...base, phase: "cancelled", source: "parent" };
+  }
+  if (lifecycle.processStatus) {
+    if (lifecycle.processStatus === "cancelled") {
+      return { ...base, phase: "cancelled", source: "process" };
+    }
+    return {
+      ...base,
+      phase: "process_exited",
+      status: lifecycle.processStatus,
+      ...(lifecycle.processExitCode === undefined
+        ? {}
+        : { exitCode: lifecycle.processExitCode }),
+    };
+  }
+  if (lifecycle.completionOutcome) {
+    if (lifecycle.completionOutcome === "cancelled") {
+      return {
+        ...base,
+        phase: "cancelled",
+        source: lifecycle.completionSource === "parent" ? "parent" : "artifact",
+      };
+    }
+    return {
+      ...base,
+      phase: "completed",
+      protocol: "v2",
+      outcome: lifecycle.completionOutcome,
+    };
+  }
+  if (lifecycle.legacyTerminal) {
+    if (lifecycle.legacyTerminal === "cancelled") {
+      return { ...base, phase: "cancelled", source: "artifact" };
+    }
+    return {
+      ...base,
+      phase: "completed",
+      protocol: "legacy",
+      outcome: lifecycle.legacyTerminal,
+    };
+  }
+  return { ...base, phase: "running" };
+}
+
+export function initialInteractiveMachineState(
+  options: InitialInteractiveMachineStateOptions = {},
+): InteractiveMachineState {
+  const lifecycle = copyLifecycle(options.lifecycle ?? {});
+  const pane = options.pane ?? { kind: "unknown" };
+  const observationRevision = options.observationRevision ?? 0;
+  return classifyMachineState(lifecycle, pane, observationRevision);
+}
+
+function foldArtifactEvent(
+  previous: Readonly<PersistedLifecycleFold>,
+  event: SubagentEvent,
+): PersistedLifecycleFold {
+  const lifecycle = copyLifecycle(previous);
+  lifecycle.startedAt ??= event.ts;
+  switch (event.type) {
+    case "process_exited":
+      lifecycle.processStatus = event.status;
+      lifecycle.processExitCode = event.exitCode;
+      return lifecycle;
+    case "turn_started":
+      lifecycle.currentTurnId = event.turnId;
+      lifecycle.completionTurnId = undefined;
+      lifecycle.completionOutcome = undefined;
+      lifecycle.completionSource = undefined;
+      lifecycle.completionExitCode = undefined;
+      lifecycle.legacyTerminal = undefined;
+      return lifecycle;
+    case "completion":
+      if (event.outcome === "cancelled" && event.source === "parent") {
+        lifecycle.parentCancelled = true;
+      }
+      if (
+        !lifecycle.currentTurnId ||
+        event.turnId === lifecycle.currentTurnId
+      ) {
+        lifecycle.completionTurnId = event.turnId;
+        lifecycle.completionOutcome = event.outcome;
+        lifecycle.completionSource = event.source;
+        lifecycle.completionExitCode = event.exitCode;
+      }
+      return lifecycle;
+    case "started":
+      lifecycle.legacyTerminal = undefined;
+      return lifecycle;
+    case "done":
+    case "error":
+    case "cancelled":
+      lifecycle.legacyTerminal = event.status;
+      lifecycle.completionExitCode =
+        "exitCode" in event ? event.exitCode : undefined;
+      return lifecycle;
+    case "tool_activity":
+      return lifecycle;
+    default:
+      return assertNever(event);
+  }
+}
+
+function applied(
+  previous: InteractiveMachineState,
+  state: InteractiveMachineState,
+): InteractiveMachineTransition {
+  return { kind: "applied", previous, state };
+}
+
+function withLifecycle(
+  state: InteractiveMachineState,
+  lifecycle: Readonly<PersistedLifecycleFold>,
+): InteractiveMachineState {
+  return classifyMachineState(lifecycle, state.pane, state.observationRevision);
+}
+
+export function transitionInteractiveMachine(
+  state: InteractiveMachineState,
+  event: InteractiveMachineEvent,
+): InteractiveMachineTransition {
+  switch (event.type) {
+    case "artifact": {
+      const lifecycle = foldArtifactEvent(state.lifecycle, event.event);
+      return applied(state, withLifecycle(state, lifecycle));
+    }
+    case "parent_cancelled": {
+      if (state.lifecycle.parentCancelled) return { kind: "unchanged", state };
+      const lifecycle = copyLifecycle(state.lifecycle);
+      lifecycle.parentCancelled = true;
+      return applied(state, withLifecycle(state, lifecycle));
+    }
+    case "followup_started": {
+      const reusableCompletion =
+        state.phase === "completed" &&
+        state.pane.kind === "alive" &&
+        !(state.protocol === "legacy" && state.outcome === "error");
+      if (!reusableCompletion) {
+        return {
+          kind: "invalid",
+          state,
+          reason:
+            "only a completed interactive process with a live pane can start a follow-up turn",
+        };
+      }
+      const lifecycle = copyLifecycle(state.lifecycle);
+      lifecycle.currentTurnId = event.turnId;
+      lifecycle.completionTurnId = undefined;
+      lifecycle.completionOutcome = undefined;
+      lifecycle.completionSource = undefined;
+      lifecycle.completionExitCode = undefined;
+      lifecycle.legacyTerminal = undefined;
+      return applied(state, withLifecycle(state, lifecycle));
+    }
+    case "pane_observation_started": {
+      const next = classifyMachineState(
+        state.lifecycle,
+        state.pane,
+        state.observationRevision + 1,
+      );
+      return applied(state, next);
+    }
+    case "pane_observed": {
+      if (event.revision !== state.observationRevision) {
+        return {
+          kind: "stale",
+          state,
+          expectedRevision: state.observationRevision,
+          receivedRevision: event.revision,
+        };
+      }
+      if (state.pane.kind === "dead" && event.liveness.kind !== "dead") {
+        return {
+          kind: "invalid",
+          state,
+          reason: "a confirmed-dead pane identity cannot become live again",
+        };
+      }
+      if (event.liveness.kind === state.pane.kind) {
+        return { kind: "unchanged", state };
+      }
+      return applied(
+        state,
+        classifyMachineState(
+          state.lifecycle,
+          event.liveness,
+          state.observationRevision,
+        ),
+      );
+    }
+    default: {
+      const unexpected: never = event;
+      return {
+        kind: "invalid",
+        state,
+        reason: `unknown interactive transition: ${String(unexpected)}`,
+      };
+    }
+  }
+}
+
+function projectPaneDependentStatus(
+  pane: PaneLiveness,
+  whenAlive: "running" | "idle",
+): InteractiveProjectedStatus {
+  switch (pane.kind) {
+    case "alive":
+      return whenAlive;
+    case "dead":
+    case "unavailable":
+    case "unknown":
+      return "unknown";
+    default:
+      return assertNever(pane);
+  }
+}
+
+export function projectInteractiveStatus(
+  state: InteractiveMachineState,
+): InteractiveProjectedStatus {
+  switch (state.phase) {
+    case "cancelled":
+      return "cancelled";
+    case "process_exited":
+      return "exited";
+    case "completed":
+      if (state.protocol === "legacy" && state.outcome === "error") {
+        return "exited";
+      }
+      if (state.pane.kind === "dead") return "exited";
+      return projectPaneDependentStatus(state.pane, "idle");
+    case "running":
+      return projectPaneDependentStatus(state.pane, "running");
+    default:
+      return assertNever(state);
+  }
+}

--- a/src/interactive-supervisor-registration.ts
+++ b/src/interactive-supervisor-registration.ts
@@ -15,6 +15,9 @@ import {
   focusInteractiveSubagent,
   interactiveSubagentHasAttachedClient,
   interactiveSubagentRegistry,
+  initializeInteractiveStateMachine,
+  interactiveStatusForState,
+  isInteractiveStateActive,
   showInteractiveSubagentNativeViewer,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
@@ -60,16 +63,6 @@ interface SupervisorProjection {
   truncated: boolean;
 }
 
-function isInteractiveStateActionable(
-  state: InteractiveSubagentState,
-): boolean {
-  return (
-    state.status === "running" ||
-    state.status === "idle" ||
-    state.status === "unknown"
-  );
-}
-
 export function directSupervisorItems(
   sessionId?: string,
 ): InteractiveSupervisorItem[] {
@@ -82,7 +75,7 @@ export function directSupervisorItems(
       kind: "interactive",
       state,
       depth: 0,
-      actionable: isInteractiveStateActionable(state),
+      actionable: isInteractiveStateActive(state),
       origin: {
         source: "registry",
         ownerSessionId: state.parentSessionId,
@@ -161,7 +154,7 @@ function stateForNode(
   } catch {
     const target = manifest.pane.windowName ?? manifest.pane.paneId;
     const detail =
-      paneLiveness === "dead"
+      paneLiveness?.kind === "dead"
         ? `pane ${target} is gone`
         : `pane ${target} could not be resolved`;
     attach = {
@@ -172,7 +165,7 @@ function stateForNode(
   // Liveness comes from the pane probe, not from `node.state`. Deriving it from
   // the same field the actionable gate then tests made that gate a tautology
   // for lineage-only nodes, and mislabelled a live pane hidden for a cycle.
-  return {
+  const state: InteractiveSubagentState = {
     id: manifest.agentId,
     name: manifest.name,
     task: manifest.taskPreview,
@@ -184,19 +177,17 @@ function stateForNode(
     cwd: manifest.cwd,
     parentSessionId: manifest.ownerSessionId,
     startedAt: parseStartedAt(manifest.startedAt),
-    status:
-      paneLiveness === undefined
-        ? node.state === "actionable"
-          ? "running"
-          : "unknown"
-        : paneLiveness === "alive"
-          ? "running"
-          : "unknown",
+    status: "unknown",
     attachCommand: attach.attachCommand,
     selectPaneCommand: attach.focusCommand,
     launchScriptFile: "unknown",
     artifactDir: manifest.artifactDir ?? "unknown",
   };
+  const initialPane: PaneLiveness =
+    paneLiveness ??
+    (node.state === "actionable" ? { kind: "alive" } : { kind: "unknown" });
+  initializeInteractiveStateMachine(state, initialPane);
+  return state;
 }
 
 /**
@@ -224,24 +215,27 @@ async function loadSupervisorProjection(
   const paneLivenessById = new Map<string, PaneLiveness>();
   const isNodeStale = async (manifest: LineageManifest): Promise<boolean> => {
     const cached = paneLivenessById.get(manifest.agentId);
-    if (cached !== undefined) return cached === "dead";
+    if (cached !== undefined) return cached.kind === "dead";
     if (
       manifest.pane.backend !== "tmux" &&
       manifest.pane.backend !== "zellij"
     ) {
-      paneLivenessById.set(manifest.agentId, "unknown");
+      paneLivenessById.set(manifest.agentId, {
+        kind: "unknown",
+        reason: `unsupported pane backend ${manifest.pane.backend}`,
+      });
       return false;
     }
     let paneLiveness: PaneLiveness;
     try {
       paneLiveness = await getMux({
         preference: manifest.pane.backend,
-      }).getPaneLivenessAsync(manifest.pane.paneId, manifest.pane.muxSession);
-    } catch {
-      paneLiveness = "unknown";
+      }).observePane(manifest.pane.paneId, manifest.pane.muxSession);
+    } catch (error) {
+      paneLiveness = { kind: "unavailable", reason: errorMessage(error) };
     }
     paneLivenessById.set(manifest.agentId, paneLiveness);
-    return paneLiveness === "dead";
+    return paneLiveness.kind === "dead";
   };
   const projection = await projectLineageStore(
     paths.nodesDir,
@@ -271,7 +265,7 @@ async function loadSupervisorProjection(
         state,
         depth: node.depth,
         actionable:
-          node.state === "actionable" && isInteractiveStateActionable(state),
+          node.state === "actionable" && isInteractiveStateActive(state),
         origin: {
           source: "lineage",
           rootId: node.manifest.rootId,
@@ -288,7 +282,7 @@ async function loadSupervisorProjection(
       items.push({
         state,
         depth: 0,
-        actionable: isInteractiveStateActionable(state),
+        actionable: isInteractiveStateActive(state),
         origin: {
           source: "registry",
           ownerSessionId: state.parentSessionId,
@@ -474,9 +468,9 @@ export function registerInteractiveSupervisor(
             const direct = interactiveSubagentRegistry.get(
               node.manifest.agentId,
             );
-            return direct
-              ? direct.status === "cancelled" || direct.status === "exited"
-              : false;
+            if (!direct) return false;
+            const status = interactiveStatusForState(direct);
+            return status === "cancelled" || status === "exited";
           },
           cancel: async (node) => {
             const nodeState = stateForNode(node);

--- a/src/interactive-supervisor-ui.ts
+++ b/src/interactive-supervisor-ui.ts
@@ -10,6 +10,8 @@ import type { JobState } from "./helpers";
 import {
   cancelInteractiveSubagent,
   interactiveSubagentRegistry,
+  interactiveStatusForState,
+  isInteractiveStateActive,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import type { WorkflowJobState } from "./workflow-jobs";
@@ -558,12 +560,13 @@ export function formatSupervisorSummary(
   state: InteractiveSubagentState,
   now: number,
 ): string {
-  const icon = statusIcon(state.status);
-  const elapsed = formatElapsed(now - state.startedAt);
+  const status = interactiveStatusForState(state);
+  const icon = statusIcon(status);
+  const elapsed = formatElapsed(Math.max(0, now - state.startedAt));
   const activity = compactText(
     state.lastToolSummary ?? state.lastToolName ?? "no activity yet",
   );
-  return `${icon} ${state.status} ${compactText(state.name)} (${state.id.slice(0, 8)}) · ${state.mux} · ${elapsed} · ${activity}`;
+  return `${icon} ${status} ${compactText(state.name)} (${state.id.slice(0, 8)}) · ${state.mux} · ${elapsed} · ${activity}`;
 }
 
 function supervisorStates(): InteractiveSubagentState[] {
@@ -588,10 +591,7 @@ function supervisorItems(): AsyncSupervisorItem[] {
     kind: "interactive",
     state,
     depth: 0,
-    actionable:
-      state.status === "running" ||
-      state.status === "idle" ||
-      state.status === "unknown",
+    actionable: isInteractiveStateActive(state),
   }));
 }
 
@@ -617,11 +617,7 @@ function supervisorItemIsActive(item: AsyncSupervisorItem): boolean {
   if (!item.actionable) return false;
   if (item.kind === "in-process") return item.job.status === "running";
   if (item.kind === "workflow") return item.job.status === "running";
-  return (
-    item.state.status === "running" ||
-    item.state.status === "idle" ||
-    item.state.status === "unknown"
-  );
+  return isInteractiveStateActive(item.state);
 }
 
 function formatAsyncSupervisorSummary(

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -45,6 +45,7 @@ import {
   type PersistedDeliveryIntent,
   type PersistedLifecycleFold,
   removeInteractiveState,
+  updateInteractiveState,
 } from "./artifact";
 import { acknowledgeDeliveryWithoutDispatch, deliveryIdFor } from "./delivery";
 import {
@@ -54,7 +55,6 @@ import {
   NoMultiplexerAvailableError,
   type MuxName,
   type Multiplexer,
-  type PaneLiveness,
   type PaneRef,
   safeSegment,
 } from "./multiplexer";
@@ -74,6 +74,16 @@ import {
   resolveLineageStorePathsSync,
   writeLineageManifestAtomicSync,
 } from "./interactive-lineage";
+import {
+  initialInteractiveMachineState,
+  projectInteractiveStatus,
+  transitionInteractiveMachine,
+  type InteractiveMachineEvent,
+  type InteractiveMachineState,
+  type InteractiveMachineTransition,
+  type InteractiveProjectedStatus,
+  type PaneLiveness,
+} from "./interactive-state";
 
 // Re-export the tmux-specific `readPaneExitCode` for the test suite. The
 // launch script's EXIT trap still writes the @pi-exit-code pane option
@@ -145,8 +155,7 @@ The child-only Pi lifecycle hook is a crash-safety fallback, not permission to o
  * - "exited"   — child pi process is actually gone (pane dead, or it called `error`); terminal
  * - "unknown"  — can't determine (rare; pane dead but no recorded event)
  */
-export type InteractiveSubagentStatus =
-  "running" | "idle" | "cancelled" | "exited" | "unknown";
+export type InteractiveSubagentStatus = InteractiveProjectedStatus;
 
 export interface InteractiveSubagentState {
   id: string;
@@ -184,11 +193,10 @@ export interface InteractiveSubagentState {
   model?: string;
   startedAt: number;
   /**
-   * Lifecycle status. Transition triggers:
-   * - spawn sets "running" (interactive-tmux.ts setup)
-   * - cli.mjs done / error event in events.ndjson sets "exited" or "cancelled"
-   * - a user message after "exited" revives it to "running" for follow-up turns
-   * - cancel_interactive_subagent tool sets "cancelled"
+   * Compatibility projection of the machine kernel. Spawn begins running;
+   * durable completion events become idle while the pane is alive, parent
+   * cancellation becomes cancelled, and confirmed process exit becomes exited.
+   * Follow-up turn records clear only turn-completion state.
    */
   status: InteractiveSubagentStatus;
   /** Receipt for the latest parent cancellation snapshot. */
@@ -262,6 +270,152 @@ if (!globalThis.__piSubagenturaInteractiveRegistry) {
 
 export const interactiveSubagentRegistry =
   globalThis.__piSubagenturaInteractiveRegistry!;
+
+const interactiveMachineStates = new WeakMap<
+  InteractiveSubagentState,
+  InteractiveMachineState
+>();
+
+function paneLivenessFromCompatibilityStatus(
+  status: InteractiveSubagentStatus,
+): PaneLiveness {
+  switch (status) {
+    case "running":
+    case "idle":
+      return { kind: "alive" };
+    case "exited":
+      return { kind: "dead" };
+    case "cancelled":
+    case "unknown":
+      return { kind: "unknown" };
+    default:
+      return assertNever(status);
+  }
+}
+
+function lifecycleForCompatibilityInitialization(
+  state: InteractiveSubagentState,
+): Readonly<PersistedLifecycleFold> {
+  const lifecycle = state.lifecycle ?? {};
+  const hasLifecycleDecision =
+    lifecycle.currentTurnId !== undefined ||
+    lifecycle.completionTurnId !== undefined ||
+    lifecycle.completionOutcome !== undefined ||
+    lifecycle.completionSource !== undefined ||
+    lifecycle.completionExitCode !== undefined ||
+    lifecycle.processStatus !== undefined ||
+    lifecycle.processExitCode !== undefined ||
+    lifecycle.parentCancelled !== undefined ||
+    lifecycle.legacyTerminal !== undefined;
+  if (hasLifecycleDecision) return lifecycle;
+
+  // One-time migration for registry objects created before the machine kernel.
+  // Once cached below, compatibility status is never consulted again.
+  switch (state.status) {
+    case "running":
+    case "unknown":
+      return lifecycle;
+    case "idle":
+      return { ...lifecycle, legacyTerminal: "done" };
+    case "cancelled":
+      return { ...lifecycle, parentCancelled: true };
+    case "exited":
+      return {
+        ...lifecycle,
+        processStatus: "error",
+        ...(state.exitCode === undefined
+          ? {}
+          : { processExitCode: state.exitCode }),
+      };
+    default:
+      return assertNever(state.status);
+  }
+}
+
+export function initializeInteractiveStateMachine(
+  state: InteractiveSubagentState,
+  pane: PaneLiveness = paneLivenessFromCompatibilityStatus(state.status),
+): InteractiveMachineState {
+  const machine = initialInteractiveMachineState({
+    lifecycle: lifecycleForCompatibilityInitialization(state),
+    pane,
+  });
+  interactiveMachineStates.set(state, machine);
+  state.lifecycle = { ...machine.lifecycle };
+  state.status = projectInteractiveStatus(machine);
+  return machine;
+}
+
+export function getInteractiveMachineState(
+  state: InteractiveSubagentState,
+): InteractiveMachineState {
+  return (
+    interactiveMachineStates.get(state) ??
+    initializeInteractiveStateMachine(state)
+  );
+}
+
+export function advanceInteractiveState(
+  state: InteractiveSubagentState,
+  event: InteractiveMachineEvent,
+): InteractiveMachineTransition {
+  const transition = transitionInteractiveMachine(
+    getInteractiveMachineState(state),
+    event,
+  );
+  if (
+    event.type === "pane_observed" &&
+    transition.state.pane.kind === "dead" &&
+    state.parentSessionId
+  ) {
+    updateInteractiveState(state.cwd, state.id, (entry) => {
+      entry.paneDeathConfirmed = true;
+    });
+  }
+  switch (transition.kind) {
+    case "applied": {
+      interactiveMachineStates.set(state, transition.state);
+      state.lifecycle = { ...transition.state.lifecycle };
+      state.status = projectInteractiveStatus(transition.state);
+      const exitCode =
+        transition.state.lifecycle.processExitCode ??
+        transition.state.lifecycle.completionExitCode;
+      if (state.status === "exited" && exitCode !== undefined) {
+        state.exitCode = exitCode;
+      }
+      return transition;
+    }
+    case "unchanged":
+    case "stale":
+    case "invalid":
+      return transition;
+    default:
+      return assertNever(transition);
+  }
+}
+
+export function interactiveStatusForState(
+  state: InteractiveSubagentState,
+): InteractiveSubagentStatus {
+  return projectInteractiveStatus(getInteractiveMachineState(state));
+}
+
+export function isInteractiveStateActive(
+  state: InteractiveSubagentState,
+): boolean {
+  const status = interactiveStatusForState(state);
+  switch (status) {
+    case "running":
+    case "idle":
+      return true;
+    case "unknown":
+    case "cancelled":
+    case "exited":
+      return false;
+    default:
+      return assertNever(status);
+  }
+}
 
 /**
  * True iff a tmux server is running and the parent is attached to one of its
@@ -514,7 +668,7 @@ export function launchInteractiveSubagent(params: {
       // active/non-dead count; unknown panes conservatively consume capacity.
       activeCount = pruneTerminalLineageNodesSync(
         lineageStore.nodesDir,
-        (manifest) => getLineagePaneLiveness(manifest) === "dead",
+        (manifest) => getLineagePaneLiveness(manifest).kind === "dead",
       ).active;
     }
     if (activeCount >= maxNodes) {
@@ -735,6 +889,7 @@ export function launchInteractiveSubagent(params: {
     pendingDeliveries: [],
     deliveryReceipts: [],
   };
+  initializeInteractiveStateMachine(state, { kind: "alive" });
   interactiveSubagentRegistry.set(id, state);
   return state;
 }
@@ -777,48 +932,73 @@ export function showInteractiveSubagentNativeViewer(
   return getMuxForState(state).showNativeViewer(state.name, content);
 }
 
-/** Probe pane liveness using the mux that created it. */
-export function getInteractivePaneLiveness(
+/**
+ * Synchronous recovery preflight. A false compatibility probe is inconclusive
+ * because the legacy boolean API also returns false for transport failures.
+ * The recurring async observer performs authoritative dead classification.
+ */
+export function inspectInteractivePaneForRehydrate(
   state: InteractiveSubagentState,
 ): PaneLiveness {
-  return getMuxForState(state).getPaneLiveness(state.paneId, state.muxSession);
+  try {
+    const mux = getMuxForState(state);
+    if (!mux.isAvailable()) {
+      return { kind: "unavailable", reason: `${state.mux} is unavailable` };
+    }
+    return mux.isPaneAlive(state.paneId, state.muxSession)
+      ? { kind: "alive" }
+      : {
+          kind: "unknown",
+          reason: "synchronous pane probe could not confirm liveness",
+        };
+  } catch (error) {
+    return {
+      kind: "unknown",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
-/** Preserve active state unless the backend explicitly confirms pane death. */
-export function isPaneAlive(state: InteractiveSubagentState): boolean {
-  return getInteractivePaneLiveness(state) !== "dead";
-}
-
-/** Probe pane liveness without blocking the parent event loop. */
-export function getInteractivePaneLivenessAsync(
+/** Observe pane liveness without blocking the parent event loop. */
+export function observeInteractivePane(
   state: InteractiveSubagentState,
 ): Promise<PaneLiveness> {
-  return getMuxForState(state).getPaneLivenessAsync(
-    state.paneId,
-    state.muxSession,
-  );
+  return getMuxForState(state).observePane(state.paneId, state.muxSession);
 }
 
-/** Preserve active state unless the async backend explicitly confirms death. */
-export async function isPaneAliveAsync(
-  state: InteractiveSubagentState,
-): Promise<boolean> {
-  return (await getInteractivePaneLivenessAsync(state)) !== "dead";
-}
-
-/** Probe the pane recorded in a lineage manifest. */
+/**
+ * Inspect the pane recorded in a lineage manifest without collapsing transport
+ * failure into confirmed death. Lineage pruning is synchronous because launch
+ * admission is synchronous, so it uses the mux tri-state compatibility probe;
+ * live owner reconciliation still uses the typed asynchronous observer.
+ */
 export function getLineagePaneLiveness(
   manifest: LineageManifest,
 ): PaneLiveness {
   const backend = manifest.pane.backend;
-  if (backend !== "tmux" && backend !== "zellij") return "unknown";
+  if (backend !== "tmux" && backend !== "zellij") {
+    return { kind: "unavailable", reason: `unsupported mux ${backend}` };
+  }
   try {
-    return getMux({ preference: backend }).getPaneLiveness(
+    const liveness = getMux({ preference: backend }).getPaneLiveness(
       manifest.pane.paneId,
       manifest.pane.muxSession,
     );
-  } catch {
-    return "unknown";
+    switch (liveness) {
+      case "alive":
+        return { kind: "alive" };
+      case "dead":
+        return { kind: "dead" };
+      case "unknown":
+        return { kind: "unknown" };
+      default:
+        return assertNever(liveness);
+    }
+  } catch (error) {
+    return {
+      kind: "unknown",
+      reason: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -886,7 +1066,7 @@ export function buildAttachCommandsForState(
  * subagent.ts; PR #2 will route through `state.mux` so this becomes mux-agnostic.
  */
 export function isTmuxPaneAlive(paneId: string): boolean {
-  return new TmuxMultiplexer().getPaneLiveness(paneId) === "alive";
+  return new TmuxMultiplexer().isPaneAlive(paneId);
 }
 
 /**
@@ -928,13 +1108,15 @@ export function cancelInteractiveSubagent(
   }
   appendCancellation(state);
 
-  // 2. Update the registry. The poller still processes the durable cancellation.
-  state.status = "cancelled";
+  // 2. Advance the registry projection. The durable artifact remains authoritative.
+  advanceInteractiveState(state, { type: "parent_cancelled" });
 
-  // 3. Kill the pane via the backend that created it. The wrapper's EXIT trap fires and records the event.
-  const mux = getMuxForState(state);
-  if (mux.getPaneLiveness(state.paneId, state.muxSession) !== "dead") {
-    mux.killPane(state.paneId, state.muxSession);
+  // 3. Kill without a blocking liveness preflight. Pane teardown is idempotent
+  // from the lifecycle's perspective; the async observer confirms death.
+  try {
+    getMuxForState(state).killPane(state.paneId, state.muxSession);
+  } catch {
+    /* best effort; the poller continues reconciling durable artifacts */
   }
   return state;
 }
@@ -1008,10 +1190,11 @@ export function cancelInteractiveDescendantByState(
     /* best effort; the owner will reconcile the durable pane state */
   }
   appendCancellation(state, false);
-  state.status = "cancelled";
-  const mux = getMuxForState(state);
-  if (mux.getPaneLiveness(state.paneId, state.muxSession) !== "dead") {
-    mux.killPane(state.paneId, state.muxSession);
+  advanceInteractiveState(state, { type: "parent_cancelled" });
+  try {
+    getMuxForState(state).killPane(state.paneId, state.muxSession);
+  } catch {
+    /* best effort; the owner reconciles durable artifacts */
   }
   return state;
 }
@@ -1028,9 +1211,8 @@ export function cancelInteractiveDescendantByState(
  *      handler clears the registry BEFORE killing panes (to prevent the
  *      in-flight poll tick race), so `cancelInteractiveSubagent(id)` would
  *      early-return `undefined` and the pane-kill would be skipped.
- *   2. NO `state.status = "cancelled"` update: the state object is a snapshot
- *      detached from the registry; mutating it would have no observable
- *      effect (the registry is already cleared, no future poll will see it).
+ *   2. State advancement is still routed through the lifecycle kernel, even
+ *      though this snapshot has already been detached from the registry.
  *   3. `mux.killPane` wrapped in try/catch: a synchronous `execFileSync` failure
  *      (e.g. tmux already exited, session torn down) must not abort the
  *      shutdown loop over remaining running states. The original function
@@ -1061,145 +1243,80 @@ export function cancelInteractiveSubagentByState(
     /* best-effort */
   }
   appendCancellation(state);
+  advanceInteractiveState(state, { type: "parent_cancelled" });
 
-  // Explicit cancellation is destructive by request: unless absence is
-  // confirmed, attempt the kill even when the listing probe is unavailable.
-  const mux = getMuxForState(state);
-  if (mux.getPaneLiveness(state.paneId, state.muxSession) !== "dead") {
-    try {
-      mux.killPane(state.paneId, state.muxSession);
-    } catch {
-      /* best-effort */
-    }
+  // 2. Kill without a blocking liveness preflight.
+  try {
+    getMuxForState(state).killPane(state.paneId, state.muxSession);
+  } catch {
+    /* best-effort */
   }
-  // Does NOT update state.status — see JSDoc point 2.
+  // The detached snapshot is advanced for consistent cancellation semantics.
 }
 
 /**
- * Pure status-decision matrix used by both `pruneDeadInteractiveSubagents` (here) and the
- * artifact poller in `subagent.ts`. Pulled out so the rules are testable without a live tmux.
- *
- * Semantics: a `done` event means "this turn is finished" — the child's REPL stays open and the
- * child is ready for a follow-up prompt. Only `error` / pane-dead / `cancelled` are terminal.
+ * Compatibility status projection retained for existing callers and tests.
+ * A v2 completion ends one turn, so done/error is idle while the pane lives;
+ * legacy error and confirmed process exit remain terminal.
  */
 export function deriveInteractiveSubagentStatus(
   lastEvent: SubagentEvent | null,
   paneAlive: boolean,
 ): InteractiveSubagentStatus {
-  if (!lastEvent) return paneAlive ? "running" : "unknown";
-  switch (lastEvent.type) {
-    case "process_exited":
-      return lastEvent.status === "cancelled" ? "cancelled" : "exited";
-    case "completion":
-      if (lastEvent.outcome === "cancelled") return "cancelled";
-      return paneAlive ? "idle" : "exited";
-    case "cancelled":
-      return "cancelled";
-    case "error":
-      // child declared it unrecoverable; terminal
-      return "exited";
-    case "done":
-      return paneAlive ? "idle" : "exited";
-    case "started":
-    case "tool_activity":
-    case "turn_started":
-      // Non-terminal activity events: still running if pane is alive.
-      return paneAlive ? "running" : "unknown";
-    default:
-      return assertNever(lastEvent);
+  let machine = initialInteractiveMachineState({
+    pane: { kind: paneAlive ? "alive" : "dead" },
+  });
+  if (lastEvent) {
+    const transition = transitionInteractiveMachine(machine, {
+      type: "artifact",
+      event: lastEvent,
+    });
+    if (transition.kind === "applied") machine = transition.state;
   }
+  return projectInteractiveStatus(machine);
 }
 
 export function deriveInteractiveSubagentStatusFromEvents(
   events: SubagentEvent[],
   paneAlive: boolean,
 ): InteractiveSubagentStatus {
-  const lifecycle: PersistedLifecycleFold = {};
-  for (const event of events) foldInteractiveLifecycle(lifecycle, event);
-  return deriveInteractiveSubagentStatusFromLifecycle(lifecycle, paneAlive);
+  let machine = initialInteractiveMachineState({
+    pane: { kind: paneAlive ? "alive" : "dead" },
+  });
+  for (const event of events) {
+    const transition = transitionInteractiveMachine(machine, {
+      type: "artifact",
+      event,
+    });
+    if (transition.kind === "applied") machine = transition.state;
+  }
+  return projectInteractiveStatus(machine);
 }
 
 export function foldInteractiveLifecycle(
   lifecycle: PersistedLifecycleFold,
   event: SubagentEvent,
 ): void {
-  lifecycle.startedAt ??= event.ts;
-  switch (event.type) {
-    case "process_exited": {
-      lifecycle.processStatus = event.status;
-      lifecycle.processExitCode = event.exitCode;
-      return;
-    }
-    case "turn_started": {
-      lifecycle.currentTurnId = event.turnId;
-      lifecycle.completionTurnId = undefined;
-      lifecycle.completionOutcome = undefined;
-      lifecycle.completionSource = undefined;
-      lifecycle.completionExitCode = undefined;
-      lifecycle.legacyTerminal = undefined;
-      return;
-    }
-    case "completion": {
-      if (event.outcome === "cancelled" && event.source === "parent") {
-        lifecycle.parentCancelled = true;
-      }
-      if (
-        !lifecycle.currentTurnId ||
-        event.turnId === lifecycle.currentTurnId
-      ) {
-        lifecycle.completionTurnId = event.turnId;
-        lifecycle.completionOutcome = event.outcome;
-        lifecycle.completionSource = event.source;
-        lifecycle.completionExitCode = event.exitCode;
-      }
-      return;
-    }
-    case "started": {
-      lifecycle.legacyTerminal = undefined;
-      return;
-    }
-    case "done":
-    case "error":
-    case "cancelled": {
-      lifecycle.legacyTerminal = event.status;
-      lifecycle.completionExitCode =
-        "exitCode" in event ? event.exitCode : undefined;
-      return;
-    }
-    case "tool_activity":
-      // Activity events do not affect lifecycle state.
-      return;
-    default:
-      return assertNever(event);
-  }
+  const machine = initialInteractiveMachineState({ lifecycle });
+  const transition = transitionInteractiveMachine(machine, {
+    type: "artifact",
+    event,
+  });
+  if (transition.kind !== "applied") return;
+  Object.assign(lifecycle, transition.state.lifecycle);
 }
 
 export function deriveInteractiveSubagentStatusFromLifecycle(
   lifecycle: PersistedLifecycleFold,
   paneState: boolean | PaneLiveness,
 ): InteractiveSubagentStatus {
-  const paneLiveness: PaneLiveness =
-    typeof paneState === "boolean" ? (paneState ? "alive" : "dead") : paneState;
-  if (lifecycle.parentCancelled) return "cancelled";
-  if (lifecycle.processStatus) {
-    return lifecycle.processStatus === "cancelled" ? "cancelled" : "exited";
-  }
-  if (lifecycle.completionOutcome) {
-    if (lifecycle.completionOutcome === "cancelled") return "cancelled";
-    if (paneLiveness === "alive") return "idle";
-    return paneLiveness === "dead" ? "exited" : "unknown";
-  }
-  if (lifecycle.legacyTerminal) {
-    if (lifecycle.legacyTerminal === "cancelled") return "cancelled";
-    if (lifecycle.legacyTerminal === "error") return "exited";
-    if (paneLiveness === "alive") return "idle";
-    return paneLiveness === "dead" ? "exited" : "unknown";
-  }
-  if (paneLiveness === "alive") return "running";
-  if (paneLiveness === "unknown") return "unknown";
-  // Keep the legacy boolean helper's no-event result stable; tri-state
-  // consumers can distinguish confirmed death and transition to exited.
-  return typeof paneState === "boolean" ? "unknown" : "exited";
+  const pane: PaneLiveness =
+    typeof paneState === "boolean"
+      ? { kind: paneState ? "alive" : "dead" }
+      : paneState;
+  return projectInteractiveStatus(
+    initialInteractiveMachineState({ lifecycle, pane }),
+  );
 }
 
 /**
@@ -1212,30 +1329,59 @@ export function deriveInteractiveSubagentStatusFromLifecycle(
  * `send_interactive_subagent_message` will accept more prompts. Only when
  * the pane is actually gone (or the child called `error`) is the sub-agent
  * terminal.
- *
- * Edge case: if the pane is dead and no `done` event was recorded (mux died
- * before the launch trap could write it), fall back to the session-file
- * existence check — same heuristic as before.
+ * Liveness probing is asynchronous so native mux subprocesses never block the
+ * parent event loop. Revision fences discard results from older observations.
  */
-export function pruneDeadInteractiveSubagents(): void {
-  for (const state of interactiveSubagentRegistry.values()) {
+export async function pruneDeadInteractiveSubagents(): Promise<void> {
+  const pending = [...interactiveSubagentRegistry.values()]
+    .filter((state) => {
+      const status = interactiveStatusForState(state);
+      return status !== "cancelled" && status !== "exited";
+    })
+    .map((state) => {
+      const started = advanceInteractiveState(state, {
+        type: "pane_observation_started",
+      });
+      return {
+        state,
+        revision:
+          started.kind === "applied"
+            ? started.state.observationRevision
+            : getInteractiveMachineState(state).observationRevision,
+      } as const;
+    });
+  const observations = await Promise.all(
+    pending.map(async ({ state, revision }) => {
+      try {
+        return {
+          state,
+          revision,
+          liveness: await observeInteractivePane(state),
+        } as const;
+      } catch (error) {
+        return {
+          state,
+          revision,
+          liveness: {
+            kind: "unknown",
+            reason: error instanceof Error ? error.message : String(error),
+          } as const,
+        } as const;
+      }
+    }),
+  );
+  for (const observation of observations) {
     if (
-      state.status !== "running" &&
-      state.status !== "idle" &&
-      state.status !== "unknown"
+      interactiveSubagentRegistry.get(observation.state.id) !==
+      observation.state
     ) {
       continue;
     }
-    const paneLiveness = getInteractivePaneLiveness(state);
-    const next = deriveInteractiveSubagentStatusFromLifecycle(
-      state.lifecycle ?? {},
-      paneLiveness,
-    );
-    if (next === state.status) continue;
-    state.status = next;
-    const exitCode =
-      state.lifecycle?.processExitCode ?? state.lifecycle?.completionExitCode;
-    if (next === "exited" && exitCode !== undefined) state.exitCode = exitCode;
+    advanceInteractiveState(observation.state, {
+      type: "pane_observed",
+      revision: observation.revision,
+      liveness: observation.liveness,
+    });
   }
 }
 
@@ -1245,7 +1391,7 @@ export function formatInteractiveState(
   const elapsed = Math.floor((Date.now() - state.startedAt) / 1000);
   const taskPreview = state.task.replace(/\s+/g, " ").slice(0, 80);
   const lines: string[] = [
-    `${state.name} (${state.id}) — ${state.status}, ${elapsed}s`,
+    `${state.name} (${state.id}) — ${interactiveStatusForState(state)}, ${elapsed}s`,
     `Task: ${taskPreview}${state.task.length > 80 ? "…" : ""}`,
     `Mux: ${state.mux}`,
     `Pane: ${state.paneId}`,

--- a/src/multiplexer-tmux.ts
+++ b/src/multiplexer-tmux.ts
@@ -23,12 +23,14 @@
  */
 
 import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
 import type {
   CapturePaneOptions,
   CapturePaneResult,
   Multiplexer,
   PaneLiveness,
   PaneRef,
+  SyncPaneLiveness,
 } from "./multiplexer";
 import {
   boundCaptureOutput,
@@ -104,6 +106,78 @@ function parsePaneListing(output: string): ReadonlySet<string> {
     throw new Error("Malformed tmux pane listing");
   }
   return new Set(paneIds);
+}
+interface ExecFileTextResult {
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface ExecFileTextOptions {
+  readonly encoding: "utf8";
+  readonly timeout: number;
+  readonly maxBuffer: number;
+  readonly killSignal: "SIGKILL";
+}
+
+function execFileText(
+  command: string,
+  args: readonly string[],
+  options: ExecFileTextOptions,
+  callback: (error: Error | null, result: ExecFileTextResult) => void,
+): void {
+  execFile(command, args, options, (error, stdout, stderr) => {
+    const result = { stdout, stderr };
+    if (error) {
+      Object.assign(error, result);
+    }
+    callback(error, result);
+  });
+}
+
+const execFileAsync = promisify(execFileText);
+
+function classifyTmuxProbeError(error: unknown): PaneLiveness {
+  const detail =
+    error instanceof Error
+      ? `${
+          typeof error === "object" &&
+          error !== null &&
+          "stderr" in error &&
+          typeof error.stderr === "string"
+            ? error.stderr
+            : ""
+        }\n${error.message}`
+      : "";
+  if (
+    /(?:can't find|no such) (?:pane|window|session)|(?:pane|session) not found|no current target/i.test(
+      detail,
+    )
+  ) {
+    return { kind: "dead" };
+  }
+
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? error.code
+      : undefined;
+  const killed =
+    typeof error === "object" && error !== null && "killed" in error
+      ? error.killed === true
+      : false;
+  if (
+    code === "ENOENT" ||
+    code === "ETIMEDOUT" ||
+    killed ||
+    /no server running|failed to connect to server|server exited unexpectedly/i.test(
+      detail,
+    )
+  ) {
+    return {
+      kind: "unavailable",
+      reason: "tmux liveness probe unavailable",
+    };
+  }
+  return { kind: "unknown", reason: "tmux liveness probe failed" };
 }
 
 export class TmuxMultiplexer implements Multiplexer {
@@ -338,7 +412,7 @@ export class TmuxMultiplexer implements Multiplexer {
     return { paneId, windowName, session };
   }
 
-  getPaneLiveness(paneId: string): PaneLiveness {
+  getPaneLiveness(paneId: string): SyncPaneLiveness {
     if (!/^%\d+$/.test(paneId)) return "unknown";
     try {
       const output = execFileSync(
@@ -356,30 +430,36 @@ export class TmuxMultiplexer implements Multiplexer {
     }
   }
 
-  getPaneLivenessAsync(paneId: string): Promise<PaneLiveness> {
-    if (!/^%\d+$/.test(paneId)) return Promise.resolve("unknown");
-    return new Promise((resolve) => {
-      try {
-        execFile(
-          "tmux",
-          withTmuxSocket(["list-panes", "-a", "-F", "#{pane_id}"]),
-          { encoding: "utf8", timeout: 5000 },
-          (error, stdout) => {
-            if (error) {
-              resolve("unknown");
-              return;
-            }
-            try {
-              resolve(parsePaneListing(stdout).has(paneId) ? "alive" : "dead");
-            } catch {
-              resolve("unknown");
-            }
-          },
-        );
-      } catch {
-        resolve("unknown");
-      }
-    });
+  isPaneAlive(paneId: string): boolean {
+    return this.getPaneLiveness(paneId) === "alive";
+  }
+
+  async observePane(paneId: string, _session?: string): Promise<PaneLiveness> {
+    if (!/^%\d+$/.test(paneId)) {
+      return { kind: "unknown", reason: "invalid tmux pane id" };
+    }
+    try {
+      const { stdout } = await execFileAsync(
+        "tmux",
+        withTmuxSocket(["display-message", "-p", "-t", paneId, "#{pane_id}"]),
+        {
+          encoding: "utf8",
+          timeout: 5000,
+          maxBuffer: 64 * 1024,
+          killSignal: "SIGKILL",
+        },
+      );
+      const observedPaneId = stdout.trim();
+      if (observedPaneId.length === 0) return { kind: "dead" };
+      return observedPaneId === paneId
+        ? { kind: "alive" }
+        : {
+            kind: "unknown",
+            reason: "tmux returned mismatched pane data",
+          };
+    } catch (error: unknown) {
+      return classifyTmuxProbeError(error);
+    }
   }
 
   sendKeys(paneId: string, text: string): void {

--- a/src/multiplexer-zellij.ts
+++ b/src/multiplexer-zellij.ts
@@ -29,12 +29,14 @@
 
 import { execFile, execFileSync, spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
 import type {
   CapturePaneOptions,
   CapturePaneResult,
   Multiplexer,
   PaneLiveness,
   PaneRef,
+  SyncPaneLiveness,
 } from "./multiplexer";
 import {
   boundCaptureOutput,
@@ -57,36 +59,62 @@ function normalizePaneId(raw: string): string {
   return raw.trim().replace(/^(?:terminal_|plugin_)/, "");
 }
 
+type ZellijPaneTarget =
+  | { readonly kind: "terminal"; readonly paneId: string }
+  | { readonly kind: "plugin"; readonly paneId: string };
+
 interface ZellijPaneRow {
   readonly id: number | string;
   readonly is_plugin?: boolean;
   readonly exited?: boolean;
 }
 
+function parseZellijPaneTarget(raw: string): ZellijPaneTarget | undefined {
+  const match = /^(?:(terminal|plugin)_)?(0|[1-9]\d*)$/.exec(raw.trim());
+  if (!match) return undefined;
+  return {
+    kind: match[1] === "plugin" ? "plugin" : "terminal",
+    paneId: match[2],
+  };
+}
+
+function isCanonicalZellijPaneId(value: unknown): value is string | number {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0;
+  }
+  return typeof value === "string" && /^(?:0|[1-9]\d*)$/.test(value);
+}
+
+class ZellijPaneListingError extends Error {}
+
 function parsePaneListing(output: string): ZellijPaneRow[] {
   const parsed: unknown = JSON.parse(output);
   if (!Array.isArray(parsed)) {
-    throw new Error("Malformed zellij pane listing");
+    throw new ZellijPaneListingError("zellij returned malformed pane data");
   }
+  const rows: ZellijPaneRow[] = [];
+  const seenTargets = new Set<string>();
   for (const row of parsed) {
-    if (row === null || typeof row !== "object") {
-      throw new Error("Malformed zellij pane listing row");
+    if (row === null || typeof row !== "object" || Array.isArray(row)) {
+      throw new ZellijPaneListingError("zellij returned malformed pane data");
     }
     const pane = row as Record<string, unknown>;
-    const validId =
-      (typeof pane.id === "number" &&
-        Number.isInteger(pane.id) &&
-        pane.id >= 0) ||
-      (typeof pane.id === "string" && /^\d+$/.test(pane.id));
     if (
-      !validId ||
+      !isCanonicalZellijPaneId(pane.id) ||
       (pane.is_plugin !== undefined && typeof pane.is_plugin !== "boolean") ||
       (pane.exited !== undefined && typeof pane.exited !== "boolean")
     ) {
-      throw new Error("Malformed zellij pane listing row");
+      throw new ZellijPaneListingError("zellij returned malformed pane data");
     }
+    const targetKind = pane.is_plugin === true ? "plugin" : "terminal";
+    const targetKey = `${targetKind}:${String(pane.id)}`;
+    if (seenTargets.has(targetKey)) {
+      throw new ZellijPaneListingError("zellij returned duplicate pane data");
+    }
+    seenTargets.add(targetKey);
+    rows.push(pane as unknown as ZellijPaneRow);
   }
-  return parsed as ZellijPaneRow[];
+  return rows;
 }
 
 class BoundedByteTail {
@@ -142,6 +170,83 @@ class BoundedByteTail {
       this.#storage.subarray(0, this.#length - first.length),
     ]);
   }
+}
+
+interface ExecFileTextResult {
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface ExecFileTextOptions {
+  readonly encoding: "utf8";
+  readonly timeout: number;
+  readonly maxBuffer: number;
+  readonly killSignal: "SIGKILL";
+}
+
+function execFileText(
+  command: string,
+  args: readonly string[],
+  options: ExecFileTextOptions,
+  callback: (error: Error | null, result: ExecFileTextResult) => void,
+): void {
+  execFile(command, args, options, (error, stdout, stderr) => {
+    const result = { stdout, stderr };
+    if (error) {
+      Object.assign(error, result);
+    }
+    callback(error, result);
+  });
+}
+
+const execFileAsync = promisify(execFileText);
+
+function classifyZellijProbeError(
+  error: unknown,
+  hasExplicitSession: boolean,
+): PaneLiveness {
+  const detail =
+    error instanceof Error
+      ? `${
+          typeof error === "object" &&
+          error !== null &&
+          "stderr" in error &&
+          typeof error.stderr === "string"
+            ? error.stderr
+            : ""
+        }\n${error.message}`
+      : "";
+  if (
+    hasExplicitSession &&
+    /session (?:[^\n]+ )?(?:not found|does not exist)|no session named|no active zellij session/i.test(
+      detail,
+    )
+  ) {
+    return { kind: "dead" };
+  }
+
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? error.code
+      : undefined;
+  const killed =
+    typeof error === "object" && error !== null && "killed" in error
+      ? error.killed === true
+      : false;
+  if (
+    code === "ENOENT" ||
+    code === "ETIMEDOUT" ||
+    killed ||
+    /connection refused|failed to connect|could not connect|no active zellij session|zellij server.*(?:unavailable|not running)/i.test(
+      detail,
+    )
+  ) {
+    return {
+      kind: "unavailable",
+      reason: "zellij liveness probe unavailable",
+    };
+  }
+  return { kind: "unknown", reason: "zellij liveness probe failed" };
 }
 
 export class ZellijMultiplexer implements Multiplexer {
@@ -360,31 +465,25 @@ export class ZellijMultiplexer implements Multiplexer {
   }
 
   /**
-   * Match a `list-panes --json` row against a pane id we hold.
-   *
-   * Plugin panes MUST be excluded, not merely deprioritized: zellij numbers
-   * `terminal_N` and `plugin_N` in SEPARATE namespaces, and `normalizePaneId`
-   * strips the prefix, so the two collapse onto the same integer. Verified
-   * against zellij 0.44.3 — a fresh session lists a `zellij:link` plugin pane
-   * with `id: 0` alongside the shell's terminal pane, also `id: 0`. Matching on
-   * the bare integer therefore reported a closed sub-agent pane as still alive
-   * (the plugin pane kept answering for it), which would make the artifact
-   * poller believe a finished child was running forever. Our pane is always a
-   * terminal pane: `createPane` only ever selects `!is_plugin`.
+   * Match a validated `list-panes --json` row against a namespace-preserving
+   * target. Zellij assigns the same numeric ids independently to terminal and
+   * plugin panes, so matching the integer alone can keep a dead terminal alive.
    */
-  private paneRowMatches(pane: ZellijPaneRow, target: string): boolean {
+  private paneRowMatches(
+    pane: ZellijPaneRow,
+    target: ZellijPaneTarget,
+  ): boolean {
+    const paneKind = pane.is_plugin === true ? "plugin" : "terminal";
     return (
-      !pane.is_plugin && String(pane.id) === target && pane.exited !== true
+      paneKind === target.kind &&
+      String(pane.id) === target.paneId &&
+      pane.exited !== true
     );
   }
 
-  /**
-   * Probe pane liveness from a complete backend pane listing. Backend and parse
-   * failures are `unknown`, distinct from a successful listing without the pane.
-   */
-  getPaneLiveness(paneId: string, session?: string): PaneLiveness {
-    const target = normalizePaneId(paneId);
-    if (!/^\d+$/.test(target)) return "unknown";
+  getPaneLiveness(paneId: string, session?: string): SyncPaneLiveness {
+    const target = parseZellijPaneTarget(paneId);
+    if (!target) return "unknown";
     try {
       const output = execFileSync(
         "zellij",
@@ -401,40 +500,41 @@ export class ZellijMultiplexer implements Multiplexer {
     }
   }
 
-  getPaneLivenessAsync(
-    paneId: string,
-    session?: string,
-  ): Promise<PaneLiveness> {
-    const target = normalizePaneId(paneId);
-    if (!/^\d+$/.test(target)) return Promise.resolve("unknown");
-    return new Promise((resolve) => {
-      try {
-        execFile(
-          "zellij",
-          [...this.sessionFlag(session), "action", "list-panes", "--json"],
-          { encoding: "utf8", timeout: 5000 },
-          (error, stdout) => {
-            if (error) {
-              resolve("unknown");
-              return;
-            }
-            try {
-              resolve(
-                parsePaneListing(stdout).some((pane) =>
-                  this.paneRowMatches(pane, target),
-                )
-                  ? "alive"
-                  : "dead",
-              );
-            } catch {
-              resolve("unknown");
-            }
-          },
-        );
-      } catch {
-        resolve("unknown");
+  isPaneAlive(paneId: string, session?: string): boolean {
+    return this.getPaneLiveness(paneId, session) === "alive";
+  }
+
+  async observePane(paneId: string, session?: string): Promise<PaneLiveness> {
+    const target = parseZellijPaneTarget(paneId);
+    if (!target) {
+      return { kind: "unknown", reason: "invalid zellij pane id" };
+    }
+    try {
+      const { stdout } = await execFileAsync(
+        "zellij",
+        [...this.sessionFlag(session), "action", "list-panes", "--json"],
+        {
+          encoding: "utf8",
+          timeout: 5000,
+          maxBuffer: 64 * 1024,
+          killSignal: "SIGKILL",
+        },
+      );
+      const panes = parsePaneListing(stdout);
+      const matched = panes.find((pane) => this.paneRowMatches(pane, target));
+      return matched ? { kind: "alive" } : { kind: "dead" };
+    } catch (error: unknown) {
+      if (error instanceof ZellijPaneListingError) {
+        return { kind: "unknown", reason: error.message };
       }
-    });
+      if (error instanceof SyntaxError) {
+        return {
+          kind: "unknown",
+          reason: "zellij returned malformed pane data",
+        };
+      }
+      return classifyZellijProbeError(error, session !== undefined);
+    }
   }
 
   /**

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -8,7 +8,7 @@
  * implementation behind the same interface.
  *
  * Backends that participate MUST:
- *   - implement the 8 methods below with the documented semantics;
+ *   - implement the methods below with the documented semantics;
  *   - stringify any internal numeric pane id to match `paneId: string` on
  *     `InteractiveSubagentState`;
  *   - be safe to instantiate cheaply (the resolver holds a long-lived instance
@@ -27,11 +27,13 @@ import { execFileSync, spawn, type ExecSyncOptions } from "node:child_process";
 import { TmuxMultiplexer } from "./multiplexer-tmux";
 import { ZellijMultiplexer } from "./multiplexer-zellij";
 import { assertNever } from "./artifact";
+import type { PaneLiveness } from "./interactive-state";
+export type { PaneLiveness } from "./interactive-state";
 
 /** Names of the supported multiplexer backends. Kept narrow on purpose. */
 export type MuxName = "tmux" | "zellij";
-/** Result of a backend pane-listing liveness probe. */
-export type PaneLiveness = "alive" | "dead" | "unknown";
+/** Synchronous listing result retained for lineage and launch preflights. */
+export type SyncPaneLiveness = "alive" | "dead" | "unknown";
 
 /** Backend-neutral structured reference to a durable mux pane. */
 export interface PaneRef {
@@ -151,7 +153,7 @@ export interface Multiplexer {
    *                           and generate their own (zellij requires unique
    *                           tab names per session).
    * @returns paneId           String id usable in subsequent `sendKeys` /
-   *                           `getPaneLiveness` / `killPane` calls. The string
+   *                           `observePane` / `killPane` calls. The string
    *                           format is backend-specific (tmux uses `%N`,
    *                           zellij uses `terminal_N` or just an integer
    *                           stringified).
@@ -174,19 +176,28 @@ export interface Multiplexer {
   }): { paneId: string; windowName?: string; session?: string };
 
   /**
-   * Probe whether the pane is still known to the backend.
-   *
-   * A successful pane listing returns `alive` when the pane is present and
-   * `dead` when it is absent. Command, setup, timeout, and parse failures return
-   * `unknown`; callers must not mistake an unavailable backend for a dead pane.
+   * Probe a complete synchronous backend listing. Only a successful listing
+   * may return `dead`; transport and parse failures return `unknown`.
+   */
+  getPaneLiveness(paneId: string, session?: string): SyncPaneLiveness;
+
+  /**
+   * Synchronously probe whether the pane appears alive. Retained for launch
+   * and rehydration preflight compatibility; `false` is inconclusive because
+   * backend, timeout, and parse failures cannot be distinguished from absence.
+   * Recurring pollers and durable death decisions MUST use `observePane`.
    *
    * @param session  The session returned by `createPane`. zellij needs it to
    *                 target the right server; tmux pane ids are server-global.
    */
-  getPaneLiveness(paneId: string, session?: string): PaneLiveness;
+  isPaneAlive(paneId: string, session?: string): boolean;
 
-  /** Asynchronously perform the same tri-state pane-listing probe. */
-  getPaneLivenessAsync(paneId: string, session?: string): Promise<PaneLiveness>;
+  /**
+   * Asynchronously observe pane liveness without blocking the parent event
+   * loop. A confirmed absent or exited pane is `dead`; transport failures
+   * preserve uncertainty as `unavailable` or `unknown`.
+   */
+  observePane(paneId: string, session?: string): Promise<PaneLiveness>;
 
   /**
    * Send literal text to the pane's shell input buffer, character-by-character.

--- a/src/rehydrate.ts
+++ b/src/rehydrate.ts
@@ -19,9 +19,10 @@ import {
 import { reconcileDeliveryReceipts } from "./delivery";
 import {
   buildAttachCommandsForState,
-  deriveInteractiveSubagentStatusFromLifecycle,
+  initializeInteractiveStateMachine,
   interactiveSubagentRegistry,
-  isPaneAlive,
+  interactiveStatusForState,
+  inspectInteractivePaneForRehydrate,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 
@@ -117,15 +118,19 @@ export function rehydrateInteractiveSubagents(
       lastStopText: undefined,
     };
 
-    const paneAlive = isPaneAlive(rehydrated);
-    const next = deriveInteractiveSubagentStatusFromLifecycle(
-      rehydrated.lifecycle ?? {},
-      paneAlive,
+    initializeInteractiveStateMachine(
+      rehydrated,
+      entry.paneDeathConfirmed
+        ? { kind: "dead" }
+        : inspectInteractivePaneForRehydrate(rehydrated),
     );
-    rehydrated.status = next;
     reconcileDeliveryReceipts(rehydrated, sessionEntries);
-    if (next === "exited" || next === "cancelled") terminal++;
-    else if (next === "running" || next === "idle") alive++;
+    const status = interactiveStatusForState(rehydrated);
+    if (status === "exited" || status === "cancelled") {
+      terminal++;
+    } else if (status === "running" || status === "idle") {
+      alive++;
+    }
     interactiveSubagentRegistry.set(entry.id, rehydrated);
   }
 

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -6,7 +6,10 @@ import { formatUsage } from "./helpers";
 import type { SubagentDetails } from "./subagent";
 import type { SubagentResult } from "./helpers";
 import { sanitizeOutput } from "./notifications";
-import type { InteractiveSubagentState } from "./interactive-tmux";
+import {
+  interactiveStatusForState,
+  type InteractiveSubagentState,
+} from "./interactive-tmux";
 
 function thinkingSuffix(level?: ThinkingLevel): string {
   return level ? ` · thinking: ${level}` : "";
@@ -250,7 +253,7 @@ export function formatActivityRow(
   state: InteractiveSubagentState,
   now: number = Date.now(),
 ): string {
-  if (state.status === "idle") {
+  if (interactiveStatusForState(state) === "idle") {
     return `○ ${state.name}: idle — ready for follow-up`;
   }
   const summary = state.lastToolSummary ?? "starting…";

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -14,6 +14,7 @@ import { snapshotInProcessSession } from "./cancellation-snapshots";
 import { rehydrateInteractiveSubagents } from "./rehydrate";
 import {
   cancelInteractiveSubagentByState,
+  interactiveStatusForState,
   interactiveSubagentRegistry,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
@@ -29,6 +30,13 @@ import {
   type SessionContextRef,
 } from "./session-context";
 import { closeActiveInteractiveSupervisor } from "./interactive-supervisor-ui";
+
+function shouldTerminateInteractiveState(
+  state: InteractiveSubagentState,
+): boolean {
+  const status = interactiveStatusForState(state);
+  return status !== "cancelled" && status !== "exited";
+}
 
 function getGlobalState() {
   return typeof global !== "undefined" ? global : globalThis;
@@ -137,11 +145,7 @@ function discardPreSessionPollerState(
       continue;
     }
     interactiveSubagentRegistry.delete(state.id);
-    if (
-      state.status === "running" ||
-      state.status === "idle" ||
-      state.status === "unknown"
-    ) {
+    if (shouldTerminateInteractiveState(state)) {
       try {
         cancelInteractiveSubagentByState(state);
       } catch {
@@ -367,9 +371,7 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
           interactiveSubagentRegistry.delete(state.id);
           if (
             !preserveInteractivePanes &&
-            (state.status === "running" ||
-              state.status === "idle" ||
-              state.status === "unknown")
+            shouldTerminateInteractiveState(state)
           ) {
             try {
               cancelInteractiveSubagentByState(state);
@@ -408,13 +410,7 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
       // kill their panes; reload/resume/quit leave them for rehydration.
       const runningStates: InteractiveSubagentState[] = [];
       for (const state of interactiveSubagentRegistry.values()) {
-        if (
-          state.status === "running" ||
-          state.status === "idle" ||
-          state.status === "unknown"
-        ) {
-          runningStates.push(state);
-        }
+        if (shouldTerminateInteractiveState(state)) runningStates.push(state);
       }
 
       // Drop in-memory state FIRST. An in-flight poll tick (dequeued from

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -25,6 +25,8 @@ import {
   cancelInteractiveSubagent,
   formatInteractiveState,
   interactiveSubagentRegistry,
+  interactiveStatusForState,
+  isInteractiveStateActive,
   launchInteractiveSubagent,
   pruneDeadInteractiveSubagents,
   sendCommandToPane,
@@ -273,7 +275,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
     }),
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<any> {
-      pruneDeadInteractiveSubagents();
+      await pruneDeadInteractiveSubagents();
       updateRunningSubagentFooter(ctx.ui);
       const states = params.jobId
         ? [interactiveSubagentRegistry.get(params.jobId)].filter(
@@ -463,18 +465,18 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
           isError: true,
         };
       }
-      // Accept both "running" (mid-turn) and "idle" (REPL open, between turns) — that's the whole
-      // point of follow-up support. Mid-turn sends are safe: tmux send-keys just queues keystrokes
-      // in the REPL input buffer, which submits when the current turn finishes.
-      if (state.status !== "running" && state.status !== "idle") {
+      // Accept both running and idle states. The compatibility status comes
+      // from the lifecycle kernel rather than an independently mutable field.
+      const status = interactiveStatusForState(state);
+      if (!isInteractiveStateActive(state)) {
         return {
           content: [
             {
               type: "text",
-              text: `Interactive sub-agent ${params.id} is ${state.status}; follow-up messages can only be sent to running or idle sub-agents. Spawn a new one if needed.`,
+              text: `Interactive sub-agent ${params.id} is ${status}; follow-up messages can only be sent to running or idle sub-agents. Spawn a new one if needed.`,
             },
           ],
-          details: { id: params.id, status: state.status },
+          details: { id: params.id, status },
           isError: true,
         };
       }
@@ -705,7 +707,7 @@ export function registerInteractiveSubagentTools(pi: ExtensionAPI): void {
     parameters: Type.Object({}),
 
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx): Promise<any> {
-      pruneDeadInteractiveSubagents();
+      await pruneDeadInteractiveSubagents();
       updateRunningSubagentFooter(ctx.ui);
       const states = [...interactiveSubagentRegistry.values()];
       const summary = states.map((s) => {

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -43,8 +43,10 @@ import {
 } from "./workflow-core";
 import { workflowStringify } from "./workflow-script";
 import {
+  advanceInteractiveState,
   cancelInteractiveSubagent,
-  isPaneAlive,
+  getInteractiveMachineState,
+  observeInteractivePane,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
@@ -698,14 +700,33 @@ export async function awaitInteractiveResult(
           return assertNever(terminal);
       }
     }
-    // No terminal event yet — if the pane has died, give it a few grace ticks for a final flush.
-    let alive = true;
+    // No terminal event yet — only a confirmed dead pane advances the grace
+    // counter. Unavailable or unknown observation cannot prove process death.
+    const started = advanceInteractiveState(state, {
+      type: "pane_observation_started",
+    });
+    const revision =
+      started.kind === "applied"
+        ? started.state.observationRevision
+        : getInteractiveMachineState(state).observationRevision;
     try {
-      alive = isPaneAlive(state);
-    } catch {
-      alive = false;
+      const liveness = await observeInteractivePane(state);
+      advanceInteractiveState(state, {
+        type: "pane_observed",
+        revision,
+        liveness,
+      });
+    } catch (error) {
+      advanceInteractiveState(state, {
+        type: "pane_observed",
+        revision,
+        liveness: {
+          kind: "unknown",
+          reason: error instanceof Error ? error.message : String(error),
+        },
+      });
     }
-    if (!alive) {
+    if (getInteractiveMachineState(state).pane.kind === "dead") {
       deadTicks++;
       debugLog("warn", "interactive_dead_pane", {
         deadTicks,

--- a/tests/artifact-delivery.integration.test.ts
+++ b/tests/artifact-delivery.integration.test.ts
@@ -371,7 +371,7 @@ describe("artifact protocol v2 delivery", () => {
       interactiveSubagentRegistry;
     __setTmuxMultiplexer({
       getPaneLiveness: () => "alive",
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async () => ({ kind: "alive" }),
     } as any);
     const first = appendDeterministicTurn(art, 1, "first immutable result");
     const second = appendDeterministicTurn(art, 2, "second immutable result");
@@ -404,7 +404,7 @@ describe("artifact protocol v2 delivery", () => {
       interactiveSubagentRegistry;
     __setTmuxMultiplexer({
       getPaneLiveness: () => "alive",
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async () => ({ kind: "alive" }),
     } as any);
     const bytes = MAX_OUTPUT_SNAPSHOT_BYTES + 1;
     writeOutput(art, "");

--- a/tests/async-shutdown-escape.test.ts
+++ b/tests/async-shutdown-escape.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  InteractiveSubagentState,
+  InteractiveSubagentStatus,
+} from "../src/interactive-tmux";
 
 const { mockStartSubagentJob, createStartGate } = vi.hoisted(() => ({
   mockStartSubagentJob: vi.fn(),
@@ -14,12 +18,26 @@ vi.mock("../src/helpers", async (importOriginal) => {
   return { ...actual, startSubagentJob: mockStartSubagentJob };
 });
 
-vi.mock("../src/interactive-tmux", () => ({
-  interactiveSubagentRegistry: new Map(),
-  isTmuxAvailable: () => false,
-  cancelInteractiveSubagent: vi.fn(),
-  cancelInteractiveSubagentByState: vi.fn(),
-}));
+vi.mock("../src/interactive-tmux", () => {
+  const interactiveStatusForState = (
+    state: InteractiveSubagentState,
+  ): InteractiveSubagentStatus => state.status;
+  const isInteractiveStateActive = (
+    state: InteractiveSubagentState,
+  ): boolean => {
+    const status = interactiveStatusForState(state);
+    return status === "running" || status === "idle";
+  };
+
+  return {
+    interactiveSubagentRegistry: new Map<string, InteractiveSubagentState>(),
+    interactiveStatusForState,
+    isInteractiveStateActive,
+    isTmuxAvailable: (): boolean => false,
+    cancelInteractiveSubagent: vi.fn(),
+    cancelInteractiveSubagentByState: vi.fn(),
+  };
+});
 
 import { jobRegistry } from "../src/helpers";
 import { registerInProcessSubagentTools } from "../src/tools/in-process";

--- a/tests/in-process-tools.test.ts
+++ b/tests/in-process-tools.test.ts
@@ -9,6 +9,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  InteractiveSubagentState,
+  InteractiveSubagentStatus,
+} from "../src/interactive-tmux";
 
 // ── Hoisted mock variables (available before vi.mock runs) ───────────
 
@@ -60,12 +64,23 @@ vi.mock("../src/notifications", async (importOriginal) => {
 // interactive-tmux.ts has a TypeScript syntax that esbuild (vitest's transformer)
 // cannot parse (line 613). We mock it so vitest never loads the source.
 vi.mock("../src/interactive-tmux", () => {
-  const fakeRegistry = new Map<string, any>();
+  const fakeRegistry = new Map<string, InteractiveSubagentState>();
+  const interactiveStatusForState = (
+    state: InteractiveSubagentState,
+  ): InteractiveSubagentStatus => state.status;
+  const isInteractiveStateActive = (
+    state: InteractiveSubagentState,
+  ): boolean => {
+    const status = interactiveStatusForState(state);
+    return status === "running" || status === "idle";
+  };
+
   return {
     interactiveSubagentRegistry: fakeRegistry,
-    isTmuxAvailable: () => false,
+    interactiveStatusForState,
+    isInteractiveStateActive,
+    isTmuxAvailable: (): boolean => false,
     default: {},
-    // The specific shape doesn't matter — only the import needs to resolve.
   };
 });
 

--- a/tests/interactive-state.test.ts
+++ b/tests/interactive-state.test.ts
@@ -1,0 +1,533 @@
+import { describe, expect, it } from "vitest";
+import type { PersistedLifecycleFold, SubagentEvent } from "../src/artifact";
+import {
+  initialInteractiveMachineState,
+  projectInteractiveStatus,
+  transitionInteractiveMachine,
+  type InteractiveMachineEvent,
+  type InteractiveMachineState,
+  type InteractiveMachineTransition,
+  type PaneLiveness,
+} from "../src/interactive-state";
+import {
+  deriveInteractiveSubagentStatusFromLifecycle,
+  foldInteractiveLifecycle,
+} from "../src/interactive-tmux";
+
+const legacyStarted = {
+  ts: 1,
+  type: "started",
+  status: "running",
+} as const satisfies SubagentEvent;
+const legacyActivity = {
+  ts: 2,
+  type: "tool_activity",
+  status: "running",
+  tool: "read",
+} as const satisfies SubagentEvent;
+const legacyDone = {
+  ts: 3,
+  type: "done",
+  status: "done",
+  exitCode: 0,
+} as const satisfies SubagentEvent;
+const legacyError = {
+  ts: 3,
+  type: "error",
+  status: "error",
+  exitCode: 1,
+  message: "failed",
+} as const satisfies SubagentEvent;
+const legacyCancelled = {
+  ts: 3,
+  type: "cancelled",
+  status: "cancelled",
+} as const satisfies SubagentEvent;
+
+function turnStarted(turnId: string, ts = 1): SubagentEvent {
+  return {
+    version: 2,
+    eventId: `start-${turnId}`,
+    turnId,
+    ts,
+    type: "turn_started",
+    status: "running",
+  };
+}
+
+function toolActivity(turnId: string, ts = 2): SubagentEvent {
+  return {
+    version: 2,
+    eventId: `tool-${turnId}`,
+    turnId,
+    ts,
+    type: "tool_activity",
+    status: "running",
+    phase: "start",
+    tool: "read",
+  };
+}
+
+function completion(
+  turnId: string,
+  outcome: "done" | "error" | "cancelled",
+  ts = 3,
+  source:
+    | "agent_settled"
+    | "agent_end"
+    | "explicit"
+    | "process_exit"
+    | "parent" = "agent_settled",
+): SubagentEvent {
+  return {
+    version: 2,
+    eventId: `completion-${turnId}-${outcome}`,
+    turnId,
+    ts,
+    type: "completion",
+    status: outcome,
+    outcome,
+    source,
+  };
+}
+
+function processExited(
+  status: "done" | "error" | "cancelled",
+  exitCode: number,
+  ts = 4,
+): SubagentEvent {
+  return {
+    version: 2,
+    eventId: `process-${status}`,
+    turnId: "turn-process",
+    ts,
+    type: "process_exited",
+    status,
+    exitCode,
+  };
+}
+
+function artifact(event: SubagentEvent): InteractiveMachineEvent {
+  return { type: "artifact", event };
+}
+
+function requireApplied(
+  transition: InteractiveMachineTransition,
+): InteractiveMachineState {
+  if (transition.kind !== "applied") {
+    throw new Error(`expected applied transition, received ${transition.kind}`);
+  }
+  return transition.state;
+}
+
+function applyEvent(
+  state: InteractiveMachineState,
+  event: InteractiveMachineEvent,
+): InteractiveMachineState {
+  return requireApplied(transitionInteractiveMachine(state, event));
+}
+
+function replay(
+  events: readonly InteractiveMachineEvent[],
+  pane: PaneLiveness = { kind: "unknown" },
+): {
+  readonly state: InteractiveMachineState;
+  readonly transitions: readonly InteractiveMachineTransition[];
+} {
+  let state = initialInteractiveMachineState({ pane });
+  const transitions: InteractiveMachineTransition[] = [];
+  for (const event of events) {
+    const transition = transitionInteractiveMachine(state, event);
+    transitions.push(transition);
+    state = transition.state;
+  }
+  return { state, transitions };
+}
+
+describe("interactive state kernel", () => {
+  it("starts from an unknown running process without inventing artifact facts", () => {
+    expect(initialInteractiveMachineState()).toEqual({
+      phase: "running",
+      lifecycle: {},
+      pane: { kind: "unknown" },
+      observationRevision: 0,
+    });
+  });
+
+  it.each([
+    ["legacy started", legacyStarted, "running"],
+    ["legacy tool activity", legacyActivity, "running"],
+    ["legacy done", legacyDone, "completed"],
+    ["legacy error", legacyError, "completed"],
+    ["legacy cancelled", legacyCancelled, "cancelled"],
+    ["v2 turn started", turnStarted("turn-1"), "running"],
+    ["v2 tool activity", toolActivity("turn-1"), "running"],
+    ["v2 done", completion("turn-1", "done"), "completed"],
+    ["v2 error", completion("turn-1", "error"), "completed"],
+    ["v2 cancelled", completion("turn-1", "cancelled"), "cancelled"],
+    ["process done", processExited("done", 0), "process_exited"],
+    ["process error", processExited("error", 1), "process_exited"],
+    ["process cancelled", processExited("cancelled", 130), "cancelled"],
+  ] as const)(
+    "applies every legal artifact transition: %s",
+    (_name, event, phase) => {
+      const initial = initialInteractiveMachineState({
+        pane: { kind: "alive" },
+      });
+      const result = transitionInteractiveMachine(initial, artifact(event));
+
+      expect(result.kind).toBe("applied");
+      if (result.kind !== "applied") return;
+      expect(result.previous).toBe(initial);
+      expect(result.state.phase).toBe(phase);
+      expect(result.state.lifecycle.startedAt).toBe(event.ts);
+    },
+  );
+
+  it("preserves legacy done and error terminal semantics for every pane observation", () => {
+    const cases = [
+      [legacyDone, { kind: "alive" }, "idle"],
+      [legacyDone, { kind: "dead" }, "exited"],
+      [legacyDone, { kind: "unavailable", reason: "tmux down" }, "unknown"],
+      [legacyDone, { kind: "unknown", reason: "bad output" }, "unknown"],
+      [legacyError, { kind: "alive" }, "exited"],
+      [legacyError, { kind: "dead" }, "exited"],
+      [legacyError, { kind: "unavailable", reason: "tmux down" }, "exited"],
+      [legacyError, { kind: "unknown", reason: "bad output" }, "exited"],
+    ] as const satisfies readonly (readonly [
+      SubagentEvent,
+      PaneLiveness,
+      "idle" | "exited" | "unknown",
+    ])[];
+
+    for (const [event, pane, expected] of cases) {
+      const state = applyEvent(
+        initialInteractiveMachineState({ pane }),
+        artifact(event),
+      );
+      expect(projectInteractiveStatus(state)).toBe(expected);
+    }
+  });
+
+  it("projects v2 done and error completion from authoritative artifact and pane facts", () => {
+    const cases = [
+      ["done", { kind: "alive" }, "idle"],
+      ["done", { kind: "dead" }, "exited"],
+      ["done", { kind: "unavailable", reason: "mux offline" }, "unknown"],
+      ["done", { kind: "unknown", reason: "malformed response" }, "unknown"],
+      ["error", { kind: "alive" }, "idle"],
+      ["error", { kind: "dead" }, "exited"],
+      ["error", { kind: "unavailable", reason: "mux offline" }, "unknown"],
+      ["error", { kind: "unknown", reason: "malformed response" }, "unknown"],
+    ] as const satisfies readonly (readonly [
+      "done" | "error",
+      PaneLiveness,
+      "idle" | "exited" | "unknown",
+    ])[];
+
+    for (const [outcome, pane, expected] of cases) {
+      const state = applyEvent(
+        initialInteractiveMachineState({ pane }),
+        artifact(completion("turn-v2", outcome)),
+      );
+      expect(state).toMatchObject({
+        phase: "completed",
+        protocol: "v2",
+        outcome,
+      });
+      expect(projectInteractiveStatus(state)).toBe(expected);
+    }
+  });
+
+  it("makes parent cancellation terminal independently of pane liveness", () => {
+    const panes = [
+      { kind: "alive" },
+      { kind: "dead" },
+      { kind: "unavailable", reason: "backend absent" },
+      { kind: "unknown", reason: "probe failed" },
+    ] as const satisfies readonly PaneLiveness[];
+
+    for (const pane of panes) {
+      const initial = initialInteractiveMachineState({ pane });
+      const cancelled = applyEvent(initial, { type: "parent_cancelled" });
+      expect(cancelled).toMatchObject({
+        phase: "cancelled",
+        source: "parent",
+        pane,
+      });
+      expect(projectInteractiveStatus(cancelled)).toBe("cancelled");
+      expect(
+        transitionInteractiveMachine(cancelled, { type: "parent_cancelled" }),
+      ).toEqual({
+        kind: "unchanged",
+        state: cancelled,
+      });
+    }
+  });
+
+  it("distinguishes process exit outcomes without consulting pane liveness", () => {
+    const done = applyEvent(
+      initialInteractiveMachineState({ pane: { kind: "alive" } }),
+      artifact(processExited("done", 0)),
+    );
+    const error = applyEvent(
+      initialInteractiveMachineState({ pane: { kind: "unavailable" } }),
+      artifact(processExited("error", 9)),
+    );
+    const cancelled = applyEvent(
+      initialInteractiveMachineState({ pane: { kind: "unknown" } }),
+      artifact(processExited("cancelled", 130)),
+    );
+
+    expect(done).toMatchObject({
+      phase: "process_exited",
+      status: "done",
+      exitCode: 0,
+    });
+    expect(error).toMatchObject({
+      phase: "process_exited",
+      status: "error",
+      exitCode: 9,
+    });
+    expect(cancelled).toMatchObject({ phase: "cancelled", source: "process" });
+    expect(projectInteractiveStatus(done)).toBe("exited");
+    expect(projectInteractiveStatus(error)).toBe("exited");
+    expect(projectInteractiveStatus(cancelled)).toBe("cancelled");
+  });
+
+  it("starts a follow-up only from a completed reusable process", () => {
+    const completed = applyEvent(
+      initialInteractiveMachineState({ pane: { kind: "alive" } }),
+      artifact(completion("turn-1", "done")),
+    );
+    const followup = transitionInteractiveMachine(completed, {
+      type: "followup_started",
+      turnId: "turn-2",
+    });
+
+    expect(followup.kind).toBe("applied");
+    if (followup.kind !== "applied") return;
+    expect(followup.state).toMatchObject({
+      phase: "running",
+      pane: { kind: "alive" },
+    });
+    expect(followup.state.lifecycle).toMatchObject({ currentTurnId: "turn-2" });
+    expect(followup.state.lifecycle.completionOutcome).toBeUndefined();
+  });
+
+  it.each([
+    ["already-running", initialInteractiveMachineState()],
+    [
+      "parent-cancelled",
+      applyEvent(initialInteractiveMachineState(), {
+        type: "parent_cancelled",
+      }),
+    ],
+    [
+      "legacy-error",
+      applyEvent(
+        initialInteractiveMachineState({ pane: { kind: "alive" } }),
+        artifact(legacyError),
+      ),
+    ],
+    [
+      "completed-dead",
+      applyEvent(
+        initialInteractiveMachineState({ pane: { kind: "dead" } }),
+        artifact(completion("dead-turn", "done")),
+      ),
+    ],
+    [
+      "completed-unavailable",
+      applyEvent(
+        initialInteractiveMachineState({
+          pane: { kind: "unavailable", reason: "mux unavailable" },
+        }),
+        artifact(completion("unavailable-turn", "done")),
+      ),
+    ],
+    [
+      "process-exited",
+      applyEvent(
+        initialInteractiveMachineState(),
+        artifact(processExited("done", 0)),
+      ),
+    ],
+  ] as const)(
+    "rejects illegal follow-up transition from %s",
+    (_name, state) => {
+      const result = transitionInteractiveMachine(state, {
+        type: "followup_started",
+        turnId: "illegal-turn",
+      });
+
+      expect(result).toMatchObject({ kind: "invalid", state });
+      if (result.kind === "invalid") expect(result.reason).not.toHaveLength(0);
+    },
+  );
+
+  it("returns an explicit invalid result for an unknown runtime event", () => {
+    const state = initialInteractiveMachineState();
+    const unknownEvent = {
+      type: "future_protocol_event",
+      payload: "opaque",
+    } as unknown as InteractiveMachineEvent;
+
+    expect(transitionInteractiveMachine(state, unknownEvent)).toMatchObject({
+      kind: "invalid",
+      state,
+      reason: expect.stringContaining("unknown interactive transition"),
+    });
+  });
+
+  it("rejects stale pane observations and leaves authoritative state untouched", () => {
+    const initial = initialInteractiveMachineState({
+      pane: { kind: "unknown" },
+    });
+    const observing = applyEvent(initial, { type: "pane_observation_started" });
+    expect(observing.observationRevision).toBe(1);
+
+    const stale = transitionInteractiveMachine(observing, {
+      type: "pane_observed",
+      revision: 0,
+      liveness: { kind: "dead" },
+    });
+    expect(stale).toEqual({
+      kind: "stale",
+      state: observing,
+      expectedRevision: 1,
+      receivedRevision: 0,
+    });
+
+    const observed = applyEvent(observing, {
+      type: "pane_observed",
+      revision: 1,
+      liveness: { kind: "alive" },
+    });
+    const nextObservation = applyEvent(observed, {
+      type: "pane_observation_started",
+    });
+    const superseded = transitionInteractiveMachine(nextObservation, {
+      type: "pane_observed",
+      revision: 1,
+      liveness: { kind: "dead" },
+    });
+    expect(superseded).toMatchObject({
+      kind: "stale",
+      state: nextObservation,
+      expectedRevision: 2,
+      receivedRevision: 1,
+    });
+  });
+
+  it("keeps a confirmed-dead pane identity terminal", () => {
+    const completed = applyEvent(
+      initialInteractiveMachineState({ pane: { kind: "alive" } }),
+      artifact(completion("terminal-turn", "done")),
+    );
+    const firstObservation = applyEvent(completed, {
+      type: "pane_observation_started",
+    });
+    const dead = applyEvent(firstObservation, {
+      type: "pane_observed",
+      revision: 1,
+      liveness: { kind: "dead" },
+    });
+    const secondObservation = applyEvent(dead, {
+      type: "pane_observation_started",
+    });
+
+    const result = transitionInteractiveMachine(secondObservation, {
+      type: "pane_observed",
+      revision: 2,
+      liveness: { kind: "alive" },
+    });
+
+    expect(result).toMatchObject({ kind: "invalid", state: secondObservation });
+    expect(projectInteractiveStatus(result.state)).toBe("exited");
+    expect(result.state.pane).toEqual({ kind: "dead" });
+  });
+
+  it("reports an observation with the same liveness kind as unchanged", () => {
+    const observing = applyEvent(
+      initialInteractiveMachineState({
+        pane: { kind: "unavailable", reason: "first failure" },
+      }),
+      { type: "pane_observation_started" },
+    );
+    expect(
+      transitionInteractiveMachine(observing, {
+        type: "pane_observed",
+        revision: 1,
+        liveness: { kind: "unavailable", reason: "second failure" },
+      }),
+    ).toEqual({ kind: "unchanged", state: observing });
+  });
+
+  it("replays the same mixed event stream deterministically", () => {
+    const events = [
+      { type: "pane_observation_started" },
+      { type: "pane_observed", revision: 1, liveness: { kind: "alive" } },
+      artifact(turnStarted("turn-1", 10)),
+      artifact(toolActivity("turn-1", 11)),
+      artifact(completion("turn-1", "error", 12)),
+      { type: "followup_started", turnId: "turn-2" },
+      { type: "pane_observation_started" },
+      { type: "pane_observed", revision: 1, liveness: { kind: "dead" } },
+      artifact(completion("turn-2", "done", 13)),
+    ] as const satisfies readonly InteractiveMachineEvent[];
+
+    const first = replay(events);
+    const second = replay(events);
+
+    expect(first).toEqual(second);
+    expect(first.state).toMatchObject({
+      phase: "completed",
+      protocol: "v2",
+      outcome: "done",
+      pane: { kind: "alive" },
+      observationRevision: 2,
+    });
+    expect(first.transitions.map((transition) => transition.kind)).toEqual([
+      "applied",
+      "applied",
+      "applied",
+      "applied",
+      "applied",
+      "applied",
+      "applied",
+      "stale",
+      "applied",
+    ]);
+  });
+
+  it("matches the established lifecycle projection for alive and dead panes", () => {
+    const sequences = [
+      [],
+      [legacyStarted],
+      [legacyStarted, legacyDone],
+      [legacyStarted, legacyError],
+      [legacyStarted, legacyCancelled],
+      [turnStarted("turn-done"), completion("turn-done", "done")],
+      [turnStarted("turn-error"), completion("turn-error", "error")],
+      [turnStarted("turn-cancel"), completion("turn-cancel", "cancelled")],
+      [processExited("done", 0)],
+      [processExited("error", 7)],
+      [processExited("cancelled", 130)],
+    ] as const satisfies readonly (readonly SubagentEvent[])[];
+
+    for (const events of sequences) {
+      const lifecycle: PersistedLifecycleFold = {};
+      for (const event of events) foldInteractiveLifecycle(lifecycle, event);
+      for (const paneAlive of [true, false] as const) {
+        const machine = replay(
+          events.map(artifact),
+          paneAlive ? { kind: "alive" } : { kind: "dead" },
+        ).state;
+        expect(projectInteractiveStatus(machine)).toBe(
+          deriveInteractiveSubagentStatusFromLifecycle(lifecycle, paneAlive),
+        );
+      }
+    }
+  });
+});

--- a/tests/interactive-supervisor.test.ts
+++ b/tests/interactive-supervisor.test.ts
@@ -22,6 +22,7 @@ import {
   writeLineageManifestAtomic,
 } from "../src/interactive-lineage";
 import {
+  advanceInteractiveState,
   captureInteractiveSubagent,
   focusInteractiveSubagent,
   interactiveSubagentRegistry,
@@ -504,7 +505,6 @@ describe("interactive supervisor", () => {
       lifecycle: {
         currentTurnId: "turn-1",
         completionOutcome: "done",
-        processStatus: "done",
       },
     });
     interactiveSubagentRegistry.set(item.id, item);
@@ -519,9 +519,7 @@ describe("interactive supervisor", () => {
     await vi.waitFor(() => {
       component.invalidate();
       const rendered = component.render(160).join("\n");
-      expect(rendered).toContain(
-        "Lifecycle: turn=turn-1 · completion=done · process=done",
-      );
+      expect(rendered).toContain("Lifecycle: turn=turn-1 · completion=done");
       expect(rendered).toContain(
         "Recent events: turn_started → tool_activity(read) → completion(done)",
       );
@@ -782,7 +780,7 @@ describe("interactive supervisor", () => {
     const active = state("active", { name: "active-agent" });
     const stale = state("stale", { name: "stale-agent", status: "unknown" });
     const cancel = vi.fn(() => {
-      active.status = "cancelled";
+      advanceInteractiveState(active, { type: "parent_cancelled" });
       return active;
     });
     const component = new InteractiveSupervisorComponent({
@@ -952,11 +950,11 @@ describe("interactive supervisor", () => {
       pane: { backend: "tmux", paneId: exited.paneId },
       artifactDir,
     });
-    const getPaneLivenessAsync = vi.fn().mockResolvedValue("alive");
+    const observePane = vi.fn().mockResolvedValue({ kind: "alive" });
     interactiveSubagentRegistry.set(exited.id, exited);
     __setTmuxMultiplexer({
-      getPaneLivenessAsync,
-      getPaneLiveness: vi.fn().mockReturnValue("dead"),
+      observePane,
+      getPaneLiveness: vi.fn().mockReturnValue({ kind: "dead" }),
     } as never);
     process.env.PI_SUBAGENTURA_ROOT_ID = rootId;
     process.env.PI_SUBAGENTURA_LINEAGE_SESSION_ROOT = sessionRoot;
@@ -988,10 +986,7 @@ describe("interactive supervisor", () => {
 
       expect.soft(rendered).not.toContain(exited.name);
       expect(exited.status).toBe("exited");
-      expect(getPaneLivenessAsync).toHaveBeenCalledWith(
-        exited.paneId,
-        undefined,
-      );
+      expect(observePane).toHaveBeenCalledWith(exited.paneId, undefined);
       expect(readdirSync(paths.nodesDir)).toContain(`${exited.id}.json`);
     } finally {
       if (previousRootId === undefined)
@@ -1250,12 +1245,16 @@ describe("interactive supervisor", () => {
     for (const id of ["alive", "unknown", "dead"]) {
       interactiveSubagentRegistry.set(id, state(id, { status: "exited" }));
     }
-    const getPaneLivenessAsync = vi.fn(async (paneId: string) =>
-      paneId === "%dead" ? "dead" : paneId === "%unknown" ? "unknown" : "alive",
+    const observePane = vi.fn(async (paneId: string) =>
+      paneId === "%dead"
+        ? { kind: "dead" as const }
+        : paneId === "%unknown"
+          ? { kind: "unknown" as const }
+          : { kind: "alive" as const },
     );
     __setTmuxMultiplexer({
-      getPaneLivenessAsync,
-      getPaneLiveness: () => "alive",
+      observePane,
+      getPaneLiveness: () => ({ kind: "alive" }),
       buildAttachCommands: () => ({
         attachCommand: "tmux attach -t x",
         focusCommand: "tmux select-window -t x",
@@ -1264,9 +1263,7 @@ describe("interactive supervisor", () => {
 
     await harness.open();
 
-    const probedPanes = getPaneLivenessAsync.mock.calls.map(
-      ([paneId]) => paneId,
-    );
+    const probedPanes = observePane.mock.calls.map(([paneId]) => paneId);
     expect(probedPanes).toEqual(
       expect.arrayContaining(["%alive", "%unknown", "%dead"]),
     );
@@ -1277,8 +1274,8 @@ describe("interactive supervisor", () => {
     const harness = await lineageHarness("prune-root");
     await harness.writeNode("dead", { paneId: "%dead" });
     __setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "dead",
-      getPaneLiveness: () => "dead",
+      observePane: async () => ({ kind: "dead" }),
+      getPaneLiveness: () => ({ kind: "dead" }),
       buildAttachCommands: () => ({
         attachCommand: "tmux attach -t x",
         focusCommand: "tmux select-window -t x",
@@ -1290,12 +1287,12 @@ describe("interactive supervisor", () => {
     expect(await harness.nodeFiles()).toEqual([]);
   });
 
-  it("keeps unknown lineage panes visible and retained", async () => {
+  it("hides unknown lineage panes while retaining their manifests", async () => {
     const harness = await lineageHarness("unknown-root");
     await harness.writeNode("unknown", { paneId: "%unknown" });
     __setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "unknown",
-      getPaneLiveness: () => "unknown",
+      observePane: async () => ({ kind: "unknown" }),
+      getPaneLiveness: () => ({ kind: "unknown" }),
       buildAttachCommands: () => ({
         attachCommand: "tmux attach -t x",
         focusCommand: "tmux select-window -t x",
@@ -1304,7 +1301,7 @@ describe("interactive supervisor", () => {
 
     const { rendered } = await harness.open();
 
-    expect(rendered).toContain("agent-unknown");
+    expect(rendered).not.toContain("agent-unknown");
     expect(await harness.nodeFiles()).toEqual(["unknown.json"]);
   });
 
@@ -1314,11 +1311,11 @@ describe("interactive supervisor", () => {
       paneId: "remote-pane",
       backend: "remote",
     });
-    const getPaneLivenessAsync = vi.fn();
+    const observePane = vi.fn();
     const buildAttachCommands = vi.fn();
     const killPane = vi.fn();
     __setTmuxMultiplexer({
-      getPaneLivenessAsync,
+      observePane,
       getPaneLiveness: vi.fn(),
       buildAttachCommands,
       killPane,
@@ -1332,7 +1329,7 @@ describe("interactive supervisor", () => {
 
     expect(rendered).not.toContain("agent-unsupported");
     expect(await harness.nodeFiles()).toEqual(["unsupported.json"]);
-    expect(getPaneLivenessAsync).not.toHaveBeenCalled();
+    expect(observePane).not.toHaveBeenCalled();
     expect(buildAttachCommands).not.toHaveBeenCalled();
     expect(killPane).not.toHaveBeenCalled();
   });
@@ -1342,9 +1339,9 @@ describe("interactive supervisor", () => {
     await harness.writeNode("alive", { paneId: "%alive" });
     await harness.writeNode("zombie", { paneId: "%zombie" });
     __setTmuxMultiplexer({
-      getPaneLivenessAsync: async (paneId: string) =>
-        paneId === "%alive" ? "alive" : "dead",
-      getPaneLiveness: () => "alive",
+      observePane: async (paneId: string) =>
+        paneId === "%alive" ? { kind: "alive" } : { kind: "dead" },
+      getPaneLiveness: () => ({ kind: "alive" }),
       buildAttachCommands: ({ paneId }: { paneId: string }) => {
         if (paneId === "%zombie") {
           throw new Error("[tmux] display-message failed: can't find pane");
@@ -1374,8 +1371,8 @@ describe("interactive supervisor", () => {
     });
     await harness.writeBroken("broken");
     __setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
-      getPaneLiveness: () => "alive",
+      observePane: async () => ({ kind: "alive" }),
+      getPaneLiveness: () => ({ kind: "alive" }),
       buildAttachCommands: () => ({
         attachCommand: "tmux attach -t x",
         focusCommand: "tmux select-window -t x",
@@ -1449,8 +1446,8 @@ describe("interactive supervisor", () => {
     });
     const killed: string[] = [];
     __setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
-      getPaneLiveness: () => "alive",
+      observePane: async () => ({ kind: "alive" }),
+      getPaneLiveness: () => ({ kind: "alive" }),
       killPane: (paneId: string) => killed.push(paneId),
       buildAttachCommands: () => ({
         attachCommand: "tmux attach -t x",

--- a/tests/interactive-tmux.test.ts
+++ b/tests/interactive-tmux.test.ts
@@ -655,7 +655,19 @@ describe("interactive-tmux", () => {
   it("pruneDeadInteractiveSubagents uses the incremental lifecycle fold", async () => {
     process.env.PI_CODING_AGENT_SESSION_DIR = makeTmp();
     process.env.TMUX = makeArgs().TMUX;
-    installMockExec(() => "");
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        const message = `can't find pane: ${MOCK_PANE_ID}`;
+        callback(new Error(message), "", message);
+      },
+    }));
 
     const mod = await importFresh<typeof import("../src/interactive-tmux")>(
       "../src/interactive-tmux",
@@ -688,7 +700,7 @@ describe("interactive-tmux", () => {
           },
         };
       mod.interactiveSubagentRegistry.set(state.id, state);
-      mod.pruneDeadInteractiveSubagents();
+      await mod.pruneDeadInteractiveSubagents();
       expect(state.status).toBe("exited");
       expect(state.exitCode).toBe(0);
     }
@@ -715,7 +727,7 @@ describe("interactive-tmux", () => {
           lifecycle: { parentCancelled: true },
         };
       mod.interactiveSubagentRegistry.set(state.id, state);
-      mod.pruneDeadInteractiveSubagents();
+      await mod.pruneDeadInteractiveSubagents();
       expect(state.status).toBe("cancelled");
     }
   });

--- a/tests/multiplexer-tmux.test.ts
+++ b/tests/multiplexer-tmux.test.ts
@@ -534,10 +534,10 @@ describe("multiplexer-tmux", () => {
   });
 
   /* ------------------------------------------------------------------ */
-  /*  getPaneLiveness                                                   */
+  /*  pane liveness                                                      */
   /* ------------------------------------------------------------------ */
 
-  it("returns alive when a successful pane listing contains the pane", async () => {
+  it("reports a pane present in a complete synchronous listing as alive", async () => {
     installMockExec((args) => {
       if (args[0] === "list-panes") return "%1\n%42\n";
       return "";
@@ -545,10 +545,10 @@ describe("multiplexer-tmux", () => {
     const { TmuxMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-tmux")
     >("../src/multiplexer-tmux");
-    expect(new TmuxMultiplexer().getPaneLiveness("%42")).toBe("alive");
+    expect(new TmuxMultiplexer().isPaneAlive("%42")).toBe(true);
   });
 
-  it("returns dead when a successful pane listing omits the pane", async () => {
+  it("returns false when a synchronous listing omits the pane", async () => {
     installMockExec((args) => {
       if (args[0] === "list-panes") return "%1\n%2\n";
       return "";
@@ -556,50 +556,34 @@ describe("multiplexer-tmux", () => {
     const { TmuxMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-tmux")
     >("../src/multiplexer-tmux");
-    expect(new TmuxMultiplexer().getPaneLiveness("%99")).toBe("dead");
+    expect(new TmuxMultiplexer().isPaneAlive("%99")).toBe(false);
   });
 
-  it("returns unknown when sync or async pane listing fails", async () => {
+  it("returns false when a synchronous listing fails or is malformed", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync: () => {
         throw new Error("server unavailable");
       },
-      execFile: (
-        _file: string,
-        _args: string[],
-        _options: object,
-        callback: (error: Error | null, stdout: string) => void,
-      ) => callback(new Error("server unavailable"), ""),
     }));
     const { TmuxMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-tmux")
     >("../src/multiplexer-tmux");
-    const mux = new TmuxMultiplexer();
-    expect(mux.getPaneLiveness("%99")).toBe("unknown");
-    await expect(mux.getPaneLivenessAsync("%99")).resolves.toBe("unknown");
-  });
+    expect(new TmuxMultiplexer().isPaneAlive("%99")).toBe(false);
 
-  it("returns unknown for malformed pane-listing output", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync: () => "not-a-pane\n",
-      execFile: (
-        _file: string,
-        _args: string[],
-        _options: object,
-        callback: (error: Error | null, stdout: string) => void,
-      ) => callback(null, "not-a-pane\n"),
     }));
-    const { TmuxMultiplexer } = await importFresh<
+    const malformedModule = await importFresh<
       typeof import("../src/multiplexer-tmux")
     >("../src/multiplexer-tmux");
-    const mux = new TmuxMultiplexer();
-    expect(mux.getPaneLiveness("%42")).toBe("unknown");
-    await expect(mux.getPaneLivenessAsync("%42")).resolves.toBe("unknown");
+    expect(new malformedModule.TmuxMultiplexer().isPaneAlive("%42")).toBe(
+      false,
+    );
   });
 
-  it("getPaneLivenessAsync lists panes without using execFileSync", async () => {
+  it("observePane uses execFile rather than execFileSync", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync: () => {
@@ -610,20 +594,20 @@ describe("multiplexer-tmux", () => {
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout: string) => void,
-      ) => callback(null, "%1\n%42\n"),
+      ) => callback(null, "%42\n"),
     }));
     const { TmuxMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-tmux")
     >("../src/multiplexer-tmux");
-    await expect(
-      new TmuxMultiplexer().getPaneLivenessAsync("%42"),
-    ).resolves.toBe("alive");
+    await expect(new TmuxMultiplexer().observePane("%42")).resolves.toEqual({
+      kind: "alive",
+    });
   });
 
-  it("treats a successful blank listing as dead", async () => {
+  it("observePane treats successful blank output as confirmed dead", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => "\n",
+      execFileSync: () => "",
       execFile: (
         _file: string,
         _args: string[],
@@ -634,13 +618,81 @@ describe("multiplexer-tmux", () => {
     const { TmuxMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-tmux")
     >("../src/multiplexer-tmux");
-    const mux = new TmuxMultiplexer();
-
-    expect(mux.getPaneLiveness("%99")).toBe("dead");
-    await expect(mux.getPaneLivenessAsync("%99")).resolves.toBe("dead");
+    await expect(new TmuxMultiplexer().observePane("%99")).resolves.toEqual({
+      kind: "dead",
+    });
   });
 
-  it("lists all panes with stable pane-id output", async () => {
+  it("observePane distinguishes backend unavailability from confirmed death", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: NodeJS.ErrnoException | null, stdout: string) => void,
+      ) => {
+        const error = new Error("spawn tmux ENOENT") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        callback(error, "");
+      },
+    }));
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+
+    const unavailable = await new TmuxMultiplexer().observePane("%42");
+    expect(unavailable.kind).toBe("unavailable");
+    if (unavailable.kind !== "unavailable") return;
+    expect(unavailable.reason).toBeTypeOf("string");
+  });
+
+  it("observePane reports invalid, mismatched, and unclassified results as unknown", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(null, "%7\n"),
+    }));
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    await expect(
+      new TmuxMultiplexer().observePane("42"),
+    ).resolves.toMatchObject({
+      kind: "unknown",
+    });
+    await expect(
+      new TmuxMultiplexer().observePane("%42"),
+    ).resolves.toMatchObject({
+      kind: "unknown",
+    });
+
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(new Error("backend refused request"), ""),
+    }));
+    const failedModule = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const unknown = await new failedModule.TmuxMultiplexer().observePane("%42");
+    expect(unknown.kind).toBe("unknown");
+    if (unknown.kind !== "unknown") return;
+    expect(unknown.reason).toBeTypeOf("string");
+  });
+
+  it("lists all panes with stable pane-id output for the synchronous probe", async () => {
     const calls: string[][] = [];
     installMockExec((args) => {
       calls.push(args);
@@ -650,7 +702,7 @@ describe("multiplexer-tmux", () => {
     const { TmuxMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-tmux")
     >("../src/multiplexer-tmux");
-    new TmuxMultiplexer().getPaneLiveness("%42");
+    new TmuxMultiplexer().isPaneAlive("%42");
 
     expect(calls.find((args) => args[0] === "list-panes")).toEqual([
       "list-panes",

--- a/tests/multiplexer-zellij.test.ts
+++ b/tests/multiplexer-zellij.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as MultiplexerZellijModule from "../src/multiplexer-zellij";
 import { importFresh } from "./test-utils";
 
 /** Standard zellij pane id returned by mocks. Zellij uses bare integers. */
@@ -316,10 +317,10 @@ describe("multiplexer-zellij", () => {
   });
 
   /* ------------------------------------------------------------------ */
-  /*  getPaneLiveness                                                   */
+  /*  pane liveness                                                      */
   /* ------------------------------------------------------------------ */
 
-  it("returns alive when a successful pane listing contains the pane", async () => {
+  it("reports a terminal pane present in a complete synchronous listing as alive", async () => {
     installMockExec((_file, args) => {
       if (args.includes("list-panes")) {
         return JSON.stringify([{ id: 1 }, { id: 42 }, { id: 3 }]);
@@ -329,10 +330,10 @@ describe("multiplexer-zellij", () => {
     const { ZellijMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-zellij")
     >("../src/multiplexer-zellij");
-    expect(new ZellijMultiplexer().getPaneLiveness("42")).toBe("alive");
+    expect(new ZellijMultiplexer().isPaneAlive("42")).toBe(true);
   });
 
-  it("returns dead when a successful pane listing omits the pane", async () => {
+  it("returns false when the synchronous listing omits the pane", async () => {
     installMockExec((_file, args) => {
       if (args.includes("list-panes")) {
         return JSON.stringify([{ id: 1 }, { id: 2 }]);
@@ -342,50 +343,34 @@ describe("multiplexer-zellij", () => {
     const { ZellijMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-zellij")
     >("../src/multiplexer-zellij");
-    expect(new ZellijMultiplexer().getPaneLiveness("99")).toBe("dead");
+    expect(new ZellijMultiplexer().isPaneAlive("99")).toBe(false);
   });
 
-  it("returns unknown when sync or async pane listing fails", async () => {
+  it("returns false when a synchronous listing fails or is malformed", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync: () => {
         throw new Error("server unavailable");
       },
-      execFile: (
-        _file: string,
-        _args: string[],
-        _options: object,
-        callback: (error: Error | null, stdout: string) => void,
-      ) => callback(new Error("server unavailable"), ""),
     }));
     const { ZellijMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-zellij")
     >("../src/multiplexer-zellij");
-    const mux = new ZellijMultiplexer();
-    expect(mux.getPaneLiveness("42")).toBe("unknown");
-    await expect(mux.getPaneLivenessAsync("42")).resolves.toBe("unknown");
-  });
+    expect(new ZellijMultiplexer().isPaneAlive("42")).toBe(false);
 
-  it("returns unknown for malformed pane-listing output", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync: () => "{}",
-      execFile: (
-        _file: string,
-        _args: string[],
-        _options: object,
-        callback: (error: Error | null, stdout: string) => void,
-      ) => callback(null, JSON.stringify([{ is_plugin: false }])),
     }));
-    const { ZellijMultiplexer } = await importFresh<
-      typeof import("../src/multiplexer-zellij")
-    >("../src/multiplexer-zellij");
-    const mux = new ZellijMultiplexer();
-    expect(mux.getPaneLiveness("42")).toBe("unknown");
-    await expect(mux.getPaneLivenessAsync("42")).resolves.toBe("unknown");
+    const malformedModule = await importFresh<typeof MultiplexerZellijModule>(
+      "../src/multiplexer-zellij",
+    );
+    expect(new malformedModule.ZellijMultiplexer().isPaneAlive("42")).toBe(
+      false,
+    );
   });
 
-  it("getPaneLivenessAsync lists panes without using execFileSync", async () => {
+  it("observePane uses execFile rather than execFileSync", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync: () => {
@@ -401,9 +386,168 @@ describe("multiplexer-zellij", () => {
     const { ZellijMultiplexer } = await importFresh<
       typeof import("../src/multiplexer-zellij")
     >("../src/multiplexer-zellij");
+    await expect(new ZellijMultiplexer().observePane("42")).resolves.toEqual({
+      kind: "alive",
+    });
+  });
+
+  it("observePane distinguishes backend unavailability from confirmed death", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: NodeJS.ErrnoException | null, stdout: string) => void,
+      ) => {
+        const error = new Error("spawn zellij ENOENT") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        callback(error, "");
+      },
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+
+    const unavailable = await new ZellijMultiplexer().observePane("42");
+    expect(unavailable.kind).toBe("unavailable");
+    if (unavailable.kind !== "unavailable") return;
+    expect(unavailable.reason).toBeTypeOf("string");
+  });
+
+  it("observePane reports malformed JSON as explicitly unknown", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(null, "{not-json"),
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+
+    const unknown = await new ZellijMultiplexer().observePane("42");
+    expect(unknown.kind).toBe("unknown");
+    if (unknown.kind !== "unknown") return;
+    expect(unknown.reason).toBeTypeOf("string");
+  });
+
+  it.each([
+    ["a non-array listing", { id: 42 }],
+    ["a non-object row", [null]],
+    ["a record without an id", [{ name: "pane" }]],
+    ["an empty pane id", [{ id: "" }]],
+    ["a prefixed pane id", [{ id: "terminal_7" }]],
+    ["a leading-zero pane id", [{ id: "07" }]],
+    ["a fractional pane id", [{ id: 4.2 }]],
+    ["an unsafe pane id", [{ id: Number.MAX_SAFE_INTEGER + 1 }]],
+    ["a record with non-boolean plugin kind", [{ id: 42, is_plugin: 0 }]],
+    ["a record with non-boolean exited", [{ id: 42, exited: "yes" }]],
+    [
+      "a valid target before a malformed record",
+      [{ id: 42, exited: true }, { id: "bad" }],
+    ],
+    ["duplicate non-target terminal ids", [{ id: 7 }, { id: "7" }]],
+    [
+      "duplicate plugin ids",
+      [
+        { id: 7, is_plugin: true },
+        { id: "7", is_plugin: true },
+      ],
+    ],
+  ] as const)("observePane reports %s as unknown", async (_name, records) => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(null, JSON.stringify(records)),
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof MultiplexerZellijModule
+    >("../src/multiplexer-zellij");
+
+    const unknown = await new ZellijMultiplexer().observePane("42");
+    expect(unknown.kind).toBe("unknown");
+    if (unknown.kind !== "unknown") return;
+    expect(unknown.reason).toBeTypeOf("string");
+  });
+
+  it("validates the complete listing before accepting a matching target", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(null, JSON.stringify([{ id: 42 }, { id: "bad" }])),
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof MultiplexerZellijModule
+    >("../src/multiplexer-zellij");
     await expect(
-      new ZellijMultiplexer().getPaneLivenessAsync("42"),
-    ).resolves.toBe("alive");
+      new ZellijMultiplexer().observePane("42"),
+    ).resolves.toMatchObject({ kind: "unknown" });
+  });
+
+  it("allows terminal and plugin rows to share an id without treating them as duplicates", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) =>
+        callback(
+          null,
+          JSON.stringify([
+            { id: 42, is_plugin: true },
+            { id: 42, is_plugin: false },
+          ]),
+        ),
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof MultiplexerZellijModule
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+    await expect(mux.observePane("terminal_42")).resolves.toEqual({
+      kind: "alive",
+    });
+    await expect(mux.observePane("plugin_42")).resolves.toEqual({
+      kind: "alive",
+    });
+  });
+
+  it("observePane treats an absent pane in valid output as confirmed dead", async () => {
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: () => "",
+      execFile: (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => callback(null, JSON.stringify([{ id: 7 }])),
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof MultiplexerZellijModule
+    >("../src/multiplexer-zellij");
+
+    await expect(new ZellijMultiplexer().observePane("42")).resolves.toEqual({
+      kind: "dead",
+    });
   });
 
   /* ------------------------------------------------------------------ */
@@ -948,12 +1092,11 @@ describe("multiplexer-zellij", () => {
   /*  plugin_<n> prefix normalization                                    */
   /* ------------------------------------------------------------------ */
 
-  it("normalizes plugin_<n> prefix symmetrically with terminal_<n>", async () => {
+  it("preserves the plugin_<n> namespace while normalizing its numeric id", async () => {
     process.env.ZELLIJ = "0";
     installMockExec((_f, args) => {
       if (args.includes("list-panes")) {
-        // list-panes --json returns bare integer ids, never plugin_ prefix
-        return JSON.stringify([{ id: 42 }]);
+        return JSON.stringify([{ id: 42, is_plugin: true }]);
       }
       return "";
     });
@@ -962,7 +1105,7 @@ describe("multiplexer-zellij", () => {
       typeof import("../src/multiplexer-zellij")
     >("../src/multiplexer-zellij");
     const mux = new ZellijMultiplexer();
-    // plugin_42 should normalize to bare integer 42 for list-panes lookup
+    // The prefix selects the plugin namespace while the backend receives id 42.
     expect(mux.getPaneLiveness("plugin_42")).toBe("alive");
     // Non-existent pane is absent from a successful listing.
     expect(mux.getPaneLiveness("plugin_99")).toBe("dead");
@@ -994,7 +1137,7 @@ describe("multiplexer-zellij", () => {
     >("../src/multiplexer-zellij");
     const mux = new ZellijMultiplexer();
     expect(mux.getPaneLiveness("0")).toBe("dead");
-    await expect(mux.getPaneLivenessAsync("0")).resolves.toBe("dead");
+    await expect(mux.observePane("0")).resolves.toEqual({ kind: "dead" });
   });
 
   it("reports alive when a terminal row accompanies a colliding plugin row", async () => {

--- a/tests/pi-session-delivery.integration.test.ts
+++ b/tests/pi-session-delivery.integration.test.ts
@@ -71,7 +71,7 @@ async function setup(mode: "notify" | "inject", triggerTurn: boolean) {
   pi.sendMessage = sendMessage;
   __setTmuxMultiplexer({
     getPaneLiveness: () => "alive",
-    getPaneLivenessAsync: async () => "alive",
+    observePane: async () => ({ kind: "alive" }),
   } as any);
   const art = artifactPath(repoRoot, "session-harness");
   const state: any = {
@@ -441,7 +441,7 @@ describe("Pi session delivery integration", () => {
     };
     interactiveSubagentRegistry.set(state.id, state);
     __setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async () => ({ kind: "alive" }),
       getPaneLiveness: () => "alive",
     } as any);
     writeOutput(art, "immutable artifact result");

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -568,7 +568,7 @@ describe("session handler lifecycle callbacks", () => {
     interactiveSubagentRegistry.set(parentState.id, parentState);
     interactiveSubagentRegistry.set(childState.id, childState);
     __setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async () => ({ kind: "alive" }),
     } as any);
 
     await vi.advanceTimersByTimeAsync(5000);

--- a/tests/subagent-auto-done.test.ts
+++ b/tests/subagent-auto-done.test.ts
@@ -105,7 +105,8 @@ describe("no parent-side timeout completion synthesis", () => {
   let root: string;
 
   beforeEach(() => {
-    // A successful pane listing containing %99 keeps the synthetic child live.
+    // The poller now uses the asynchronous observePane contract. Return the
+    // pane id exactly as tmux does so the synthetic %99 pane is observed alive.
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
       execFileSync: () => Buffer.from("%99\n"),
@@ -113,8 +114,8 @@ describe("no parent-side timeout completion synthesis", () => {
         _file: string,
         _args: string[],
         _options: object,
-        callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "%99\n"),
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => callback(null, "%99", ""),
     }));
     root = makeTmp();
     const g = globalThis as any;

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -26,6 +26,9 @@ import {
   readEventRecords,
   writeOutput,
 } from "../src/artifact";
+import type { PaneLiveness } from "../src/interactive-state";
+import type { Multiplexer } from "../src/multiplexer";
+import type * as SubagentModule from "../src/subagent";
 import { importFresh } from "./test-utils";
 import {
   advanceSessionContextGeneration,
@@ -35,6 +38,16 @@ import {
 } from "../src/session-context";
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
+}
+
+function missingTmuxPaneError(paneId = "%99"): Error & {
+  readonly code: number;
+  readonly stderr: string;
+} {
+  return Object.assign(new Error(`can't find pane: ${paneId}`), {
+    code: 1,
+    stderr: `can't find pane: ${paneId}`,
+  });
 }
 
 function makeState(): {
@@ -134,10 +147,10 @@ describe("pollArtifactChanges", () => {
       releaseLiveness = resolve;
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => {
+      observePane: async (): Promise<PaneLiveness> => {
         livenessStarted = true;
         await blockedLiveness;
-        return "alive";
+        return { kind: "alive" };
       },
     } as any);
 
@@ -202,8 +215,8 @@ describe("pollArtifactChanges", () => {
       sendMessage: wrongSendMessage,
     };
     multiplexer.__setTmuxMultiplexer({
-      getPaneLiveness: () => "alive",
-      getPaneLivenessAsync: async () => "alive",
+      isPaneAlive: () => true,
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
     } as any);
     await mod.pollArtifactChanges(
       { sendMessage: wrongSendMessage } as any,
@@ -252,10 +265,10 @@ describe("pollArtifactChanges", () => {
       releaseA = resolve;
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: (paneId: string) =>
+      observePane: (paneId: string): Promise<PaneLiveness> =>
         paneId === "%a"
-          ? blockedA.then(() => "alive" as const)
-          : Promise.resolve("alive" as const),
+          ? blockedA.then(() => ({ kind: "alive" as const }))
+          : Promise.resolve({ kind: "alive" as const }),
     } as any);
 
     const pollA = mod.pollArtifactChanges({} as any, ownerA);
@@ -297,7 +310,7 @@ describe("pollArtifactChanges", () => {
       sessionManager: { getSessionId: () => "session-b" },
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
     } as any);
 
     await mod.pollArtifactChanges({} as any, ownerA);
@@ -349,7 +362,7 @@ describe("pollArtifactChanges", () => {
       sessionManager: { getSessionId: () => "session-b" },
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
     } as any);
 
     await mod.pollArtifactChanges({} as any, ownerA);
@@ -388,7 +401,7 @@ describe("pollArtifactChanges", () => {
     });
     (globalThis as any).__piSubagenturaUi = ui;
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
     } as any);
 
     await mod.pollArtifactChanges({} as any);
@@ -438,7 +451,7 @@ describe("pollArtifactChanges", () => {
     });
     (globalThis as any).__piSubagenturaUi = ui;
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
     } as any);
 
     await mod.pollArtifactChanges({} as any);
@@ -485,7 +498,7 @@ describe("pollArtifactChanges", () => {
     mod.interactiveSubagentRegistry.set(item.id, item.state);
     (globalThis as any).__piSubagenturaUi = ui;
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
     } as any);
 
     await mod.pollArtifactChanges({} as any);
@@ -537,11 +550,11 @@ describe("pollArtifactChanges", () => {
     const blocked = new Promise<void>((resolve) => {
       releaseLiveness = resolve;
     });
-    const getPaneLivenessAsync = vi.fn(async () => {
+    const observePane = vi.fn(async (): Promise<PaneLiveness> => {
       await blocked;
-      return "alive";
+      return { kind: "alive" };
     });
-    multiplexer.__setTmuxMultiplexer({ getPaneLivenessAsync } as any);
+    multiplexer.__setTmuxMultiplexer({ observePane } as any);
 
     const first = mod.pollArtifactChanges({} as any, owner);
     await Promise.resolve();
@@ -549,17 +562,17 @@ describe("pollArtifactChanges", () => {
 
     // The second tick joins the in-flight poll instead of starting a second
     // pass that would race on the shared eventByteCursor / delivery queue.
-    expect(getPaneLivenessAsync).toHaveBeenCalledTimes(1);
+    expect(observePane).toHaveBeenCalledTimes(1);
     releaseLiveness();
     await Promise.all([first, second]);
 
-    expect(getPaneLivenessAsync).toHaveBeenCalledTimes(1);
+    expect(observePane).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(item.state.pendingDeliveries ?? []).toHaveLength(1);
 
     // Once the in-flight poll settles the key is released, so a later tick runs.
     await mod.pollArtifactChanges({} as any, owner);
-    expect(getPaneLivenessAsync).toHaveBeenCalledTimes(2);
+    expect(observePane).toHaveBeenCalledTimes(2);
     // The completion cursor already advanced, so the second pass adds no new
     // delivery intent for the same turn.
     expect(item.state.pendingDeliveries ?? []).toHaveLength(1);
@@ -576,7 +589,7 @@ describe("pollArtifactChanges", () => {
     mod.interactiveSubagentRegistry.set(item.id, item.state);
     installDeliverySpies();
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "unknown",
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "unknown" }),
     } as never);
 
     await mod.pollArtifactChanges({} as never);
@@ -616,7 +629,7 @@ describe("pollArtifactChanges", () => {
     }
     (globalThis as any).__piSubagenturaUi = ui;
     multiplexer.__setTmuxMultiplexer({
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
     } as any);
 
     await mod.pollArtifactChanges({} as any);
@@ -688,17 +701,17 @@ describe("pollArtifactChanges", () => {
     const multiplexer = await import("../src/multiplexer");
     const { state, artifactDir } = makeState();
     mkdirSync(artifactDir, { recursive: true });
-    let resolveProbe!: (liveness: "alive") => void;
+    let resolveProbe!: (liveness: PaneLiveness) => void;
     let probeStarted = false;
     let settled = false;
-    const probe = new Promise<"alive">((resolve) => {
+    const probe = new Promise<PaneLiveness>((resolve) => {
       resolveProbe = resolve;
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLiveness: () => {
+      isPaneAlive: () => {
         throw new Error("sync liveness probe must not run");
       },
-      getPaneLivenessAsync: () => {
+      observePane: (): Promise<PaneLiveness> => {
         probeStarted = true;
         return probe;
       },
@@ -720,7 +733,7 @@ describe("pollArtifactChanges", () => {
     });
     expect(timerRan).toBe(true);
     expect(settled).toBe(false);
-    resolveProbe("alive");
+    resolveProbe({ kind: "alive" });
     await polling;
     expect(settled).toBe(true);
     multiplexer.__setTmuxMultiplexer(undefined);
@@ -738,22 +751,22 @@ describe("pollArtifactChanges", () => {
       status: "done",
       exitCode: 0,
     });
-    let resolveProbe!: (liveness: "alive") => void;
-    const probe = new Promise<"alive">((resolve) => {
+    let resolveProbe!: (liveness: PaneLiveness) => void;
+    const probe = new Promise<PaneLiveness>((resolve) => {
       resolveProbe = resolve;
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLiveness: () => {
+      isPaneAlive: () => {
         throw new Error("sync liveness probe must not run");
       },
-      getPaneLivenessAsync: () => probe,
+      observePane: (): Promise<PaneLiveness> => probe,
     } as any);
     mod.interactiveSubagentRegistry.set(state.id, state);
     const sendMessage = vi.fn();
     const polling = mod.pollArtifactChanges({ sendMessage } as any);
     await Promise.resolve();
     mod.interactiveSubagentRegistry.clear();
-    resolveProbe("alive");
+    resolveProbe({ kind: "alive" });
     await polling;
     expect(state.eventByteCursor).toBeUndefined();
     expect(sendMessage).not.toHaveBeenCalled();
@@ -767,15 +780,15 @@ describe("pollArtifactChanges", () => {
     const { state, artifactDir } = makeState();
     mkdirSync(artifactDir, { recursive: true });
     let probeCalls = 0;
-    let resolveProbe!: (liveness: "alive") => void;
-    const probe = new Promise<"alive">((resolve) => {
+    let resolveProbe!: (liveness: PaneLiveness) => void;
+    const probe = new Promise<PaneLiveness>((resolve) => {
       resolveProbe = resolve;
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLiveness: () => {
+      isPaneAlive: () => {
         throw new Error("sync liveness probe must not run");
       },
-      getPaneLivenessAsync: () => {
+      observePane: (): Promise<PaneLiveness> => {
         probeCalls++;
         return probe;
       },
@@ -785,7 +798,7 @@ describe("pollArtifactChanges", () => {
     const second = mod.pollArtifactChanges({ sendMessage: vi.fn() } as any);
     await Promise.resolve();
     expect(probeCalls).toBe(1);
-    resolveProbe("alive");
+    resolveProbe({ kind: "alive" });
     await Promise.all([first, second]);
     multiplexer.__setTmuxMultiplexer(undefined);
   });
@@ -892,7 +905,8 @@ describe("pollArtifactChanges", () => {
       parentSessionId: "pi",
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLiveness: () => "unknown",
+      isPaneAlive: () => true,
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
       killPane: () => {
         completionsAtKill = readFileSync(
           join(artifactDir, "events.ndjson"),
@@ -946,7 +960,7 @@ describe("pollArtifactChanges", () => {
       source: "explicit",
     });
     multiplexer.__setTmuxMultiplexer({
-      getPaneLiveness: () => "alive",
+      isPaneAlive: () => true,
       killPane: vi.fn(),
     } as any);
     interactive.interactiveSubagentRegistry.set(state.id, state);
@@ -1093,13 +1107,16 @@ describe("pollArtifactChanges", () => {
     // Return a successful pane listing containing the tracked pane.
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => Buffer.from("%99\n"),
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("%99");
+        return "";
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "%99\n"),
+      ) => callback(null, "%99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1119,13 +1136,15 @@ describe("pollArtifactChanges", () => {
     // A successful listing without the pane is confirmed dead.
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => "",
+      execFileSync: () => {
+        throw missingTmuxPaneError();
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, ""),
+      ) => callback(missingTmuxPaneError(), ""),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1170,10 +1189,13 @@ describe("pollArtifactChanges", () => {
     vi.resetModules();
     let paneProbeCount = 0;
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => {
-        paneProbeCount++;
-        if (paneProbeCount === 1) {
-          throw new Error("pane not ready yet");
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") {
+          paneProbeCount++;
+          if (paneProbeCount === 1) {
+            throw new Error("pane not ready yet");
+          }
+          return Buffer.from("%99");
         }
         return Buffer.from("%99\n");
       },
@@ -1186,7 +1208,7 @@ describe("pollArtifactChanges", () => {
         paneProbeCount++;
         callback(
           paneProbeCount === 1 ? new Error("pane not ready yet") : null,
-          "%99\n",
+          "%99",
         );
       },
     }));
@@ -1213,13 +1235,16 @@ describe("pollArtifactChanges", () => {
     // it so a second `done` event (from a follow-up turn) re-fires the pointer notification.
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => Buffer.from("%99\n"),
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("%99");
+        return "";
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "%99\n"),
+      ) => callback(null, "%99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1298,8 +1323,8 @@ describe("pollArtifactChanges", () => {
       });
       mod.interactiveSubagentRegistry.set(state.id, state);
       multiplexer.__setTmuxMultiplexer({
-        getPaneLiveness: () => "alive",
-        getPaneLivenessAsync: async () => "alive",
+        isPaneAlive: () => true,
+        observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
       } as any);
       const art = artifactPath(join(artifactDir, ".."), state.id);
       const raw =
@@ -1474,13 +1499,16 @@ describe("pollArtifactChanges", () => {
     it("dispatches pointer-only envelopes for legacy follow-up completions", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => Buffer.from("%99\n"),
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "display-message") return Buffer.from("%99");
+          return "";
+        },
         execFile: (
           _file: string,
           _args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, "%99\n"),
+        ) => callback(null, "%99"),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1539,13 +1567,16 @@ describe("pollArtifactChanges", () => {
     it("does not snapshot mutable output.md for legacy completions", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => Buffer.from("%99\n"),
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "display-message") return Buffer.from("%99");
+          return "";
+        },
         execFile: (
           _file: string,
           _args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, "%99\n"),
+        ) => callback(null, "%99"),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1580,13 +1611,16 @@ describe("pollArtifactChanges", () => {
     it("does not snapshot legacy output when notifyOnComplete is unset", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => Buffer.from("%99\n"),
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "display-message") return Buffer.from("%99");
+          return "";
+        },
         execFile: (
           _file: string,
           _args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, "%99\n"),
+        ) => callback(null, "%99"),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1609,13 +1643,16 @@ describe("pollArtifactChanges", () => {
     it("never creates legacy snapshots while mutable output changes", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => Buffer.from("%99\n"),
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "display-message") return Buffer.from("%99");
+          return "";
+        },
         execFile: (
           _file: string,
           _args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, "%99\n"),
+        ) => callback(null, "%99"),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1668,13 +1705,26 @@ describe("pollArtifactChanges", () => {
       // the third is conclusively absent.
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => Buffer.from("%90\n%91\n"),
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "display-message") {
+            const paneId = args[3];
+            if (paneId === "%92") {
+              throw missingTmuxPaneError("%92");
+            }
+            return Buffer.from(paneId ?? "");
+          }
+          return "";
+        },
         execFile: (
           _file: string,
-          _args: string[],
+          args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, "%90\n%91\n"),
+        ) =>
+          callback(
+            args[3] === "%92" ? missingTmuxPaneError("%92") : null,
+            args[3],
+          ),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1749,20 +1799,24 @@ describe("pollArtifactChanges", () => {
     it("AC-B1b: rehydrates a completed live pane as idle and ready", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => Buffer.from("%99\n"),
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "display-message") return Buffer.from("%99");
+          return "";
+        },
         execFile: (
           _file: string,
           _args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, "%99\n"),
+        ) => callback(null, "%99"),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
       const multiplexer = await import("../src/multiplexer");
       multiplexer.__setTmuxMultiplexer({
-        getPaneLiveness: () => "alive",
-        getPaneLivenessAsync: async () => "alive",
+        isAvailable: () => true,
+        isPaneAlive: () => true,
+        observePane: async (): Promise<PaneLiveness> => ({ kind: "alive" }),
       } as any);
       const cwd = makeTmp();
       const id = "rehydrated-idle";
@@ -1821,13 +1875,16 @@ describe("pollArtifactChanges", () => {
     it("AC-B2: clears footer and widget when all sub-agents are exited", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => "",
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "-lc") return Buffer.from("");
+          throw missingTmuxPaneError();
+        },
         execFile: (
           _file: string,
           _args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, ""),
+        ) => callback(missingTmuxPaneError(), ""),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1873,13 +1930,16 @@ describe("pollArtifactChanges", () => {
     it("AC-B3: combines interactive and in-process footer counts", async () => {
       vi.resetModules();
       vi.doMock("node:child_process", () => ({
-        execFileSync: () => Buffer.from("%99\n"),
+        execFileSync: (_file: string, args: string[]) => {
+          if (args[0] === "display-message") return Buffer.from("%99");
+          return "";
+        },
         execFile: (
           _file: string,
           _args: string[],
           _options: object,
           callback: (error: Error | null, stdout?: string) => void,
-        ) => callback(null, "%99\n"),
+        ) => callback(null, "%99"),
       }));
       const mod =
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -1987,13 +2047,15 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
   it("keeps terminal state until the custom-message receipt is visible", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => "",
+      execFileSync: () => {
+        throw missingTmuxPaneError();
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, ""),
+      ) => callback(missingTmuxPaneError(), ""),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -2016,13 +2078,15 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
   it("reconciles same-session inject receipt before terminal cleanup", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => "",
+      execFileSync: () => {
+        throw missingTmuxPaneError();
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, ""),
+      ) => callback(missingTmuxPaneError(), ""),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -2048,13 +2112,16 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
   it("keeps the state.json entry after delivering a done event when the pane is alive", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => Buffer.from("%99\n"),
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("%99");
+        return "";
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "%99\n"),
+      ) => callback(null, "%99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -2074,13 +2141,16 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
   it("keeps a live pane idle after a v2 error completion", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => Buffer.from("%99\n"),
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("%99");
+        return "";
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "%99\n"),
+      ) => callback(null, "%99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -2109,13 +2179,16 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
   it("removes state after process_exited even if pane liveness reports true", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({
-      execFileSync: () => Buffer.from("%99\n"),
+      execFileSync: (_file: string, args: string[]) => {
+        if (args[0] === "display-message") return Buffer.from("%99");
+        return "";
+      },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "%99\n"),
+      ) => callback(null, "%99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -2182,6 +2255,91 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
     ]);
   });
 
+  it("persists confirmed pane death before a later reload", async () => {
+    const mod = await importFresh<typeof SubagentModule>("../src/subagent");
+    // importFresh resets the module graph; use its matching mux singleton.
+    const multiplexer = await import("../src/multiplexer");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    multiplexer.__setTmuxMultiplexer({
+      observePane: async (): Promise<PaneLiveness> => ({ kind: "dead" }),
+    } as unknown as Multiplexer);
+
+    await mod.pollArtifactChanges({
+      sendMessage: vi.fn(),
+    } as unknown as Parameters<typeof mod.pollArtifactChanges>[0]);
+
+    expect(state.status).toBe("unknown");
+    expect(loadInteractiveStates(cwd)?.states[id].paneDeathConfirmed).toBe(
+      true,
+    );
+    multiplexer.__setTmuxMultiplexer(undefined);
+  });
+
+  it("retains parent-cancelled state when an in-flight poll observed a live pane", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const interactive = await import("../src/interactive-tmux");
+    const multiplexer = await import("../src/multiplexer");
+    const { cwd, id, state } = makePersistedState();
+    mod.interactiveSubagentRegistry.set(id, state);
+    let resolveObservation!: () => void;
+    let observationStarted = false;
+    const observation = new Promise<void>((resolve) => {
+      resolveObservation = resolve;
+    });
+    multiplexer.__setTmuxMultiplexer({
+      observePane: async (): Promise<PaneLiveness> => {
+        observationStarted = true;
+        await observation;
+        return { kind: "alive" };
+      },
+      isPaneAlive: () => true,
+      killPane: vi.fn(),
+    } as unknown as import("../src/multiplexer").Multiplexer);
+    const pi = {
+      sendMessage: vi.fn(),
+    } as unknown as Parameters<typeof mod.pollArtifactChanges>[0];
+
+    const polling = mod.pollArtifactChanges(pi);
+    await Promise.resolve();
+    expect(observationStarted).toBe(true);
+    interactive.cancelInteractiveSubagent(id);
+    resolveObservation();
+    await polling;
+
+    expect(state.status).toBe("cancelled");
+    expect(mod.interactiveSubagentRegistry.get(id)).toBe(state);
+    expect(loadInteractiveStates(cwd)?.states[id]).toBeDefined();
+    multiplexer.__setTmuxMultiplexer(undefined);
+  });
+
+  it("does not retire cancelled state when pane observation is unavailable", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const { cwd, id, state } = makePersistedState();
+    state.status = "cancelled";
+    mod.interactiveSubagentRegistry.set(id, state);
+    let observation: "unavailable" | "dead" = "unavailable";
+    multiplexer.__setTmuxMultiplexer({
+      observePane: async (): Promise<PaneLiveness> => ({ kind: observation }),
+    } as unknown as import("../src/multiplexer").Multiplexer);
+    const pi = {
+      sendMessage: vi.fn(),
+    } as unknown as Parameters<typeof mod.pollArtifactChanges>[0];
+
+    await mod.pollArtifactChanges(pi);
+
+    expect(mod.interactiveSubagentRegistry.get(id)).toBe(state);
+    expect(loadInteractiveStates(cwd)?.states[id]).toBeDefined();
+
+    observation = "dead";
+    await mod.pollArtifactChanges(pi);
+    expect(loadInteractiveStates(cwd)?.states[id]).toBeUndefined();
+    multiplexer.__setTmuxMultiplexer(undefined);
+  });
+
   it("keeps the state.json entry and cursor when notification delivery fails", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -2219,7 +2377,7 @@ describe("pollArtifactChanges — terminal cleanup of state.json", () => {
         _args: string[],
         _options: object,
         callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "#99"),
+      ) => callback(null, "%99"),
     }));
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");

--- a/tests/subagent-rehydrate-core.test.ts
+++ b/tests/subagent-rehydrate-core.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/artifact";
 import type { InteractiveSubagentState } from "../src/interactive-tmux";
 import { interactiveSubagentRegistry } from "../src/interactive-tmux";
+import type * as SubagentModule from "../src/subagent";
 import { flushDeliveries } from "../src/delivery";
 import { importFresh } from "./test-utils";
 import { makeTmp, makeState } from "./subagent-rehydrate-helpers";
@@ -24,10 +25,16 @@ describe("rehydrateInteractiveSubagents", () => {
   beforeEach(() => {
     cwd = makeTmp();
     vi.resetModules();
+    const alivePaneId = "%alive1";
     vi.doMock("../src/multiplexer", () => ({
       getMux: () => ({
         name: "tmux",
-        getPaneLiveness: () => "dead",
+        isAvailable: () => true,
+        isPaneAlive: (paneId: string) => paneId === alivePaneId,
+        observePane: async (paneId: string) =>
+          paneId === alivePaneId
+            ? ({ kind: "alive" } as const)
+            : ({ kind: "dead" } as const),
         buildAttachCommands: (state: { windowName?: string }) => ({
           attachCommand: `tmux attach -t ${state.windowName ?? "session"}`,
           focusCommand: `tmux select-window -t ${state.windowName ?? "session"}`,
@@ -321,7 +328,7 @@ describe("rehydrateInteractiveSubagents", () => {
     expect(result.terminal).toBe(1);
   });
 
-  it("restores completion status from persisted lifecycle without log replay", async () => {
+  it("preserves an uncertain synchronous pane miss during rehydrate", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const state = makeState(cwd, "abc12345");
@@ -345,18 +352,38 @@ describe("rehydrateInteractiveSubagents", () => {
 
     mod.rehydrateInteractiveSubagents(cwd);
 
-    expect(interactiveSubagentRegistry.get(state.id)?.status).toBe("exited");
+    expect(interactiveSubagentRegistry.get(state.id)?.status).toBe("unknown");
     expect(interactiveSubagentRegistry.get(state.id)?.eventByteCursor).toBe(
       1_000_000,
     );
   });
 
+  it("restores a persisted confirmed pane death despite id reuse", async () => {
+    const mod = await importFresh<typeof SubagentModule>("../src/subagent");
+    const id = "alive1";
+    appendInteractiveState(cwd, {
+      id,
+      paneId: "%alive1",
+      mux: "tmux",
+      artifactDir: join(cwd, id),
+      sessionFile: "/tmp/sess.jsonl",
+      paneDeathConfirmed: true,
+      lifecycle: {
+        completionOutcome: "done",
+        completionSource: "explicit",
+      },
+    });
+
+    mod.rehydrateInteractiveSubagents(cwd);
+
+    expect(interactiveSubagentRegistry.get(id)?.status).toBe("exited");
+  });
+
   it("counts alive vs terminal in the return value", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
-    // Two entries: alive1 (no events, pane not alive → unknown), done1 (done event,
-    // pane not alive → exited). We can predict exact counts here because the test
-    // runs in a tmux environment and isPaneAlive returns false for fake pane IDs.
+    // alive1 is synchronously observed alive. A false compatibility probe for
+    // done1 is uncertain until the async poll can classify the failure.
     const cwdA = cwd;
     const cwdB = cwd;
     for (const id of ["alive1", "done1"]) {
@@ -382,11 +409,10 @@ describe("rehydrateInteractiveSubagents", () => {
     const result = mod.rehydrateInteractiveSubagents(cwdA);
 
     expect(result.total).toBe(2);
-    // alive1 has no events → status=unknown (not counted); done1 has done event → status=exited (terminal)
-    expect(result.alive).toBe(0);
-    expect(result.terminal).toBe(1);
-    expect(interactiveSubagentRegistry.get("alive1")?.status).toBe("unknown");
-    expect(interactiveSubagentRegistry.get("done1")?.status).toBe("exited");
+    expect(result.alive).toBe(1);
+    expect(result.terminal).toBe(0);
+    expect(interactiveSubagentRegistry.get("alive1")?.status).toBe("running");
+    expect(interactiveSubagentRegistry.get("done1")?.status).toBe("unknown");
   });
 
   it("does not throw when ctx.cwd is unreachable (best-effort recovery)", async () => {

--- a/tests/subagent-session-log.test.ts
+++ b/tests/subagent-session-log.test.ts
@@ -65,22 +65,19 @@ describe("session-log tail-read", () => {
     g.__piSubagenturaInteractiveRegistry?.clear?.();
     g.__piSubagenturaPiRef = undefined;
     g.__piSubagenturaUi = undefined;
-    // Force `isTmuxPaneAlive` to return true so the poller's status-decision does not flip our
-    // sub-agent to "unknown" (which would skip it on subsequent polls). The test does not have a
-    // live tmux server, and host tmux behaviour varies — some versions exit 0 for unknown panes,
-    // some exit 1, and on a machine without tmux at all `execFileSync` throws. Mocking here keeps the
-    // suite hermetic and matches the pattern in subagent-poll.test.ts.
+    // The poller uses the asynchronous observePane contract. Return the pane
+    // id exactly as tmux does so the synthetic %99 pane is observed alive.
     vi.doMock("node:child_process", () => ({
       execFileSync: (_file: string, args: string[]) => {
-        if (args[0] === "display-message") return Buffer.from("#99");
+        if (args[0] === "display-message") return Buffer.from("%99");
         return "";
       },
       execFile: (
         _file: string,
         _args: string[],
         _options: object,
-        callback: (error: Error | null, stdout?: string) => void,
-      ) => callback(null, "#99"),
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => callback(null, "%99", ""),
     }));
   });
 

--- a/tests/subagent-shutdown.test.ts
+++ b/tests/subagent-shutdown.test.ts
@@ -133,7 +133,7 @@ describe("session_shutdown handler", () => {
     workflowJobRegistry.clear();
     __setTmuxMultiplexer({
       getPaneLiveness: () => "alive",
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async () => ({ kind: "alive" }),
     } as any);
 
     // Stub the global timers. setInterval returns a fake handle with a
@@ -498,7 +498,7 @@ describe("session_shutdown handler", () => {
     interactiveTmux.interactiveSubagentRegistry.set(running.id, running);
     __setTmuxMultiplexer({
       getPaneLiveness: () => "alive",
-      getPaneLivenessAsync: async () => "alive",
+      observePane: async () => ({ kind: "alive" }),
     } as any);
 
     const ui = {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../src/workflow";
 import { withOrchestrationContext } from "../src/orchestration-context";
 import type { SubagentResult } from "../src/helpers";
+import type { InteractiveSubagentState } from "../src/interactive-tmux";
 import {
   appendCompletionEvent,
   appendEvent,
@@ -113,8 +114,23 @@ function echoRunner(): WorkflowAgentRunner {
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
-function fakeState(dir: string) {
-  return { id: "abcd1234", artifactDir: dir, model: "test/model" } as any;
+function fakeState(dir: string): InteractiveSubagentState {
+  return {
+    id: "abcd1234",
+    name: "workflow-test-agent",
+    task: "test workflow",
+    paneId: "%99",
+    mux: "tmux",
+    sessionFile: join(dir, "session.jsonl"),
+    cwd: dir,
+    model: "test/model",
+    startedAt: Date.now(),
+    status: "running",
+    attachCommand: "tmux attach",
+    selectPaneCommand: "tmux select-pane -t '%99'",
+    launchScriptFile: join(dir, "launch.sh"),
+    artifactDir: dir,
+  };
 }
 
 describe("parseWorkflow", () => {

--- a/tests/zellij.integration.test.ts
+++ b/tests/zellij.integration.test.ts
@@ -160,9 +160,9 @@ describe.skipIf(!hasZellij)("zellij backend against the real binary", () => {
     // Normalized to the bare integer form `list-panes --json` reports.
     expect(pane.paneId).toMatch(/^\d+$/);
     expect(mux.getPaneLiveness(pane.paneId, pane.session)).toBe("alive");
-    await expect(
-      mux.getPaneLivenessAsync(pane.paneId, pane.session),
-    ).resolves.toBe("alive");
+    await expect(mux.observePane(pane.paneId, pane.session)).resolves.toEqual({
+      kind: "alive",
+    });
   });
 
   it("reports dead for an id the session never had", async () => {
@@ -294,9 +294,9 @@ describe.skipIf(!hasZellij)("zellij backend against the real binary", () => {
       () => mux.getPaneLiveness(pane.paneId, pane.session) === "dead",
       "pane never reported dead after killPane",
     );
-    await expect(
-      mux.getPaneLivenessAsync(pane.paneId, pane.session),
-    ).resolves.toBe("dead");
+    await expect(mux.observePane(pane.paneId, pane.session)).resolves.toEqual({
+      kind: "dead",
+    });
     expect(() => mux.killPane(pane.paneId, pane.session)).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

- add a pure, typed reducer for interactive lifecycle, cancellation, follow-up, and pane-liveness transitions
- replace ambiguous asynchronous mux liveness checks with discriminated `alive` / `dead` / `unavailable` / `unknown` observations
- preserve durable pane-death ordering across polling and rehydration while keeping unknown states observable but non-actionable
- integrate canonical projections through the supervisor, tools, shutdown paths, and rendering
- harden tmux/Zellij decoding and add reducer, crash-order, rehydrate, and mux regressions

## Testing

- `npm run typecheck`
- `npm test` — 55 files, 1365 tests passed
- `npm run format:check`
- `npm run pack:check`

## Review

Independent review of the rebased diff: approved with no actionable P0–P2 findings.

Stacked on #65 (`feat/interactive-subagent-overlay`).