### PR TITLE
feat: add workflow pricing and usage displays

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -238,7 +238,8 @@ Notable dependency facts:
 It registers `subagent_with_context`, `subagent_isolated`, `get_subagent_status`, `get_subagent_result`, `cancel_subagent`, `list_available_models`, `prune_subagent_jobs`, and artifact cleanup.
 
 `src/helpers.ts:startSubagentJob` is the execution kernel.
-It resolves Pi runtime compatibility, creates an in-memory `SessionManager` and `AgentSession`, subscribes to Pi events, builds the prompt, aggregates usage, and disposes the session.
+It resolves Pi runtime compatibility, creates an in-memory `SessionManager` and `AgentSession`, subscribes to Pi events, builds the prompt, maintains cumulative live usage across assistant turns, aggregates final usage, and disposes the session.
+A live sample combines completed turns with the current partial assistant message exactly once; the latest turn alone is never presented as the agent total.
 
 `src/orchestration-context.ts` carries nested `jobId`, depth, and root-session identity through `AsyncLocalStorage`.
 `src/session-scope.ts` supplies parent session scopes, ownership tokens, and generation fences.
@@ -794,8 +795,8 @@ Only structured-cloneable messages cross this boundary.
 Default isolation is `process`.
 The workflow host calls `launchInteractiveSubagent` in the parent process; the Worker itself does not launch tmux.
 `awaitInteractiveResult` then waits on artifact events for that one delegated turn, reads the selected immutable output or fallback output, and aggregates usage from the child session JSONL.
-It probes pane liveness with a bounded dead-pane grace.
-On abort it calls interactive cancellation and records any snapshot receipt.
+Its poll wait wakes immediately on abort, so cancellation can kill the pane and parse already-persisted session usage without waiting for the normal one-second interval.
+It probes pane liveness with a bounded dead-pane grace and returns parsed partial usage on cancellation or premature pane exit.
 If process launch fails, the adapter warns and falls back to in-process execution.
 
 Explicit `isolation: "in-process"` calls `startSubagentJob`, starts the gated session, and awaits its promise directly.
@@ -846,10 +847,23 @@ At capacity, only an eligible terminal job belonging to the requesting owner may
 `get_workflow_status` is nonblocking.
 `get_workflow_result` can wait on the existing promise; caller abort cancels only the wait.
 `cancel_workflow` aborts the job, normalizes state immediately, briefly waits for active runner cancellation receipts, posts worker abort, and terminates the worker.
+When execution rejects, `WorkflowExecutionError.usage` is copied into the job snapshot before cancellation normalization and completion callbacks, so status, result, notification, and tree consumers observe the same terminal accounting.
 
 On completion, `notifyWorkflowCompletion` sends `workflow-notify` as a Pi follow-up with `triggerTurn: true`.
 It sends a bounded summary and job pointer, not the potentially large result.
 Delivery is owner-fenced, guarded against reentrancy, retried a bounded number of times, and suppressed by owner cleanup.
+
+### 9.7 Usage accounting, pricing provenance, and live projection
+
+Usage tracks input, output, cache-read, cache-write, cost, and turns. The compatibility field `tokensSpent` and the workflow `budget` remain completed output-token values; the budget is a soft target that parallel agents may overshoot, never a USD limit.
+
+Pi SDK assistant-message `usage.cost` is calculated locally from model rates, so its object shape is not provider-billing evidence. Without explicit provenance, a positive calculated cost is `estimated`, zero cost with nonzero usage is `unavailable`, and an all-zero sample has no provenance. Explicit `provider`, `estimated`, or `unavailable` sources are retained; differing sources aggregate to `mixed`.
+
+Canonical displays render provider cost as `$`, estimates as `~$`, unavailable cost as `$?`, and mixed provenance as `$? (mixed)`. The same formatter feeds workflow progress, status, results, notifications, footer/widget rows, tree details, and supervisor details.
+
+Each runner attempt is accounted at most once, including returned errors, schema retries, thrown errors carrying usage, and bounded cancellation drains. Process cancellation uses the abort-responsive artifact wait; in-process cancellation aggregates the child session messages.
+
+Background jobs retain live samples by agent ID and aggregate only still-running agents that have reported a sample, so one parallel completion cannot erase another agent's sample. Terminal settlement clears live usage, while final agent records prefer the runner-reported model and fall back to the requested model.
 
 ---
 
@@ -901,19 +915,21 @@ Delivery is owner-fenced, guarded against reentrancy, retried a bounded number o
 
 ### 11.2 Authority table
 
-| Question                                        | Authoritative source                                                  | Explicit non-authorities                                    |
-| ----------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------- |
-| Is an in-process job running?                   | `JobState` in `jobRegistry` plus its signal/session                   | Interactive artifacts, UI footer                            |
-| What did a sync in-process job return?          | Direct settled `SubagentResult`                                       | Notification queue                                          |
-| Has an interactive turn completed?              | Completion record in physical `events.ndjson` order                   | Timestamp order, pane death, screen text, `output.md` alone |
-| What exact v2 bytes completed?                  | Contained regular immutable snapshot matching path, size, and SHA-256 | Mutable staging file, mux capture                           |
-| Is an interactive process alive?                | Recorded mux backend's liveness probe                                 | Last event timestamp                                        |
-| Was a parent delivery committed?                | Matching parent session custom entry with `details.deliveryIds`       | Successful `sendMessage` return, UI toast                   |
-| Where does artifact polling resume?             | Persisted physical byte cursor and partial-line replay boundary       | Event timestamp                                             |
-| Who owns a state?                               | Exact parent session ID plus live scope generation                    | Current top UI alone                                        |
-| What is interactive descendant topology?        | Validated lineage manifests                                           | Artifact event parent guesses                               |
-| What is a workflow job result?                  | Settled `WorkflowJobState` promise/result                             | Worker progress log, notification summary                   |
-| What usage did process workflow runner consume? | Aggregated assistant usage in child session JSONL                     | Artifact output byte size                                   |
+| Question                                        | Authoritative source                                                                               | Explicit non-authorities                                    |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Is an in-process job running?                   | `JobState` in `jobRegistry` plus its signal/session                                                | Interactive artifacts, UI footer                            |
+| What did a sync in-process job return?          | Direct settled `SubagentResult`                                                                    | Notification queue                                          |
+| Has an interactive turn completed?              | Completion record in physical `events.ndjson` order                                                | Timestamp order, pane death, screen text, `output.md` alone |
+| What exact v2 bytes completed?                  | Contained regular immutable snapshot matching path, size, and SHA-256                              | Mutable staging file, mux capture                           |
+| Is an interactive process alive?                | Recorded mux backend's liveness probe                                                              | Last event timestamp                                        |
+| Was a parent delivery committed?                | Matching parent session custom entry with `details.deliveryIds`                                    | Successful `sendMessage` return, UI toast                   |
+| Where does artifact polling resume?             | Persisted physical byte cursor and partial-line replay boundary                                    | Event timestamp                                             |
+| Who owns a state?                               | Exact parent session ID plus live scope generation                                                 | Current top UI alone                                        |
+| What is interactive descendant topology?        | Validated lineage manifests                                                                        | Artifact event parent guesses                               |
+| What is a workflow job result?                  | Settled `WorkflowJobState` promise/result                                                          | Worker progress log, notification summary                   |
+| What usage did process workflow runner consume? | Aggregated assistant usage in child session JSONL                                                  | Artifact output byte size                                   |
+| What does a workflow cost value mean?           | Numeric usage plus explicit `costSource`; Pi SDK-derived cost defaults to an estimate              | Object-shaped SDK cost, `$0` as proof of free pricing       |
+| What usage does a failed background job expose? | `WorkflowExecutionError.usage` mirrored into `WorkflowJobState.snapshot` before terminal consumers | Stale progress or the last live agent sample                |
 
 ---
 
@@ -1079,6 +1095,11 @@ The restrictive exports map matters: shipping all source files in `package.json#
 - [ ] Process and in-process runners use separate semaphores.
 - [ ] Schema retries consume the lifetime attempt cap and aggregate usage.
 - [ ] Process runner completion comes from artifact events; usage comes from child session JSONL.
+- [ ] Pi SDK cost object shape never implies provider-reported billing.
+- [ ] Output budget and `tokensSpent` remain completed output-token values, not USD.
+- [ ] Live usage is cumulative per agent and aggregates every still-running agent that has reported a live sample.
+- [ ] Cancellation/error usage reaches the terminal background snapshot before completion delivery.
+- [ ] Final per-agent model attribution prefers the runner result and falls back to the request.
 - [ ] Background workflow notification carries a pointer; explicit result retrieval returns the retained value.
 - [ ] Workflow state is never claimed to survive process restart.
 - [ ] Nested saved workflow execution reuses the same Worker and shared budgets.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -267,12 +267,12 @@ The `workflow` tool runs scripts inside a [`Worker` thread](../src/workflow-work
 Every `agent()`, `phase()`, and `log()` call emits a progress event. The parent pipes these through `renderProgress()` and streams them as `onUpdate` calls:
 
 ```
-● workflow — 4 agent(s), ⚡ 3 running, ↑1200 ↓120/5000 R0 W0 $?
+● workflow — 4 agent(s), ⚡ 3 running, 0 tokens
   → started verify:status-token-wrong-company
   → done verify:status-token-wrong-company
   → started verify:cached-status-token
 ◆ phase: Sweep
-● workflow — 4 agent(s), 0 running, ↑1200 ↓120/5000 R0 W0 $0.018
+● workflow — 4 agent(s), 0 running, 0 tokens
   → started sweep:ui-agents
   → started sweep:backend
   → done sweep:backend
@@ -283,7 +283,7 @@ Every `agent()`, `phase()`, and `log()` call emits a progress event. The parent 
 | Mode                      | How progress flows                                                           | TUI effect                                                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | **Sync** (`async: false`) | `onProgress` → `onUpdate` per event                                          | Live stream in the reply; each `agent()`, `phase()`, and `log()` call fires an inline update.                                       |
-| **Async** (default)       | Written to `WorkflowJobState.snapshot`; artifact poller paints footer/widget | Footer shows `⚡ N workflow(s) running`; below-editor widget shows running workflow rows with phase/agent/usage/last-event summary. |
+| **Async** (default)       | Written to `WorkflowJobState.snapshot`; artifact poller paints footer/widget | Footer shows `⚡ N workflow(s) running`; below-editor widget shows running workflow rows with phase/agent/token/last-event summary. |
 
 ### Current visibility
 
@@ -293,31 +293,13 @@ Async workflows are discoverable without polling tools:
 
 ```
 ⚡ 2 workflows running
-◇ pr-review (wf_ab12): 3 agents · 2 running · ↑1200 ↓120 R0 W0 $? · 5s · phase: Review — → started tests
-◇ ralplan (wf_cd34): 1 agent · 1 running · ↑800 ↓80 R0 W0 ~$0.004 · 1m 12s · phase: Planner — ◆ phase: Planner
+◇ pr-review (wf_ab12): 3 agents · 2 running · 120 tokens · 5s · phase: Review — → started tests
+◇ ralplan (wf_cd34): 1 agent · 1 running · 80 tokens · 1m 12s · phase: Planner — ◆ phase: Planner
 ```
 
 The footer uses `subagentura-workflows`; the workflow widget uses
 `subagentura-workflow-activity` and is capped to 5 rows with an overflow row.
 Use `/workflow-status` for the full textual status dump, or `/workflow-tree` for an interactive drill-down overlay.
