### PR TITLE
fix: batch completion follow-ups until parent settles

### DIFF
--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -37,6 +37,13 @@ export const MAX_FLUSH_BYTES = 64 * 1024;
 export const MAX_ARTIFACT_OUTPUT_BYTES = 1024 * 1024;
 const MAX_FORMATTED_IDENTIFIER = 96;
 
+function parentIsStreaming(): boolean {
+  const state = globalThis as any;
+  return typeof state.__piSubagenturaParentAgentActive === "boolean"
+    ? state.__piSubagenturaParentAgentActive
+    : state.__piSubagenturaParentStreaming === true;
+}
+
 function runningInProcessJobCount(owner?: ActiveSessionContextToken): number {
   const g = globalThis as any;
   const registry = g.__piSubagenturaRegistry;
@@ -353,7 +360,7 @@ export function flushDeliveries(
     bytes += separatorBytes + itemBytes;
   }
   const triggersTurn = selected.some(({ intent }) => intent.triggerTurn);
-  if (g.__piSubagenturaParentStreaming && !triggersTurn) return;
+  if (parentIsStreaming()) return;
   const deliveryIds = selected.map(({ intent }) => intent.deliveryId);
   try {
     pi.sendMessage(
@@ -415,8 +422,7 @@ export function reconcileDeliveryReceipts(
     }
   }
   let changed = false;
-  const canRetryUncommittedDispatch = !(globalThis as any)
-    .__piSubagenturaParentStreaming;
+  const canRetryUncommittedDispatch = !parentIsStreaming();
   for (const intent of state.pendingDeliveries ?? []) {
     if (seen.has(intent.deliveryId)) {
       (state.deliveryReceipts ??= []).push(intent.deliveryId);

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -18,6 +18,13 @@ import {
   type ActiveSessionContextToken,
 } from "./session-context";
 
+function parentIsStreaming(): boolean {
+  const state = globalThis as any;
+  return typeof state.__piSubagenturaParentAgentActive === "boolean"
+    ? state.__piSubagenturaParentAgentActive
+    : state.__piSubagenturaParentStreaming === true;
+}
+
 /**
  * @deprecated Delivery is queue-bounded rather than concurrency-capped.
  * Retained as a runtime export for compatibility with existing consumers.
@@ -513,21 +520,11 @@ export function notifyInProcessCompletionWithoutDelivery(
 }
 
 function requestInProcessDeliveryFlush(): void {
-  const g = globalThis as any;
-  if (!g.__piSubagenturaParentStreaming) {
-    flushInProcessDeliveries();
-    return;
-  }
-  if (g.__piSubagenturaInProcessFlushScheduled) return;
-  g.__piSubagenturaInProcessFlushScheduled = true;
-  queueMicrotask(() => {
-    g.__piSubagenturaInProcessFlushScheduled = false;
-    flushInProcessDeliveries();
-  });
+  if (parentIsStreaming()) return;
+  flushInProcessDeliveries();
 }
 
 export function flushInProcessDeliveries(): void {
-  const g = globalThis as any;
   const queue = pendingJobDeliveries();
   for (let index = 0; index < queue.length;) {
     if (resolvePendingDeliveryTarget(queue[index])) {
@@ -538,9 +535,9 @@ export function flushInProcessDeliveries(): void {
   }
   if (queue.length === 0) return;
 
-  const streaming = Boolean(g.__piSubagenturaParentStreaming);
-  const deliveryOwner =
-    (streaming ? queue.find(pendingTriggersTurn) : undefined) ?? queue[0];
+  const streaming = parentIsStreaming();
+  if (streaming) return;
+  const deliveryOwner = queue[0];
   const target = resolvePendingDeliveryTarget(deliveryOwner);
   if (!target) return;
 
@@ -600,7 +597,6 @@ export function flushInProcessDeliveries(): void {
 
   if (llm.length === 0) return;
   const triggersTurn = llm.some(({ trigger }) => trigger);
-  if (streaming && !triggersTurn) return;
   const deliveryIds = llm.map(({ pending }) => pending.deliveryId);
   try {
     target.pi.sendMessage(

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -192,12 +192,15 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
 
   g2.__piSubagenturaPiRef = pi;
   g2.__piSubagenturaParentStreaming = false;
+  g2.__piSubagenturaParentAgentActive = false;
 
   pi.on("agent_start", () => {
     g2.__piSubagenturaParentStreaming = true;
+    g2.__piSubagenturaParentAgentActive = true;
   });
   pi.on("agent_settled", () => {
     g2.__piSubagenturaParentStreaming = false;
+    g2.__piSubagenturaParentAgentActive = false;
     flushDeliveries(pi, sessionContext.ui, {
       id: sessionContext.id,
       generation: sessionContext.generation,
@@ -225,6 +228,7 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
     g2.__piSubagenturaSessionManager = ctx.sessionManager;
     g2.__piSubagenturaPiRef = pi;
     g2.__piSubagenturaParentStreaming = false;
+    g2.__piSubagenturaParentAgentActive = false;
 
     // Rehydrate on startup (resumed session after quit), reload, and resume.
     // The session ID filter ensures only subagents created in this specific session
@@ -307,6 +311,7 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
       }
       setActiveSessionRefs(startedAncestors[startedAncestors.length - 1]);
       g2.__piSubagenturaParentStreaming = false;
+      g2.__piSubagenturaParentAgentActive = false;
 
       // A live ancestor may defer global teardown while this nested context
       // cleans its own state. Descendants never participate in this decision:
@@ -496,6 +501,7 @@ export function registerSessionHandlers(pi: ExtensionAPI): SessionContextRef {
       g2.__piSubagenturaPiRef = undefined;
       g2.__piSubagenturaSessionManager = undefined;
       g2.__piSubagenturaParentStreaming = false;
+      g2.__piSubagenturaParentAgentActive = false;
       // Clean-slate the state file on /new. On quit/reload/resume we KEEP the file so the
       // next session_start can rehydrate the sub-agents (their panes survive).
       if (event?.reason === "new" && ctx?.cwd) {

--- a/tests/artifact-delivery.integration.test.ts
+++ b/tests/artifact-delivery.integration.test.ts
@@ -533,9 +533,12 @@ describe("artifact protocol v2 delivery", () => {
     const notify = vi.fn();
     const ui = { notify } as any;
     (globalThis as any).__piSubagenturaParentStreaming = true;
-
+    (globalThis as any).__piSubagenturaParentAgentActive = true;
     flushDeliveries({ sendMessage } as any, ui);
-
+    expect(sendMessage).not.toHaveBeenCalled();
+    (globalThis as any).__piSubagenturaParentStreaming = false;
+    (globalThis as any).__piSubagenturaParentAgentActive = false;
+    flushDeliveries({ sendMessage } as any, ui);
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage.mock.calls[0][0].details.deliveryIds).toEqual([
       deliveryId,

--- a/tests/notifications-unit.test.ts
+++ b/tests/notifications-unit.test.ts
@@ -58,6 +58,7 @@ function cleanGlobals() {
   globalState.__piSubagenturaSessionManager = undefined;
   globalState.__piSubagenturaActiveSessionContextId = undefined;
   globalState.__piSubagenturaParentStreaming = false;
+  globalState.__piSubagenturaParentAgentActive = false;
   globalState.__piSubagenturaPendingJobDeliveries = [];
   globalState.__piSubagenturaInProcessFlushScheduled = false;
   jobRegistry.clear();
@@ -159,26 +160,92 @@ describe("in-process completion delivery queue", () => {
     expect(job.notificationDelivered).toBe(true);
   });
 
-  it("dispatches triggering completion through native followUp while streaming", async () => {
+  it("batches triggering completions until the parent settles", async () => {
     const sendMessage = vi.fn();
     (globalThis as any).__piSubagenturaPiRef = { sendMessage };
     (globalThis as any).__piSubagenturaParentStreaming = true;
-    const job = makeJobState({ notifyOnComplete: "inject" });
+    (globalThis as any).__piSubagenturaParentAgentActive = true;
+    const first = makeJobState({
+      id: "first-triggering-job",
+      notifyOnComplete: "inject",
+    });
+    const second = makeJobState({
+      id: "second-triggering-job",
+      notifyOnComplete: "inject",
+    });
 
-    deliverNotification(job, SUCCESS_RESULT);
-    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce());
+    deliverNotification(first, SUCCESS_RESULT);
+    await Promise.resolve();
+    expect(sendMessage).not.toHaveBeenCalled();
 
+    deliverNotification(second, SUCCESS_RESULT);
+    await Promise.resolve();
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    (globalThis as any).__piSubagenturaParentStreaming = false;
+    (globalThis as any).__piSubagenturaParentAgentActive = false;
+    flushInProcessDeliveries();
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage.mock.calls[0][0].content).toContain(
+      "first-triggering-job",
+    );
+    expect(sendMessage.mock.calls[0][0].content).toContain(
+      "second-triggering-job",
+    );
+    expect(sendMessage.mock.calls[0][0].details.deliveryIds).toHaveLength(2);
     expect(sendMessage.mock.calls[0][1]).toMatchObject({
       deliverAs: "followUp",
       triggerTurn: true,
     });
-    expect(job.notificationDelivered).toBe(true);
+    expect(first.notificationDelivered).toBe(true);
+    expect(second.notificationDelivered).toBe(true);
+  });
+
+  it("batches notify completions that explicitly trigger a turn", async () => {
+    const sendMessage = vi.fn();
+    (globalThis as any).__piSubagenturaPiRef = { sendMessage };
+    (globalThis as any).__piSubagenturaParentStreaming = true;
+    (globalThis as any).__piSubagenturaParentAgentActive = true;
+    const first = makeJobState({
+      id: "first-notify-job",
+      notifyOnComplete: "notify",
+      triggerTurnOnComplete: true,
+    });
+    const second = makeJobState({
+      id: "second-notify-job",
+      notifyOnComplete: "notify",
+      triggerTurnOnComplete: true,
+    });
+
+    deliverNotification(first, SUCCESS_RESULT);
+    await Promise.resolve();
+    deliverNotification(second, SUCCESS_RESULT);
+    await Promise.resolve();
+
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    (globalThis as any).__piSubagenturaParentStreaming = false;
+    (globalThis as any).__piSubagenturaParentAgentActive = false;
+    flushInProcessDeliveries();
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage.mock.calls[0][0].details.mode).toBe("notify");
+    expect(sendMessage.mock.calls[0][0].details.deliveryIds).toHaveLength(2);
+    expect(sendMessage.mock.calls[0][1]).toMatchObject({
+      deliverAs: "followUp",
+      triggerTurn: true,
+    });
+    expect(sendMessage.mock.calls[0][0].content).not.toContain(
+      SUCCESS_RESULT.output,
+    );
   });
 
   it("waits for idle when completion must not trigger a turn", async () => {
     const sendMessage = vi.fn();
     (globalThis as any).__piSubagenturaPiRef = { sendMessage };
     (globalThis as any).__piSubagenturaParentStreaming = true;
+    (globalThis as any).__piSubagenturaParentAgentActive = true;
     const job = makeJobState({ notifyOnComplete: "notify" });
 
     deliverNotification(job, SUCCESS_RESULT);
@@ -187,6 +254,7 @@ describe("in-process completion delivery queue", () => {
     expect(job.notificationDelivered).toBeFalsy();
 
     (globalThis as any).__piSubagenturaParentStreaming = false;
+    (globalThis as any).__piSubagenturaParentAgentActive = false;
     flushInProcessDeliveries();
 
     expect(sendMessage).toHaveBeenCalledOnce();
@@ -207,6 +275,7 @@ describe("in-process completion delivery queue", () => {
       getSessionId: () => "parent-session-a",
     };
     (globalThis as any).__piSubagenturaParentStreaming = true;
+    (globalThis as any).__piSubagenturaParentAgentActive = true;
     const job = makeJobState({ notifyOnComplete: "notify" });
 
     deliverNotification(job, SUCCESS_RESULT);
@@ -220,6 +289,7 @@ describe("in-process completion delivery queue", () => {
       getSessionId: () => "parent-session-b",
     };
     (globalThis as any).__piSubagenturaParentStreaming = false;
+    (globalThis as any).__piSubagenturaParentAgentActive = false;
     flushInProcessDeliveries();
 
     expect(secondSessionSend).not.toHaveBeenCalled();
@@ -238,6 +308,7 @@ describe("in-process completion delivery queue", () => {
       getSessionId: () => "parent-session-a",
     };
     globalState.__piSubagenturaParentStreaming = true;
+    globalState.__piSubagenturaParentAgentActive = true;
     const job = makeJobState({ notifyOnComplete: "notify" });
 
     deliverNotification(job, SUCCESS_RESULT);
@@ -252,6 +323,7 @@ describe("in-process completion delivery queue", () => {
       getSessionId: () => "parent-session-a",
     };
     globalState.__piSubagenturaParentStreaming = false;
+    globalState.__piSubagenturaParentAgentActive = false;
     flushInProcessDeliveries();
 
     expect(secondSessionSend).not.toHaveBeenCalled();

--- a/tests/pi-session-delivery.integration.test.ts
+++ b/tests/pi-session-delivery.integration.test.ts
@@ -38,6 +38,7 @@ afterEach(() => {
   }
   interactiveSubagentRegistry.clear();
   delete (globalThis as any).__piSubagenturaParentStreaming;
+  delete (globalThis as any).__piSubagenturaParentAgentActive;
   delete (globalThis as any).__piSubagenturaPiRef;
   delete (globalThis as any).__piSubagenturaUi;
   delete (globalThis as any).__piSubagenturaSessionManager;
@@ -190,27 +191,39 @@ describe("Pi session delivery integration", () => {
     await harness.session.waitForIdle();
   });
 
-  it("queues one streaming inject before its provider turn", async () => {
+  it("batches streaming inject notifications before their provider turn", async () => {
     const { harness, sendMessage, state } = await setup("inject", true);
     const firstTurn = harness.session.prompt("parent turn");
     await vi.waitFor(() => expect(harness.contexts).toHaveLength(1));
     (globalThis as any).__piSubagenturaSessionManager = harness.sessionManager;
 
+    enqueueDelivery(state, {
+      deliveryId: "second-streaming-delivery",
+      subagentId: state.id,
+      turnId: "turn-2",
+      eventId: "event-2",
+      mode: "inject",
+      triggerTurn: true,
+      status: "cancelled",
+      artifactDir: state.artifactDir,
+      message: "second completion",
+      state: "queued",
+    });
     flushDeliveries(
       (globalThis as any).__piSubagenturaPiRef,
       (globalThis as any).__piSubagenturaUi,
     );
-    expect(sendMessage).toHaveBeenCalledOnce();
-    flushDeliveries(
-      (globalThis as any).__piSubagenturaPiRef,
-      (globalThis as any).__piSubagenturaUi,
-    );
-    expect(sendMessage).toHaveBeenCalledOnce();
-    expect(state.pendingDeliveries).toHaveLength(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(state.pendingDeliveries).toHaveLength(2);
     expect(harness.contexts).toHaveLength(1);
 
     harness.completeNext("parent done");
     await vi.waitFor(() => expect(harness.contexts).toHaveLength(2));
+    expect(sendMessage).toHaveBeenCalledOnce();
+    const message = sendMessage.mock.calls[0][0] as any;
+    expect(message.content).toContain("inject completion");
+    expect(message.content).toContain("second completion");
+    expect(message.details.deliveryIds).toHaveLength(2);
     expect(harness.contexts[1].messages.at(-1)).toMatchObject({
       role: "user",
     });
@@ -374,7 +387,7 @@ describe("Pi session delivery integration", () => {
     },
   );
 
-  it("batches a triggering burst despite a stale streaming flag", async () => {
+  it("batches triggering completions while the parent is active", async () => {
     const harness = await createPiSessionHarness(repoRoot);
     harnesses.push(harness);
     const sessionContext = getSessionContextStack().at(-1);
@@ -382,7 +395,9 @@ describe("Pi session delivery integration", () => {
       sessionContext.lifecycle = "started";
       sessionContext.sessionManager = harness.sessionManager;
     }
-    (globalThis as any).__piSubagenturaParentStreaming = true;
+    const firstTurn = harness.session.prompt("parent turn");
+    await vi.waitFor(() => expect(harness.contexts).toHaveLength(1));
+
     const result: any = {
       isError: false,
       output: "result",
@@ -409,7 +424,16 @@ describe("Pi session delivery integration", () => {
     };
     deliverNotification(first, result);
     deliverNotification(second, result);
-    await vi.waitFor(() => expect(harness.contexts).toHaveLength(1));
+    await Promise.resolve();
+    expect(harness.contexts).toHaveLength(1);
+    expect(
+      harness.sessionManager
+        .getEntries()
+        .filter((entry: any) => entry.type === "custom_message"),
+    ).toHaveLength(0);
+
+    harness.completeNext();
+    await vi.waitFor(() => expect(harness.contexts).toHaveLength(2));
     expect(
       harness.sessionManager
         .getEntries()
@@ -417,6 +441,7 @@ describe("Pi session delivery integration", () => {
     ).toHaveLength(1);
     harness.completeNext();
     await harness.session.waitForIdle();
+    await firstTurn;
   });
 
   it("delivers artifact completion through poller and broker", async () => {

--- a/tests/subagent-notify.test.ts
+++ b/tests/subagent-notify.test.ts
@@ -238,6 +238,7 @@ describe("notifyOnComplete", () => {
     registerExtension(_api as any);
     const sessionContext = getSessionContextStack().at(-1);
     if (sessionContext) sessionContext.lifecycle = "started";
+    (globalThis as any).__piSubagenturaParentAgentActive = undefined;
     (globalThis as any).__piSubagenturaUi = { notify: _api.notify };
 
     const isolatedDef = _api.registerTool.mock.calls.find(
@@ -655,8 +656,9 @@ describe("notifyOnComplete", () => {
       );
     });
 
-    it("queues triggering inject completion through Pi while streaming", async () => {
+    it("batches triggering inject completion until the parent settles", async () => {
       (globalThis as any).__piSubagenturaParentStreaming = true;
+      (globalThis as any).__piSubagenturaParentAgentActive = true;
       const jobId = "inject-cap";
       const control = createJobControl();
       mockStartSubagentJob.mockImplementationOnce(() =>
@@ -677,19 +679,21 @@ describe("notifyOnComplete", () => {
       );
 
       control.resolve(SUCCESS_RESULT);
-      await vi.waitFor(() => {
-        expect(jobRegistry.get(jobId)?.status).toBe("done");
-        expect(api.sendMessage).toHaveBeenCalledOnce();
-      });
+      await vi.waitFor(() =>
+        expect(jobRegistry.get(jobId)?.status).toBe("done"),
+      );
+      await Promise.resolve();
+      expect(api.sendMessage).not.toHaveBeenCalled();
+
+      (globalThis as any).__piSubagenturaParentStreaming = false;
+      (globalThis as any).__piSubagenturaParentAgentActive = false;
+      flushInProcessDeliveries();
+      expect(api.sendMessage).toHaveBeenCalledOnce();
       expect(api.sendMessage.mock.calls[0][1]).toMatchObject({
         deliverAs: "followUp",
         triggerTurn: true,
       });
       expect(api.sendUserMessage).not.toHaveBeenCalled();
-
-      (globalThis as any).__piSubagenturaParentStreaming = false;
-      flushInProcessDeliveries();
-      expect(api.sendMessage).toHaveBeenCalledOnce();
     });
 
     it("allows sequential inject completions without a lifetime cap", async () => {


### PR DESCRIPTION
## Summary
- defer sub-agent completion follow-ups while the parent agent is active
- batch queued `notify` and `inject` deliveries into one native Pi follow-up
- preserve distinct completion turns/statuses and delivery receipts

## Verification
- `npm run typecheck`
- `npm test` — 57 files, 1357 tests
- `npm run format:check`
- `npm run pack:check`
