### PR TITLE
fix(workflow): harden pricing and usage accounting

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -41,6 +41,9 @@ import { coarseElapsedMs, formatActivityRow } from "./rendering";
 import {
   addWorkflowUsage,
   formatWorkflowUsage,
+  hasWorkflowUsage,
+  presentWorkflowUsage,
+  type WorkflowUsage,
   zeroWorkflowUsage,
 } from "./workflow-core";
 import { closeSync, openSync, readSync, statSync } from "node:fs";
@@ -73,8 +76,19 @@ interface WidgetSurfaceState {
   rendered: string[] | undefined;
   painted: boolean;
 }
+interface SubagentFooterContribution {
+  kind: "subagent";
+  count: number;
+}
+interface WorkflowFooterContribution {
+  kind: "workflow";
+  count: number;
+  usage?: WorkflowUsage;
+}
+type FooterContribution =
+  SubagentFooterContribution | WorkflowFooterContribution;
 interface FooterSurfaceState {
-  contributions: Map<string, string>;
+  contributions: Map<string, FooterContribution>;
   rendered: string | undefined;
   painted: boolean;
 }
@@ -132,34 +146,55 @@ function getRunningSubagentCount(
   return inProcessCount + interactiveCount;
 }
 
+function addAggregateWorkflowUsage(
+  total: WorkflowUsage,
+  usage: WorkflowUsage | undefined,
+): WorkflowUsage {
+  if (!usage) return total;
+  return addWorkflowUsage(total, {
+    input: usage.input,
+    output: usage.output,
+    cacheRead: usage.cacheRead,
+    cacheWrite: usage.cacheWrite,
+    cost: usage.costUsd,
+    costSource: usage.costSource,
+    turns: usage.turns,
+  });
+}
+
 function mergeFooterContributions(
   key: string,
-  contributions: Iterable<string>,
+  contributions: Iterable<FooterContribution>,
 ): string | undefined {
-  let total = 0;
-  let count = 0;
-  let last: string | undefined;
-  for (const contribution of contributions) {
-    last = contribution;
-    count++;
-    const match = /^⚡ (\d+) /.exec(contribution);
-    if (match) total += Number(match[1]);
-  }
-  if (count === 0) return undefined;
-  if (count === 1 || total === 0) return last;
   if (key === FOOTER_KEY) {
+    let total = 0;
+    for (const contribution of contributions) {
+      if (contribution.kind === "subagent") total += contribution.count;
+    }
+    if (total === 0) return undefined;
     return `⚡ ${total} sub-agent${total > 1 ? "s" : ""} active`;
   }
   if (key === WORKFLOW_FOOTER_KEY) {
-    return `⚡ ${total} workflow${total > 1 ? "s" : ""} running`;
+    let total = 0;
+    let usage = zeroWorkflowUsage();
+    for (const contribution of contributions) {
+      if (contribution.kind !== "workflow") continue;
+      total += contribution.count;
+      usage = addAggregateWorkflowUsage(usage, contribution.usage);
+    }
+    if (total === 0) return undefined;
+    const presentedUsage = hasWorkflowUsage(usage)
+      ? ` · ${formatWorkflowUsage(usage)}`
+      : "";
+    return `⚡ ${total} workflow${total > 1 ? "s" : ""} running${presentedUsage}`;
   }
-  return last;
+  return undefined;
 }
 
 function updateFooterStatus(
   ui: StatusUi,
   key: string,
-  statusText: string | undefined,
+  contribution: FooterContribution | undefined,
   owner?: SessionOwnerToken,
 ): void {
   let surfaces = footerStatusesByUi.get(ui);
@@ -183,8 +218,8 @@ function updateFooterStatus(
       }
     }
   }