-
-#### Usage and pricing accounting
-
-Workflow surfaces use one canonical usage formatter. Compact views show:
-
-```text
-↑ input · ↓ output · R cache-read · W cache-write · $ cost
-```
-
-Expanded workflow-tree rows include explicit labels, a legend, turns, and
-per-agent/model usage when the runner provides it. ASCII-safe output is used for
-terminals that cannot render the icons.
-
-The `budget` value is a soft completed-output-token target. Parallel agents may
-overshoot it; it is not a USD budget. Provider-reported costs use `$`, estimates
-use `~$`, and unavailable or mixed pricing uses `$?` rather than implying that
-unknown pricing is free. Live usage is shown when the runner exposes progress
-usage; process-isolated agents may only provide final usage after completion.
 
 #### 2. Per-agent visibility
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -267,12 +267,12 @@ The `workflow` tool runs scripts inside a [`Worker` thread](../src/workflow-work
 Every `agent()`, `phase()`, and `log()` call emits a progress event. The parent pipes these through `renderProgress()` and streams them as `onUpdate` calls:
 
 ```
-● workflow — 4 agent(s), ⚡ 3 running, 0 tokens
+● workflow — 4 agent(s), ⚡ 3 running, ↑1200 ↓120/5000 R0 W0 $?
   → started verify:status-token-wrong-company
   → done verify:status-token-wrong-company
   → started verify:cached-status-token
 ◆ phase: Sweep
-● workflow — 4 agent(s), 0 running, 0 tokens
+● workflow — 4 agent(s), 0 running, ↑1200 ↓120/5000 R0 W0 $0.018
   → started sweep:ui-agents
   → started sweep:backend
   → done sweep:backend
@@ -283,7 +283,7 @@ Every `agent()`, `phase()`, and `log()` call emits a progress event. The parent 
 | Mode                      | How progress flows                                                           | TUI effect                                                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | **Sync** (`async: false`) | `onProgress` → `onUpdate` per event                                          | Live stream in the reply; each `agent()`, `phase()`, and `log()` call fires an inline update.                                       |
-| **Async** (default)       | Written to `WorkflowJobState.snapshot`; artifact poller paints footer/widget | Footer shows `⚡ N workflow(s) running`; below-editor widget shows running workflow rows with phase/agent/token/last-event summary. |
+| **Async** (default)       | Written to `WorkflowJobState.snapshot`; artifact poller paints footer/widget | Footer shows `⚡ N workflow(s) running`; below-editor widget shows running workflow rows with phase/agent/usage/last-event summary. |
 
 ### Current visibility
 
@@ -293,13 +293,31 @@ Async workflows are discoverable without polling tools:
 
 ```
 ⚡ 2 workflows running
-◇ pr-review (wf_ab12): 3 agents · 2 running · 120 tokens · 5s · phase: Review — → started tests
-◇ ralplan (wf_cd34): 1 agent · 1 running · 80 tokens · 1m 12s · phase: Planner — ◆ phase: Planner
+◇ pr-review (wf_ab12): 3 agents · 2 running · ↑1200 ↓120 R0 W0 $? · 5s · phase: Review — → started tests
+◇ ralplan (wf_cd34): 1 agent · 1 running · ↑800 ↓80 R0 W0 ~$0.004 · 1m 12s · phase: Planner — ◆ phase: Planner
 ```
 
 The footer uses `subagentura-workflows`; the workflow widget uses
 `subagentura-workflow-activity` and is capped to 5 rows with an overflow row.
 Use `/workflow-status` for the full textual status dump, or `/workflow-tree` for an interactive drill-down overlay.
+
+#### Usage and pricing accounting
+
+Workflow surfaces use one canonical usage formatter. Compact views show:
+
+```text
+↑ input · ↓ output · R cache-read · W cache-write · $ cost
+```
+
+Expanded workflow-tree rows include explicit labels, a legend, turns, and
+per-agent/model usage when the runner provides it. ASCII-safe output is used for
+terminals that cannot render the icons.
+
+The `budget` value is a soft completed-output-token target. Parallel agents may
+overshoot it; it is not a USD budget. Provider-reported costs use `$`, estimates
+use `~$`, and unavailable or mixed pricing uses `$?` rather than implying that
+unknown pricing is free. Live usage is shown when the runner exposes progress
+usage; process-isolated agents may only provide final usage after completion.
 
 #### 2. Per-agent visibility
 

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -634,8 +634,7 @@ function formatWorkflowFooterUsage(
       cacheRead: usage.cacheRead,
       cacheWrite: usage.cacheWrite,
       cost: usage.costUsd,
-      costSource:
-        usage.costSource === "mixed" ? "unavailable" : usage.costSource,
+      costSource: usage.costSource,
       turns: usage.turns,
     });
     hasUsage = true;

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -38,7 +38,11 @@ import { shouldNotify } from "./notifications";
 import { deliveryIdFor, enqueueDelivery, flushDeliveries } from "./delivery";
 import { debugLog, jobRegistry, type JobState } from "./helpers";
 import { coarseElapsedMs, formatActivityRow } from "./rendering";
-import { formatWorkflowUsage } from "./workflow-core";
+import {
+  addWorkflowUsage,
+  formatWorkflowUsage,
+  zeroWorkflowUsage,
+} from "./workflow-core";
 import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import ndjson from "ndjson";
@@ -565,9 +569,10 @@ async function runPollArtifactChanges(
       try {
         const wfCount = getRunningWorkflowCount(owner);
         const workflowRows = formatWorkflowWidgetRows(owner, now);
+        const workflowUsage = formatWorkflowFooterUsage(owner);
         const workflowStatus =
           wfCount > 0
-            ? `⚡ ${wfCount} workflow${wfCount > 1 ? "s" : ""} running`
+            ? `⚡ ${wfCount} workflow${wfCount > 1 ? "s" : ""} running${workflowUsage}`
             : undefined;
         updateFooterStatus(ui, WORKFLOW_FOOTER_KEY, workflowStatus, owner);
         updateWidgetRows(ui, WORKFLOW_WIDGET_KEY, workflowRows, owner);
@@ -596,8 +601,10 @@ function formatWorkflowWidgetRows(
     const parts = [
       `${s.agentsSpawned} agent${s.agentsSpawned === 1 ? "" : "s"}`,
       `${s.runningCount ?? 0} running`,
-      `${s.tokensSpent} output tokens`,
-      ...(s.usage ? [formatWorkflowUsage(s.usage)] : []),
+      ...(s.usage
+        ? [formatWorkflowUsage(s.usage, { outputBudget: s.budgetTotal })]
+        : []),
+      ...(s.liveUsage ? [`live ${formatWorkflowUsage(s.liveUsage)}`] : []),
       formatWorkflowElapsed(now - st.startedAt),
     ];
     if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);
@@ -610,6 +617,38 @@ function formatWorkflowWidgetRows(
     rows.push(`… and ${extra} more workflow${extra === 1 ? "" : "s"}`);
   }
   return rows;
+}
+
+function formatWorkflowFooterUsage(
+  owner: SessionOwnerToken | undefined,
+): string {
+  let aggregate = zeroWorkflowUsage();
+  let hasUsage = false;
+  for (const job of workflowJobRegistry.values()) {
+    if (!workflowJobBelongsToOwner(job, owner)) continue;
+    if (job.status !== "running" || !job.snapshot.usage) continue;
+    const usage = job.snapshot.usage;
+    aggregate = addWorkflowUsage(aggregate, {
+      input: usage.input,
+      output: usage.output,
+      cacheRead: usage.cacheRead,
+      cacheWrite: usage.cacheWrite,
+      cost: usage.costUsd,
+      costSource:
+        usage.costSource === "mixed" ? "unavailable" : usage.costSource,
+      turns: usage.turns,
+    });
+    hasUsage = true;
+  }
+  if (!hasUsage) return "";
+  if (
+    aggregate.totalTokens === 0 &&
+    aggregate.costUsd === 0 &&
+    aggregate.turns === 0
+  ) {
+    return "";
+  }
+  return ` · ${formatWorkflowUsage(aggregate)}`;
 }
 
 /** Coarse elapsed clock; see ACTIVITY_ELAPSED_BUCKET_MS for why it is bucketed. */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -123,8 +123,8 @@ export interface Usage {
   cacheRead: number;
   cacheWrite: number;
   cost: number;
-  /** Optional pricing provenance supplied by a provider or test adapter. */
-  costSource?: "provider" | "estimated" | "unavailable";
+  /** Pricing provenance; "mixed" is used only for aggregated samples. */
+  costSource?: "provider" | "estimated" | "unavailable" | "mixed";
   turns: number;
 }
 
@@ -132,29 +132,78 @@ function usageNumber(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-/** Extract one provider assistant-message usage record without mutating it. */
+type AssistantCostSource = Exclude<NonNullable<Usage["costSource"]>, "mixed">;
+
+function mergeUsageCostSource(
+  existing: Usage["costSource"],
+  next: Usage["costSource"],
+): Usage["costSource"] {
+  if (!next) return existing;
+  if (!existing) return next;
+  if (existing === next) return existing;
+  return "mixed";
+}
+
+function addUsageSamples(total: Usage, next: Usage): Usage {
+  const costSource = mergeUsageCostSource(total.costSource, next.costSource);
+  return {
+    input: total.input + next.input,
+    output: total.output + next.output,
+    cacheRead: total.cacheRead + next.cacheRead,
+    cacheWrite: total.cacheWrite + next.cacheWrite,
+    cost: total.cost + next.cost,
+    ...(costSource ? { costSource } : {}),
+    turns: total.turns + next.turns,
+  };
+}
+
+/** Extract one assistant-message usage record without mutating it. */
 export function usageFromAssistantMessage(
   message: unknown,
   turns = 1,
 ): Usage | undefined {
   if (!message || typeof message !== "object") return undefined;
-  const candidate = message as { role?: unknown; usage?: any };
-  if (candidate.role !== "assistant" || !candidate.usage) return undefined;
-  const raw = candidate.usage;
-  const hasProviderCost =
-    raw.cost !== null &&
-    typeof raw.cost === "object" &&
-    typeof raw.cost.total === "number" &&
-    Number.isFinite(raw.cost.total);
+  const candidate = message as { role?: unknown; usage?: unknown };
+  if (
+    candidate.role !== "assistant" ||
+    !candidate.usage ||
+    typeof candidate.usage !== "object"
+  ) {
+    return undefined;
+  }
+  const raw = candidate.usage as Record<string, unknown>;
+  const rawCost = raw.cost;
   const cost =
-    typeof raw.cost === "number" ? raw.cost : usageNumber(raw.cost?.total);
+    typeof rawCost === "number"
+      ? usageNumber(rawCost)
+      : rawCost && typeof rawCost === "object"
+        ? usageNumber((rawCost as Record<string, unknown>).total)
+        : 0;
+  const input = usageNumber(raw.input);
+  const output = usageNumber(raw.output);
+  const cacheRead = usageNumber(raw.cacheRead);
+  const cacheWrite = usageNumber(raw.cacheWrite);
+  const rawCostSource = raw.costSource;
+  const explicitSource: AssistantCostSource | undefined =
+    rawCostSource === "provider" ||
+    rawCostSource === "estimated" ||
+    rawCostSource === "unavailable"
+      ? rawCostSource
+      : undefined;
+  const costSource =
+    explicitSource ??
+    (cost > 0
+      ? "estimated"
+      : input + output + cacheRead + cacheWrite > 0
+        ? "unavailable"
+        : undefined);
   return {
-    input: usageNumber(raw.input),
-    output: usageNumber(raw.output),
-    cacheRead: usageNumber(raw.cacheRead),
-    cacheWrite: usageNumber(raw.cacheWrite),
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
     cost,
-    ...(hasProviderCost ? { costSource: "provider" as const } : {}),
+    ...(costSource ? { costSource } : {}),
     turns: Math.max(0, turns),
   };
 }
@@ -164,14 +213,14 @@ export function usageFromAssistantMessages(
   messages: readonly unknown[],
   fallback: Usage,
 ): Usage {
-  const total = { ...zeroUsageShape() };
+  const total = zeroUsageShape();
   let found = false;
-  let providerReported = false;
+  let costSource: Usage["costSource"];
   for (const message of messages) {
     const usage = usageFromAssistantMessage(message);
     if (!usage) continue;
     found = true;
-    providerReported ||= usage.costSource === "provider";
+    costSource = mergeUsageCostSource(costSource, usage.costSource);
     total.input += usage.input;
     total.output += usage.output;
     total.cacheRead += usage.cacheRead;
@@ -180,7 +229,8 @@ export function usageFromAssistantMessages(
     total.turns += usage.turns;
   }
   if (!found) return { ...fallback };
-  return providerReported ? { ...total, costSource: "provider" } : total;
+  if (costSource) total.costSource = costSource;
+  return total;
 }
 
 function zeroUsageShape(): Usage {
@@ -911,10 +961,11 @@ export async function startSubagentJob(
     }
   }
 
+  let completedLiveUsage = zeroUsageShape();
   const updateLiveUsageFromMessage = (message: unknown): void => {
-    const usage = usageFromAssistantMessage(message, liveStatus.turn);
-    if (!usage) return;
-    liveStatus.usage = usage;
+    const currentTurnUsage = usageFromAssistantMessage(message);
+    if (!currentTurnUsage) return;
+    liveStatus.usage = addUsageSamples(completedLiveUsage, currentTurnUsage);
   };
 
   // Wire session events
@@ -922,7 +973,10 @@ export async function startSubagentJob(
     switch (event.type) {
       case "turn_start": {
         liveStatus.turn++;
-        liveStatus.usage.turns = liveStatus.turn;
+        liveStatus.usage = {
+          ...completedLiveUsage,
+          turns: liveStatus.turn,
+        };
         liveStatus.output = "";
         debugLog("info", "turn_start", { jobId, turn: liveStatus.turn });
         onUpdate?.(buildLiveUpdate(liveStatus, modelLabel));
@@ -949,7 +1003,10 @@ export async function startSubagentJob(
         break;
       }
       case "turn_end": {
-        updateLiveUsageFromMessage((event as any).message);
+        updateLiveUsageFromMessage(
+          "message" in event ? event.message : undefined,
+        );
+        completedLiveUsage = { ...liveStatus.usage };
         debugLog("info", "turn_end", {
           jobId,
           turn: liveStatus.turn,
@@ -981,7 +1038,9 @@ export async function startSubagentJob(
           }),
           ...(evt.type === "toolcall_end" && { toolCallId: evt.toolCall?.id }),
         });
-        updateLiveUsageFromMessage((event as any).message);
+        updateLiveUsageFromMessage(
+          "message" in event ? event.message : undefined,
+        );
         if (evt.type === "text_delta") {
           liveStatus.output += evt.delta;
           onUpdate?.(buildLiveUpdate(liveStatus, modelLabel));

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -123,7 +123,75 @@ export interface Usage {
   cacheRead: number;
   cacheWrite: number;
   cost: number;
+  /** Optional pricing provenance supplied by a provider or test adapter. */
+  costSource?: "provider" | "estimated" | "unavailable";
   turns: number;
+}
+
+function usageNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/** Extract one provider assistant-message usage record without mutating it. */
+export function usageFromAssistantMessage(
+  message: unknown,
+  turns = 1,
+): Usage | undefined {
+  if (!message || typeof message !== "object") return undefined;
+  const candidate = message as { role?: unknown; usage?: any };
+  if (candidate.role !== "assistant" || !candidate.usage) return undefined;
+  const raw = candidate.usage;
+  const hasProviderCost =
+    raw.cost !== null &&
+    typeof raw.cost === "object" &&
+    typeof raw.cost.total === "number" &&
+    Number.isFinite(raw.cost.total);
+  const cost =
+    typeof raw.cost === "number" ? raw.cost : usageNumber(raw.cost?.total);
+  return {
+    input: usageNumber(raw.input),
+    output: usageNumber(raw.output),
+    cacheRead: usageNumber(raw.cacheRead),
+    cacheWrite: usageNumber(raw.cacheWrite),
+    cost,
+    ...(hasProviderCost ? { costSource: "provider" as const } : {}),
+    turns: Math.max(0, turns),
+  };
+}
+
+/** Aggregate assistant usage from a session, falling back to the live sample. */
+export function usageFromAssistantMessages(
+  messages: readonly unknown[],
+  fallback: Usage,
+): Usage {
+  const total = { ...zeroUsageShape() };
+  let found = false;
+  let providerReported = false;
+  for (const message of messages) {
+    const usage = usageFromAssistantMessage(message);
+    if (!usage) continue;
+    found = true;
+    providerReported ||= usage.costSource === "provider";
+    total.input += usage.input;
+    total.output += usage.output;
+    total.cacheRead += usage.cacheRead;
+    total.cacheWrite += usage.cacheWrite;
+    total.cost += usage.cost;
+    total.turns += usage.turns;
+  }
+  if (!found) return { ...fallback };
+  return providerReported ? { ...total, costSource: "provider" } : total;
+}
+
+function zeroUsageShape(): Usage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    cost: 0,
+    turns: 0,
+  };
 }
 
 export type SubagentResult =
@@ -843,6 +911,12 @@ export async function startSubagentJob(
     }
   }
 
+  const updateLiveUsageFromMessage = (message: unknown): void => {
+    const usage = usageFromAssistantMessage(message, liveStatus.turn);
+    if (!usage) return;
+    liveStatus.usage = usage;
+  };
+
   // Wire session events
   unsubscribe = session.subscribe((event: AgentSessionEvent) => {
     switch (event.type) {
@@ -875,6 +949,7 @@ export async function startSubagentJob(
         break;
       }
       case "turn_end": {
+        updateLiveUsageFromMessage((event as any).message);
         debugLog("info", "turn_end", {
           jobId,
           turn: liveStatus.turn,
@@ -906,6 +981,7 @@ export async function startSubagentJob(
           }),
           ...(evt.type === "toolcall_end" && { toolCallId: evt.toolCall?.id }),
         });
+        updateLiveUsageFromMessage((event as any).message);
         if (evt.type === "text_delta") {
           liveStatus.output += evt.delta;
           onUpdate?.(buildLiveUpdate(liveStatus, modelLabel));
@@ -970,6 +1046,11 @@ export async function startSubagentJob(
     thinkingLevel: effectiveThinkingLevel,
     errorMessage: "No subagent result captured.",
   };
+  const currentSessionUsage = (): Usage =>
+    usageFromAssistantMessages(
+      session.agent.state.messages as readonly unknown[],
+      liveStatus.usage,
+    );
   const jobPromise = (async (): Promise<SubagentResult> => {
     try {
       await startGate;
@@ -1018,14 +1099,7 @@ export async function startSubagentJob(
           isError: false,
           cancelled: true,
           output: `Sub-agent cancelled before completion${info.reason ? `: ${info.reason}` : ""}.`,
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            cost: 0,
-            turns: 0,
-          },
+          usage: currentSessionUsage(),
           model: session.model
             ? `${session.model.provider}/${session.model.id}`
             : undefined,
@@ -1066,24 +1140,7 @@ export async function startSubagentJob(
         }
       }
 
-      const usage = {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        cost: 0,
-        turns: 0,
-      };
-      for (const msg of messages) {
-        if (msg.role === "assistant" && msg.usage) {
-          usage.turns++;
-          usage.input += msg.usage.input;
-          usage.output += msg.usage.output;
-          usage.cacheRead += msg.usage.cacheRead;
-          usage.cacheWrite += msg.usage.cacheWrite;
-          usage.cost += msg.usage.cost.total;
-        }
-      }
+      const usage = currentSessionUsage();
 
       if (session.agent.state.errorMessage) {
         result = attachWorkflowStructuredOutput({
@@ -1116,14 +1173,7 @@ export async function startSubagentJob(
       });
       result = attachWorkflowStructuredOutput({
         output: `Sub-agent crashed: ${msg}`,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          cost: 0,
-          turns: 0,
-        },
+        usage: currentSessionUsage(),
         model: undefined,
         thinkingLevel: effectiveThinkingLevel,
         isError: true,

--- a/src/interactive-supervisor-ui.ts
+++ b/src/interactive-supervisor-ui.ts
@@ -14,6 +14,10 @@ import {
 } from "./interactive-tmux";
 import type { SessionOwnerToken } from "./session-scope";
 import type { WorkflowJobState } from "./workflow-jobs";
+import {
+  formatWorkflowUsage,
+  formatWorkflowUsageLegend,
+} from "./workflow-core";
 
 export const INTERACTIVE_SUPERVISOR_SHORTCUT = "ctrl+alt+a";
 const DEFAULT_REFRESH_INTERVAL_MS = 1_000;
@@ -700,13 +704,26 @@ function formatWorkflowDetails(job: WorkflowJobState, width: number): string[] {
   const omitted =
     (snapshot.agentRecordsOmitted ?? 0) +
     Math.max(0, allRecords.length - records.length);
+  const usage = snapshot.usage
+    ? formatWorkflowUsage(snapshot.usage, {
+        expanded: true,
+        ascii: true,
+        outputBudget: snapshot.budgetTotal,
+      })
+    : "unavailable";
   const fields = [
     `Workflow: ${job.name} (${job.id})`,
     `Phase: ${snapshot.currentPhase ?? "none"}`,
     `Agents: ${snapshot.agentsSpawned} total · ${snapshot.runningCount ?? 0} running`,
     `Errors: ${snapshot.errorCount}`,
-    `Output tokens: ${snapshot.tokensSpent}`,
+    `Usage: ${usage}`,
+    formatWorkflowUsageLegend(true),
     `Last activity: ${snapshot.lastMessage ?? "none yet"}`,
+    ...(snapshot.liveUsage
+      ? [
+          `Live usage: ${formatWorkflowUsage(snapshot.liveUsage, { ascii: true })}`,
+        ]
+      : []),
   ];
   if (omitted > 0) fields.push(`… ${omitted} older agent records omitted`);
   for (const record of records) {
@@ -714,7 +731,11 @@ function formatWorkflowDetails(job: WorkflowJobState, width: number): string[] {
     const model = record.model ? ` @${record.model}` : "";
     const phase = record.phase ? ` (${record.phase})` : "";
     fields.push(
-      `Agent: ${statusIcon(record.status)} ${record.status} ${label} #${record.agentId}${model}${phase}`,
+      `Agent: ${statusIcon(record.status)} ${record.status} ${label} #${record.agentId}${model}${phase}${
+        record.usage
+          ? ` — ${formatWorkflowUsage(record.usage, { ascii: true })}`
+          : ""
+      }`,
     );
   }
   return fields.map((field) => trunc(`│     ${field}`, width));

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -77,12 +77,11 @@ function usageCostSource(
     usage.output === 0 &&
     usage.cacheRead === 0 &&
     usage.cacheWrite === 0 &&
-    usage.cost === 0 &&
-    usage.turns === 0
+    usage.cost === 0
   ) {
     return undefined;
   }
