### PR TITLE
feat(debug): add interactive lifecycle diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ logs/
 .claude
 coverage/
 terminal-e2e-recordings/
+session-harness/

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "src/artifact.ts",
     "src/artifact-poller.ts",
     "src/child-protocol.ts",
+    "src/interactive-debug.ts",
     "src/delivery.ts",
     "src/helpers.ts",
     "src/orchestration-context.ts",

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -34,6 +34,7 @@ import {
   getInteractivePaneLivenessAsync,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
+import { appendInteractiveDebugEvent } from "./interactive-debug";
 import { shouldNotify } from "./notifications";
 import { deliveryIdFor, enqueueDelivery, flushDeliveries } from "./delivery";
 import { debugLog, jobRegistry, type JobState } from "./helpers";
@@ -448,13 +449,24 @@ async function runPollArtifactChanges(
           (ev as unknown as { eventId?: string }).eventId ??
           `legacy-${record.startOffset}`;
         const status = deliveryStatusFromEvent(ev);
+        const deliveryId = deliveryIdFor({
+          parentSessionId: state.parentSessionId ?? "pi",
+          subagentId: state.id,
+          turnId,
+          mode,
+        });
+        appendInteractiveDebugEvent(state.artifactDir, "completion_observed", {
+          byteStart: record.startOffset,
+          byteEnd: record.endOffset,
+          eventId,
+          turnId,
+          source: v2?.source ?? ev.type,
+          outcome: v2?.outcome ?? status,
+          outputBytes: v2?.output?.bytes,
+          activeTurnId: state.activeTurnId,
+        });
         enqueueDelivery(state, {
-          deliveryId: deliveryIdFor({
-            parentSessionId: state.parentSessionId ?? "pi",
-            subagentId: state.id,
-            turnId,
-            mode,
-          }),
+          deliveryId,
           subagentId: state.id,
           turnId,
           eventId,
@@ -465,6 +477,14 @@ async function runPollArtifactChanges(
           output: v2?.output,
           message: deliveryMessageFromEvent(ev),
           state: "queued",
+        });
+        appendInteractiveDebugEvent(state.artifactDir, "delivery_enqueued", {
+          deliveryId,
+          turnId,
+          mode,
+          triggerTurn,
+          status,
+          pendingCount: state.pendingDeliveries?.length,
         });
       }
       for (const issue of batch.issues) {

--- a/src/child-protocol.ts
+++ b/src/child-protocol.ts
@@ -1,4 +1,10 @@
-import { readFileSync, renameSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, dirname, join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
@@ -9,6 +15,7 @@ import {
   writeOutput,
   type SubagentEventV2,
 } from "./artifact";
+import { appendInteractiveDebugEvent } from "./interactive-debug";
 
 interface ActiveTurn {
   turnId: string;
@@ -62,12 +69,28 @@ function latestUserEntryId(ctx: any): string | undefined {
   return undefined;
 }
 
+function outputBytes(art: ReturnType<typeof getArtifact>): number | undefined {
+  try {
+    return statSync(join(art.dir, "output.md")).size;
+  } catch {
+    // Missing output is itself useful diagnostic data; keep lifecycle safe.
+    return undefined;
+  }
+}
+
 function appendActivity(
   art: ReturnType<typeof getArtifact>,
   phase: "start" | "end",
   event: { toolName?: string; toolCallId?: string; isError?: boolean },
 ): void {
   const active = readActiveTurn(art);
+  appendInteractiveDebugEvent(art.dir, "tool_activity", {
+    phase,
+    turnId: active?.turnId,
+    toolName: event.toolName,
+    toolCallId: event.toolCallId,
+    isError: event.isError,
+  });
   if (!active) return;
   const activity: SubagentEventV2 = {
     version: 2,
@@ -92,6 +115,7 @@ export function registerChildProtocol(pi: ExtensionAPI): void {
     turnId: string,
     timestamp: number,
     previousUserEntryId?: string,
+    reason = "persisted_user_entry",
   ): ActiveTurn => {
     const turn: ActiveTurn = {
       turnId,
@@ -110,21 +134,39 @@ export function registerChildProtocol(pi: ExtensionAPI): void {
       type: "turn_started",
       status: "running",
     });
+    appendInteractiveDebugEvent(art.dir, "turn_started", {
+      turnId,
+      previousUserEntryId,
+      reason,
+    });
     return turn;
   };
   const bindPersistedTurn = (
     ctx: any,
     timestamp: number,
+    source: string,
   ): ActiveTurn | null => {
     const active = readActiveTurn(art);
-    if (!active) return null;
     const persistedId = latestUserEntryId(ctx);
+    appendInteractiveDebugEvent(art.dir, "turn_bind", {
+      source,
+      activeTurnId: active?.turnId,
+      activeStarted: active?.started,
+      persistedUserEntryId: persistedId,
+      previousUserEntryId: active?.previousUserEntryId,
+    });
+    if (!active) return null;
     if (active.started) {
       if (!persistedId || persistedId === active.turnId) return active;
       // Pi handles Enter during streaming as a steering message inside the
       // existing agent run, so it emits no before_agent_start. The persisted
       // user entry is the authoritative boundary for that new child turn.
-      return startPersistedTurn(persistedId, timestamp, active.turnId);
+      return startPersistedTurn(
+        persistedId,
+        timestamp,
+        active.turnId,
+        "user_entry_changed",
+      );
     }
     if (!persistedId || persistedId === active.previousUserEntryId) {
       return active;
@@ -133,24 +175,30 @@ export function registerChildProtocol(pi: ExtensionAPI): void {
       persistedId,
       timestamp,
       active.previousUserEntryId,
+      "initial_user_entry_bound",
     );
   };
   pi.on("before_agent_start", (_event, ctx) => {
+    const previousUserEntryId = latestUserEntryId(ctx);
     const turn: ActiveTurn = {
       turnId: `turn-${newEventId()}`,
       startedAt: Date.now(),
       started: false,
-      previousUserEntryId: latestUserEntryId(ctx),
+      previousUserEntryId,
     };
     latestAgentMessages = [];
     writeOutput(art, "");
     writeActiveTurn(turn, art);
+    appendInteractiveDebugEvent(art.dir, "before_agent_start", {
+      provisionalTurnId: turn.turnId,
+      previousUserEntryId,
+    });
   });
 
   pi.on("turn_start", (event, ctx) => {
-    bindPersistedTurn(ctx, event.timestamp);
+    bindPersistedTurn(ctx, event.timestamp, "turn_start");
     const deferredBind = setTimeout(
-      () => bindPersistedTurn(ctx, event.timestamp),
+      () => bindPersistedTurn(ctx, event.timestamp, "turn_start_deferred"),
       0,
     );
     deferredBind.unref();
@@ -158,24 +206,31 @@ export function registerChildProtocol(pi: ExtensionAPI): void {
   // In createAgentSession 0.80.6, the first turn_start can precede persistence
   // of the user message. This is the earliest guaranteed pre-model fallback.
   pi.on("before_provider_request", (_event, ctx) => {
-    bindPersistedTurn(ctx, Date.now());
+    bindPersistedTurn(ctx, Date.now(), "before_provider_request");
   });
 
   pi.on("tool_execution_start", (event, ctx) => {
-    bindPersistedTurn(ctx, Date.now());
+    bindPersistedTurn(ctx, Date.now(), "tool_execution_start");
     appendActivity(art, "start", event);
   });
   pi.on("tool_execution_end", (event, ctx) => {
-    bindPersistedTurn(ctx, Date.now());
+    bindPersistedTurn(ctx, Date.now(), "tool_execution_end");
     appendActivity(art, "end", event);
   });
   pi.on("agent_end", (event, ctx) => {
-    bindPersistedTurn(ctx, Date.now());
+    bindPersistedTurn(ctx, Date.now(), "agent_end");
     latestAgentMessages = [...event.messages];
+    appendInteractiveDebugEvent(art.dir, "agent_end", {
+      messageCount: latestAgentMessages.length,
+      outputBytes: outputBytes(art),
+    });
   });
   pi.on("agent_settled", (_event, ctx) => {
-    const active = bindPersistedTurn(ctx, Date.now());
-    if (!active) return;
+    const active = bindPersistedTurn(ctx, Date.now(), "agent_settled");
+    if (!active) {
+      appendInteractiveDebugEvent(art.dir, "agent_settled_without_active");
+      return;
+    }
     const assistant = [...latestAgentMessages]
       .reverse()
       .find((message: any) => message?.role === "assistant") as any;
@@ -187,13 +242,27 @@ export function registerChildProtocol(pi: ExtensionAPI): void {
       Boolean(errorMessage) ||
       assistant?.stopReason === "error" ||
       assistant?.stopReason === "aborted";
-    appendCompletionEvent(art, {
+    appendInteractiveDebugEvent(art.dir, "agent_settled_decision", {
+      turnId: active.turnId,
+      messageCount: latestAgentMessages.length,
+      stopReason: assistant?.stopReason,
+      hasErrorMessage: Boolean(errorMessage),
+      outputBytes: outputBytes(art),
+      outcome: failed ? "error" : "done",
+    });
+    const completion = appendCompletionEvent(art, {
       turnId: active.turnId,
       outcome: failed ? "error" : "done",
       source: "agent_settled",
       exitCode: failed ? 1 : 0,
       errorMessage,
       message: errorMessage,
+    });
+    appendInteractiveDebugEvent(art.dir, "completion_emitted", {
+      turnId: active.turnId,
+      source: "agent_settled",
+      emitted: completion !== null,
+      eventId: completion?.eventId,
     });
   });
 }

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -20,6 +20,7 @@ import {
   updateInteractiveState,
   type PersistedDeliveryIntent,
 } from "./artifact";
+import { appendInteractiveDebugEvent } from "./interactive-debug";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 import { notifyCompletionDelivery, sanitizeOutput } from "./notifications";
 import {
@@ -347,6 +348,26 @@ function formatIntent(
   );
 }
 
+function logDeliveryBatch(
+  items: Array<{
+    state: InteractiveSubagentState;
+    intent: PersistedDeliveryIntent;
+  }>,
+  event: string,
+  data: Record<string, unknown> = {},
+): void {
+  for (const { state, intent } of items) {
+    appendInteractiveDebugEvent(state.artifactDir, event, {
+      deliveryId: intent.deliveryId,
+      turnId: intent.turnId,
+      status: intent.status,
+      mode: intent.mode,
+      triggerTurn: intent.triggerTurn,
+      ...data,
+    });
+  }
+}
+
 export function flushDeliveries(
   pi: ExtensionAPI,
   ui: ExtensionUIContext | undefined,
@@ -378,8 +399,18 @@ export function flushDeliveries(
     bytes += separatorBytes + itemBytes;
   }
   const triggersTurn = selected.some(({ intent }) => intent.triggerTurn);
-  if (resolveStreamingFlag(owner) && !triggersTurn) return;
+  if (resolveStreamingFlag(owner) && !triggersTurn) {
+    logDeliveryBatch(selected, "delivery_deferred", {
+      reason: "parent_streaming",
+      selectedCount: selected.length,
+    });
+    return;
+  }
   const deliveryIds = selected.map(({ intent }) => intent.deliveryId);
+  logDeliveryBatch(selected, "delivery_attempt", {
+    selectedCount: selected.length,
+    deliveryIds,
+  });
   try {
     pi.sendMessage(
       {
@@ -406,9 +437,15 @@ export function flushDeliveries(
         triggerTurn: triggersTurn,
       },
     );
-  } catch {
+  } catch (error) {
+    logDeliveryBatch(selected, "delivery_failed", {
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
     return;
   }
+  logDeliveryBatch(selected, "delivery_sent", {
+    selectedCount: selected.length,
+  });
   notifyCompletionDelivery(
     ui,
     selected.map(({ intent }) => ({
@@ -421,6 +458,10 @@ export function flushDeliveries(
   for (const { state, intent } of selected) {
     intent.state = "dispatchAttempted";
     persistState(state);
+    appendInteractiveDebugEvent(state.artifactDir, "delivery_persisted", {
+      deliveryId: intent.deliveryId,
+      state: intent.state,
+    });
   }
   reconcileAllDeliveryReceipts(owner);
 }

--- a/src/interactive-debug.ts
+++ b/src/interactive-debug.ts
@@ -1,0 +1,55 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const DEBUG_FILE = "debug.ndjson";
+const MAX_DEBUG_STRING = 256;
+const MAX_DEBUG_KEYS = 32;
+const MAX_DEBUG_ITEMS = 16;
+
+function boundDebugValue(value: unknown, depth = 0): unknown {
+  if (typeof value === "string") return value.slice(0, MAX_DEBUG_STRING);
+  if (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (depth >= 2) return "[truncated]";
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_DEBUG_ITEMS)
+      .map((item) => boundDebugValue(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .slice(0, MAX_DEBUG_KEYS)
+        .map(([key, item]) => [key, boundDebugValue(item, depth + 1)]),
+    );
+  }
+  return String(value).slice(0, MAX_DEBUG_STRING);
+}
+
+export function appendInteractiveDebugEvent(
+  artifactDir: string,
+  event: string,
+  data: Record<string, unknown> = {},
+): void {
+  try {
+    mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
+    const bounded = boundDebugValue(data) as Record<string, unknown>;
+    appendFileSync(
+      join(artifactDir, DEBUG_FILE),
+      JSON.stringify({
+        ts: Date.now(),
+        pid: process.pid,
+        event,
+        ...bounded,
+      }) + "\n",
+      { mode: 0o600 },
+    );
+  } catch {
+    // Diagnostics must never change the child lifecycle or delivery outcome.
+  }
+}

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -55,6 +55,7 @@ import {
   type PersistedLifecycleFold,
   removeInteractiveState,
 } from "./artifact";
+import { appendInteractiveDebugEvent } from "./interactive-debug";
 import { acknowledgeDeliveryWithoutDispatch, deliveryIdFor } from "./delivery";
 import {
   type CapturePaneOptions,
@@ -742,6 +743,17 @@ export function launchInteractiveSubagent(params: {
       PI_SUBAGENTURA_MAX_DEPTH: String(effectiveMaxDepth),
       PI_SUBAGENTURA_MAX_NODES: String(maxNodes),
     });
+    appendInteractiveDebugEvent(paths.artifactDir, "child_spawned", {
+      subagentId: id,
+      model: params.model,
+      cwd,
+      sessionFile: paths.sessionFile,
+      paneId,
+      mux: mux.name,
+      muxSession,
+      notifyOnComplete: params.notifyOnComplete,
+      triggerTurnOnComplete: params.triggerTurnOnComplete,
+    });
     const escape = (v: string) => `'${v.replace(/'/g, `'\\''`)}'`;
     mux.sendKeys(
       paneId,
@@ -978,6 +990,14 @@ export function cancelInteractiveSubagent(
   const state =
     ownedState?.id === id ? ownedState : interactiveSubagentRegistry.get(id);
   if (!state) return undefined;
+  appendInteractiveDebugEvent(state.artifactDir, "cancel_requested", {
+    source,
+    subagentId: state.id,
+    status: state.status,
+    activeTurnId: state.activeTurnId,
+    paneId: state.paneId,
+    mux: state.mux,
+  });
 
   const snapshot = snapshotInteractiveContext({
     kind: "interactive",
@@ -1134,6 +1154,14 @@ export function cancelInteractiveSubagentByState(
     /* best-effort */
   }
   appendCancellation(state);
+  appendInteractiveDebugEvent(state.artifactDir, "cancel_requested", {
+    source: "session_shutdown",
+    subagentId: state.id,
+    status: state.status,
+    activeTurnId: state.activeTurnId,
+    paneId: state.paneId,
+    mux: state.mux,
+  });
 
   // Explicit cancellation is destructive by request: unless absence is
   // confirmed, attempt the kill even when the listing probe is unavailable.

--- a/src/subagent-artifact-cli.ts
+++ b/src/subagent-artifact-cli.ts
@@ -65,6 +65,17 @@ const boundedOptionalEventText = (value) =>
 const cmd = process.argv[2];
 const arg = process.argv[3];
 const write = (obj) => appendFileSync(statusFile, JSON.stringify(obj) + "\n", { mode: 0o600 });
+const debug = (event, data = {}) => {
+  try {
+    appendFileSync(
+      join(dir, "debug.ndjson"),
+      JSON.stringify({ ts: Date.now(), pid: process.pid, event, ...data }) + "\n",
+      { mode: 0o600 },
+    );
+  } catch {
+    // Diagnostics must never change the lifecycle command's exit status.
+  }
+};
 const readEvents = () => {
   try {
     return readFileSync(statusFile, "utf8")
@@ -172,8 +183,17 @@ const snapshot = (eventId) => {
   };
 };
 const completion = (outcome, source, extra = {}) => {
+  debug("completion_attempt", {
+    turnId,
+    outcome,
+    source,
+    alreadyCompleted: completed(),
+  });
   withCompletionLock(() => {
-    if (completed()) return;
+    if (completed()) {
+      debug("completion_skipped", { turnId, outcome, source });
+      return;
+    }
     const eventId = randomUUID();
     const snapshotResult = snapshot(eventId);
     write({
@@ -188,12 +208,20 @@ const completion = (outcome, source, extra = {}) => {
       ...snapshotResult,
       ...extra,
     });
+    debug("completion_recorded", {
+      turnId,
+      eventId,
+      outcome,
+      source,
+      outputBytes: snapshotResult.output?.bytes,
+    });
   });
 };
 
 switch (cmd) {
   case "start":
     write({ ts: Date.now(), type: "started", status: "running" });
+    debug("process_start", { turnId });
     break;
   case "done": {
     const exitCode = Number(arg ?? 0);
@@ -212,6 +240,12 @@ switch (cmd) {
   case "process-exit": {
     const exitCode = Number(arg ?? 0);
     const cancelled = existsSync(join(dir, ".cancelled"));
+    debug("process_exit", {
+      turnId,
+      exitCode,
+      cancelled,
+      completedBeforeExit: completed(),
+    });
     if (!completed()) {
       completion(cancelled ? "cancelled" : "error", "process_exit", {
         exitCode,

--- a/tests/interactive-debug.test.ts
+++ b/tests/interactive-debug.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendInteractiveDebugEvent } from "../src/interactive-debug";
+
+describe("interactive debug events", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes bounded structured events without changing the artifact protocol", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-subagentura-debug-"));
+    tempDirs.push(dir);
+    const longValue = "x".repeat(512);
+
+    appendInteractiveDebugEvent(dir, "turn_bind", {
+      turnId: "turn-1",
+      persistedUserEntryId: longValue,
+    });
+
+    const event = JSON.parse(readFileSync(join(dir, "debug.ndjson"), "utf8"));
+    expect(event).toMatchObject({ event: "turn_bind", turnId: "turn-1" });
+    expect(event.persistedUserEntryId).toHaveLength(256);
+    expect(event.pid).toEqual(expect.any(Number));
+    expect(event.ts).toEqual(expect.any(Number));
+    expect(existsSync(join(dir, "events.ndjson"))).toBe(false);
+  });
+});

--- a/tests/subagent-artifact-cli.test.ts
+++ b/tests/subagent-artifact-cli.test.ts
@@ -103,6 +103,24 @@ describe("subagent-artifact CLI", () => {
       expect(ev.exitCode).toBe(0);
     });
 
+    it("records completion diagnostics separately from lifecycle events", () => {
+      writeFileSync(join(tmp, "output.md"), "");
+      runCli(tmp, ["done", "0"]);
+      const debugEvents = readFileSync(join(tmp, "debug.ndjson"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(debugEvents.map((event) => event.event)).toEqual([
+        "completion_attempt",
+        "completion_recorded",
+      ]);
+      expect(debugEvents[1]).toMatchObject({
+        source: "explicit",
+        outcome: "done",
+        outputBytes: 0,
+      });
+    });
+
     it("writes a done event with non-zero exit code → status error", () => {
       runCli(tmp, ["done", "1"]);
       const ev = JSON.parse(


### PR DESCRIPTION
## Summary
- add per-artifact `debug.ndjson` diagnostics for interactive child lifecycle transitions
- record turn binding/rotation, tool activity, settlement decisions, explicit/process-exit completion, cancellation origin, polling, and delivery state
- bound diagnostic values and avoid logging raw delivery error messages
- include the new source file in the published package and add focused coverage

## Why
The PR review agents produced empty artifacts and repeated completion events. These diagnostics make it possible to distinguish child lifecycle failures, phantom turn binding, parent cancellation, artifact polling, and delayed delivery without changing the authoritative protocol events.

## Verification
- `npm run typecheck`
- `npm test -- --run` — 58 files, 1373 tests passed
- `npm test -- --run tests/published-tarball.test.ts tests/subagent-artifact-cli.test.ts tests/interactive-debug.test.ts`
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`