-  if (statusText === undefined) surface.contributions.delete(contributionKey);
-  else surface.contributions.set(contributionKey, statusText);
+  if (contribution === undefined) surface.contributions.delete(contributionKey);
+  else surface.contributions.set(contributionKey, contribution);
   const rendered = mergeFooterContributions(
     key,
     surface.contributions.values(),
@@ -214,11 +249,9 @@ export function updateRunningSubagentFooter(
   const ownerContext = resolveLiveSessionScope(owner);
   const runningCount =
     owner !== undefined && !ownerContext ? 0 : getRunningSubagentCount([owner]);
-  const statusText =
-    runningCount > 0
-      ? `⚡ ${runningCount} sub-agent${runningCount > 1 ? "s" : ""} active`
-      : undefined;
-  updateFooterStatus(ui, FOOTER_KEY, statusText, owner);
+  const contribution: SubagentFooterContribution | undefined =
+    runningCount > 0 ? { kind: "subagent", count: runningCount } : undefined;
+  updateFooterStatus(ui, FOOTER_KEY, contribution, owner);
 }
 
 function widgetRowsEqual(
@@ -569,12 +602,20 @@ async function runPollArtifactChanges(
       try {
         const wfCount = getRunningWorkflowCount(owner);
         const workflowRows = formatWorkflowWidgetRows(owner, now);
-        const workflowUsage = formatWorkflowFooterUsage(owner);
-        const workflowStatus =
+        const workflowContribution: WorkflowFooterContribution | undefined =
           wfCount > 0
-            ? `⚡ ${wfCount} workflow${wfCount > 1 ? "s" : ""} running${workflowUsage}`
+            ? {
+                kind: "workflow",
+                count: wfCount,
+                usage: aggregateWorkflowFooterUsage(owner),
+              }
             : undefined;
-        updateFooterStatus(ui, WORKFLOW_FOOTER_KEY, workflowStatus, owner);
+        updateFooterStatus(
+          ui,
+          WORKFLOW_FOOTER_KEY,
+          workflowContribution,
+          owner,
+        );
         updateWidgetRows(ui, WORKFLOW_WIDGET_KEY, workflowRows, owner);
       } catch {
         /* ui stale */
@@ -598,13 +639,15 @@ function formatWorkflowWidgetRows(
     if (!workflowJobBelongsToOwner(st, owner)) continue;
     if (st.status !== "running") continue;
     const s = st.snapshot;
+    const usage = presentWorkflowUsage(s.usage);
+    const liveUsage = presentWorkflowUsage(s.liveUsage);
     const parts = [
       `${s.agentsSpawned} agent${s.agentsSpawned === 1 ? "" : "s"}`,
       `${s.runningCount ?? 0} running`,
-      ...(s.usage
-        ? [formatWorkflowUsage(s.usage, { outputBudget: s.budgetTotal })]
+      ...(usage
+        ? [formatWorkflowUsage(usage, { outputBudget: s.budgetTotal })]
         : []),
-      ...(s.liveUsage ? [`live ${formatWorkflowUsage(s.liveUsage)}`] : []),
+      ...(liveUsage ? [`live ${formatWorkflowUsage(liveUsage)}`] : []),
       formatWorkflowElapsed(now - st.startedAt),
     ];
     if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);
@@ -619,35 +662,16 @@ function formatWorkflowWidgetRows(
   return rows;
 }
 
-function formatWorkflowFooterUsage(
+function aggregateWorkflowFooterUsage(
   owner: SessionOwnerToken | undefined,
-): string {
+): WorkflowUsage | undefined {
   let aggregate = zeroWorkflowUsage();
-  let hasUsage = false;
   for (const job of workflowJobRegistry.values()) {
     if (!workflowJobBelongsToOwner(job, owner)) continue;
-    if (job.status !== "running" || !job.snapshot.usage) continue;
-    const usage = job.snapshot.usage;
-    aggregate = addWorkflowUsage(aggregate, {
-      input: usage.input,
-      output: usage.output,
-      cacheRead: usage.cacheRead,
-      cacheWrite: usage.cacheWrite,
-      cost: usage.costUsd,
-      costSource: usage.costSource,
-      turns: usage.turns,
-    });
-    hasUsage = true;
+    if (job.status !== "running") continue;
+    aggregate = addAggregateWorkflowUsage(aggregate, job.snapshot.usage);
   }
-  if (!hasUsage) return "";
-  if (
-    aggregate.totalTokens === 0 &&
-    aggregate.costUsd === 0 &&
-    aggregate.turns === 0
-  ) {
-    return "";
-  }
-  return ` · ${formatWorkflowUsage(aggregate)}`;
+  return hasWorkflowUsage(aggregate) ? aggregate : undefined;
 }
 
 /** Coarse elapsed clock; see ACTIVITY_ELAPSED_BUCKET_MS for why it is bucketed. */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -129,7 +129,31 @@ export interface Usage {
 }
 
 function usageNumber(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : 0;
+}
+
+export function normalizeUsage(usage: Usage | undefined): Usage | undefined {
+  if (!usage) return undefined;
+  const input = usageNumber(usage.input);
+  const output = usageNumber(usage.output);
+  const cacheRead = usageNumber(usage.cacheRead);
+  const cacheWrite = usageNumber(usage.cacheWrite);
+  const cost = usageNumber(usage.cost);
+  const hasAccounting =
+    input > 0 || output > 0 || cacheRead > 0 || cacheWrite > 0 || cost > 0;
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    cost,
+    ...(hasAccounting && usage.costSource
+      ? { costSource: usage.costSource }
+      : {}),
+    turns: usageNumber(usage.turns),
+  };
 }
 
 type AssistantCostSource = Exclude<NonNullable<Usage["costSource"]>, "mixed">;
@@ -190,13 +214,11 @@ export function usageFromAssistantMessage(
     rawCostSource === "unavailable"
       ? rawCostSource
       : undefined;
-  const costSource =
-    explicitSource ??
-    (cost > 0
-      ? "estimated"
-      : input + output + cacheRead + cacheWrite > 0
-        ? "unavailable"
-        : undefined);
+  const hasAccounting =
+    input > 0 || output > 0 || cacheRead > 0 || cacheWrite > 0 || cost > 0;
+  const costSource = hasAccounting
+    ? (explicitSource ?? (cost > 0 ? "estimated" : "unavailable"))
+    : undefined;
   return {
     input,
     output,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -962,9 +962,11 @@ export async function startSubagentJob(
   }
 
   let completedLiveUsage = zeroUsageShape();
+  let observedUsageEvent = false;
   const updateLiveUsageFromMessage = (message: unknown): void => {
     const currentTurnUsage = usageFromAssistantMessage(message);
     if (!currentTurnUsage) return;
+    observedUsageEvent = true;
     liveStatus.usage = addUsageSamples(completedLiveUsage, currentTurnUsage);
   };
 
@@ -1106,10 +1108,12 @@ export async function startSubagentJob(
     errorMessage: "No subagent result captured.",
   };
   const currentSessionUsage = (): Usage =>
-    usageFromAssistantMessages(
-      session.agent.state.messages as readonly unknown[],
-      liveStatus.usage,
-    );
+    observedUsageEvent
+      ? { ...liveStatus.usage }
+      : usageFromAssistantMessages(
+          session.agent.state.messages as readonly unknown[],
+          liveStatus.usage,
+        );
   const jobPromise = (async (): Promise<SubagentResult> => {
     try {
       await startGate;

--- a/src/interactive-supervisor-ui.ts
+++ b/src/interactive-supervisor-ui.ts
@@ -16,7 +16,9 @@ import type { SessionOwnerToken } from "./session-scope";
 import type { WorkflowJobState } from "./workflow-jobs";
 import {
   formatWorkflowUsage,
+  formatWorkflowUsageFields,
   formatWorkflowUsageLegend,
+  presentWorkflowUsage,
 } from "./workflow-core";
 
 export const INTERACTIVE_SUPERVISOR_SHORTCUT = "ctrl+alt+a";
@@ -704,25 +706,24 @@ function formatWorkflowDetails(job: WorkflowJobState, width: number): string[] {
   const omitted =
     (snapshot.agentRecordsOmitted ?? 0) +
     Math.max(0, allRecords.length - records.length);
-  const usage = snapshot.usage
-    ? formatWorkflowUsage(snapshot.usage, {
-        expanded: true,
+  const usage = presentWorkflowUsage(snapshot.usage);
+  const usageFields = usage
+    ? formatWorkflowUsageFields(usage, {
         ascii: true,
         outputBudget: snapshot.budgetTotal,
-      })
-    : "unavailable";
+      }).map((field) => `Usage: ${field}`)
+    : [];
+  const liveUsage = presentWorkflowUsage(snapshot.liveUsage);
   const fields = [
     `Workflow: ${job.name} (${job.id})`,
     `Phase: ${snapshot.currentPhase ?? "none"}`,
     `Agents: ${snapshot.agentsSpawned} total · ${snapshot.runningCount ?? 0} running`,
     `Errors: ${snapshot.errorCount}`,
-    `Usage: ${usage}`,
-    formatWorkflowUsageLegend(true),
+    ...usageFields,
+    ...(usage ? [formatWorkflowUsageLegend(true)] : []),
     `Last activity: ${snapshot.lastMessage ?? "none yet"}`,
-    ...(snapshot.liveUsage
-      ? [
-          `Live usage: ${formatWorkflowUsage(snapshot.liveUsage, { ascii: true })}`,
-        ]
+    ...(liveUsage
+      ? [`Live usage: ${formatWorkflowUsage(liveUsage, { ascii: true })}`]
       : []),
   ];
   if (omitted > 0) fields.push(`… ${omitted} older agent records omitted`);
@@ -730,10 +731,11 @@ function formatWorkflowDetails(job: WorkflowJobState, width: number): string[] {
     const label = record.label ?? "agent";
     const model = record.model ? ` @${record.model}` : "";
     const phase = record.phase ? ` (${record.phase})` : "";
+    const recordUsage = presentWorkflowUsage(record.usage);
     fields.push(
       `Agent: ${statusIcon(record.status)} ${record.status} ${label} #${record.agentId}${model}${phase}${
-        record.usage
-          ? ` — ${formatWorkflowUsage(record.usage, { ascii: true })}`
+        recordUsage
+          ? ` — ${formatWorkflowUsage(recordUsage, { ascii: true })}`
           : ""
       }`,
     );

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -67,6 +67,25 @@ export function zeroWorkflowUsage(): WorkflowUsage {
   };
 }
 
+export function hasWorkflowUsage(usage: WorkflowUsage | undefined): boolean {
+  return Boolean(
+    usage &&
+    (usage.input > 0 ||
+      usage.output > 0 ||
+      usage.cacheRead > 0 ||
+      usage.cacheWrite > 0 ||
+      usage.totalTokens > 0 ||
+      usage.costUsd > 0 ||
+      usage.costSource !== undefined),
+  );
+}
+
+export function presentWorkflowUsage(
+  usage: WorkflowUsage | undefined,
+): WorkflowUsage | undefined {
+  return hasWorkflowUsage(usage) ? usage : undefined;
+}
+
 function usageCostSource(
   usage: Usage | undefined,
 ): WorkflowCostSource | undefined {
@@ -89,7 +108,12 @@ function mergeCostSource(
   next: WorkflowCostSource | undefined,
 ): WorkflowCostSource | undefined {
   const existing =
-    total.costSource ?? (total.costUsd > 0 ? "estimated" : undefined);
+    total.costSource ??
+    (total.costUsd > 0
+      ? "estimated"
+      : hasWorkflowUsage(total)
+        ? "unavailable"
+        : undefined);
   if (!next) return existing;
   if (!existing) return next;
   if (existing === next) return next;
@@ -152,10 +176,10 @@ export interface WorkflowUsageFormatOptions {
   outputBudget?: number | null;
 }
 
-export function formatWorkflowUsage(
-  usage: WorkflowUsage,
-  options: WorkflowUsageFormatOptions = {},
-): string {
+function workflowCostPresentation(usage: WorkflowUsage): {
+  source: WorkflowCostSource;
+  cost: string;
+} {
   const source =
     usage.costSource ?? (usage.costUsd > 0 ? "estimated" : "unavailable");
   const cost =
@@ -166,29 +190,19 @@ export function formatWorkflowUsage(
         : source === "estimated"
           ? `~$${formatWorkflowCost(usage.costUsd)}`
           : `$${formatWorkflowCost(usage.costUsd)}`;
+  return { source, cost };
+}
+
+export function formatWorkflowUsageFields(
+  usage: WorkflowUsage,
+  options: WorkflowUsageFormatOptions = {},
+): string[] {
+  const { source, cost } = workflowCostPresentation(usage);
   const budget =
     options.outputBudget == null
       ? ""
       : `/${formatWorkflowCost(options.outputBudget)}`;
-  if (!options.expanded) {
-    const icons = options.ascii
-      ? [
-          `input=${usage.input}`,
-          `output=${usage.output}${budget}`,
-          `cache-read=${usage.cacheRead}`,
-          `cache-write=${usage.cacheWrite}`,
-          `cost=${cost}`,
-        ]
-      : [
-          `↑${usage.input}`,
-          `↓${usage.output}${budget}`,
-          `R${usage.cacheRead}`,
-          `W${usage.cacheWrite}`,
-          `${cost}`,
-        ];
-    return icons.join(" ");
-  }
-  const labels = options.ascii
+  return options.ascii
     ? [
         `input tokens: ${usage.input}`,
         `output tokens: ${usage.output}${budget}`,
@@ -205,7 +219,36 @@ export function formatWorkflowUsage(
         `$ cost: ${cost} (${source})`,
         `turns: ${usage.turns}`,
       ];
-  return labels.join("; ");
+}
+
+export function formatWorkflowUsage(
+  usage: WorkflowUsage,
+  options: WorkflowUsageFormatOptions = {},
+): string {
+  if (options.expanded) {
+    return formatWorkflowUsageFields(usage, options).join("; ");
+  }
+  const { cost } = workflowCostPresentation(usage);
+  const budget =
+    options.outputBudget == null
+      ? ""
+      : `/${formatWorkflowCost(options.outputBudget)}`;
+  const icons = options.ascii
+    ? [
+        `input=${usage.input}`,
+        `output=${usage.output}${budget}`,
+        `cache-read=${usage.cacheRead}`,
+        `cache-write=${usage.cacheWrite}`,
+        `cost=${cost}`,
+      ]
+    : [
+        `↑${usage.input}`,
+        `↓${usage.output}${budget}`,
+        `R${usage.cacheRead}`,
+        `W${usage.cacheWrite}`,
+        `${cost}`,
+      ];
+  return icons.join(" ");
 }
 
 export function formatWorkflowUsageLegend(ascii = false): string {

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { SubagentResult, Usage } from "./helpers";
+import { normalizeUsage, type SubagentResult, type Usage } from "./helpers";
 
 // ── Limits ───────────────────────────────────────────────────────────
 export const MAX_TOTAL_AGENTS = 1000;
@@ -125,11 +125,12 @@ export function addWorkflowUsage(
   total: WorkflowUsage,
   usage: Usage | undefined,
 ): WorkflowUsage {
-  const input = total.input + (usage?.input ?? 0);
-  const output = total.output + (usage?.output ?? 0);
-  const cacheRead = total.cacheRead + (usage?.cacheRead ?? 0);
-  const cacheWrite = total.cacheWrite + (usage?.cacheWrite ?? 0);
-  const nextCostSource = usageCostSource(usage);
+  const normalized = normalizeUsage(usage);
+  const input = total.input + (normalized?.input ?? 0);
+  const output = total.output + (normalized?.output ?? 0);
+  const cacheRead = total.cacheRead + (normalized?.cacheRead ?? 0);
+  const cacheWrite = total.cacheWrite + (normalized?.cacheWrite ?? 0);
+  const nextCostSource = usageCostSource(normalized);
   const costSource = mergeCostSource(total, nextCostSource);
   const provenance = costSource ? { costSource } : {};
   return {
@@ -138,8 +139,8 @@ export function addWorkflowUsage(
     cacheRead,
     cacheWrite,
     totalTokens: input + output + cacheRead + cacheWrite,
-    costUsd: total.costUsd + (usage?.cost ?? 0),
-    turns: total.turns + (usage?.turns ?? 0),
+    costUsd: total.costUsd + (normalized?.cost ?? 0),
+    turns: total.turns + (normalized?.turns ?? 0),
     ...provenance,
   };
 }
@@ -147,19 +148,10 @@ export function addWorkflowUsage(
 export function workflowUsageFromUsage(
   usage: Usage | undefined,
 ): WorkflowUsage | undefined {
-  const source = usageCostSource(usage);
-  if (!usage || source === undefined) return undefined;
-  if (
-    usage.input === 0 &&
-    usage.output === 0 &&
-    usage.cacheRead === 0 &&
-    usage.cacheWrite === 0 &&
-    usage.cost === 0 &&
-    usage.costSource === undefined
-  ) {
+  const normalized = normalizeUsage(usage);
+  if (!normalized || usageCostSource(normalized) === undefined)
     return undefined;
-  }
-  return addWorkflowUsage(zeroWorkflowUsage(), usage);
+  return addWorkflowUsage(zeroWorkflowUsage(), normalized);
 }
 
 function formatWorkflowCost(costUsd: number): string {

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -429,30 +429,31 @@ function recordWorkflowAgentProgress(
   if (typeof progress.agentId !== "number") return;
   const records = (snapshot.agentRecords ??= []);
   if (progress.kind === "agent_start") {
-    records.push({
+    const nextRecord: WorkflowAgentRecord = {
       agentId: progress.agentId,
       phase: progress.phase,
       label: progress.label,
-      model: progress.model,
       status: "running",
-    });
+    };
+    if (progress.model !== undefined) nextRecord.model = progress.model;
+    records.push(nextRecord);
   } else {
     const record = records.find(
       (candidate) => candidate.agentId === progress.agentId,
     );
     if (record) {
       record.status = progress.status ?? "done";
-      if (progress.agentUsage) record.usage = progress.agentUsage;
-      if (progress.model) record.model = progress.model;
+      if (progress.agentUsage) record.usage = { ...progress.agentUsage };
+      if (progress.model !== undefined) record.model = progress.model;
     } else {
       const nextRecord: WorkflowAgentRecord = {
         agentId: progress.agentId,
         phase: progress.phase,
         label: progress.label,
-        model: progress.model,
         status: progress.status ?? "done",
       };
-      if (progress.agentUsage) nextRecord.usage = progress.agentUsage;
+      if (progress.agentUsage) nextRecord.usage = { ...progress.agentUsage };
+      if (progress.model !== undefined) nextRecord.model = progress.model;
       records.push(nextRecord);
     }
   }

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -27,6 +27,7 @@ import {
   type WorkflowRunResult,
   type WorkflowUsage,
   formatWorkflowUsage,
+  presentWorkflowUsage,
   workflowUsageFromUsage,
 } from "./workflow-core";
 import {
@@ -116,18 +117,6 @@ async function waitForCancellationReceipts(
   }
 }
 
-function presentWorkflowUsage(
-  usage: WorkflowUsage | undefined,
-): WorkflowUsage | undefined {
-  if (
-    !usage ||
-    (usage.totalTokens === 0 && usage.costUsd === 0 && usage.turns === 0)
-  ) {
-    return undefined;
-  }
-  return usage;
-}
-
 function workflowErrorUsage(error: unknown): WorkflowUsage | undefined {
   return error instanceof WorkflowExecutionError
     ? presentWorkflowUsage(error.usage)
@@ -139,13 +128,22 @@ export function formatWorkflowNotificationSummary(
 ): string {
   const run = job.result;
   if (run) {
-    return (
-      `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ` +
-      `${run.usage ? formatWorkflowUsage(run.usage, { outputBudget: job.snapshot.budgetTotal }) : "usage unavailable"}.`
-    );
+    const usage = presentWorkflowUsage(run.usage);
+    const usageSummary = usage
+      ? `, ${formatWorkflowUsage(usage, {
+          outputBudget: job.snapshot.budgetTotal,
+        })}`
+      : "";
+    return `${run.agentsSpawned} agent(s), ${run.errorCount} error(s)${usageSummary}.`;
   }
   const usage = presentWorkflowUsage(job.snapshot.usage);
-  return `${job.error ?? "Workflow did not produce a result."}${usage ? ` (${formatWorkflowUsage(usage)})` : ""}`;
+  return `${job.error ?? "Workflow did not produce a result."}${
+    usage
+      ? ` (${formatWorkflowUsage(usage, {
+          outputBudget: job.snapshot.budgetTotal,
+        })})`
+      : ""
+  }`;
 }
 
 export function registerWorkflowTool(
@@ -376,6 +374,7 @@ export function registerWorkflowTool(
             status: job.status,
             presentationStatus: presentation.label,
             usage: run?.usage ?? job.snapshot.usage,
+            budgetTotal: job.snapshot.budgetTotal,
           },
         },
         { deliverAs: "followUp", triggerTurn: true },
@@ -591,6 +590,7 @@ export function registerWorkflowTool(
                 errorCount: p.errorCount,
                 tokensSpent: p.tokensSpent,
                 usage: p.usage,
+                budgetTotal: p.budgetTotal,
               },
             });
           } catch {
@@ -623,9 +623,16 @@ export function registerWorkflowTool(
         const completionLabel = presentation.icon
           ? presentation.label
           : "complete";
+        const usage = presentWorkflowUsage(run.usage);
         const summary =
           `${completionPrefix}Workflow "${run.meta.name}" ${completionLabel} — ` +
-          `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${formatWorkflowUsage(run.usage, { outputBudget: job.snapshot.budgetTotal })}.`;
+          `${run.agentsSpawned} agent(s), ${run.errorCount} error(s)${
+            usage
+              ? `, ${formatWorkflowUsage(usage, {
+                  outputBudget: job.snapshot.budgetTotal,
+                })}`
+              : ""
+          }.`;
         return {
           content: [{ type: "text", text: `${summary}\n\n${resultText}` }],
           details: {
@@ -636,6 +643,7 @@ export function registerWorkflowTool(
             errorCount: run.errorCount,
             tokensSpent: run.tokensSpent,
             usage: run.usage,
+            budgetTotal: job.snapshot.budgetTotal,
             phases: run.phases,
           },
         };
@@ -643,14 +651,26 @@ export function registerWorkflowTool(
         const msg = err instanceof Error ? err.message : String(err);
         const usage = workflowErrorUsage(err);
         const usageDetails = usage ? { usage } : {};
+        const budgetTotal = params.budget ?? null;
         return {
           content: [
             {
               type: "text",
-              text: `Workflow failed: ${msg}${usage ? ` (${formatWorkflowUsage(usage)})` : ""}`,
+              text: `Workflow failed: ${msg}${
+                usage
+                  ? ` (${formatWorkflowUsage(usage, {
+                      outputBudget: budgetTotal,
+                    })})`
+                  : ""
+              }`,
             },
           ],
-          details: { status: "error", error: msg, ...usageDetails },
+          details: {
+            status: "error",
+            error: msg,
+            budgetTotal,
+            ...usageDetails,
+          },
           isError: true,
         };
       }
@@ -685,6 +705,8 @@ export function registerWorkflowTool(
         errorCount,
       );
       const statusPrefix = presentation.icon ? `${presentation.icon} ` : "";
+      const usage = presentWorkflowUsage(st.snapshot.usage);
+      const liveUsage = presentWorkflowUsage(st.snapshot.liveUsage);
       return {
         content: [
           {
@@ -695,12 +717,10 @@ export function registerWorkflowTool(
                 ? `, ${st.snapshot.runningCount} running`
                 : "") +
               `, ${errorCount} error(s)` +
-              (st.snapshot.usage
-                ? `, ${formatWorkflowUsage(st.snapshot.usage, { outputBudget: st.snapshot.budgetTotal })}`
-                : ", usage unavailable") +
-              (st.snapshot.liveUsage
-                ? `, live ${formatWorkflowUsage(st.snapshot.liveUsage)}`
+              (usage
+                ? `, ${formatWorkflowUsage(usage, { outputBudget: st.snapshot.budgetTotal })}`
                 : "") +
+              (liveUsage ? `, live ${formatWorkflowUsage(liveUsage)}` : "") +
               (st.snapshot.currentPhase
                 ? `, phase: ${st.snapshot.currentPhase}`
                 : "") +
@@ -781,18 +801,26 @@ export function registerWorkflowTool(
         // Non-abort errors preserve the original structured handling
         const msg = err instanceof Error ? err.message : String(err);
         const usage = presentWorkflowUsage(st.snapshot?.usage);
+        const outputBudget = st.snapshot?.budgetTotal;
         const usageDetails = usage ? { usage } : {};
         return {
           content: [
             {
               type: "text",
-              text: `Workflow ${st.id} ${st.status}: ${msg}${usage ? ` (${formatWorkflowUsage(usage)})` : ""}`,
+              text: `Workflow ${st.id} ${st.status}: ${msg}${
+                usage
+                  ? ` (${formatWorkflowUsage(usage, {
+                      outputBudget,
+                    })})`
+                  : ""
+              }`,
             },
           ],
           details: {
             status: st.status,
             workflowId: st.id,
             error: msg,
+            ...(outputBudget == null ? {} : { budgetTotal: outputBudget }),
             ...usageDetails,
           },
           isError: true,
@@ -805,6 +833,7 @@ export function registerWorkflowTool(
         "done",
         run.errorCount,
       );
+      const usage = presentWorkflowUsage(run.usage);
       return {
         content: [
           {
@@ -814,7 +843,13 @@ export function registerWorkflowTool(
               const label = presentation.icon ? presentation.label : "complete";
               return (
                 `${prefix}Workflow "${run.meta.name}" ${label} — ` +
-                `${run.agentsSpawned} agent(s), ${run.errorCount} error(s), ${run.usage ? formatWorkflowUsage(run.usage, { outputBudget: st.snapshot.budgetTotal }) : "usage unavailable"}.\n\n${resultText}`
+                `${run.agentsSpawned} agent(s), ${run.errorCount} error(s)${
+                  usage
+                    ? `, ${formatWorkflowUsage(usage, {
+                        outputBudget: st.snapshot.budgetTotal,
+                      })}`
+                    : ""
+                }.\n\n${resultText}`
               );
             })(),
           },
@@ -828,6 +863,7 @@ export function registerWorkflowTool(
           errorCount: run.errorCount,
           tokensSpent: run.tokensSpent,
           usage: run.usage,
+          budgetTotal: st.snapshot.budgetTotal,
           phases: run.phases,
         },
       };
@@ -1366,10 +1402,9 @@ export function registerWorkflowTool(
         parts.push(`⚡ ${s.runningCount} running`);
       }
       if (errorCount > 0) parts.push(`⚠ ${errorCount} error(s)`);
-      if (s.usage) {
-        parts.push(
-          formatWorkflowUsage(s.usage, { outputBudget: s.budgetTotal }),
-        );
+      const usage = presentWorkflowUsage(s.usage);
+      if (usage) {
+        parts.push(formatWorkflowUsage(usage, { outputBudget: s.budgetTotal }));
       }
       parts.push(elapsed);
       if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);

--- a/src/workflow-tree-ui.ts
+++ b/src/workflow-tree-ui.ts
@@ -7,7 +7,9 @@ import {
 } from "./workflow-jobs";
 import {
   formatWorkflowUsage,
+  formatWorkflowUsageFields,
   formatWorkflowUsageLegend,
+  presentWorkflowUsage,
 } from "./workflow-core";
 import type { SessionOwnerToken } from "./session-scope";
 
@@ -217,8 +219,9 @@ function formatWorkflowSummary(job: WorkflowJobState): string {
     `${s.runningCount ?? 0} running`,
   ];
   if (errorCount > 0) parts.push(`${errorCount} errors`);
-  if (s.usage) {
-    parts.push(formatWorkflowUsage(s.usage, { outputBudget: s.budgetTotal }));
+  const usage = presentWorkflowUsage(s.usage);
+  if (usage) {
+    parts.push(formatWorkflowUsage(usage, { outputBudget: s.budgetTotal }));
   }
   if (s.currentPhase) parts.push(`phase: ${s.currentPhase}`);
   return parts.join(" · ");
@@ -226,13 +229,18 @@ function formatWorkflowSummary(job: WorkflowJobState): string {
 
 function formatWorkflowDetails(job: WorkflowJobState): WorkflowRow[] {
   const rows: WorkflowRow[] = [];
-  if (job.snapshot.usage) {
-    rows.push({
-      job,
-      depth: 1,
-      selectable: false,
-      text: formatWorkflowUsage(job.snapshot.usage, { expanded: true }),
-    });
+  const usage = presentWorkflowUsage(job.snapshot.usage);
+  if (usage) {
+    for (const field of formatWorkflowUsageFields(usage, {
+      outputBudget: job.snapshot.budgetTotal,
+    })) {
+      rows.push({
+        job,
+        depth: 1,
+        selectable: false,
+        text: field,
+      });
+    }
     rows.push({
       job,
       depth: 1,
@@ -273,13 +281,14 @@ function formatWorkflowDetails(job: WorkflowJobState): WorkflowRow[] {
     const label = `${record.label ?? "agent"} #${record.agentId}`;
     const model = record.model ? ` @${record.model}` : "";
     const phase = record.phase ? ` (${record.phase})` : "";
+    const recordUsage = presentWorkflowUsage(record.usage);
     rows.push({
       job,
       depth: 1,
       selectable: false,
       text: `${marker} ${record.status} ${label}${model}${phase}${
-        record.usage
-          ? ` — ${formatWorkflowUsage(record.usage, { ascii: true })}`
+        recordUsage
+          ? ` — ${formatWorkflowUsage(recordUsage, { ascii: true })}`
           : ""
       }`,
     });

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -1,4 +1,8 @@
-import { formatWorkflowUsage, type WorkflowProgress } from "./workflow-core";
+import {
+  formatWorkflowUsage,
+  presentWorkflowUsage,
+  type WorkflowProgress,
+} from "./workflow-core";
 import { assertNever } from "./artifact";
 
 // ── Workflow progress renderer ───────────────────────────────────────
@@ -6,11 +10,13 @@ export function renderProgress(p: WorkflowProgress): string {
   const parts = [`● workflow — ${p.agentsSpawned} agent(s)`];
   if (p.runningCount > 0) parts.push(`⚡ ${p.runningCount} running`);
   if (p.errorCount > 0) parts.push(`⚠ ${p.errorCount} error(s)`);
-  if (p.usage) {
-    parts.push(formatWorkflowUsage(p.usage, { outputBudget: p.budgetTotal }));
+  const usage = presentWorkflowUsage(p.usage);
+  if (usage) {
+    parts.push(formatWorkflowUsage(usage, { outputBudget: p.budgetTotal }));
   }
-  if (p.liveUsage) {
-    parts.push(`live ${formatWorkflowUsage(p.liveUsage)}`);
+  const liveUsage = presentWorkflowUsage(p.liveUsage);
+  if (liveUsage) {
+    parts.push(`live ${formatWorkflowUsage(liveUsage)}`);
   }
   const head = parts.join(", ");
   switch (p.kind) {

--- a/src/workflow-worker-thread.mjs
+++ b/src/workflow-worker-thread.mjs
@@ -67,6 +67,7 @@ parentPort.on("message", (msg) => {
   if (typeof msg.id === "number" && pending.has(msg.id)) {
     const waiter = pending.get(msg.id);
     pending.delete(msg.id);
+    tokensSpent += typeof msg.tokensDelta === "number" ? msg.tokensDelta : 0;
     if (msg.ok) waiter.resolve(msg.value);
     else waiter.reject(new Error(String(msg.error || "Workflow RPC failed.")));
   }
@@ -106,13 +107,10 @@ async function executeBody(meta, body, args, depth) {
           ? String(opts.phase)
           : currentPhase;
       const callOpts = { ...opts, phase: resolvedPhase };
-      const res = await rpc("agent", {
+      return await rpc("agent", {
         prompt,
         opts: callOpts,
       });
-      tokensSpent +=
-        res && typeof res.tokensDelta === "number" ? res.tokensDelta : 0;
-      return res ? res.value : null;
     })();
     outstandingAgentCalls.add(call);
     void call.then(

--- a/src/workflow-worker-thread.mjs
+++ b/src/workflow-worker-thread.mjs
@@ -23,6 +23,7 @@ let workerConfig = {
   cwd: "",
 };
 let tokensSpent = 0;
+const rpcErrorIds = new WeakMap();
 
 function rpc(method, payload) {
   if (aborted) return Promise.reject(new Error("Workflow aborted."));
@@ -31,6 +32,11 @@ function rpc(method, payload) {
     pending.set(id, { resolve, reject });
     parentPort.postMessage({ id, method, payload });
   });
+}
+
+function rpcIdFromError(error) {
+  if (error === null || typeof error !== "object") return undefined;
+  return rpcErrorIds.get(error);
 }
 
 parentPort.on("message", (msg) => {
@@ -55,12 +61,14 @@ parentPort.on("message", (msg) => {
     };
     executeScript(msg.script, msg.args, 0)
       .then((value) => parentPort.postMessage({ type: "result", value }))
-      .catch((err) =>
+      .catch((err) => {
+        const rpcId = rpcIdFromError(err);
         parentPort.postMessage({
           type: "error",
           error: err instanceof Error ? err.message : String(err),
-        }),
-      );
+          ...(rpcId === undefined ? {} : { rpcId }),
+        });
+      });
     return;
   }
 
@@ -68,8 +76,13 @@ parentPort.on("message", (msg) => {
     const waiter = pending.get(msg.id);
     pending.delete(msg.id);
     tokensSpent += typeof msg.tokensDelta === "number" ? msg.tokensDelta : 0;
-    if (msg.ok) waiter.resolve(msg.value);
-    else waiter.reject(new Error(String(msg.error || "Workflow RPC failed.")));
+    if (msg.ok) {
+      waiter.resolve(msg.value);
+    } else {
+      const error = new Error(String(msg.error || "Workflow RPC failed."));
+      rpcErrorIds.set(error, msg.id);
+      waiter.reject(error);
+    }
   }
 });
 
@@ -249,7 +262,10 @@ async function executeBody(meta, body, args, depth) {
     );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`Workflow "${meta.name}" failed: ${msg}`);
+    const wrapped = new Error(`Workflow "${meta.name}" failed: ${msg}`);
+    const rpcId = rpcIdFromError(err);
+    if (rpcId !== undefined) rpcErrorIds.set(wrapped, rpcId);
+    throw wrapped;
   }
 }
 

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -229,13 +229,15 @@ export async function runWorkflow(
       phases: [...engine.phases],
     };
   } catch (error) {
-    if (abort.signal.aborted) await drainActiveAgentRuns(engine);
+    const cause = workflowFailureCause(error, engine, opts.signal);
+    if (!abort.signal.aborted) abort.abort(error);
+    await drainActiveAgentRuns(engine);
     if (error instanceof WorkflowExecutionError && error.usage) throw error;
     const message = error instanceof Error ? error.message : String(error);
     throw new WorkflowExecutionError(
       message,
       usageIfPresent(engine.usage),
-      workflowFailureCause(error, engine, opts.signal),
+      cause,
     );
   } finally {
     opts.signal?.removeEventListener("abort", forwardAbort);
@@ -248,7 +250,18 @@ type WorkerRpcResponse = {
   ok: boolean;
   value?: unknown;
   error?: string;
+  tokensDelta: number;
 };
+
+class WorkerRpcFailure extends Error {
+  readonly tokensDelta: number;
+
+  constructor(error: unknown, tokensDelta: number) {
+    super(error instanceof Error ? error.message : String(error));
+    this.name = "WorkerRpcFailure";
+    this.tokensDelta = tokensDelta;
+  }
+}
 
 async function executeScript(
   script: string,
@@ -378,6 +391,8 @@ async function executeScript(
                 (activeRun.liveUsage
                   ? usageAsProjectUsage(activeRun.liveUsage)
                   : undefined);
+              tokensDelta += partialUsage?.output ?? 0;
+              agentUsage = workflowUsageFromUsage(partialUsage);
               accountAgentUsage(engine, activeRun, partialUsage);
               status = "error";
               engine.failureCause = error;
@@ -448,6 +463,8 @@ async function executeScript(
         message: `agent(schema) failed after ${attempts} attempts: ${lastErr}`,
       });
       return { value: null, tokensDelta };
+    } catch (error) {
+      throw new WorkerRpcFailure(error, tokensDelta);
     } finally {
       sem.release();
     }
@@ -546,7 +563,14 @@ function runWorkflowWorker(
         runAgentCall,
       ).catch((err) => {
         const error = err instanceof Error ? err.message : String(err);
-        postWorkerResponse(worker, { id: msg.id, ok: false, error });
+        const tokensDelta =
+          err instanceof WorkerRpcFailure ? err.tokensDelta : 0;
+        postWorkerResponse(worker, {
+          id: msg.id,
+          ok: false,
+          error,
+          tokensDelta,
+        });
       });
     });
     worker.on("error", fail);
@@ -577,8 +601,13 @@ async function handleWorkerRpc(
   }) => Promise<{ value: unknown; tokensDelta: number }>,
 ): Promise<void> {
   if (msg.method === "agent") {
-    const value = await runAgentCall(msg.payload);
-    postWorkerResponse(worker, { id: msg.id, ok: true, value });
+    const response = await runAgentCall(msg.payload);
+    postWorkerResponse(worker, {
+      id: msg.id,
+      ok: true,
+      value: response.value,
+      tokensDelta: response.tokensDelta,
+    });
     return;
   }
   if (msg.method === "loadWorkflow") {
@@ -586,7 +615,12 @@ async function handleWorkerRpc(
     if (script == null && typeof msg.payload === "string") {
       throw new Error(`workflow(): no saved workflow named "${msg.payload}".`);
     }
-    postWorkerResponse(worker, { id: msg.id, ok: true, value: script });
+    postWorkerResponse(worker, {
+      id: msg.id,
+      ok: true,
+      value: script,
+      tokensDelta: 0,
+    });
     return;
   }
   throw new Error(`Unknown workflow worker RPC method: ${msg.method}`);
@@ -734,7 +768,6 @@ export async function awaitInteractiveResult(
         isError: true,
         output: "",
         usage: cancellationUsage,
-        model: undefined,
         errorMessage: "aborted",
       };
     }
@@ -751,7 +784,7 @@ export async function awaitInteractiveResult(
                 output:
                   readOutputForTurnId(art, terminal.turnId) ?? "(no output)",
                 usage,
-                model: state.model ?? "process",
+                ...(state.model !== undefined ? { model: state.model } : {}),
               };
             case "error":
             case "cancelled":
@@ -760,7 +793,6 @@ export async function awaitInteractiveResult(
                 output:
                   readOutputForTurnId(art, terminal.turnId) ?? "(no output)",
                 usage,
-                model: undefined,
                 errorMessage:
                   terminal.errorMessage ??
                   terminal.message ??
@@ -774,7 +806,7 @@ export async function awaitInteractiveResult(
             isError: false,
             output: readOutput(art) ?? "(no output)",
             usage,
-            model: state.model ?? "process",
+            ...(state.model !== undefined ? { model: state.model } : {}),
           };
         case "error":
         case "cancelled":
@@ -782,7 +814,6 @@ export async function awaitInteractiveResult(
             isError: true,
             output: readOutput(art) ?? "(no output)",
             usage,
-            model: undefined,
             errorMessage:
               terminal.message ?? `interactive sub-agent ${terminal.type}`,
           };
@@ -809,7 +840,6 @@ export async function awaitInteractiveResult(
           isError: true,
           output,
           usage: parseUsageFromSessionFile(state.sessionFile),
-          model: undefined,
           errorMessage: "interactive sub-agent pane exited before completing",
         };
       }

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -82,7 +82,6 @@ interface Engine {
 
   usage: WorkflowUsage;
   activeAgentRuns: Set<ActiveAgentRun>;
-  failureCause?: unknown;
   phases: string[];
 }
 
@@ -165,17 +164,10 @@ async function drainActiveAgentRuns(engine: Engine): Promise<void> {
 
 function workflowFailureCause(
   error: unknown,
-  engine: Engine,
   signal: AbortSignal | undefined,
 ): unknown {
   if (signal?.aborted && signal.reason !== undefined) return signal.reason;
-  const candidate = engine.failureCause;
-  if (candidate !== undefined) {
-    const message =
-      candidate instanceof Error ? candidate.message : String(candidate);
-    if (error instanceof Error && error.message.includes(message))
-      return candidate;
-  }
+  if (error instanceof WorkerTerminalFailure) return error.originalCause;
   return error;
 }
 
@@ -229,7 +221,7 @@ export async function runWorkflow(
       phases: [...engine.phases],
     };
   } catch (error) {
-    const cause = workflowFailureCause(error, engine, opts.signal);
+    const cause = workflowFailureCause(error, opts.signal);
     if (!abort.signal.aborted) abort.abort(error);
     await drainActiveAgentRuns(engine);
     if (error instanceof WorkflowExecutionError && error.usage) throw error;
@@ -255,11 +247,27 @@ type WorkerRpcResponse = {
 
 class WorkerRpcFailure extends Error {
   readonly tokensDelta: number;
+  readonly runnerFailure: { cause: unknown } | undefined;
 
-  constructor(error: unknown, tokensDelta: number) {
+  constructor(
+    error: unknown,
+    tokensDelta: number,
+    runnerFailure?: { cause: unknown },
+  ) {
     super(error instanceof Error ? error.message : String(error));
     this.name = "WorkerRpcFailure";
     this.tokensDelta = tokensDelta;
+    this.runnerFailure = runnerFailure;
+  }
+}
+
+class WorkerTerminalFailure extends Error {
+  readonly originalCause: unknown;
+
+  constructor(message: string, originalCause: unknown) {
+    super(message);
+    this.name = "WorkerTerminalFailure";
+    this.originalCause = originalCause;
   }
 }
 
@@ -309,6 +317,7 @@ async function executeScript(
       agentOpts.phase != null ? String(agentOpts.phase) : undefined;
     await sem.acquire();
     let tokensDelta = 0;
+    let runnerFailure: { cause: unknown } | undefined;
     try {
       let lastErr = "";
       const attempts = hasSchema ? SCHEMA_RETRIES : 1;
@@ -386,16 +395,20 @@ async function executeScript(
               res = await agentRun;
               finalModel = res.model ?? agentOpts.model;
             } catch (error) {
+              const errorUsage = (error as { usage?: Usage } | null)?.usage;
+              const terminalAgentUsage = workflowUsageFromUsage(errorUsage);
               const partialUsage =
-                (error as { usage?: Usage })?.usage ??
-                (activeRun.liveUsage
-                  ? usageAsProjectUsage(activeRun.liveUsage)
-                  : undefined);
+                terminalAgentUsage !== undefined
+                  ? errorUsage
+                  : activeRun.liveUsage
+                    ? usageAsProjectUsage(activeRun.liveUsage)
+                    : undefined;
               tokensDelta += partialUsage?.output ?? 0;
-              agentUsage = workflowUsageFromUsage(partialUsage);
+              agentUsage =
+                terminalAgentUsage ?? workflowUsageFromUsage(partialUsage);
               accountAgentUsage(engine, activeRun, partialUsage);
               status = "error";
-              engine.failureCause = error;
+              runnerFailure = { cause: error };
               if (!engine.signal.aborted) engine.counters.errorCount++;
               throw error;
             }
@@ -464,7 +477,7 @@ async function executeScript(
       });
       return { value: null, tokensDelta };
     } catch (error) {
-      throw new WorkerRpcFailure(error, tokensDelta);
+      throw new WorkerRpcFailure(error, tokensDelta, runnerFailure);
     } finally {
       sem.release();
     }
@@ -494,6 +507,7 @@ function runWorkflowWorker(
 ): Promise<{ meta: WorkflowMeta; result: unknown }> {
   return new Promise((resolve, reject) => {
     let settled = false;
+    const runnerFailures = new Map<number, unknown>();
     const worker = new Worker(
       new URL("./workflow-worker-thread.mjs", import.meta.url),
     );
@@ -532,6 +546,7 @@ function runWorkflowWorker(
     const cleanup = () => {
       clearTimeout(timeout);
       engine.signal.removeEventListener("abort", onAbort);
+      runnerFailures.clear();
       worker.removeAllListeners();
     };
 
@@ -548,7 +563,14 @@ function runWorkflowWorker(
         return;
       }
       if (msg.type === "error") {
-        fail(new Error(String(msg.error ?? "Workflow worker failed.")));
+        const message = String(msg.error ?? "Workflow worker failed.");
+        if (typeof msg.rpcId === "number" && runnerFailures.has(msg.rpcId)) {
+          fail(
+            new WorkerTerminalFailure(message, runnerFailures.get(msg.rpcId)),
+          );
+        } else {
+          fail(new Error(message));
+        }
         return;
       }
       if (msg.type === "progress") {
@@ -562,6 +584,9 @@ function runWorkflowWorker(
         engine,
         runAgentCall,
       ).catch((err) => {
+        if (err instanceof WorkerRpcFailure && err.runnerFailure) {
+          runnerFailures.set(msg.id, err.runnerFailure.cause);
+        }
         const error = err instanceof Error ? err.message : String(err);
         const tokensDelta =
           err instanceof WorkerRpcFailure ? err.tokensDelta : 0;

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -137,8 +137,10 @@ function accountAgentUsage(
   usage: Usage | undefined,
 ): void {
   if (run.usageAccounted || !usage) return;
-  engine.usage = addWorkflowUsage(engine.usage, usage);
-  engine.counters.tokensSpent += usage.output;
+  const previousOutput = engine.usage.output;
+  const aggregate = addWorkflowUsage(engine.usage, usage);
+  engine.counters.tokensSpent += aggregate.output - previousOutput;
+  engine.usage = aggregate;
   run.usageAccounted = true;
 }
 
@@ -403,9 +405,9 @@ async function executeScript(
                   : activeRun.liveUsage
                     ? usageAsProjectUsage(activeRun.liveUsage)
                     : undefined;
-              tokensDelta += partialUsage?.output ?? 0;
               agentUsage =
                 terminalAgentUsage ?? workflowUsageFromUsage(partialUsage);
+              tokensDelta += agentUsage?.output ?? 0;
               accountAgentUsage(engine, activeRun, partialUsage);
               status = "error";
               runnerFailure = { cause: error };
@@ -415,9 +417,9 @@ async function executeScript(
           } finally {
             engine.activeAgentRuns.delete(activeRun);
           }
-          const outTokens = res.usage?.output ?? 0;
-          tokensDelta += outTokens;
           agentUsage = workflowUsageFromUsage(res.usage);
+          const outTokens = agentUsage?.output ?? 0;
+          tokensDelta += outTokens;
           accountAgentUsage(engine, activeRun, res.usage);
           if (res.isError) {
             status = "error";

--- a/tests/interactive-supervisor.test.ts
+++ b/tests/interactive-supervisor.test.ts
@@ -309,6 +309,78 @@ describe("interactive supervisor", () => {
     );
   });
 
+  it("keeps every workflow total field on its own row at narrow widths", () => {
+    const workflow = workflowJob("wf-budget", {
+      snapshot: {
+        ...workflowJob("snapshot").snapshot,
+        budgetTotal: 20,
+        usage: {
+          input: 11,
+          output: 7,
+          cacheRead: 5,
+          cacheWrite: 3,
+          totalTokens: 26,
+          costUsd: 0.125,
+          turns: 2,
+          costSource: "provider",
+        },
+      },
+    });
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => [
+        { kind: "workflow", job: workflow, depth: 0, actionable: true },
+      ],
+    });
+    component.handleInput("\r");
+    const lines = component.render(60);
+
+    expect(lines.some((line) => line.includes("input tokens: 11"))).toBe(true);
+    expect(lines.some((line) => line.includes("output tokens: 7/20"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("cache-read tokens: 5"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("cache-write tokens: 3"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("cost: $0.125 (provider)"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("turns: 2"))).toBe(true);
+    expect(lines.every((line) => line.length <= 60)).toBe(true);
+  });
+
+  it("omits empty provenance-free workflow totals", () => {
+    const workflow = workflowJob("wf-empty", {
+      snapshot: {
+        ...workflowJob("snapshot").snapshot,
+        budgetTotal: 20,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          costUsd: 0,
+          turns: 0,
+        },
+      },
+    });
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => [
+        { kind: "workflow", job: workflow, depth: 0, actionable: true },
+      ],
+    });
+    component.handleInput("\r");
+    const rendered = component.render(80).join("\n");
+
+    expect(rendered).not.toContain("$?");
+    expect(rendered).not.toContain("output tokens: 0/20");
+  });
+
   it("reports omitted workflow agent records", () => {
     const records = Array.from({ length: 25 }, (_, index) => ({
       agentId: index + 1,

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -322,6 +322,166 @@ describe("pollArtifactChanges", () => {
     expect(footerCalls.at(-1)?.[1]).toBe("⚡ 1 sub-agent active");
   });
 
+  it("aggregates workflow footer contributions across owners sharing one UI", async () => {
+    const mod = await importFresh<typeof import("../src/artifact-poller")>(
+      "../src/artifact-poller",
+    );
+    const { workflowJobRegistry } = await import("../src/workflow");
+    const sharedUi = {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      setWidget: vi.fn(),
+    };
+    const ownerA = { id: 509, generation: 1 };
+    const ownerB = { id: 510, generation: 1 };
+    registerSessionScope({
+      ...ownerA,
+      pi: { sendMessage: vi.fn() } as any,
+      ui: sharedUi as any,
+      sessionManager: { getSessionId: () => "session-a" },
+    });
+    registerSessionScope({
+      ...ownerB,
+      pi: { sendMessage: vi.fn() } as any,
+      ui: sharedUi as any,
+      sessionManager: { getSessionId: () => "session-b" },
+    });
+    workflowJobRegistry.set("workflow-a", {
+      id: "workflow-a",
+      name: "flow-a",
+      status: "running",
+      startedAt: Date.now(),
+      promise: Promise.resolve({}) as any,
+      abort: new AbortController(),
+      parentSessionOwner: ownerA,
+      snapshot: {
+        agentsSpawned: 1,
+        errorCount: 0,
+        tokensSpent: 2,
+        budgetTotal: 20,
+        usage: {
+          input: 4,
+          output: 2,
+          cacheRead: 1,
+          cacheWrite: 0,
+          totalTokens: 7,
+          costUsd: 0.01,
+          turns: 1,
+          costSource: "provider",
+        },
+        phases: [],
+        runningCount: 1,
+      },
+    });
+    workflowJobRegistry.set("workflow-b", {
+      id: "workflow-b",
+      name: "flow-b",
+      status: "running",
+      startedAt: Date.now(),
+      promise: Promise.resolve({}) as any,
+      abort: new AbortController(),
+      parentSessionOwner: ownerB,
+      snapshot: {
+        agentsSpawned: 1,
+        errorCount: 0,
+        tokensSpent: 3,
+        budgetTotal: 30,
+        usage: {
+          input: 6,
+          output: 3,
+          cacheRead: 0,
+          cacheWrite: 2,
+          totalTokens: 11,
+          costUsd: 0.02,
+          turns: 1,
+          costSource: "provider",
+        },
+        phases: [],
+        runningCount: 1,
+      },
+    });
+
+    await mod.pollArtifactChanges({} as any, ownerA);
+    await mod.pollArtifactChanges({} as any, ownerB);
+
+    const workflowFooterCalls = sharedUi.setStatus.mock.calls.filter(
+      ([key]) => key === "subagentura-workflows",
+    );
+    expect(workflowFooterCalls.at(-1)?.[1]).toBe(
+      "⚡ 2 workflows running · ↑10 ↓5 R1 W2 $0.03",
+    );
+
+    mod.clearSessionScopeUiContributions(sharedUi as any, ownerA);
+    removeSessionScope(ownerA.id);
+
+    expect(
+      sharedUi.setStatus.mock.calls
+        .filter(([key]) => key === "subagentura-workflows")
+        .at(-1)?.[1],
+    ).toBe("⚡ 1 workflow running · ↑6 ↓3 R0 W2 $0.02");
+  });
+
+  it("omits provenance-free all-zero workflow usage from the footer", async () => {
+    const mod = await importFresh<typeof import("../src/artifact-poller")>(
+      "../src/artifact-poller",
+    );
+    const { workflowJobRegistry } = await import("../src/workflow");
+    workflowJobRegistry.set("zero-usage", {
+      id: "zero-usage",
+      name: "zero-flow",
+      status: "running",
+      startedAt: Date.now(),
+      promise: Promise.resolve({}) as any,
+      abort: new AbortController(),
+      snapshot: {
+        agentsSpawned: 1,
+        errorCount: 0,
+        tokensSpent: 0,
+        budgetTotal: 99,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          costUsd: 0,
+          turns: 3,
+        },
+        liveUsage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          costUsd: 0,
+          turns: 1,
+        },
+        phases: [],
+        runningCount: 1,
+      },
+    });
+    const setStatus = vi.fn();
+    const setWidget = vi.fn();
+    (globalThis as any).__piSubagenturaUi = {
+      setStatus,
+      setWidget,
+    };
+
+    await mod.pollArtifactChanges({} as any);
+
+    expect(setStatus).toHaveBeenCalledWith(
+      "subagentura-workflows",
+      "⚡ 1 workflow running",
+    );
+    const workflowRows = setWidget.mock.calls
+      .filter(([key]) => key === "subagentura-workflow-activity")
+      .at(-1)?.[1] as string[];
+    expect(workflowRows).toHaveLength(1);
+    expect(workflowRows[0]).not.toContain("↑0");
+    expect(workflowRows[0]).not.toContain("$?");
+    expect(workflowRows[0]).not.toContain("live");
+  });
+
   it("shows workflow children on the owning session's widget and footer", async () => {
     // Workflow children are launched without a parentSessionId, so scoping either
     // surface on (ui identity + parentSessionId) makes them structurally

--- a/tests/thinking-level-effective.test.ts
+++ b/tests/thinking-level-effective.test.ts
@@ -196,4 +196,178 @@ describe("startSubagentJob effective thinking level", () => {
     expect(started.liveStatus.usage.cost).toBeCloseTo(0.3);
     expect(result.usage).toEqual(started.liveStatus.usage);
   });
+
+  it("retains retryable turn usage after Pi prunes the failed assistant message", async () => {
+    type TestSessionEvent =
+      | { type: "turn_start" }
+      | { type: "turn_end"; message: unknown }
+      | {
+          type: "message_update";
+          message: unknown;
+          assistantMessageEvent: { type: "text_delta"; delta: string };
+        };
+    let subscriber: (event: TestSessionEvent) => void = () => undefined;
+    const messages: unknown[] = [];
+    const failedRetry = {
+      role: "assistant",
+      content: [{ type: "text", text: "retry me" }],
+      stopReason: "error",
+      usage: {
+        input: 11,
+        output: 5,
+        cacheRead: 2,
+        cacheWrite: 1,
+        cost: { total: 1.25 },
+        costSource: "provider",
+      },
+    };
+    const success = {
+      role: "assistant",
+      content: [{ type: "text", text: "success" }],
+      usage: {
+        input: 19,
+        output: 7,
+        cacheRead: 3,
+        cacheWrite: 1,
+        cost: { total: 2.75 },
+        costSource: "estimated",
+      },
+    };
+    const session = {
+      thinkingLevel: "medium",
+      model: undefined,
+      subscribe: vi.fn((listener: (event: TestSessionEvent) => void) => {
+        subscriber = listener;
+        return () => undefined;
+      }),
+      prompt: vi.fn(async () => {
+        subscriber({ type: "turn_start" });
+        messages.push(failedRetry);
+        subscriber({ type: "turn_end", message: failedRetry });
+        messages.splice(0, 1);
+
+        subscriber({ type: "turn_start" });
+        messages.push(success);
+        subscriber({
+          type: "message_update",
+          message: success,
+          assistantMessageEvent: { type: "text_delta", delta: "success" },
+        });
+        subscriber({ type: "turn_end", message: success });
+      }),
+      agent: { state: { messages, errorMessage: null } },
+      dispose: vi.fn(),
+    };
+    mockCreateAgentSession.mockResolvedValue({ session });
+
+    const started = await startSubagentJob(params());
+    started.start();
+    const result = await started.jobPromise;
+
+    expect(result.usage).toEqual({
+      input: 30,
+      output: 12,
+      cacheRead: 5,
+      cacheWrite: 2,
+      cost: 4,
+      costSource: "mixed",
+      turns: 2,
+    });
+  });
+
+  it.each(["cancellation", "prompt exception"] as const)(
+    "preserves current partial-turn usage during %s",
+    async (outcome) => {
+      type TestSessionEvent =
+        | { type: "turn_start" }
+        | { type: "turn_end"; message: unknown }
+        | {
+            type: "message_update";
+            message: unknown;
+            assistantMessageEvent: { type: "text_delta"; delta: string };
+          };
+      let subscriber: (event: TestSessionEvent) => void = () => undefined;
+      const messages: unknown[] = [];
+      const completed = {
+        role: "assistant",
+        content: [{ type: "text", text: "completed" }],
+        usage: {
+          input: 4,
+          output: 2,
+          cacheRead: 1,
+          cacheWrite: 0,
+          cost: { total: 0.5 },
+          costSource: "provider",
+        },
+      };
+      const partial = {
+        role: "assistant",
+        content: [{ type: "text", text: "partial" }],
+        usage: {
+          input: 3,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 2,
+          cost: { total: 0.25 },
+          costSource: "estimated",
+        },
+      };
+      const controller = new AbortController();
+      const session = {
+        thinkingLevel: "medium",
+        model: undefined,
+        subscribe: vi.fn((listener: (event: TestSessionEvent) => void) => {
+          subscriber = listener;
+          return () => undefined;
+        }),
+        prompt: vi.fn(async () => {
+          subscriber({ type: "turn_start" });
+          messages.push(completed);
+          subscriber({
+            type: "message_update",
+            message: completed,
+            assistantMessageEvent: { type: "text_delta", delta: "completed" },
+          });
+          subscriber({ type: "turn_end", message: completed });
+
+          subscriber({ type: "turn_start" });
+          subscriber({
+            type: "message_update",
+            message: partial,
+            assistantMessageEvent: { type: "text_delta", delta: "partial" },
+          });
+          if (outcome === "cancellation") {
+            controller.abort("stop");
+            return;
+          }
+          throw new Error("prompt failed");
+        }),
+        abort: vi.fn(async () => undefined),
+        agent: { state: { messages, errorMessage: null } },
+        dispose: vi.fn(),
+      };
+      mockCreateAgentSession.mockResolvedValue({ session });
+
+      const started = await startSubagentJob({
+        ...params(),
+        signal: outcome === "cancellation" ? controller.signal : undefined,
+      });
+      started.start();
+      const result = await started.jobPromise;
+
+      expect(result.usage).toEqual({
+        input: 7,
+        output: 3,
+        cacheRead: 1,
+        cacheWrite: 2,
+        cost: 0.75,
+        costSource: "mixed",
+        turns: 2,
+      });
+      expect(result.cancelled).toBe(
+        outcome === "cancellation" ? true : undefined,
+      );
+      expect(result.isError).toBe(outcome === "prompt exception");
+    },
+  );
 });

--- a/tests/workflow-tree-ui.test.ts
+++ b/tests/workflow-tree-ui.test.ts
@@ -154,6 +154,74 @@ describe("WorkflowTreeComponent", () => {
     expect(expanded).toContain("Legend: ↑ input");
   });
 
+  it("keeps every aggregate field on its own row at narrow widths", () => {
+    workflowJobRegistry.set(
+      "wf_test",
+      makeJob({
+        snapshot: {
+          ...makeJob().snapshot,
+          budgetTotal: 20,
+          usage: {
+            input: 11,
+            output: 7,
+            cacheRead: 5,
+            cacheWrite: 3,
+            totalTokens: 26,
+            costUsd: 0.125,
+            turns: 2,
+            costSource: "provider",
+          },
+        },
+      }),
+    );
+    const component = new WorkflowTreeComponent({ done: vi.fn() });
+    component.handleInput("\r");
+    const lines = component.render(60);
+
+    expect(lines.some((line) => line.includes("input tokens: 11"))).toBe(true);
+    expect(lines.some((line) => line.includes("output tokens: 7/20"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("cache-read tokens: 5"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("cache-write tokens: 3"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("cost: $0.125 (provider)"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("turns: 2"))).toBe(true);
+    expect(lines.every((line) => line.length <= 60)).toBe(true);
+  });
+
+  it("omits empty provenance-free workflow totals", () => {
+    workflowJobRegistry.set(
+      "wf_test",
+      makeJob({
+        snapshot: {
+          ...makeJob().snapshot,
+          budgetTotal: 20,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            costUsd: 0,
+            turns: 0,
+          },
+        },
+      }),
+    );
+    const component = new WorkflowTreeComponent({ done: vi.fn() });
+    component.handleInput("\r");
+    const rendered = component.render(100).join("\n");
+
+    expect(rendered).not.toContain("$?");
+    expect(rendered).not.toContain("output tokens: 0/20");
+  });
+
   it("handles legacy snapshots without agent records", () => {
     const job = makeJob();
     delete job.snapshot.agentRecords;

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -709,6 +709,74 @@ describe("agent() + budget", () => {
       workflowJobRegistry.delete(job.id);
     }
   });
+
+  it("falls back to live usage when rejected terminal usage is empty", async () => {
+    const prompts: string[] = [];
+    const liveUsage: WorkflowUsage = {
+      input: 12,
+      output: 100,
+      cacheRead: 4,
+      cacheWrite: 2,
+      totalTokens: 118,
+      costUsd: 0.5,
+      turns: 1,
+      costSource: "provider",
+    };
+    const emptyTerminalUsage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 0,
+    };
+    let failedEventUsage: WorkflowUsage | undefined;
+
+    const result = await runWorkflow(
+      meta +
+        `let rejected = false; ` +
+        `try { await agent("rejected"); } catch { rejected = true; } ` +
+        `let blocked = false; ` +
+        `try { await agent("blocked"); } catch { blocked = true; } ` +
+        `return { rejected, blocked, spent: budget.spent() };`,
+      {
+        budgetTotal: 100,
+        runAgent: async ({ prompt, onProgress }) => {
+          prompts.push(prompt);
+          if (prompt === "rejected") {
+            onProgress?.({
+              kind: "log",
+              message: "cumulative usage before rejection",
+              liveUsage,
+            });
+            throw Object.assign(new Error("empty terminal usage"), {
+              usage: emptyTerminalUsage,
+            });
+          }
+          return ok("unexpected");
+        },
+        onProgress: (progress) => {
+          if (
+            progress.kind === "agent_done" &&
+            progress.status === "error" &&
+            progress.agentUsage
+          ) {
+            failedEventUsage = { ...progress.agentUsage };
+          }
+        },
+      },
+    );
+
+    expect(prompts).toEqual(["rejected"]);
+    expect(result.result).toEqual({
+      rejected: true,
+      blocked: true,
+      spent: 100,
+    });
+    expect(result.tokensSpent).toBe(100);
+    expect(result.usage).toEqual(liveUsage);
+    expect(failedEventUsage).toEqual(liveUsage);
+  });
   it("allows parallel in-flight calls to overshoot the soft output target", async () => {
     let started = 0;
     let release!: () => void;
@@ -3429,6 +3497,99 @@ it("preserves non-abort cause identity alongside accumulated usage", async () =>
     usage: { totalTokens: 26 },
   });
   expect(calls).toBe(2);
+});
+
+it("correlates concurrent runner failures with the rejecting agent RPC", async () => {
+  const firstFailure = new Error("first runner failure");
+  const secondFailure = new Error("second runner failure");
+  let firstStarted!: () => void;
+  const firstStartedPromise = new Promise<void>(
+    (resolve) => (firstStarted = resolve),
+  );
+  let secondStarted!: () => void;
+  const secondStartedPromise = new Promise<void>(
+    (resolve) => (secondStarted = resolve),
+  );
+  let rejectFirst!: (reason: unknown) => void;
+  const firstResult = new Promise<SubagentResult>(
+    (_resolve, reject) => (rejectFirst = reject),
+  );
+  let rejectSecond!: (reason: unknown) => void;
+  const secondResult = new Promise<SubagentResult>(
+    (_resolve, reject) => (rejectSecond = reject),
+  );
+  let firstRejected!: () => void;
+  const firstRejectedPromise = new Promise<void>(
+    (resolve) => (firstRejected = resolve),
+  );
+
+  const running = runWorkflow(
+    `export const meta = { name: "rpc-cause", description: "d" };\n` +
+      `const first = agent("first");\n` +
+      `const second = agent("second");\n` +
+      `void first.catch(() => phase("first rejected"));\n` +
+      `try { await second; } catch {}\n` +
+      `await first;`,
+    {
+      processConcurrency: 2,
+      runAgent: ({ prompt }) => {
+        if (prompt === "first") {
+          firstStarted();
+          return firstResult;
+        }
+        secondStarted();
+        return secondResult;
+      },
+      onProgress: (progress) => {
+        if (progress.kind === "phase" && progress.phase === "first rejected") {
+          firstRejected();
+        }
+      },
+    },
+  );
+
+  await Promise.all([firstStartedPromise, secondStartedPromise]);
+  rejectFirst(firstFailure);
+  await firstRejectedPromise;
+  rejectSecond(secondFailure);
+
+  let failure: unknown;
+  try {
+    await running;
+  } catch (error) {
+    failure = error;
+  }
+  expect(failure).toBeInstanceOf(Error);
+  expect((failure as Error & { cause?: unknown }).cause).toBe(firstFailure);
+});
+
+it("does not trust workflow-visible rpcId properties for cause correlation", async () => {
+  const runnerFailure = new Error("runner failure");
+  const running = runWorkflow(
+    `export const meta = { name: "rpc-cause-forgery", description: "d" };\n` +
+      `let rpcId; ` +
+      `try { await agent("runner"); } catch (error) { rpcId = error.rpcId; } ` +
+      `const unrelated = new Error("script failure"); ` +
+      `unrelated.rpcId = rpcId; ` +
+      `throw unrelated;`,
+    {
+      runAgent: async () => {
+        throw runnerFailure;
+      },
+    },
+  );
+
+  let failure: unknown;
+  try {
+    await running;
+  } catch (error) {
+    failure = error;
+  }
+  const cause = (failure as Error & { cause?: unknown }).cause;
+  expect(cause).not.toBe(runnerFailure);
+  expect(cause).toMatchObject({
+    message: expect.stringContaining("script failure"),
+  });
 });
 
 it("preserves caller abort reason alongside accumulated usage", async () => {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -9,8 +9,11 @@ import {
   deleteWorkflowScript,
   extractJson,
   formatWorkflowUsage,
+  formatWorkflowUsageFields,
   formatWorkflowUsageLegend,
   addWorkflowUsage,
+  hasWorkflowUsage,
+  presentWorkflowUsage,
   workflowUsageFromUsage,
   getWorkflowCompletionPresentation,
   listSavedWorkflows,
@@ -420,6 +423,76 @@ describe("agent() + budget", () => {
     release();
     expect((await completion).result).toBe("workflow-result");
   });
+  it("aborts and drains unawaited agents before rejecting a script failure", async () => {
+    let backgroundStarted!: () => void;
+    const backgroundStartedPromise = new Promise<void>(
+      (resolve) => (backgroundStarted = resolve),
+    );
+    let backgroundSignal: AbortSignal | undefined;
+    let backgroundDrained = false;
+    const completion = runWorkflow(
+      meta +
+        `agent("background"); ` +
+        `await agent("foreground"); ` +
+        `throw new Error("script failure");`,
+      {
+        processConcurrency: 2,
+        runAgent: async ({ prompt, signal }) => {
+          if (prompt === "foreground") {
+            await backgroundStartedPromise;
+            return ok("foreground");
+          }
+          backgroundSignal = signal;
+          backgroundStarted();
+          await new Promise<void>((resolve) => {
+            if (signal?.aborted) return resolve();
+            signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          backgroundDrained = true;
+          return fail("aborted");
+        },
+      },
+    );
+
+    await expect(completion).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        message: expect.stringContaining("script failure"),
+      }),
+    });
+    expect(backgroundSignal?.aborted).toBe(true);
+    expect(backgroundDrained).toBe(true);
+  });
+
+  it("preserves an awaited agent failure while draining unawaited agents", async () => {
+    const original = new Error("foreground failure");
+    let backgroundStarted!: () => void;
+    const backgroundStartedPromise = new Promise<void>(
+      (resolve) => (backgroundStarted = resolve),
+    );
+    let backgroundDrained = false;
+    const completion = runWorkflow(
+      meta + `agent("background"); await agent("foreground");`,
+      {
+        processConcurrency: 2,
+        runAgent: async ({ prompt, signal }) => {
+          if (prompt === "foreground") {
+            await backgroundStartedPromise;
+            throw original;
+          }
+          backgroundStarted();
+          await new Promise<void>((resolve) => {
+            if (signal?.aborted) return resolve();
+            signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          backgroundDrained = true;
+          throw new Error("background aborted");
+        },
+      },
+    );
+
+    await expect(completion).rejects.toMatchObject({ cause: original });
+    expect(backgroundDrained).toBe(true);
+  });
 
   it("waits for agent work chained from an unawaited call", async () => {
     let releaseSecond!: () => void;
@@ -544,6 +617,97 @@ describe("agent() + budget", () => {
         },
       ),
     ).rejects.toThrow(/budget exhausted/i);
+  });
+
+  it("charges rejected usage before later calls and retains it on the failed record", async () => {
+    const prompts: string[] = [];
+    const rejectedUsage = {
+      input: 0,
+      output: 100,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    };
+    const rejectedLiveUsage: WorkflowUsage = {
+      input: 0,
+      output: 100,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 100,
+      costUsd: 0,
+      turns: 1,
+    };
+    let failedEventUsage: WorkflowUsage | undefined;
+    const job = startWorkflowJob(
+      "rejected-budget",
+      meta +
+        `let rejected = false; ` +
+        `try { await agent("rejected"); } catch { rejected = true; } ` +
+        `const successful = await agent("successful"); ` +
+        `let blocked = false; ` +
+        `try { await agent("blocked"); } catch { blocked = true; } ` +
+        `return { rejected, successful, blocked, spent: budget.spent() };`,
+      {
+        budgetTotal: 150,
+        runAgent: async ({ prompt, onProgress }) => {
+          prompts.push(prompt);
+          if (prompt === "rejected") {
+            onProgress?.({
+              kind: "log",
+              message: "charged before rejection",
+              liveUsage: rejectedLiveUsage,
+            });
+            throw Object.assign(new Error("charged failure"), {
+              usage: rejectedUsage,
+            });
+          }
+          return ok("success", 100);
+        },
+        onProgress: (progress) => {
+          if (
+            progress.kind === "agent_done" &&
+            progress.status === "error" &&
+            progress.agentUsage
+          ) {
+            failedEventUsage = { ...progress.agentUsage };
+            progress.agentUsage.output = 999;
+          }
+        },
+      },
+    );
+
+    try {
+      const result = await job.promise;
+      expect(prompts).toEqual(["rejected", "successful"]);
+      expect(result.result).toEqual({
+        rejected: true,
+        successful: "success",
+        blocked: true,
+        spent: 200,
+      });
+      expect(result.tokensSpent).toBe(200);
+      expect(result.usage.output).toBe(200);
+      expect(result.usage.totalTokens).toBe(200);
+      expect(result.usage.turns).toBe(2);
+      expect(failedEventUsage).toMatchObject({
+        output: 100,
+        totalTokens: 100,
+        turns: 1,
+      });
+      expect(
+        job.snapshot.agentRecords?.find((record) => record.status === "error"),
+      ).toMatchObject({
+        status: "error",
+        usage: {
+          output: 100,
+          totalTokens: 100,
+          turns: 1,
+        },
+      });
+    } finally {
+      workflowJobRegistry.delete(job.id);
+    }
   });
   it("allows parallel in-flight calls to overshoot the soft output target", async () => {
     let started = 0;
@@ -1357,6 +1521,23 @@ describe("awaitInteractiveResult", () => {
     expect(res.output).toBe("final answer");
   });
 
+  it("omits a model when the interactive runner did not report one", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wf-int-model-"));
+    writeFileSync(join(dir, "output.md"), "final answer");
+    writeFileSync(
+      join(dir, "events.ndjson"),
+      JSON.stringify({ ts: 1, type: "done", status: "done", exitCode: 0 }) +
+        "\n",
+    );
+    const state = fakeState(dir);
+    delete state.model;
+
+    const result = await awaitInteractiveResult(state, undefined, 5);
+
+    expect(result.isError).toBe(false);
+    expect(result).not.toHaveProperty("model");
+  });
+
   it("does not reuse a legacy completion from a previous turn", async () => {
     const dir = mkdtempSync(join(tmpdir(), "wf-int-stale-"));
     writeFileSync(join(dir, "output.md"), "stale answer");
@@ -1932,6 +2113,30 @@ describe("renderProgress", () => {
     expect(result).toContain("◆ phase: Scanning");
   });
 
+  it("omits all-zero provenance-free aggregate usage", () => {
+    const result = renderProgress({
+      kind: "phase",
+      phase: "done",
+      agentsSpawned: 0,
+      errorCount: 0,
+      tokensSpent: 0,
+      runningCount: 0,
+      budgetTotal: 20,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        costUsd: 0,
+        turns: 0,
+      },
+    });
+
+    expect(result).not.toContain("$?");
+    expect(result).not.toContain("↓0/20");
+  });
+
   it("formats a log progress update", () => {
     const p: WorkflowProgress = {
       kind: "log",
@@ -2169,6 +2374,7 @@ describe("registerWorkflowTool", () => {
           `export const meta = { name: "tool-cwd", description: "d" };\n` +
           `return cwd;`,
         async: false,
+        budget: 20,
       },
       undefined,
       undefined,
@@ -2177,6 +2383,9 @@ describe("registerWorkflowTool", () => {
 
     expect(result.details.status).toBe("done");
     expect(result.content[0].text).toContain("/tmp/tool-context");
+    expect(result.details.budgetTotal).toBe(20);
+    expect(result.content[0].text).not.toContain("$?");
+    expect(result.content[0].text).not.toContain("↓0/20");
   });
 
   it("tracks an explicit synchronous workflow while it is running", async () => {
@@ -2906,6 +3115,7 @@ describe("registerWorkflowTool", () => {
           'export const meta = { name: "sync-err", description: "d" };\n' +
           'throw new Error("partial failure");',
         async: false,
+        budget: 20,
       },
       undefined,
       vi.fn(),
@@ -2914,6 +3124,7 @@ describe("registerWorkflowTool", () => {
     expect(result.details.status).toBe("error");
     expect(result.isError).toBe(true);
     expect(result.details.usage).toBeUndefined();
+    expect(result.details.budgetTotal).toBe(20);
     expect(result.content[0].text).toContain("Workflow failed");
   });
 
@@ -3150,10 +3361,16 @@ it("includes accumulated usage in async workflow error results", async () => {
     "late-error",
     `export const meta = { name: "late-error", description: "d" };\n` +
       `await agent("hello"); throw new Error("later failure");`,
-    { runAgent: async ({ prompt }) => richOk(prompt) },
+    { runAgent: async ({ prompt }) => richOk(prompt), budgetTotal: 20 },
   );
   try {
     await expect(job.promise).rejects.toThrow("later failure");
+    const getStatus = tools.find(
+      (tool) => tool.name === "get_workflow_status",
+    )!;
+    const status = await getStatus.execute("", { workflowId: job.id });
+    expect(status.content[0].text).toContain("↓7/20");
+    expect(status.details.budgetTotal).toBe(20);
     const getResult = tools.find(
       (tool) => tool.name === "get_workflow_result",
     )!;
@@ -3169,7 +3386,8 @@ it("includes accumulated usage in async workflow error results", async () => {
       turns: 2,
       costSource: "estimated",
     });
-    expect(result.content[0].text).toContain("↓7");
+    expect(result.content[0].text).toContain("↓7/20");
+    expect(result.details.budgetTotal).toBe(20);
   } finally {
     workflowJobRegistry.delete(job.id);
   }
@@ -3180,12 +3398,12 @@ it("includes snapshot usage in failed completion notification summaries", async 
     "notify-late-error",
     `export const meta = { name: "notify-late-error", description: "d" };\n` +
       `await agent("hello"); throw new Error("later failure");`,
-    { runAgent: async ({ prompt }) => richOk(prompt) },
+    { runAgent: async ({ prompt }) => richOk(prompt), budgetTotal: 20 },
   );
   try {
     await expect(job.promise).rejects.toThrow("later failure");
     expect(formatWorkflowNotificationSummary(job)).toContain(
-      "↑11 ↓7 R5 W3 ~$0.125",
+      "↑11 ↓7/20 R5 W3 ~$0.125",
     );
   } finally {
     workflowJobRegistry.delete(job.id);
@@ -3436,6 +3654,82 @@ describe("canonical workflow usage formatting", () => {
     expect(formatWorkflowUsage(usage)).toBe("↑11 ↓7 R5 W3 ~$0.125");
     expect(formatWorkflowUsage(usage, { outputBudget: 20 })).toContain("↓7/20");
     expect(formatWorkflowUsage(usage)).not.toContain("total tokens");
+  });
+
+  it("omits provenance-free identities while preserving explicit free pricing", () => {
+    const empty: WorkflowUsage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      turns: 9,
+    };
+    const providerFree: WorkflowUsage = {
+      ...empty,
+      turns: 0,
+      costSource: "provider",
+    };
+
+    expect(hasWorkflowUsage(empty)).toBe(false);
+    expect(presentWorkflowUsage(empty)).toBeUndefined();
+    expect(hasWorkflowUsage(providerFree)).toBe(true);
+    expect(presentWorkflowUsage(providerFree)).toBe(providerFree);
+    expect(formatWorkflowUsage(providerFree)).toContain("$0");
+  });
+
+  it("keeps legacy unknown aggregate provenance mixed with priced usage", () => {
+    const mixed = addWorkflowUsage(
+      {
+        input: 4,
+        output: 2,
+        cacheRead: 1,
+        cacheWrite: 0,
+        totalTokens: 7,
+        costUsd: 0,
+        turns: 1,
+      },
+      {
+        input: 3,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0.02,
+        costSource: "provider",
+        turns: 1,
+      },
+    );
+
+    expect(mixed.costSource).toBe("mixed");
+    expect(formatWorkflowUsage(mixed)).toContain("$? (mixed)");
+  });
+
+  it("returns expanded accounting as independent fields", () => {
+    const usage: WorkflowUsage = {
+      input: 11,
+      output: 7,
+      cacheRead: 5,
+      cacheWrite: 3,
+      totalTokens: 26,
+      costUsd: 0.125,
+      turns: 2,
+      costSource: "provider",
+    };
+
+    expect(
+      formatWorkflowUsageFields(usage, {
+        ascii: true,
+        outputBudget: 20,
+      }),
+    ).toEqual([
+      "input tokens: 11",
+      "output tokens: 7/20",
+      "cache-read tokens: 5",
+      "cache-write tokens: 3",
+      "cost: $0.125 (provider)",
+      "turns: 2",
+    ]);
   });
 
   it("labels unavailable and estimated pricing instead of showing $0", () => {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -38,6 +38,7 @@ import { withOrchestrationContext } from "../src/orchestration-context";
 import {
   usageFromAssistantMessages,
   type SubagentResult,
+  type Usage,
 } from "../src/helpers";
 import {
   appendCompletionEvent,
@@ -70,7 +71,7 @@ function ok(output: string, outTokens = 0): SubagentResult {
 
 function richOk(
   output: string,
-  usage = {
+  usage: Usage = {
     input: 11,
     output: 7,
     cacheRead: 5,
@@ -728,6 +729,7 @@ describe("agent() + budget", () => {
       cacheRead: 0,
       cacheWrite: 0,
       cost: 0,
+      costSource: "provider" as const,
       turns: 0,
     };
     let failedEventUsage: WorkflowUsage | undefined;
@@ -776,6 +778,38 @@ describe("agent() + budget", () => {
     expect(result.tokensSpent).toBe(100);
     expect(result.usage).toEqual(liveUsage);
     expect(failedEventUsage).toEqual(liveUsage);
+  });
+  it("clamps negative runner usage before budget accounting", async () => {
+    const result = await runWorkflow(
+      meta +
+        `await agent("negative"); ` +
+        `return { spent: budget.spent(), remaining: budget.remaining() };`,
+      {
+        budgetTotal: 10,
+        runAgent: async () =>
+          richOk("done", {
+            input: -2,
+            output: -5,
+            cacheRead: -3,
+            cacheWrite: -4,
+            cost: -1,
+            costSource: "provider",
+            turns: -1,
+          }),
+      },
+    );
+
+    expect(result.result).toEqual({ spent: 0, remaining: 10 });
+    expect(result.tokensSpent).toBe(0);
+    expect(result.usage).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      turns: 0,
+    });
   });
   it("allows parallel in-flight calls to overshoot the soft output target", async () => {
     let started = 0;
@@ -4144,6 +4178,42 @@ describe("canonical workflow usage formatting", () => {
     );
 
     expect(usage.costSource).toBeUndefined();
+    expect(workflowUsageFromUsage(usage)).toBeUndefined();
+  });
+
+  it("clamps negative assistant accounting to a zero sample", () => {
+    const usage = usageFromAssistantMessages(
+      [
+        {
+          role: "assistant",
+          usage: {
+            input: -2,
+            output: -5,
+            cacheRead: -3,
+            cacheWrite: -4,
+            cost: { total: -1 },
+            costSource: "provider",
+          },
+        },
+      ],
+      {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    );
+
+    expect(usage).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    });
     expect(workflowUsageFromUsage(usage)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- retain rejected, retried, cancelled, and terminal agent usage in workflow aggregates and per-agent records
- enforce output-token budgets against every attempted agent turn, including rejected attempts
- abort and boundedly drain active children before publishing terminal workflow failures while preserving the triggering cause
- normalize empty usage and pricing provenance across result, status, notification, tree, supervisor, widget, and shared-footer surfaces
- propagate output-token budgets consistently and render expanded usage as width-safe fields
- aggregate shared-owner footer usage structurally instead of reparsing formatted strings

## Context

Stacked on #79 (`feat/workflow-pricing-display`) for Track A integration. This PR is limited to accounting, terminal lifecycle, provenance, and presentation correctness; durable workflow persistence remains separate work.

## Verification

- `npx vitest run tests/workflow.test.ts tests/subagent-poll.test.ts` — 241 passed
- `npm test -- --maxWorkers=1` — 58 files, 1,408 tests passed
- `npm run typecheck`
- `npm run format:check`
- `npm run pack:check`

Independent Luna review found and re-verified fixes for terminal cause preservation and zero-usage widget rendering.