-  return usage.cost > 0 ? "provider" : "unavailable";
+  return usage.cost > 0 ? "estimated" : "unavailable";
 }
 
 function mergeCostSource(
@@ -90,7 +89,7 @@ function mergeCostSource(
   next: WorkflowCostSource | undefined,
 ): WorkflowCostSource | undefined {
   const existing =
-    total.costSource ?? (total.costUsd > 0 ? "provider" : undefined);
+    total.costSource ?? (total.costUsd > 0 ? "estimated" : undefined);
   if (!next) return existing;
   if (!existing) return next;
   if (existing === next) return next;
@@ -108,12 +107,7 @@ export function addWorkflowUsage(
   const cacheWrite = total.cacheWrite + (usage?.cacheWrite ?? 0);
   const nextCostSource = usageCostSource(usage);
   const costSource = mergeCostSource(total, nextCostSource);
-  const hasExplicitProvenance =
-    usage?.costSource !== undefined || total.costSource !== undefined;
-  const provenance =
-    costSource && (hasExplicitProvenance || costSource === "mixed")
-      ? { costSource }
-      : {};
+  const provenance = costSource ? { costSource } : {};
   return {
     input,
     output,
@@ -163,7 +157,7 @@ export function formatWorkflowUsage(
   options: WorkflowUsageFormatOptions = {},
 ): string {
   const source =
-    usage.costSource ?? (usage.costUsd > 0 ? "provider" : "unavailable");
+    usage.costSource ?? (usage.costUsd > 0 ? "estimated" : "unavailable");
   const cost =
     source === "unavailable"
       ? "$?"

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -40,6 +40,9 @@ export function zeroUsage(): Usage {
   };
 }
 
+export type WorkflowCostSource =
+  "provider" | "estimated" | "unavailable" | "mixed";
+
 export interface WorkflowUsage {
   input: number;
   output: number;
@@ -48,6 +51,8 @@ export interface WorkflowUsage {
   totalTokens: number;
   costUsd: number;
   turns: number;
+  /** Pricing provenance; omitted only for legacy/empty aggregates. */
+  costSource?: WorkflowCostSource;
 }
 
 export function zeroWorkflowUsage(): WorkflowUsage {
@@ -62,6 +67,36 @@ export function zeroWorkflowUsage(): WorkflowUsage {
   };
 }
 
+function usageCostSource(
+  usage: Usage | undefined,
+): WorkflowCostSource | undefined {
+  if (!usage) return undefined;
+  if (usage.costSource) return usage.costSource;
+  if (
+    usage.input === 0 &&
+    usage.output === 0 &&
+    usage.cacheRead === 0 &&
+    usage.cacheWrite === 0 &&
+    usage.cost === 0 &&
+    usage.turns === 0
+  ) {
+    return undefined;
+  }
+  return usage.cost > 0 ? "provider" : "unavailable";
+}
+
+function mergeCostSource(
+  total: WorkflowUsage,
+  next: WorkflowCostSource | undefined,
+): WorkflowCostSource | undefined {
+  const existing =
+    total.costSource ?? (total.costUsd > 0 ? "provider" : undefined);
+  if (!next) return existing;
+  if (!existing) return next;
+  if (existing === next) return next;
+  return "mixed";
+}
+
 /** Return a new aggregate; callers never share mutable accounting state. */
 export function addWorkflowUsage(
   total: WorkflowUsage,
@@ -71,6 +106,14 @@ export function addWorkflowUsage(
   const output = total.output + (usage?.output ?? 0);
   const cacheRead = total.cacheRead + (usage?.cacheRead ?? 0);
   const cacheWrite = total.cacheWrite + (usage?.cacheWrite ?? 0);
+  const nextCostSource = usageCostSource(usage);
+  const costSource = mergeCostSource(total, nextCostSource);
+  const hasExplicitProvenance =
+    usage?.costSource !== undefined || total.costSource !== undefined;
+  const provenance =
+    costSource && (hasExplicitProvenance || costSource === "mixed")
+      ? { costSource }
+      : {};
   return {
     input,
     output,
@@ -79,7 +122,26 @@ export function addWorkflowUsage(
     totalTokens: input + output + cacheRead + cacheWrite,
     costUsd: total.costUsd + (usage?.cost ?? 0),
     turns: total.turns + (usage?.turns ?? 0),
+    ...provenance,
   };
+}
+
+export function workflowUsageFromUsage(
+  usage: Usage | undefined,
+): WorkflowUsage | undefined {
+  const source = usageCostSource(usage);
+  if (!usage || source === undefined) return undefined;
+  if (
+    usage.input === 0 &&
+    usage.output === 0 &&
+    usage.cacheRead === 0 &&
+    usage.cacheWrite === 0 &&
+    usage.cost === 0 &&
+    usage.costSource === undefined
+  ) {
+    return undefined;
+  }
+  return addWorkflowUsage(zeroWorkflowUsage(), usage);
 }
 
 function formatWorkflowCost(costUsd: number): string {
@@ -90,8 +152,72 @@ function formatWorkflowCost(costUsd: number): string {
   });
 }
 
-export function formatWorkflowUsage(usage: WorkflowUsage): string {
-  return `${usage.totalTokens} total tokens, $${formatWorkflowCost(usage.costUsd)}`;
+export interface WorkflowUsageFormatOptions {
+  expanded?: boolean;
+  ascii?: boolean;
+  outputBudget?: number | null;
+}
+
+export function formatWorkflowUsage(
+  usage: WorkflowUsage,
+  options: WorkflowUsageFormatOptions = {},
+): string {
+  const source =
+    usage.costSource ?? (usage.costUsd > 0 ? "provider" : "unavailable");
+  const cost =
+    source === "unavailable"
+      ? "$?"
+      : source === "mixed"
+        ? "$? (mixed)"
+        : source === "estimated"
+          ? `~$${formatWorkflowCost(usage.costUsd)}`
+          : `$${formatWorkflowCost(usage.costUsd)}`;
+  const budget =
+    options.outputBudget == null
+      ? ""
+      : `/${formatWorkflowCost(options.outputBudget)}`;
+  if (!options.expanded) {
+    const icons = options.ascii
+      ? [
+          `input=${usage.input}`,
+          `output=${usage.output}${budget}`,
+          `cache-read=${usage.cacheRead}`,
+          `cache-write=${usage.cacheWrite}`,
+          `cost=${cost}`,
+        ]
+      : [
+          `↑${usage.input}`,
+          `↓${usage.output}${budget}`,
+          `R${usage.cacheRead}`,
+          `W${usage.cacheWrite}`,
+          `${cost}`,
+        ];
+    return icons.join(" ");
+  }
+  const labels = options.ascii
+    ? [
+        `input tokens: ${usage.input}`,
+        `output tokens: ${usage.output}${budget}`,
+        `cache-read tokens: ${usage.cacheRead}`,
+        `cache-write tokens: ${usage.cacheWrite}`,
+        `cost: ${cost} (${source})`,
+        `turns: ${usage.turns}`,
+      ]
+    : [
+        `↑ input tokens: ${usage.input}`,
+        `↓ output tokens: ${usage.output}${budget}`,
+        `R cache-read tokens: ${usage.cacheRead}`,
+        `W cache-write tokens: ${usage.cacheWrite}`,
+        `$ cost: ${cost} (${source})`,
+        `turns: ${usage.turns}`,
+      ];
+  return labels.join("; ");
+}
+
+export function formatWorkflowUsageLegend(ascii = false): string {
+  return ascii
+    ? "Legend: input, output, cache-read, cache-write, cost"
+    : "Legend: ↑ input · ↓ output · R cache-read · W cache-write · $ cost";
 }
 
 // ── Public types ─────────────────────────────────────────────────────
@@ -117,6 +243,8 @@ export type WorkflowAgentProgress =
       message?: string;
       label?: string;
       agentId?: number;
+      /** Latest live usage from the active agent, when available. */
+      liveUsage?: WorkflowUsage;
     }
   | {
       kind: "log";
@@ -124,6 +252,8 @@ export type WorkflowAgentProgress =
       phase?: string;
       label?: string;
       agentId?: number;
+      /** Latest live usage from the active agent, when available. */
+      liveUsage?: WorkflowUsage;
     };
 
 /** Injectable spawn function — wraps in-process or process-backed agents. */
@@ -164,9 +294,13 @@ export type WorkflowProgress =
       agentId?: number;
       agentsSpawned: number;
       errorCount: number;
-      /** @deprecated Output-token count; use usage.totalTokens. */
+      /** @deprecated Output-token count; use usage.output. */
       tokensSpent: number;
+      /** Soft completed-output-token target, if configured. */
+      budgetTotal?: number | null;
       usage?: WorkflowUsage;
+      /** Latest live usage from the active agent, when available. */
+      liveUsage?: WorkflowUsage;
       runningCount: number;
       model?: string;
     }
@@ -178,9 +312,12 @@ export type WorkflowProgress =
       agentId?: number;
       agentsSpawned: number;
       errorCount: number;
-      /** @deprecated Output-token count; use usage.totalTokens. */
+      /** @deprecated Output-token count; use usage.output. */
       tokensSpent: number;
+      budgetTotal?: number | null;
       usage?: WorkflowUsage;
+      /** Latest live usage from the active agent, when available. */
+      liveUsage?: WorkflowUsage;
       runningCount: number;
       model?: string;
     }
@@ -192,9 +329,12 @@ export type WorkflowProgress =
       agentId?: number;
       agentsSpawned: number;
       errorCount: number;
-      /** @deprecated Output-token count; use usage.totalTokens. */
+      /** @deprecated Output-token count; use usage.output. */
       tokensSpent: number;
+      budgetTotal?: number | null;
       usage?: WorkflowUsage;
+      /** Latest live usage from the active agent, when available. */
+      liveUsage?: WorkflowUsage;
       runningCount: number;
       model?: string;
     }
@@ -207,11 +347,16 @@ export type WorkflowProgress =
       agentId?: number;
       agentsSpawned: number;
       errorCount: number;
-      /** @deprecated Output-token count; use usage.totalTokens. */
+      /** @deprecated Output-token count; use usage.output. */
       tokensSpent: number;
+      budgetTotal?: number | null;
       usage?: WorkflowUsage;
+      /** Latest live usage from the active agent, when available. */
+      liveUsage?: WorkflowUsage;
       runningCount: number;
       model?: string;
+      /** Usage attributed to this agent attempt, when available. */
+      agentUsage?: WorkflowUsage;
     };
 
 export interface WorkflowAgentRecord {
@@ -220,6 +365,8 @@ export interface WorkflowAgentRecord {
   label?: string;
   model?: string;
   status: "running" | "done" | "error" | "cancelled";
+  /** Usage attributed to this attempt; absent when the runner produced none. */
+  usage?: WorkflowUsage;
 }
 
 export const MAX_WORKFLOW_AGENT_RECORDS = 50;
@@ -227,7 +374,12 @@ export const MAX_WORKFLOW_AGENT_RECORDS = 50;
 export type WorkflowProgressUpdate = {
   [K in WorkflowProgress["kind"]]: Omit<
     Extract<WorkflowProgress, { kind: K }>,
-    "agentsSpawned" | "errorCount" | "tokensSpent" | "usage" | "runningCount"
+    | "agentsSpawned"
+    | "errorCount"
+    | "tokensSpent"
+    | "budgetTotal"
+    | "usage"
+    | "runningCount"
   >;
 }[WorkflowProgress["kind"]];
 
@@ -237,7 +389,7 @@ export interface WorkflowRunResult {
   result: unknown;
   agentsSpawned: number;
   errorCount: number;
-  /** @deprecated Output-token count; use usage.totalTokens. */
+  /** @deprecated Output-token count; use usage.output. */
   tokensSpent: number;
   usage?: WorkflowUsage;
   phases: string[];

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -39,9 +39,13 @@ export interface WorkflowJobState {
   snapshot: {
     agentsSpawned: number;
     errorCount: number;
-    /** @deprecated Output-token count; use usage.totalTokens. */
+    /** @deprecated Output-token count; use usage.output. */
     tokensSpent: number;
+    /** Soft completed-output-token target, if configured. */
+    budgetTotal?: number | null;
     usage?: WorkflowUsage;
+    /** Latest usage sample from an active agent, when supported. */
+    liveUsage?: WorkflowUsage;
     phases: string[];
     lastMessage?: string;
     currentPhase?: string;
@@ -238,6 +242,7 @@ export function startWorkflowJob(
       agentsSpawned: 0,
       errorCount: 0,
       tokensSpent: 0,
+      budgetTotal: opts.budgetTotal ?? null,
       usage: zeroWorkflowUsage(),
       phases: [],
       agentRecords: [],
@@ -259,7 +264,11 @@ export function startWorkflowJob(
       state.snapshot.agentsSpawned = p.agentsSpawned;
       state.snapshot.errorCount = p.errorCount;
       state.snapshot.tokensSpent = p.tokensSpent;
+      state.snapshot.budgetTotal = p.budgetTotal ?? state.snapshot.budgetTotal;
       state.snapshot.usage = p.usage ? { ...p.usage } : state.snapshot.usage;
+      state.snapshot.liveUsage = p.liveUsage
+        ? { ...p.liveUsage }
+        : state.snapshot.liveUsage;
       state.snapshot.runningCount = p.runningCount;
       if (p.kind === "phase" && p.phase) {
         state.snapshot.currentPhase = p.phase;
@@ -271,9 +280,13 @@ export function startWorkflowJob(
         state.snapshot.lastMessage = `→ started${formatWorkflowAgentTag(p)}`;
       } else if (p.kind === "agent_done") {
         state.snapshot.lastMessage = `→ done${formatWorkflowAgentTag(p)}`;
+        state.snapshot.liveUsage = undefined;
       }
       if (p.kind === "agent_start" || p.kind === "agent_done") {
         recordWorkflowAgentProgress(state.snapshot, p);
+      }
+      if (p.liveUsage && typeof p.agentId === "number") {
+        recordWorkflowAgentLiveUsage(state.snapshot, p.agentId, p.liveUsage);
       }
       opts.onProgress?.(p);
     },
@@ -284,6 +297,7 @@ export function startWorkflowJob(
     .then((r) => {
       if (state.status === "running") state.status = "done";
       state.result = r;
+      state.snapshot.liveUsage = undefined;
       if (state.status === "cancelled") normalizeCancelledWorkflowState(state);
       invokeCompletionHook(state);
       return r;
@@ -292,6 +306,7 @@ export function startWorkflowJob(
       const msg = err instanceof Error ? err.message : String(err);
       state.status = abort.signal.aborted ? "cancelled" : "error";
       state.error = msg;
+      state.snapshot.liveUsage = undefined;
       if (state.status === "cancelled") normalizeCancelledWorkflowState(state);
       invokeCompletionHook(state);
       throw err;
@@ -380,6 +395,7 @@ export function retryPendingWorkflowNotifications(
 export function normalizeCancelledWorkflowState(state: WorkflowJobState): void {
   if (!state.snapshot) return;
   state.snapshot.runningCount = 0;
+  state.snapshot.liveUsage = undefined;
   for (const record of state.snapshot.agentRecords ?? []) {
     if (record.status === "running") record.status = "cancelled";
   }
@@ -417,20 +433,35 @@ function recordWorkflowAgentProgress(
     );
     if (record) {
       record.status = progress.status ?? "done";
+      if (progress.agentUsage) record.usage = progress.agentUsage;
+      if (progress.model) record.model = progress.model;
     } else {
-      records.push({
+      const nextRecord: WorkflowAgentRecord = {
         agentId: progress.agentId,
         phase: progress.phase,
         label: progress.label,
         model: progress.model,
         status: progress.status ?? "done",
-      });
+      };
+      if (progress.agentUsage) nextRecord.usage = progress.agentUsage;
+      records.push(nextRecord);
     }
   }
   while (records.length > MAX_WORKFLOW_AGENT_RECORDS) {
     records.shift();
     snapshot.agentRecordsOmitted = (snapshot.agentRecordsOmitted ?? 0) + 1;
   }
+}
+
+function recordWorkflowAgentLiveUsage(
+  snapshot: WorkflowJobState["snapshot"],
+  agentId: number,
+  usage: WorkflowUsage,
+): void {
+  const record = snapshot.agentRecords?.find(
+    (candidate) => candidate.agentId === agentId,
+  );
+  if (record?.status === "running") record.usage = { ...usage };
 }
 
 function formatWorkflowAgentTag(p: WorkflowProgress): string {

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -15,6 +15,7 @@ import {
   type WorkflowRunResult,
   type WorkflowRunResultWithUsage,
   type WorkflowUsage,
+  WorkflowExecutionError,
   MAX_WORKFLOW_AGENT_RECORDS,
   zeroWorkflowUsage,
 } from "./workflow-core";
@@ -44,7 +45,7 @@ export interface WorkflowJobState {
     /** Soft completed-output-token target, if configured. */
     budgetTotal?: number | null;
     usage?: WorkflowUsage;
-    /** Latest usage sample from an active agent, when supported. */
+    /** Aggregate usage from every active agent that reports a live sample. */
     liveUsage?: WorkflowUsage;
     phases: string[];
     lastMessage?: string;
@@ -255,6 +256,7 @@ export function startWorkflowJob(
     activeAgentRuns: new Set(),
     parentSessionOwner,
   };
+  const liveUsageByAgent = new Map<number, WorkflowUsage>();
   state.promise = runWorkflow(script, {
     ...opts,
     runAgent: (request) =>
@@ -266,9 +268,6 @@ export function startWorkflowJob(
       state.snapshot.tokensSpent = p.tokensSpent;
       state.snapshot.budgetTotal = p.budgetTotal ?? state.snapshot.budgetTotal;
       state.snapshot.usage = p.usage ? { ...p.usage } : state.snapshot.usage;
-      state.snapshot.liveUsage = p.liveUsage
-        ? { ...p.liveUsage }
-        : state.snapshot.liveUsage;
       state.snapshot.runningCount = p.runningCount;
       if (p.kind === "phase" && p.phase) {
         state.snapshot.currentPhase = p.phase;
@@ -280,14 +279,18 @@ export function startWorkflowJob(
         state.snapshot.lastMessage = `→ started${formatWorkflowAgentTag(p)}`;
       } else if (p.kind === "agent_done") {
         state.snapshot.lastMessage = `→ done${formatWorkflowAgentTag(p)}`;
-        state.snapshot.liveUsage = undefined;
       }
       if (p.kind === "agent_start" || p.kind === "agent_done") {
         recordWorkflowAgentProgress(state.snapshot, p);
       }
-      if (p.liveUsage && typeof p.agentId === "number") {
-        recordWorkflowAgentLiveUsage(state.snapshot, p.agentId, p.liveUsage);
+      if (typeof p.agentId === "number") {
+        if (p.liveUsage) {
+          liveUsageByAgent.set(p.agentId, { ...p.liveUsage });
+          recordWorkflowAgentLiveUsage(state.snapshot, p.agentId, p.liveUsage);
+        }
+        if (p.kind === "agent_done") liveUsageByAgent.delete(p.agentId);
       }
+      state.snapshot.liveUsage = aggregateWorkflowLiveUsage(liveUsageByAgent);
       opts.onProgress?.(p);
     },
     onCancellationSnapshot: (receipt) => {
@@ -298,6 +301,7 @@ export function startWorkflowJob(
       if (state.status === "running") state.status = "done";
       state.result = r;
       state.snapshot.liveUsage = undefined;
+      liveUsageByAgent.clear();
       if (state.status === "cancelled") normalizeCancelledWorkflowState(state);
       invokeCompletionHook(state);
       return r;
@@ -306,7 +310,12 @@ export function startWorkflowJob(
       const msg = err instanceof Error ? err.message : String(err);
       state.status = abort.signal.aborted ? "cancelled" : "error";
       state.error = msg;
+      if (err instanceof WorkflowExecutionError && err.usage) {
+        state.snapshot.usage = { ...err.usage };
+        state.snapshot.tokensSpent = err.usage.output;
+      }
       state.snapshot.liveUsage = undefined;
+      liveUsageByAgent.clear();
       if (state.status === "cancelled") normalizeCancelledWorkflowState(state);
       invokeCompletionHook(state);
       throw err;
@@ -462,6 +471,39 @@ function recordWorkflowAgentLiveUsage(
     (candidate) => candidate.agentId === agentId,
   );
   if (record?.status === "running") record.usage = { ...usage };
+}
+
+function aggregateWorkflowLiveUsage(
+  samples: ReadonlyMap<number, WorkflowUsage>,
+): WorkflowUsage | undefined {
+  if (samples.size === 0) return undefined;
+  const total = zeroWorkflowUsage();
+  let costSource: WorkflowUsage["costSource"];
+  for (const usage of samples.values()) {
+    total.input += usage.input;
+    total.output += usage.output;
+    total.cacheRead += usage.cacheRead;
+    total.cacheWrite += usage.cacheWrite;
+    total.costUsd += usage.costUsd;
+    total.turns += usage.turns;
+    const nextSource =
+      usage.costSource ??
+      (usage.costUsd > 0
+        ? "estimated"
+        : usage.totalTokens > 0
+          ? "unavailable"
+          : undefined);
+    if (nextSource) {
+      costSource =
+        costSource === undefined || costSource === nextSource
+          ? nextSource
+          : "mixed";
+    }
+  }
+  total.totalTokens =
+    total.input + total.output + total.cacheRead + total.cacheWrite;
+  if (costSource) total.costSource = costSource;
+  return total;
 }
 
 function formatWorkflowAgentTag(p: WorkflowProgress): string {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -27,6 +27,7 @@ import {
   type WorkflowRunResult,
   type WorkflowUsage,
   formatWorkflowUsage,
+  workflowUsageFromUsage,
 } from "./workflow-core";
 import {
   getWorkflowCompletionPresentation,
@@ -140,7 +141,7 @@ export function formatWorkflowNotificationSummary(
   if (run) {
     return (
       `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ` +
-      `${run.tokensSpent} output tokens${run.usage ? ` (${formatWorkflowUsage(run.usage)})` : ""}.`
+      `${run.usage ? formatWorkflowUsage(run.usage, { outputBudget: job.snapshot.budgetTotal }) : "usage unavailable"}.`
     );
   }
   const usage = presentWorkflowUsage(job.snapshot.usage);
@@ -183,11 +184,11 @@ export function registerWorkflowTool(
       let lastUpdateTs = 0;
       const THROTTLE_MS = 2000;
 
-      const maybeEmitUpdate = (msg: string) => {
+      const maybeEmitUpdate = (msg: string, liveUsage?: WorkflowUsage) => {
         const now = Date.now();
         if (now - lastUpdateTs >= THROTTLE_MS) {
           lastUpdateTs = now;
-          onProgress?.({ kind: "log", message: msg, label });
+          onProgress?.({ kind: "log", message: msg, label, liveUsage });
         }
       };
 
@@ -256,16 +257,19 @@ export function registerWorkflowTool(
         contextText: null,
         signal: abort.signal,
         onUpdate: (partial) => {
+          const liveUsage = workflowUsageFromUsage(
+            partial.details?.subagentStatus?.usage,
+          );
           const status = partial.details?.subagentStatus;
           if (status?.activeTool) {
-            maybeEmitUpdate(`⚙ ${status.activeTool.name}`);
+            maybeEmitUpdate(`⚙ ${status.activeTool.name}`, liveUsage);
           } else if (status?.output) {
             const preview = (status.output || "")
               .slice(0, 60)
               .replace(/\s+/g, " ")
               .trim();
-            if (preview) maybeEmitUpdate(`💭 ${preview}`);
-          }
+            if (preview) maybeEmitUpdate(`💭 ${preview}`, liveUsage);
+          } else if (liveUsage) maybeEmitUpdate("↻ usage", liveUsage);
         },
         defaultModel: ctx.model,
         parentModelRegistry: ctx.modelRegistry,
@@ -621,7 +625,7 @@ export function registerWorkflowTool(
           : "complete";
         const summary =
           `${completionPrefix}Workflow "${run.meta.name}" ${completionLabel} — ` +
-          `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} output tokens (${formatWorkflowUsage(run.usage)}).`;
+          `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${formatWorkflowUsage(run.usage, { outputBudget: job.snapshot.budgetTotal })}.`;
         return {
           content: [{ type: "text", text: `${summary}\n\n${resultText}` }],
           details: {
@@ -658,7 +662,7 @@ export function registerWorkflowTool(
     name: "get_workflow_status",
     label: "Workflow Status",
     description:
-      "Poll a background workflow's live progress (agents spawned, errors, output tokens, total usage, current phase).",
+      "Poll a background workflow's live progress (agents, errors, canonical usage, output budget, and current phase). Usage icons: ↑ input, ↓ output, R/W cache, $ cost.",
     parameters: Type.Object({
       workflowId: Type.String({
         description: "Workflow ID returned by an async `workflow` spawn.",
@@ -690,9 +694,12 @@ export function registerWorkflowTool(
               (st.snapshot.runningCount && st.snapshot.runningCount > 0
                 ? `, ${st.snapshot.runningCount} running`
                 : "") +
-              `, ${errorCount} error(s), ${st.snapshot.tokensSpent} output tokens` +
+              `, ${errorCount} error(s)` +
               (st.snapshot.usage
-                ? ` (${formatWorkflowUsage(st.snapshot.usage)})`
+                ? `, ${formatWorkflowUsage(st.snapshot.usage, { outputBudget: st.snapshot.budgetTotal })}`
+                : ", usage unavailable") +
+              (st.snapshot.liveUsage
+                ? `, live ${formatWorkflowUsage(st.snapshot.liveUsage)}`
                 : "") +
               (st.snapshot.currentPhase
                 ? `, phase: ${st.snapshot.currentPhase}`
@@ -807,7 +814,7 @@ export function registerWorkflowTool(
               const label = presentation.icon ? presentation.label : "complete";
               return (
                 `${prefix}Workflow "${run.meta.name}" ${label} — ` +
-                `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.tokensSpent} output tokens${run.usage ? ` (${formatWorkflowUsage(run.usage)})` : ""}.\n\n${resultText}`
+                `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.usage ? formatWorkflowUsage(run.usage, { outputBudget: st.snapshot.budgetTotal }) : "usage unavailable"}.\n\n${resultText}`
               );
             })(),
           },
@@ -1218,7 +1225,7 @@ export function registerWorkflowTool(
 
     pi.registerCommand("workflow-status", {
       description:
-        "List running and completed workflow jobs with status, agent counts, output tokens, total usage, and elapsed time.",
+        "List running and completed workflow jobs with status, agent counts, canonical usage, output budget, and elapsed time.",
       handler: async (_args: string, ctx: ExtensionCommandContext) => {
         const text = renderWorkflowJobs(owner());
         ctx.ui.notify("📋 Workflow status listed.");
@@ -1359,8 +1366,11 @@ export function registerWorkflowTool(
         parts.push(`⚡ ${s.runningCount} running`);
       }
       if (errorCount > 0) parts.push(`⚠ ${errorCount} error(s)`);
-      parts.push(`${s.tokensSpent} output tokens`);
-      if (s.usage) parts.push(formatWorkflowUsage(s.usage));
+      if (s.usage) {
+        parts.push(
+          formatWorkflowUsage(s.usage, { outputBudget: s.budgetTotal }),
+        );
+      }
       parts.push(elapsed);
       if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);
       if (st.error) parts.push(`error: ${st.error}`);

--- a/src/workflow-tree-ui.ts
+++ b/src/workflow-tree-ui.ts
@@ -5,7 +5,10 @@ import {
   workflowJobsForOwner,
   type WorkflowJobState,
 } from "./workflow-jobs";
-import { formatWorkflowUsage } from "./workflow-core";
+import {
+  formatWorkflowUsage,
+  formatWorkflowUsageLegend,
+} from "./workflow-core";
 import type { SessionOwnerToken } from "./session-scope";
 
 const MAX_WORKFLOW_TREE_AGENT_ROWS = 20;
@@ -51,6 +54,7 @@ export class WorkflowTreeComponent {
         width,
       ),
     );
+    lines.push(trunc(`│ ${formatWorkflowUsageLegend()}`, width));
 
     if (rows.length === 0) {
       lines.push(trunc("│ No workflow jobs.", width));
@@ -213,14 +217,29 @@ function formatWorkflowSummary(job: WorkflowJobState): string {
     `${s.runningCount ?? 0} running`,
   ];
   if (errorCount > 0) parts.push(`${errorCount} errors`);
-  parts.push(`${s.tokensSpent} output tokens`);
-  if (s.usage) parts.push(formatWorkflowUsage(s.usage));
+  if (s.usage) {
+    parts.push(formatWorkflowUsage(s.usage, { outputBudget: s.budgetTotal }));
+  }
   if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);
   return parts.join(" · ");
 }
 
 function formatWorkflowDetails(job: WorkflowJobState): WorkflowRow[] {
   const rows: WorkflowRow[] = [];
+  if (job.snapshot.usage) {
+    rows.push({
+      job,
+      depth: 1,
+      selectable: false,
+      text: formatWorkflowUsage(job.snapshot.usage, { expanded: true }),
+    });
+    rows.push({
+      job,
+      depth: 1,
+      selectable: false,
+      text: formatWorkflowUsageLegend(),
+    });
+  }
   for (const phase of job.snapshot.phases) {
     rows.push({
       job,
@@ -258,7 +277,11 @@ function formatWorkflowDetails(job: WorkflowJobState): WorkflowRow[] {
       job,
       depth: 1,
       selectable: false,
-      text: `${marker} ${record.status} ${label}${model}${phase}`,
+      text: `${marker} ${record.status} ${label}${model}${phase}${
+        record.usage
+          ? ` — ${formatWorkflowUsage(record.usage, { ascii: true })}`
+          : ""
+      }`,
     });
   }
   if (job.snapshot.lastMessage) {

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -6,8 +6,12 @@ export function renderProgress(p: WorkflowProgress): string {
   const parts = [`● workflow — ${p.agentsSpawned} agent(s)`];
   if (p.runningCount > 0) parts.push(`⚡ ${p.runningCount} running`);
   if (p.errorCount > 0) parts.push(`⚠ ${p.errorCount} error(s)`);
-  parts.push(`${p.tokensSpent} output tokens`);
-  if (p.usage) parts.push(formatWorkflowUsage(p.usage));
+  if (p.usage) {
+    parts.push(formatWorkflowUsage(p.usage, { outputBudget: p.budgetTotal }));
+  }
+  if (p.liveUsage) {
+    parts.push(`live ${formatWorkflowUsage(p.liveUsage)}`);
+  }
   const head = parts.join(", ");
   switch (p.kind) {
     case "phase":

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -10,7 +10,7 @@ import {
   type SubagentEvent,
   type TurnTerminalEvent,
 } from "./artifact";
-import { debugLog } from "./helpers";
+import { debugLog, usageFromAssistantMessages } from "./helpers";
 import type { SubagentResult, Usage } from "./helpers";
 import {
   INTERACTIVE_DEAD_GRACE_TICKS,
@@ -38,6 +38,7 @@ import {
   WorkflowExecutionError,
   type WorkflowUsage,
   addWorkflowUsage,
+  workflowUsageFromUsage,
   zeroUsage,
   zeroWorkflowUsage,
 } from "./workflow-core";
@@ -50,6 +51,12 @@ import {
 import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
 
 // ── Engine (shared across nested workflows) ──────────────────────────
+
+interface ActiveAgentRun {
+  promise: Promise<SubagentResult>;
+  liveUsage?: WorkflowUsage;
+  usageAccounted: boolean;
+}
 
 interface Engine {
   runAgent: WorkflowAgentRunner;
@@ -67,13 +74,14 @@ interface Engine {
   counters: {
     agentsSpawned: number;
     errorCount: number;
-    /** @deprecated Output-token count; use usage.totalTokens. */
+    /** @deprecated Output-token count; use usage.output. */
     tokensSpent: number;
     runningCount: number;
   };
   nextAgentAttemptId: number;
 
   usage: WorkflowUsage;
+  activeAgentRuns: Set<ActiveAgentRun>;
   failureCause?: unknown;
   phases: string[];
 }
@@ -82,23 +90,79 @@ function withProgressCounters(
   progress: WorkflowProgressUpdate,
   counters: Engine["counters"],
   usage: WorkflowUsage,
+  budgetTotal: number | null,
 ): WorkflowProgress {
   switch (progress.kind) {
     case "phase":
     case "log":
     case "agent_start":
     case "agent_done":
-      return { ...progress, ...counters, usage: { ...usage } };
+      return {
+        ...progress,
+        ...counters,
+        budgetTotal,
+        usage: { ...usage },
+      };
     default:
       return assertNever(progress);
   }
 }
 
 function usageIfPresent(usage: WorkflowUsage): WorkflowUsage | undefined {
-  if (usage.totalTokens === 0 && usage.costUsd === 0 && usage.turns === 0) {
+  if (
+    usage.totalTokens === 0 &&
+    usage.costUsd === 0 &&
+    usage.turns === 0 &&
+    usage.costSource === undefined
+  ) {
     return undefined;
   }
   return { ...usage };
+}
+
+function usageAsProjectUsage(usage: WorkflowUsage): Usage {
+  return {
+    input: usage.input,
+    output: usage.output,
+    cacheRead: usage.cacheRead,
+    cacheWrite: usage.cacheWrite,
+    cost: usage.costUsd,
+    ...(usage.costSource && usage.costSource !== "mixed"
+      ? { costSource: usage.costSource }
+      : {}),
+    turns: usage.turns,
+  };
+}
+
+function accountAgentUsage(
+  engine: Engine,
+  run: ActiveAgentRun,
+  usage: Usage | undefined,
+): void {
+  if (run.usageAccounted || !usage) return;
+  engine.usage = addWorkflowUsage(engine.usage, usage);
+  engine.counters.tokensSpent += usage.output;
+  run.usageAccounted = true;
+}
+
+function captureActiveAgentUsage(engine: Engine): void {
+  for (const run of engine.activeAgentRuns) {
+    accountAgentUsage(
+      engine,
+      run,
+      run.liveUsage ? usageAsProjectUsage(run.liveUsage) : undefined,
+    );
+  }
+}
+
+async function drainActiveAgentRuns(engine: Engine): Promise<void> {
+  const pending = [...engine.activeAgentRuns].map((run) => run.promise);
+  if (pending.length === 0) return;
+  await Promise.race([
+    Promise.allSettled(pending),
+    new Promise<void>((resolve) => setTimeout(resolve, 250)),
+  ]);
+  captureActiveAgentUsage(engine);
 }
 
 function workflowFailureCause(
@@ -151,6 +215,7 @@ export async function runWorkflow(
     nextAgentAttemptId: 0,
 
     usage: zeroWorkflowUsage(),
+    activeAgentRuns: new Set(),
     workflowTimeoutMs: opts.workflowTimeoutMs ?? WORKFLOW_WALL_TIMEOUT_MS,
     phases: [],
   };
@@ -166,6 +231,7 @@ export async function runWorkflow(
       phases: [...engine.phases],
     };
   } catch (error) {
+    if (abort.signal.aborted) await drainActiveAgentRuns(engine);
     if (error instanceof WorkflowExecutionError && error.usage) throw error;
     const message = error instanceof Error ? error.message : String(error);
     throw new WorkflowExecutionError(
@@ -197,7 +263,14 @@ async function executeScript(
     if (p.kind === "phase" && p.phase) {
       engine.phases.push(p.phase);
     }
-    engine.onProgress?.(withProgressCounters(p, engine.counters, engine.usage));
+    engine.onProgress?.(
+      withProgressCounters(
+        p,
+        engine.counters,
+        engine.usage,
+        engine.budgetTotal,
+      ),
+    );
   };
   const runAgentCall = async (payload: {
     prompt: unknown;
@@ -239,6 +312,7 @@ async function executeScript(
         const agentId = ++engine.nextAgentAttemptId;
         engine.counters.runningCount++;
         let status: "done" | "error" = "done";
+        let agentUsage: WorkflowUsage | undefined;
         try {
           emit({
             kind: "agent_start",
@@ -258,8 +332,12 @@ async function executeScript(
               : buildInProcessSchemaPrompt(prompt, attempt, lastErr)
             : prompt;
           let res: SubagentResult;
-          try {
-            res = await engine.runAgent({
+          const activeRun: ActiveAgentRun = {
+            promise: undefined as unknown as Promise<SubagentResult>,
+            usageAccounted: false,
+          };
+          const agentRun = Promise.resolve().then(() =>
+            engine.runAgent({
               prompt: finalPrompt,
               persona: agentOpts.persona,
               model: agentOpts.model,
@@ -270,6 +348,7 @@ async function executeScript(
               onCancellationSnapshot: engine.onCancellationSnapshot,
               thinkingLevel: agentOpts.thinkingLevel,
               onProgress: (ev) => {
+                if (ev.liveUsage) activeRun.liveUsage = { ...ev.liveUsage };
                 if (ev.kind === "phase") {
                   if (ev.phase) {
                     emit({
@@ -286,17 +365,32 @@ async function executeScript(
                   agentId,
                 });
               },
-            });
-          } catch (error) {
-            status = "error";
-            engine.failureCause = error;
-            if (!engine.signal.aborted) engine.counters.errorCount++;
-            throw error;
+            }),
+          );
+          activeRun.promise = agentRun;
+          engine.activeAgentRuns.add(activeRun);
+          try {
+            try {
+              res = await agentRun;
+            } catch (error) {
+              const partialUsage =
+                (error as { usage?: Usage })?.usage ??
+                (activeRun.liveUsage
+                  ? usageAsProjectUsage(activeRun.liveUsage)
+                  : undefined);
+              accountAgentUsage(engine, activeRun, partialUsage);
+              status = "error";
+              engine.failureCause = error;
+              if (!engine.signal.aborted) engine.counters.errorCount++;
+              throw error;
+            }
+          } finally {
+            engine.activeAgentRuns.delete(activeRun);
           }
           const outTokens = res.usage?.output ?? 0;
           tokensDelta += outTokens;
-          engine.usage = addWorkflowUsage(engine.usage, res.usage);
-          engine.counters.tokensSpent += outTokens;
+          agentUsage = workflowUsageFromUsage(res.usage);
+          accountAgentUsage(engine, activeRun, res.usage);
           if (res.isError) {
             status = "error";
             engine.counters.errorCount++;
@@ -344,6 +438,7 @@ async function executeScript(
             model: agentOpts.model,
             status,
             agentId,
+            agentUsage,
           });
         }
       }
@@ -563,26 +658,18 @@ function parseUsageFromSessionFile(sessionFile: string | undefined): Usage {
   try {
     if (!sessionFile || !existsSync(sessionFile)) return zeroUsage();
     const raw = readFileSync(sessionFile, "utf8");
-    const lines = raw.split("\n").filter((l) => l.trim());
-    const usage: Usage = { ...zeroUsage() };
-    for (const line of lines) {
+    const messages: unknown[] = [];
+    for (const line of raw.split("\n").filter((l) => l.trim())) {
       try {
         const entry = JSON.parse(line);
-        if (entry?.type !== "message") continue;
-        const msg = entry.message;
-        if (msg?.role !== "assistant" || !msg?.usage) continue;
-        const u = msg.usage;
-        usage.turns++;
-        usage.input += u.input ?? 0;
-        usage.output += u.output ?? 0;
-        usage.cacheRead += u.cacheRead ?? 0;
-        usage.cacheWrite += u.cacheWrite ?? 0;
-        if (u.cost?.total != null) usage.cost += u.cost.total;
+        if (entry?.type === "message" && entry.message) {
+          messages.push(entry.message);
+        }
       } catch {
         /* skip malformed lines */
       }
     }
-    return usage;
+    return usageFromAssistantMessages(messages, zeroUsage());
   } catch {
     return zeroUsage();
   }
@@ -642,10 +729,11 @@ export async function awaitInteractiveResult(
       } catch {
         /* best effort */
       }
+      const cancellationUsage = parseUsageFromSessionFile(state.sessionFile);
       return {
         isError: true,
         output: "",
-        usage: zeroUsage(),
+        usage: cancellationUsage,
         model: undefined,
         errorMessage: "aborted",
       };
@@ -720,7 +808,7 @@ export async function awaitInteractiveResult(
         return {
           isError: true,
           output,
-          usage: zeroUsage(),
+          usage: parseUsageFromSessionFile(state.sessionFile),
           model: undefined,
           errorMessage: "interactive sub-agent pane exited before completing",
         };

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -127,9 +127,7 @@ function usageAsProjectUsage(usage: WorkflowUsage): Usage {
     cacheRead: usage.cacheRead,
     cacheWrite: usage.cacheWrite,
     cost: usage.costUsd,
-    ...(usage.costSource && usage.costSource !== "mixed"
-      ? { costSource: usage.costSource }
-      : {}),
+    ...(usage.costSource ? { costSource: usage.costSource } : {}),
     turns: usage.turns,
   };
 }
@@ -313,6 +311,7 @@ async function executeScript(
         engine.counters.runningCount++;
         let status: "done" | "error" = "done";
         let agentUsage: WorkflowUsage | undefined;
+        let finalModel = agentOpts.model;
         try {
           emit({
             kind: "agent_start",
@@ -372,6 +371,7 @@ async function executeScript(
           try {
             try {
               res = await agentRun;
+              finalModel = res.model ?? agentOpts.model;
             } catch (error) {
               const partialUsage =
                 (error as { usage?: Usage })?.usage ??
@@ -435,7 +435,7 @@ async function executeScript(
             kind: "agent_done",
             label: agentOpts.label,
             phase: resolvedPhase,
-            model: agentOpts.model,
+            model: finalModel,
             status,
             agentId,
             agentUsage,
@@ -816,6 +816,18 @@ export async function awaitInteractiveResult(
     } else {
       deadTicks = 0;
     }
-    await new Promise((r) => setTimeout(r, pollMs));
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, pollMs);
+      signal?.addEventListener("abort", finish, { once: true });
+      if (signal?.aborted) finish();
+    });
   }
 }

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -876,6 +876,16 @@ describe("pollArtifactChanges", () => {
         agentsSpawned: 3,
         errorCount: 0,
         tokensSpent: 120,
+        usage: {
+          input: 4,
+          output: 2,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 6,
+          costUsd: 0.01,
+          turns: 1,
+          costSource: "mixed",
+        },
         phases: ["Scan"],
         currentPhase: "Scan",
         lastMessage: "→ started scout",
@@ -891,7 +901,7 @@ describe("pollArtifactChanges", () => {
 
     expect(setStatus).toHaveBeenCalledWith(
       "subagentura-workflows",
-      "⚡ 1 workflow running",
+      "⚡ 1 workflow running · ↑4 ↓2 R0 W0 $? (mixed)",
     );
     expect(setWidget).toHaveBeenCalledWith(
       "subagentura-workflow-activity",

--- a/tests/thinking-level-effective.test.ts
+++ b/tests/thinking-level-effective.test.ts
@@ -116,4 +116,84 @@ describe("startSubagentJob effective thinking level", () => {
     expect(session.prompt).not.toHaveBeenCalled();
     expect(session.dispose).toHaveBeenCalledOnce();
   });
+
+  it("keeps live usage cumulative across turns without counting the current message twice", async () => {
+    type TestSessionEvent =
+      | { type: "turn_start" }
+      | { type: "turn_end"; message: unknown }
+      | {
+          type: "message_update";
+          message: unknown;
+          assistantMessageEvent: { type: "text_delta"; delta: string };
+        };
+    let subscriber: (event: TestSessionEvent) => void = () => undefined;
+    const messages: unknown[] = [];
+    const first = {
+      role: "assistant",
+      content: [{ type: "text", text: "first" }],
+      usage: {
+        input: 10,
+        output: 4,
+        cacheRead: 2,
+        cacheWrite: 1,
+        cost: { total: 0.1 },
+      },
+    };
+    const second = {
+      role: "assistant",
+      content: [{ type: "text", text: "second" }],
+      usage: {
+        input: 20,
+        output: 6,
+        cacheRead: 3,
+        cacheWrite: 2,
+        cost: { total: 0.2 },
+      },
+    };
+    const session = {
+      thinkingLevel: "medium",
+      model: undefined,
+      subscribe: vi.fn((listener: (event: TestSessionEvent) => void) => {
+        subscriber = listener;
+        return () => undefined;
+      }),
+      prompt: vi.fn(async () => {
+        subscriber({ type: "turn_start" });
+        messages.push(first);
+        subscriber({
+          type: "message_update",
+          message: first,
+          assistantMessageEvent: { type: "text_delta", delta: "first" },
+        });
+        subscriber({ type: "turn_end", message: first });
+
+        subscriber({ type: "turn_start" });
+        messages.push(second);
+        subscriber({
+          type: "message_update",
+          message: second,
+          assistantMessageEvent: { type: "text_delta", delta: "second" },
+        });
+        subscriber({ type: "turn_end", message: second });
+      }),
+      agent: { state: { messages, errorMessage: null } },
+      dispose: vi.fn(),
+    };
+    mockCreateAgentSession.mockResolvedValue({ session });
+
+    const started = await startSubagentJob(params());
+    started.start();
+    const result = await started.jobPromise;
+
+    expect(started.liveStatus.usage).toMatchObject({
+      input: 30,
+      output: 10,
+      cacheRead: 5,
+      cacheWrite: 3,
+      costSource: "estimated",
+      turns: 2,
+    });
+    expect(started.liveStatus.usage.cost).toBeCloseTo(0.3);
+    expect(result.usage).toEqual(started.liveStatus.usage);
+  });
 });

--- a/tests/workflow-cancellation.test.ts
+++ b/tests/workflow-cancellation.test.ts
@@ -132,4 +132,91 @@ describe("cancelled workflow snapshot normalization", () => {
     });
     expect(afterSettlementStatus.details.runningCount).toBe(0);
   });
+
+  it("clears live usage when cancellation makes the workflow terminal", async () => {
+    let entered!: () => void;
+    const enteredPromise = new Promise<void>((resolve) => (entered = resolve));
+    const job = startWorkflowJob("cancel-live-usage", SCRIPT, {
+      runAgent: async ({ signal, onProgress }) => {
+        onProgress?.({
+          kind: "log",
+          message: "usage",
+          liveUsage: {
+            input: 4,
+            output: 2,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 6,
+            costUsd: 0,
+            turns: 1,
+            costSource: "provider",
+          },
+        });
+        entered();
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) return resolve();
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return {
+          isError: true,
+          output: "",
+          usage: {
+            input: 4,
+            output: 2,
+            cacheRead: 0,
+            cacheWrite: 0,
+            cost: 0,
+            turns: 1,
+          },
+          model: undefined,
+          errorMessage: "aborted",
+        } as any;
+      },
+    });
+    jobs.push(job);
+    await enteredPromise;
+    expect(job.snapshot.liveUsage).toBeDefined();
+    const cancel = workflowTools().cancel_workflow;
+    await cancel.execute("cancel", { workflowId: job.id });
+    expect(job.snapshot.liveUsage).toBeUndefined();
+    await expect(job.promise).rejects.toThrow(/aborted/i);
+    expect(job.snapshot.liveUsage).toBeUndefined();
+  });
+
+  it("clears live usage when the active agent finishes", async () => {
+    const job = startWorkflowJob("finish-live-usage", SCRIPT, {
+      runAgent: async ({ onProgress }) => {
+        onProgress?.({
+          kind: "log",
+          message: "usage",
+          liveUsage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            costUsd: 0.01,
+            turns: 1,
+            costSource: "provider",
+          },
+        });
+        return {
+          isError: false,
+          output: "ok",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            cost: 0.01,
+            turns: 1,
+          },
+          model: "test/model",
+        } as any;
+      },
+    });
+    jobs.push(job);
+    await job.promise;
+    expect(job.snapshot.liveUsage).toBeUndefined();
+  });
 });

--- a/tests/workflow-cancellation.test.ts
+++ b/tests/workflow-cancellation.test.ts
@@ -179,7 +179,16 @@ describe("cancelled workflow snapshot normalization", () => {
     const cancel = workflowTools().cancel_workflow;
     await cancel.execute("cancel", { workflowId: job.id });
     expect(job.snapshot.liveUsage).toBeUndefined();
-    await expect(job.promise).rejects.toThrow(/aborted/i);
+    await expect(job.promise).rejects.toMatchObject({
+      message: expect.stringMatching(/aborted/i),
+      usage: {
+        input: 4,
+        output: 2,
+        totalTokens: 6,
+        costUsd: 0,
+        turns: 1,
+      },
+    });
     expect(job.snapshot.liveUsage).toBeUndefined();
   });
 

--- a/tests/workflow-job-accounting.test.ts
+++ b/tests/workflow-job-accounting.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockRunWorkflow } = vi.hoisted(() => ({
+  mockRunWorkflow: vi.fn(),
+}));
+
+vi.mock("../src/workflow-worker", () => ({
+  runWorkflow: mockRunWorkflow,
+}));
+
+import {
+  WorkflowExecutionError,
+  type WorkflowUsage,
+} from "../src/workflow-core";
+import {
+  startWorkflowJob,
+  workflowJobRegistry,
+  type WorkflowJobState,
+} from "../src/workflow-jobs";
+
+describe("async workflow rejection accounting", () => {
+  afterEach(() => {
+    workflowJobRegistry.clear();
+    vi.clearAllMocks();
+  });
+
+  it("publishes cancelled WorkflowExecutionError usage before completion consumers run", async () => {
+    const usage: WorkflowUsage = {
+      input: 13,
+      output: 7,
+      cacheRead: 3,
+      cacheWrite: 2,
+      totalTokens: 25,
+      costUsd: 0.04,
+      turns: 2,
+      costSource: "estimated",
+    };
+    const failure = new WorkflowExecutionError("priced failure", usage);
+    let rejectWorkflow!: (reason?: unknown) => void;
+    mockRunWorkflow.mockImplementationOnce(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectWorkflow = reject;
+        }),
+    );
+    let observedAtCompletion:
+      | {
+          status: WorkflowJobState["status"];
+          usage: WorkflowUsage | undefined;
+          tokensSpent: number;
+        }
+      | undefined;
+
+    const job = startWorkflowJob(
+      "priced-failure",
+      `export const meta = { name: "priced-failure", description: "d" };\nthrow new Error("boom");`,
+      {
+        runAgent: async () => {
+          throw new Error("mocked runWorkflow should own execution");
+        },
+      },
+      undefined,
+      (completed: WorkflowJobState) => {
+        observedAtCompletion = {
+          status: completed.status,
+          usage: completed.snapshot.usage
+            ? { ...completed.snapshot.usage }
+            : undefined,
+          tokensSpent: completed.snapshot.tokensSpent,
+        };
+        return true;
+      },
+    );
+
+    job.abort.abort(new Error("cancelled by test"));
+    rejectWorkflow(failure);
+    await expect(job.promise).rejects.toBe(failure);
+    expect(observedAtCompletion).toEqual({
+      status: "cancelled",
+      usage,
+      tokensSpent: usage.output,
+    });
+    expect(job.status).toBe("cancelled");
+    expect(job.snapshot.usage).toEqual(usage);
+    expect(job.snapshot.tokensSpent).toBe(usage.output);
+  });
+});

--- a/tests/workflow-schema.test.ts
+++ b/tests/workflow-schema.test.ts
@@ -248,6 +248,7 @@ describe("workflow schema usage accounting", () => {
       totalTokens: 34,
       costUsd: 0.1,
       turns: 2,
+      costSource: "estimated",
     });
   });
 });
@@ -291,6 +292,7 @@ it("aggregates all failed schema attempts in result and progress", async () => {
     totalTokens: 30,
     costUsd: 0.1 * 3,
     turns: 3,
+    costSource: "estimated",
   });
   expect(progress.at(-1)?.usage).toEqual(result.usage);
 });

--- a/tests/workflow-tree-ui.test.ts
+++ b/tests/workflow-tree-ui.test.ts
@@ -118,6 +118,42 @@ describe("WorkflowTreeComponent", () => {
     expect(expanded).toContain("✗ error worker #2 @m-2");
   });
 
+  it("shows aggregate and per-agent usage attribution in expanded details", () => {
+    const usage = {
+      input: 11,
+      output: 7,
+      cacheRead: 5,
+      cacheWrite: 3,
+      totalTokens: 26,
+      costUsd: 0.125,
+      turns: 2,
+    };
+    workflowJobRegistry.set(
+      "wf_test",
+      makeJob({
+        snapshot: {
+          ...makeJob().snapshot,
+          usage,
+          agentRecords: [
+            {
+              agentId: 1,
+              label: "worker",
+              model: "m-1",
+              status: "done",
+              usage,
+            },
+          ],
+        },
+      }),
+    );
+    const component = new WorkflowTreeComponent({ done: vi.fn() });
+    component.handleInput("\r");
+    const expanded = component.render(240).join("\n");
+    expect(expanded).toContain("↑ input tokens: 11");
+    expect(expanded).toContain("input=11 output=7");
+    expect(expanded).toContain("Legend: ↑ input");
+  });
+
   it("handles legacy snapshots without agent records", () => {
     const job = makeJob();
     delete job.snapshot.agentRecords;

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -9,6 +9,9 @@ import {
   deleteWorkflowScript,
   extractJson,
   formatWorkflowUsage,
+  formatWorkflowUsageLegend,
+  addWorkflowUsage,
+  workflowUsageFromUsage,
   getWorkflowCompletionPresentation,
   listSavedWorkflows,
   loadWorkflowScript,
@@ -29,7 +32,10 @@ import {
   workflowJobRegistry,
 } from "../src/workflow";
 import { withOrchestrationContext } from "../src/orchestration-context";
-import type { SubagentResult } from "../src/helpers";
+import {
+  usageFromAssistantMessages,
+  type SubagentResult,
+} from "../src/helpers";
 import {
   appendCompletionEvent,
   appendEvent,
@@ -1457,6 +1463,36 @@ describe("awaitInteractiveResult", () => {
     expect(res.isError).toBe(true);
     expect((res as any).errorMessage).toMatch(/aborted/);
   });
+
+  it("keeps process-session usage when cancellation arrives first", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-cancel-"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          usage: {
+            input: 12,
+            output: 6,
+            cacheRead: 2,
+            cacheWrite: 1,
+            cost: { total: 0.03 },
+          },
+        },
+      }) + "\n",
+    );
+    const state = fakeState(dir);
+    state.sessionFile = sessionFile;
+    const ac = new AbortController();
+    ac.abort();
+    const res = await awaitInteractiveResult(state, ac.signal, 5);
+    expect(res).toMatchObject({
+      isError: true,
+      usage: { input: 12, output: 6, cacheRead: 2, cost: 0.03 },
+    });
+  });
 });
 
 describe("abort signal propagation", () => {
@@ -1700,7 +1736,7 @@ describe("renderProgress", () => {
     const result = renderProgress(p);
     expect(result).toContain("● workflow — 2 agent(s)");
     expect(result).toContain("⚡ 1 running");
-    expect(result).toContain("100 output tokens");
+    expect(result).not.toContain("output tokens");
     expect(result).toContain("◆ phase: Scanning");
   });
 
@@ -1716,7 +1752,7 @@ describe("renderProgress", () => {
     const result = renderProgress(p);
     expect(result).toContain("● workflow — 3 agent(s)");
     expect(result).not.toContain("⚡");
-    expect(result).toContain("50 output tokens");
+    expect(result).not.toContain("output tokens");
     expect(result).toContain("hello");
   });
 
@@ -1815,7 +1851,7 @@ describe("renderProgress", () => {
     expect(result).toContain("⚡ 2 running");
     expect(result).toContain("⚠ 3 error(s)");
     expect(result).toContain("10 agent(s)");
-    expect(result).toContain("500 output tokens");
+    expect(result).not.toContain("output tokens");
   });
 });
 
@@ -2904,7 +2940,7 @@ it("formats USD usage without floating-point artifacts", () => {
     costUsd: 0.1 + 0.2,
     turns: 1,
   };
-  expect(formatWorkflowUsage(usage)).toBe("1 total tokens, $0.3");
+  expect(formatWorkflowUsage(usage)).toBe("↑0 ↓1 R0 W0 $0.3");
 });
 
 it("includes accumulated usage in async workflow error results", async () => {
@@ -2938,7 +2974,7 @@ it("includes accumulated usage in async workflow error results", async () => {
       costUsd: 0.125,
       turns: 2,
     });
-    expect(result.content[0].text).toContain("26 total tokens");
+    expect(result.content[0].text).toContain("↓7");
   } finally {
     workflowJobRegistry.delete(job.id);
   }
@@ -2954,7 +2990,7 @@ it("includes snapshot usage in failed completion notification summaries", async 
   try {
     await expect(job.promise).rejects.toThrow("later failure");
     expect(formatWorkflowNotificationSummary(job)).toContain(
-      "26 total tokens, $0.125",
+      "↑11 ↓7 R5 W3 $0.125",
     );
   } finally {
     workflowJobRegistry.delete(job.id);
@@ -3007,6 +3043,103 @@ it("preserves caller abort reason alongside accumulated usage", async () => {
   await expect(running).rejects.toMatchObject({
     cause: reason,
     usage: { totalTokens: 26 },
+  });
+});
+
+it("aggregates partial usage returned by an active runner on cancellation", async () => {
+  const controller = new AbortController();
+  let started!: () => void;
+  const startedPromise = new Promise<void>((resolve) => (started = resolve));
+  const partial: SubagentResult = {
+    isError: true,
+    output: "partial",
+    usage: {
+      input: 4,
+      output: 3,
+      cacheRead: 2,
+      cacheWrite: 1,
+      cost: 0.02,
+      turns: 1,
+    },
+    model: undefined,
+    errorMessage: "aborted",
+  };
+  const running = runWorkflow(
+    `export const meta = { name: "cancel-usage", description: "d" };\n` +
+      `return await agent("in flight");`,
+    {
+      signal: controller.signal,
+      runAgent: async ({ signal }) => {
+        started();
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) return resolve();
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return partial;
+      },
+    },
+  );
+  await startedPromise;
+  controller.abort(new Error("cancelled"));
+  await expect(running).rejects.toMatchObject({
+    usage: {
+      input: 4,
+      output: 3,
+      cacheRead: 2,
+      cacheWrite: 1,
+      costUsd: 0.02,
+      totalTokens: 10,
+      turns: 1,
+    },
+  });
+});
+
+it("aggregates live usage when a runner rejects during cancellation", async () => {
+  const controller = new AbortController();
+  let started!: () => void;
+  const startedPromise = new Promise<void>((resolve) => (started = resolve));
+  const running = runWorkflow(
+    `export const meta = { name: "cancel-live-reject", description: "d" };\n` +
+      `return await agent("in flight");`,
+    {
+      signal: controller.signal,
+      runAgent: async ({ signal, onProgress }) => {
+        onProgress?.({
+          kind: "log",
+          message: "usage",
+          liveUsage: {
+            input: 4,
+            output: 3,
+            cacheRead: 2,
+            cacheWrite: 1,
+            totalTokens: 10,
+            costUsd: 0.02,
+            turns: 1,
+            costSource: "provider",
+          },
+        });
+        started();
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) return resolve();
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        throw new Error("aborted");
+      },
+    },
+  );
+  await startedPromise;
+  controller.abort(new Error("cancelled"));
+  await expect(running).rejects.toMatchObject({
+    usage: {
+      input: 4,
+      output: 3,
+      cacheRead: 2,
+      cacheWrite: 1,
+      costUsd: 0.02,
+      totalTokens: 10,
+      turns: 1,
+      costSource: "provider",
+    },
   });
 });
 
@@ -3090,5 +3223,207 @@ describe("workflow usage accounting", () => {
     } finally {
       workflowJobRegistry.delete(job.id);
     }
+  });
+});
+
+describe("canonical workflow usage formatting", () => {
+  it("uses icon-first compact accounting without a duplicate total", () => {
+    const usage: WorkflowUsage = {
+      input: 11,
+      output: 7,
+      cacheRead: 5,
+      cacheWrite: 3,
+      totalTokens: 26,
+      costUsd: 0.125,
+      turns: 2,
+    };
+    expect(formatWorkflowUsage(usage)).toBe("↑11 ↓7 R5 W3 $0.125");
+    expect(formatWorkflowUsage(usage, { outputBudget: 20 })).toContain("↓7/20");
+    expect(formatWorkflowUsage(usage)).not.toContain("total tokens");
+  });
+
+  it("labels unavailable and estimated pricing instead of showing $0", () => {
+    const unavailable = addWorkflowUsage(
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        costUsd: 0,
+        turns: 0,
+      },
+      {
+        input: 2,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 1,
+      },
+    );
+    const estimated = addWorkflowUsage(
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        costUsd: 0,
+        turns: 0,
+      },
+      {
+        input: 2,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0.01,
+        costSource: "estimated",
+        turns: 1,
+      },
+    );
+    expect(formatWorkflowUsage(unavailable)).toContain("$?");
+    expect(formatWorkflowUsage(estimated)).toContain("~$0.01");
+    expect(formatWorkflowUsage(unavailable, { expanded: true })).toContain(
+      "unavailable",
+    );
+  });
+
+  it("marks mixed pricing and provides an ASCII fallback legend", () => {
+    const base: WorkflowUsage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      turns: 0,
+    };
+    const mixed = addWorkflowUsage(
+      addWorkflowUsage(base, {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0.01,
+        turns: 1,
+      }),
+      {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 1,
+      },
+    );
+    expect(mixed.costSource).toBe("mixed");
+    expect(formatWorkflowUsage(mixed)).toContain("$? (mixed)");
+    expect(
+      formatWorkflowUsage(mixed, { expanded: true, ascii: true }),
+    ).toContain("input tokens");
+    expect(formatWorkflowUsageLegend(true)).toBe(
+      "Legend: input, output, cache-read, cache-write, cost",
+    );
+  });
+
+  it("preserves explicit free provider pricing and hides zero live samples", () => {
+    const providerFree = addWorkflowUsage(
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        costUsd: 0,
+        turns: 0,
+      },
+      {
+        input: 1,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        costSource: "provider",
+        turns: 1,
+      },
+    );
+    expect(providerFree.costSource).toBe("provider");
+    expect(formatWorkflowUsage(providerFree)).toContain("$0");
+    expect(
+      workflowUsageFromUsage({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 1,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves partial assistant usage for cancellation accounting", () => {
+    const usage = usageFromAssistantMessages(
+      [
+        {
+          role: "assistant",
+          usage: {
+            input: 10,
+            output: 4,
+            cacheRead: 2,
+            cacheWrite: 1,
+            cost: { total: 0.02 },
+          },
+        },
+      ],
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    );
+    expect(usage).toEqual({
+      input: 10,
+      output: 4,
+      cacheRead: 2,
+      cacheWrite: 1,
+      cost: 0.02,
+      costSource: "provider",
+      turns: 1,
+    });
+  });
+
+  it("preserves provider provenance for an explicitly free assistant turn", () => {
+    const usage = usageFromAssistantMessages(
+      [
+        {
+          role: "assistant",
+          usage: {
+            input: 2,
+            output: 1,
+            cost: { total: 0 },
+          },
+        },
+      ],
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    );
+    expect(usage).toMatchObject({ cost: 0, costSource: "provider" });
+    expect(workflowUsageFromUsage(usage)).toMatchObject({
+      costUsd: 0,
+      costSource: "provider",
+    });
+    expect(
+      formatWorkflowUsage(workflowUsageFromUsage(usage) as WorkflowUsage),
+    ).toContain("$0");
   });
 });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1017,6 +1017,145 @@ describe("background workflow jobs", () => {
     ).toBe(true);
   });
 
+  it("keeps parallel live usage owned by every still-running agent", async () => {
+    const firstUsage: WorkflowUsage = {
+      input: 1,
+      output: 2,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 3,
+      costUsd: 0.01,
+      turns: 1,
+      costSource: "provider",
+    };
+    const secondUsage: WorkflowUsage = {
+      input: 10,
+      output: 20,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 30,
+      costUsd: 0.2,
+      turns: 2,
+      costSource: "estimated",
+    };
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => (releaseFirst = resolve));
+    const secondGate = new Promise<void>(
+      (resolve) => (releaseSecond = resolve),
+    );
+    let started = 0;
+    let bothStarted!: () => void;
+    const bothStartedPromise = new Promise<void>(
+      (resolve) => (bothStarted = resolve),
+    );
+    const runAgent: WorkflowAgentRunner = async ({ prompt, onProgress }) => {
+      const sample = prompt === "first" ? firstUsage : secondUsage;
+      onProgress?.({ kind: "log", message: "usage", liveUsage: sample });
+      started++;
+      if (started === 2) bothStarted();
+      await (prompt === "first" ? firstGate : secondGate);
+      return {
+        isError: false,
+        output: prompt,
+        usage: {
+          input: sample.input,
+          output: sample.output,
+          cacheRead: sample.cacheRead,
+          cacheWrite: sample.cacheWrite,
+          cost: sample.costUsd,
+          costSource:
+            sample.costSource === "provider" ? "provider" : "estimated",
+          turns: sample.turns,
+        },
+        model: `runner/${prompt}`,
+      };
+    };
+    const script =
+      `export const meta = { name: "parallel-live", description: "d" };\n` +
+      `return await parallel([` +
+      `() => agent("first", { label: "first", isolation: "in-process" }),` +
+      `() => agent("second", { label: "second", isolation: "in-process" })]);`;
+    const job = startWorkflowJob("parallel-live", script, { runAgent });
+
+    await bothStartedPromise;
+    await vi.waitFor(() =>
+      expect(job.snapshot.liveUsage).toEqual({
+        input: 11,
+        output: 22,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 33,
+        costUsd: 0.21000000000000002,
+        turns: 3,
+        costSource: "mixed",
+      }),
+    );
+
+    releaseFirst();
+    await vi.waitFor(() => {
+      expect(
+        job.snapshot.agentRecords?.find((record) => record.label === "first")
+          ?.status,
+      ).toBe("done");
+      expect(
+        job.snapshot.agentRecords?.find((record) => record.label === "second")
+          ?.status,
+      ).toBe("running");
+    });
+    expect(job.snapshot.liveUsage).toEqual(secondUsage);
+
+    releaseSecond();
+    await job.promise;
+    expect(job.snapshot.liveUsage).toBeUndefined();
+    expect(job.snapshot.usage?.costSource).toBe("mixed");
+  });
+
+  it("attributes a completed agent to the runner-reported model", async () => {
+    const progress: WorkflowProgress[] = [];
+    const job = startWorkflowJob(
+      "runner-model",
+      `export const meta = { name: "runner-model", description: "d" };\n` +
+        `return await agent("model", { model: "requested/model" });`,
+      {
+        runAgent: async () => {
+          const result = ok("done");
+          if (result.isError)
+            throw new Error("expected successful test result");
+          return { ...result, model: "runner/reported-model" };
+        },
+        onProgress: (event) => progress.push(event),
+      },
+    );
+
+    await job.promise;
+
+    expect(progress.find((event) => event.kind === "agent_done")?.model).toBe(
+      "runner/reported-model",
+    );
+    expect(job.snapshot.agentRecords?.[0]?.model).toBe("runner/reported-model");
+  });
+
+  it("uses the requested model when the runner reports no final model", async () => {
+    const progress: WorkflowProgress[] = [];
+    const job = startWorkflowJob(
+      "requested-model-fallback",
+      `export const meta = { name: "requested-model-fallback", description: "d" };\n` +
+        `return await agent("model", { model: "requested/model" });`,
+      {
+        runAgent: async () => ({ ...ok("done"), model: undefined }),
+        onProgress: (event) => progress.push(event),
+      },
+    );
+
+    await job.promise;
+
+    expect(progress.find((event) => event.kind === "agent_done")?.model).toBe(
+      "requested/model",
+    );
+    expect(job.snapshot.agentRecords?.[0]?.model).toBe("requested/model");
+  });
+
   it("calls the completion hook after all agents finish", async () => {
     const onComplete = vi.fn();
     const script =
@@ -1137,7 +1276,7 @@ describe("background workflow jobs", () => {
     release();
     await job.promise;
     expect(job.snapshot.agentsSpawned).toBe(1);
-    expect(job.snapshot.lastMessage).toBe("→ done agent");
+    expect(job.snapshot.lastMessage).toBe("→ done agent @test/model");
   }, 10_000);
 
   it("clears runningCount when runAgent throws", async () => {
@@ -1462,6 +1601,59 @@ describe("awaitInteractiveResult", () => {
     const res = await awaitInteractiveResult(fakeState(dir), ac.signal, 5);
     expect(res.isError).toBe(true);
     expect((res as any).errorMessage).toMatch(/aborted/);
+  });
+
+  it("wakes the default poll immediately on abort and captures session usage", async () => {
+    vi.useFakeTimers();
+    try {
+      const dir = mkdtempSync(join(tmpdir(), "wf-int-abort-wake-"));
+      const sessionFile = join(dir, "session.jsonl");
+      writeFileSync(
+        sessionFile,
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            usage: {
+              input: 8,
+              output: 5,
+              cacheRead: 1,
+              cacheWrite: 0,
+              cost: { total: 0.02 },
+            },
+          },
+        }) + "\n",
+      );
+      const state = fakeState(dir);
+      state.sessionFile = sessionFile;
+      const controller = new AbortController();
+      let result: SubagentResult | undefined;
+      const pending = awaitInteractiveResult(state, controller.signal).then(
+        (settled) => {
+          result = settled;
+        },
+      );
+
+      controller.abort();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(result).toBeDefined();
+      if (!result) return;
+      expect(result).toMatchObject({
+        isError: true,
+        usage: {
+          input: 8,
+          output: 5,
+          cacheRead: 1,
+          cost: 0.02,
+          costSource: "estimated",
+        },
+      });
+      await pending;
+    } finally {
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+    }
   });
 
   it("keeps process-session usage when cancellation arrives first", async () => {
@@ -2908,6 +3100,7 @@ it("includes usage from returned error results", async () => {
     totalTokens: 39,
     costUsd: 0.375,
     turns: 3,
+    costSource: "estimated",
   });
 });
 
@@ -2920,6 +3113,7 @@ it("preserves accumulated usage when a later workflow error rejects", async () =
     totalTokens: 26,
     costUsd: 0.125,
     turns: 2,
+    costSource: "estimated",
   };
   const rejected = runWorkflow(
     `export const meta = { name: "late-error", description: "d" };\n` +
@@ -2940,7 +3134,7 @@ it("formats USD usage without floating-point artifacts", () => {
     costUsd: 0.1 + 0.2,
     turns: 1,
   };
-  expect(formatWorkflowUsage(usage)).toBe("↑0 ↓1 R0 W0 $0.3");
+  expect(formatWorkflowUsage(usage)).toBe("↑0 ↓1 R0 W0 ~$0.3");
 });
 
 it("includes accumulated usage in async workflow error results", async () => {
@@ -2973,6 +3167,7 @@ it("includes accumulated usage in async workflow error results", async () => {
       totalTokens: 26,
       costUsd: 0.125,
       turns: 2,
+      costSource: "estimated",
     });
     expect(result.content[0].text).toContain("↓7");
   } finally {
@@ -2990,7 +3185,7 @@ it("includes snapshot usage in failed completion notification summaries", async 
   try {
     await expect(job.promise).rejects.toThrow("later failure");
     expect(formatWorkflowNotificationSummary(job)).toContain(
-      "↑11 ↓7 R5 W3 $0.125",
+      "↑11 ↓7 R5 W3 ~$0.125",
     );
   } finally {
     workflowJobRegistry.delete(job.id);
@@ -3165,6 +3360,7 @@ describe("workflow usage accounting", () => {
     costUsd: 0.125,
     totalTokens: 26,
     turns: 2,
+    costSource: "estimated" as const,
   };
 
   it("does not add usage when a runner throws without a result", async () => {
@@ -3237,7 +3433,7 @@ describe("canonical workflow usage formatting", () => {
       costUsd: 0.125,
       turns: 2,
     };
-    expect(formatWorkflowUsage(usage)).toBe("↑11 ↓7 R5 W3 $0.125");
+    expect(formatWorkflowUsage(usage)).toBe("↑11 ↓7 R5 W3 ~$0.125");
     expect(formatWorkflowUsage(usage, { outputBudget: 20 })).toContain("↓7/20");
     expect(formatWorkflowUsage(usage)).not.toContain("total tokens");
   });
@@ -3391,12 +3587,12 @@ describe("canonical workflow usage formatting", () => {
       cacheRead: 2,
       cacheWrite: 1,
       cost: 0.02,
-      costSource: "provider",
+      costSource: "estimated",
       turns: 1,
     });
   });
 
-  it("preserves provider provenance for an explicitly free assistant turn", () => {
+  it("marks zero calculated SDK cost unavailable when tokens were used", () => {
     const usage = usageFromAssistantMessages(
       [
         {
@@ -3417,13 +3613,82 @@ describe("canonical workflow usage formatting", () => {
         turns: 0,
       },
     );
-    expect(usage).toMatchObject({ cost: 0, costSource: "provider" });
+    expect(usage).toMatchObject({ cost: 0, costSource: "unavailable" });
     expect(workflowUsageFromUsage(usage)).toMatchObject({
       costUsd: 0,
-      costSource: "provider",
+      costSource: "unavailable",
     });
     expect(
       formatWorkflowUsage(workflowUsageFromUsage(usage) as WorkflowUsage),
-    ).toContain("$0");
+    ).toContain("$?");
+  });
+
+  it("preserves explicit trusted provenance and mixed turn provenance", () => {
+    const usage = usageFromAssistantMessages(
+      [
+        {
+          role: "assistant",
+          usage: {
+            input: 2,
+            output: 1,
+            cost: { total: 0.01 },
+            costSource: "provider",
+          },
+        },
+        {
+          role: "assistant",
+          usage: {
+            input: 3,
+            output: 2,
+            cost: { total: 0.02 },
+          },
+        },
+      ],
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    );
+
+    expect(usage).toMatchObject({
+      input: 5,
+      output: 3,
+      cost: 0.03,
+      costSource: "mixed",
+      turns: 2,
+    });
+    expect(workflowUsageFromUsage(usage)?.costSource).toBe("mixed");
+  });
+
+  it("keeps an all-zero assistant sample provenance-free", () => {
+    const usage = usageFromAssistantMessages(
+      [
+        {
+          role: "assistant",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            cost: { total: 0 },
+          },
+        },
+      ],
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    );
+
+    expect(usage.costSource).toBeUndefined();
+    expect(workflowUsageFromUsage(usage)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Add one canonical workflow usage/cost formatter for progress, status, result, footer, widget, tree, and supervisor surfaces.
- Show `↑` input, `↓` output, `R` cache-read, `W` cache-write, and `$` cost, with explicit labels and an ASCII fallback.
- Track pricing provenance (`provider`, `estimated`, `unavailable`, and `mixed`) so unknown pricing is rendered as `$?` instead of misleading `$0`.
- Preserve output-token budget semantics and display the soft output budget without introducing a USD budget.
- Propagate live usage, aggregate per-agent/model usage, and retain usage from cancellation/retry/error paths, including process-session usage available before cancellation.
- Clear stale live usage when agents/workflows finish or become terminal.
- Update workflow documentation and add regression/UI/accounting coverage.

## Complexity assessment

Medium-high / cross-cutting: 13 files, 1,008 insertions, and 114 deletions. The main complexity is intentionally centralized in the formatter/provenance model and the worker accounting boundary; the remaining changes are adapters for existing UI surfaces plus tests/docs. No unrelated refactor is included.

## Compatibility and risks

- Existing `tokensSpent` remains available as the completed output-token count; workflow budgets remain output-token based.
- Legacy snapshots without usage/provenance continue to render safely.
- Process-isolated agents may expose only final usage; live usage is shown when the runner supplies progress usage.
- Cancellation uses bounded draining and preserves the latest known partial usage when a runner rejects before returning a result.

## Validation

- `npm run typecheck`
- `npm test -- --reporter=verbose` — 57 files, 1,383 tests passed
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`
