### PR TITLE
feat(workflow): add eager routing preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Non-durable declarative workflow plans with ordered sequential phases, stable task IDs, in-process execution, and the existing async status, result, cancellation, and tree surfaces.
 - Opt-in sequential durable plan preview with owner-fenced recovery, explicit trusted resume, committed-result replay, and cold status, result, cancellation, and tree queries.
+- Opt-in `workflow-eager=preferred|always` routing with same-turn host-enforced durable plan creation, an honest `routing_unconfirmed` policy fallback, mandatory suppression rules, and `/workflow-plan create`.
 
 ## [3.3.0] - 2026-08-05
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ manual in this preview: inspect the interrupted run, then use the fenced
 `/workflow-resume` command. Process isolation, parallel phases, automatic
 resume, durable JavaScript, and completion delivery are not supported yet.
 
+### Automatic durable routing preview
+
+Natural-request routing is opt-in and defaults to `off`:
+
+```bash
+pi --workflow-eager preferred
+```
+
+`preferred` routes only requests that show multiple independent work slices or
+phased continuation. `always` routes other actionable requests too, but still
+suppresses questions, social conversation, one-command operations, plan-only
+requests, workflow-management commands, child contexts, replies to a pending
+parent question, and requests while another workflow is active.
+
+On Pi hosts with input interception, an eligible request is handled before the
+parent model can perform direct work. A bounded in-process planner gets at most
+one correction, the resulting sequential plan is validated, and the durable
+controller commits and starts it in the same input turn. Planner model usage is
+additional workflow-routing usage. Invalid plans, unavailable storage, and
+authority failures surface their exact cause and do not invoke the legacy
+`/workflow <task>` path.
+
+If a host cannot register input interception, the extension uses the
+minimum-capability model-policy lane instead. It instructs the parent to make a
+durable declarative `workflow` call, observes up to two such calls, and emits
+`routing_unconfirmed` after settlement when no call was observed. This fallback
+is never reported as host-enforced.
+
+Use `/workflow-plan create <task>` to invoke the same host-owned planner and
+controller path explicitly. Eager and command-created plans retain the durable
+preview restrictions above: sequential phases, in-process tasks, manual
+recovery, and no durable completion notification.
+
 Workflow scripts are trusted agent-authored JavaScript. The VM improves
 determinism but is not a security boundary, so never run untrusted JavaScript.
 Non-durable background workflow jobs are scoped to the current parent session
@@ -121,6 +154,7 @@ These commands are intended for people at the Pi prompt.
 | `/workflow-status`  | List workflow jobs and their live or terminal status              |
 | `/workflow-tree`    | Open the specialized workflow progress tree                       |
 | `/workflow-resume`  | Resume an interrupted durable plan with current authority fences  |
+| `/workflow-plan`    | Create and start a host-owned durable plan from a task            |
 | `/subagents`        | Supervise all async work (`Ctrl+Alt+A`)                           |
 | `/delete-workflow`  | Delete a saved workflow by name or picker                         |
 | `/cancel-all-flows` | Cancel active jobs, workflows, and running interactive sub-agents |

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "src/workflow-run-store.ts",
     "src/workflow-recovery.ts",
     "src/workflow-projection-repository.ts",
+    "src/workflow-routing.ts",
+    "src/workflow-routing-runtime.ts",
     "src/workflow-durable-plan-runner.ts",
     "src/workflow-owner.ts",
     "src/workflow-tool.ts",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -755,6 +755,8 @@ export interface StartSubagentJobParams {
   parentModelRegistry?: ModelRegistry;
   /** Optional JSON Schema delivered via a workflow structured-output tool in in-process mode. */
   workflowStructuredOutputSchema?: unknown;
+  /** Restrict the child to the structured-output custom tool. */
+  structuredOutputOnly?: boolean;
   onCancellationSnapshot?: (receipt: CancellationSnapshotReceipt) => void;
   cancellationSource?: CancellationSnapshotSource;
   /** Thinking/reasoning level. Pass through to createAgentSession. */
@@ -809,6 +811,7 @@ export async function startSubagentJob(
     defaultModel,
     parentModelRegistry,
     workflowStructuredOutputSchema,
+    structuredOutputOnly,
     onCancellationSnapshot,
     cancellationSource,
     thinkingLevel,
@@ -816,6 +819,11 @@ export async function startSubagentJob(
     rootSessionId,
     owner,
   } = params;
+  if (structuredOutputOnly && workflowStructuredOutputSchema === undefined) {
+    throw new Error(
+      "structuredOutputOnly requires workflowStructuredOutputSchema",
+    );
+  }
 
   // Enforce the cap within this exact scope; peer sessions never evict each other.
   while (inProcessJobsForOwner(owner).size >= MAX_REGISTRY_SIZE) {
@@ -922,6 +930,9 @@ export async function startSubagentJob(
     model: targetModel,
     cwd,
     ...(thinkingLevel ? { thinkingLevel } : {}),
+    ...(structuredOutputOnly && workflowStructuredOutputTool
+      ? { tools: [workflowStructuredOutputTool.name] }
+      : {}),
     ...(workflowStructuredOutputTool
       ? { customTools: [workflowStructuredOutputTool] }
       : {}),

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -42,6 +42,7 @@ import { registerChildProtocol } from "./child-protocol";
 import { registerCancelAllFlows } from "./cancel-all-flows-registration";
 import { renderSubagentNotify } from "./rendering";
 import { registerInteractiveSupervisor } from "./interactive-supervisor-registration";
+import { registerWorkflowRouting } from "./workflow-routing-runtime";
 /** @internal Session-rehydration helper used by session-handlers.ts */
 export { rehydrateInteractiveSubagents } from "./rehydrate";
 /**
@@ -107,6 +108,11 @@ export default function (pi: ExtensionAPI) {
     type: "boolean",
     default: false,
   });
+  pi.registerFlag("workflow-eager", {
+    description: "Route eligible parent requests to durable workflow plans",
+    type: "string",
+    default: "off",
+  });
   pi.on("before_agent_start", (event) => {
     if (pi.getFlag("orchestrator") !== true) return;
     return {
@@ -117,7 +123,8 @@ export default function (pi: ExtensionAPI) {
   const sessionScope = registerSessionHandlers(pi);
   registerInteractiveSubagentTools(pi, sessionScope);
   registerInteractiveSupervisor(pi, sessionScope);
-  registerWorkflowTool(pi, sessionScope);
+  const workflowRoutingHost = registerWorkflowTool(pi, sessionScope);
+  registerWorkflowRouting(pi, workflowRoutingHost);
   registerInProcessSubagentTools(pi, sessionScope);
   registerInProcessMaintenanceTools(pi, sessionScope);
   // ── Cancel-all-flows shortcut and command ──────────────────────

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -294,6 +294,8 @@ export type WorkflowAgentRunner = (req: {
   isolation?: string;
   label?: string;
   schema?: unknown;
+  /** Disable built-in read/write/shell tools for schema-only planner calls. */
+  structuredOutputOnly?: boolean;
   /** Thinking/reasoning for the sub-agent. */
   thinkingLevel?: ThinkingLevel;
   /**

--- a/src/workflow-routing-runtime.ts
+++ b/src/workflow-routing-runtime.ts
@@ -1,0 +1,349 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+  decideWorkflowRouting,
+  parseWorkflowEagerMode,
+  WorkflowRoutingMetrics,
+} from "./workflow-routing";
+
+export interface WorkflowRoutingStartResult {
+  readonly status: "started";
+  readonly workflowId: string;
+  readonly name: string;
+  readonly revision: number;
+  readonly runEpoch: number;
+  readonly ownerGeneration: number;
+  readonly leaseEpoch: number;
+}
+
+export interface WorkflowRoutingHost {
+  hasActiveWorkflow(): Promise<boolean>;
+  planAndStart(
+    task: string,
+    ctx: ExtensionContext,
+    signal?: AbortSignal,
+  ): Promise<WorkflowRoutingStartResult>;
+}
+
+interface PendingPolicyRoute {
+  workflowCalls: number;
+  observed: boolean;
+  correctionAvailable: boolean;
+  workflowCallId?: string;
+}
+
+const POLICY_INSTRUCTION = `Automatic durable workflow routing selected this request.
+Before direct work or side effects, construct a bounded schemaVersion 1 declarative
+plan with stable IDs, sequential phases, and in-process tasks, then call the
+workflow tool with plan and durable:true. Validate before calling. You may make
+at most one corrected workflow call if validation fails. Do not invoke legacy
+/workflow <task>. If the durable call cannot be made, report the exact cause and
+do not describe this route as host-enforced.`;
+
+export function registerWorkflowRouting(
+  pi: ExtensionAPI,
+  host?: WorkflowRoutingHost,
+): WorkflowRoutingMetrics {
+  const metrics = new WorkflowRoutingMetrics();
+  let pendingPolicy: PendingPolicyRoute | undefined;
+  let hostCreationInFlight = false;
+
+  const mode = () => parseWorkflowEagerMode(pi.getFlag("workflow-eager"));
+  const sendRoutingMessage = (
+    content: string,
+    details: Record<string, unknown>,
+  ) => {
+    pi.sendMessage(
+      {
+        customType: "workflow-routing",
+        content,
+        display: true,
+        details,
+      },
+      { triggerTurn: false },
+    );
+  };
+
+  const startHostRoute = async (
+    task: string,
+    ctx: ExtensionContext,
+  ): Promise<WorkflowRoutingStartResult> => {
+    if (!host) throw new Error("host-enforced workflow routing is unavailable");
+    if (hostCreationInFlight) {
+      throw new Error("another eager workflow plan is already being created");
+    }
+    hostCreationInFlight = true;
+    try {
+      return await host.planAndStart(task, ctx, ctx.signal);
+    } finally {
+      hostCreationInFlight = false;
+    }
+  };
+
+  let policyFallbackCause: string | undefined;
+  const registerPolicyLane = () => {
+    pi.on("before_agent_start", async (event, ctx) => {
+      const eagerMode = mode();
+      if (eagerMode === "off") {
+        const decision = decideWorkflowRouting({
+          mode: eagerMode,
+          text: event.prompt,
+        });
+        metrics.recordDecision(decision);
+        pendingPolicy = undefined;
+        return;
+      }
+      const routingInput = {
+        mode: eagerMode,
+        text: event.prompt,
+        awaitingUserInput: previousAssistantAwaitsInput(ctx),
+        childContext: process.env.PI_SUBAGENTURA_CHILD === "1",
+      };
+      let decision = decideWorkflowRouting(routingInput);
+      if (decision.kind === "durable_plan" && host) {
+        try {
+          if (await host.hasActiveWorkflow()) {
+            decision = decideWorkflowRouting({
+              ...routingInput,
+              hasActiveWorkflow: true,
+            });
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          pendingPolicy = undefined;
+          sendRoutingMessage(`Workflow routing failed: ${message}`, {
+            lane: "model_policy",
+            status: "error",
+            error: message,
+          });
+          return;
+        }
+      }
+      metrics.recordDecision(decision);
+      if (decision.kind === "direct") {
+        pendingPolicy = undefined;
+        return;
+      }
+      pendingPolicy = {
+        workflowCalls: 0,
+        observed: false,
+        correctionAvailable: true,
+      };
+      return {
+        systemPrompt: `${event.systemPrompt}\n\n${POLICY_INSTRUCTION}`,
+      };
+    });
+
+    pi.on("tool_call", (event) => {
+      const pending = pendingPolicy;
+      if (!pending) return;
+      if (event.toolName !== "workflow") {
+        return {
+          block: true,
+          reason:
+            "Automatic durable workflow routing is pending; call workflow with plan and durable:true before other tools.",
+        };
+      }
+      if (
+        pending.workflowCalls >= 2 ||
+        (pending.workflowCalls > 0 && !pending.correctionAvailable)
+      ) {
+        return {
+          block: true,
+          reason:
+            pending.workflowCalls >= 2
+              ? "Automatic workflow plan correction limit reached (two calls)."
+              : "A workflow plan call is already running or succeeded; a correction is not allowed.",
+        };
+      }
+      pending.workflowCalls++;
+      const input = event.input as Record<string, unknown>;
+      if (input.durable !== true || input.plan === undefined) {
+        pending.correctionAvailable = true;
+        return {
+          block: true,
+          reason:
+            "Automatic routing requires the workflow tool with plan and durable:true; legacy workflow execution is disabled.",
+        };
+      }
+      pending.correctionAvailable = false;
+      pending.workflowCallId = event.toolCallId;
+      if (!pending.observed) {
+        pending.observed = true;
+        metrics.recordPolicyObserved();
+      }
+    });
+
+    pi.on("tool_execution_end", (event) => {
+      const pending = pendingPolicy;
+      if (!pending || event.toolCallId !== pending.workflowCallId) return;
+      pending.workflowCallId = undefined;
+      pending.correctionAvailable = event.isError;
+    });
+
+    pi.on("agent_settled", () => {
+      const pending = pendingPolicy;
+      pendingPolicy = undefined;
+      if (!pending || pending.observed) return;
+      metrics.recordRoutingUnconfirmed();
+      sendRoutingMessage(
+        "routing_unconfirmed: the model-policy lane did not produce an observed durable workflow plan call.",
+        {
+          lane: "model_policy",
+          status: "routing_unconfirmed",
+          ...(policyFallbackCause
+            ? { capabilityReason: policyFallbackCause }
+            : {}),
+        },
+      );
+    });
+  };
+
+  if (host) {
+    try {
+      pi.on("input", async (event, ctx) => {
+        let decision;
+        try {
+          const eagerMode = mode();
+          if (eagerMode === "off") {
+            decision = decideWorkflowRouting({
+              mode: eagerMode,
+              text: event.text,
+            });
+          } else {
+            const routingInput = {
+              mode: eagerMode,
+              text: event.text,
+              awaitingUserInput:
+                event.streamingBehavior !== undefined ||
+                !ctx.isIdle() ||
+                previousAssistantAwaitsInput(ctx),
+              childContext: process.env.PI_SUBAGENTURA_CHILD === "1",
+            };
+            decision = decideWorkflowRouting(routingInput);
+            if (decision.kind === "durable_plan") {
+              const active =
+                hostCreationInFlight || (await host.hasActiveWorkflow());
+              if (active) {
+                decision = decideWorkflowRouting({
+                  ...routingInput,
+                  hasActiveWorkflow: true,
+                });
+              }
+            }
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          sendRoutingMessage(
+            `Workflow routing failed: ${message}\nUse /workflow-plan create <task> to retry the host-owned declarative path.`,
+            { lane: "host_enforced", status: "error", error: message },
+          );
+          return { action: "handled" } as const;
+        }
+        metrics.recordDecision(decision);
+        if (decision.kind === "direct") return { action: "continue" } as const;
+
+        try {
+          const started = await startHostRoute(event.text, ctx);
+          metrics.recordHostStarted();
+          sendRoutingMessage(
+            `Durable workflow plan "${started.name}" started in this turn as ${started.workflowId}.`,
+            { lane: "host_enforced", ...started },
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          sendRoutingMessage(
+            `Workflow routing failed: ${message}\nUse /workflow-plan create <task> to retry the host-owned declarative path.`,
+            { lane: "host_enforced", status: "error", error: message },
+          );
+        }
+        return { action: "handled" } as const;
+      });
+    } catch (error) {
+      policyFallbackCause =
+        error instanceof Error ? error.message : String(error);
+      registerPolicyLane();
+    }
+  } else {
+    registerPolicyLane();
+  }
+
+  if (typeof pi.registerCommand === "function") {
+    pi.registerCommand("workflow-plan", {
+      description: "Create a durable declarative workflow plan from a task.",
+      handler: async (args: string, ctx: ExtensionCommandContext) => {
+        const prefix = "create ";
+        const task = args.trim().startsWith(prefix)
+          ? args.trim().slice(prefix.length).trim()
+          : "";
+        if (!task) {
+          const usage = "Usage: /workflow-plan create <task>";
+          ctx.ui.notify(usage, "error");
+          sendRoutingMessage(usage, { status: "error" });
+          return;
+        }
+        try {
+          const started = await startHostRoute(task, ctx);
+          metrics.recordHostStarted();
+          const text = `Durable workflow plan "${started.name}" started as ${started.workflowId}.`;
+          ctx.ui.notify(text);
+          sendRoutingMessage(text, { lane: "host_command", ...started });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const text = `Workflow plan not started: ${message}`;
+          ctx.ui.notify(text, "error");
+          sendRoutingMessage(text, {
+            lane: "host_command",
+            status: "error",
+            error: message,
+          });
+        }
+      },
+    });
+  }
+
+  return metrics;
+}
+
+function previousAssistantAwaitsInput(ctx: ExtensionContext): boolean {
+  const manager = ctx.sessionManager as unknown as {
+    getBranch?: () => unknown[];
+    getEntries?: () => unknown[];
+  };
+  const entries =
+    typeof manager?.getBranch === "function"
+      ? manager.getBranch()
+      : typeof manager?.getEntries === "function"
+        ? manager.getEntries()
+        : [];
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index] as Record<string, unknown>;
+    const message =
+      entry.message && typeof entry.message === "object"
+        ? (entry.message as Record<string, unknown>)
+        : entry;
+    if (message.role !== "assistant") continue;
+    const text = messageText(message.content);
+    return /\?\s*$/.test(text);
+  }
+  return false;
+}
+
+function messageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (!part || typeof part !== "object") return "";
+      const text = (part as Record<string, unknown>).text;
+      return typeof text === "string" ? text : "";
+    })
+    .join("\n");
+}

--- a/src/workflow-routing.ts
+++ b/src/workflow-routing.ts
@@ -1,0 +1,208 @@
+export type WorkflowEagerMode = "off" | "preferred" | "always";
+
+export const WORKFLOW_EAGER_DEFAULT: WorkflowEagerMode = "off";
+
+export type WorkflowDirectReason =
+  | "routing_disabled"
+  | "empty_request"
+  | "child_context"
+  | "active_workflow"
+  | "awaiting_user_input"
+  | "management_command"
+  | "plan_only"
+  | "pure_question"
+  | "social_conversation"
+  | "one_command_operation"
+  | "non_actionable_request"
+  | "simple_request";
+
+export type WorkflowRoutingDecision =
+  | { kind: "direct"; reason: WorkflowDirectReason }
+  | {
+      kind: "durable_plan";
+      reason: "eligible_complex_request" | "eligible_actionable_request";
+      mode: Exclude<WorkflowEagerMode, "off">;
+    };
+
+export interface WorkflowRoutingInput {
+  mode: WorkflowEagerMode;
+  text: string;
+  hasActiveWorkflow?: boolean;
+  awaitingUserInput?: boolean;
+  childContext?: boolean;
+  managementCommand?: boolean;
+  planOnly?: boolean;
+}
+
+export interface WorkflowRoutingMetricsSnapshot {
+  readonly decisions: number;
+  readonly eligible: number;
+  readonly hostStarted: number;
+  readonly policyObserved: number;
+  readonly routingUnconfirmed: number;
+  readonly unconfirmedRate: number;
+  readonly directReasons: Readonly<Record<string, number>>;
+}
+
+const ACTION =
+  /\b(?:add|analyze|audit|build|change|compare|coordinate|create|debug|delete|design|document|execute|fix|implement|investigate|migrate|move|optimize|refactor|release|remove|rename|review|run|test|update|verify|write)\b/gi;
+const COMPLEX_SHAPE =
+  /\b(?:across|codebase|end[- ]to[- ]end|in parallel|multiple|phases?|pull request|repository|several)\b/i;
+const ORDERED_WORK = /\b(?:after|before|first|next|then)\b/i;
+const SOCIAL =
+  /^(?:good (?:morning|afternoon|evening)|hello|hey|hi|how are you|nice|ok(?:ay)?|thanks?|thank you)[!.\s]*$/i;
+const QUESTION_LEAD =
+  /^(?:can|could|how|is|may|should|what|when|where|which|who|why|will|would)\b/i;
+const AUXILIARY_QUESTION =
+  /^(?:do|does)\s+(?:i|you|we|they|he|she|it|this|that)\b/i;
+const ACTION_REQUEST_QUESTION =
+  /^(?:can|could|will|would)\s+you\b.*\b(?:add|analyze|audit|build|change|compare|coordinate|create|debug|delete|design|document|execute|fix|implement|investigate|migrate|move|optimize|refactor|release|remove|rename|review|run|test|update|verify|write)\b/i;
+const IMPERATIVE_ACTION =
+  /^(?:please\s+)?(?:add|analyze|audit|build|change|compare|coordinate|create|debug|delete|design|document|execute|fix|implement|investigate|migrate|move|optimize|refactor|release|remove|rename|review|run|test|update|verify|write)\b/i;
+const DO_IMPERATIVE = /^do\s+(?:a|an)\b/i;
+const REQUEST_CONTEXT =
+  /^(?:(?:i|we)\s+(?:need|want)\s+(?:you\s+)?to|need to|(?:the|your)\s+task\s+is\s+to|help me)\b/i;
+const PLAN_ONLY =
+  /^(?:please\s+)?(?:do not (?:change|edit|implement|modify)|don't (?:change|edit|implement|modify)|no (?:changes|implementation)|plan only|planning only|proposal only|just (?:make|write|create) (?:a )?plan|(?:make|write|create) (?:me )?(?:a )?plan(?: only)?)\b/i;
+const MANAGEMENT =
+  /^(?:\/(?:workflow|workflows|workflow-[a-z-]+)\b|(?:cancel|continue|inspect|list|resume|show|status|stop)\s+(?:the\s+)?(?:active\s+)?workflow\b)/i;
+const ONE_COMMAND =
+  /^(?:(?:can|could|will|would)\s+you\s+|please\s+)?(?:run|execute)\s+(?:the\s+)?(?:(?:npm\s+(?:run\s+)?)?(?:build|format(?::check)?|formatter|lint(?:er)?|tests?|typecheck)|git\s+(?:diff|status))(?:\s+[^;&|]+)?[.!?]?$/i;
+
+export function parseWorkflowEagerMode(value: unknown): WorkflowEagerMode {
+  if (
+    value === undefined ||
+    value === null ||
+    value === false ||
+    value === ""
+  ) {
+    return WORKFLOW_EAGER_DEFAULT;
+  }
+  if (value === "off" || value === "preferred" || value === "always") {
+    return value;
+  }
+  throw new Error("workflow-eager must be off, preferred, or always");
+}
+
+export function decideWorkflowRouting(
+  input: WorkflowRoutingInput,
+): WorkflowRoutingDecision {
+  const text = input.text.trim();
+  if (input.mode === "off") {
+    return { kind: "direct", reason: "routing_disabled" };
+  }
+  if (!text) return { kind: "direct", reason: "empty_request" };
+  if (input.childContext) return { kind: "direct", reason: "child_context" };
+  if (input.hasActiveWorkflow) {
+    return { kind: "direct", reason: "active_workflow" };
+  }
+  if (input.awaitingUserInput) {
+    return { kind: "direct", reason: "awaiting_user_input" };
+  }
+  if (input.managementCommand || MANAGEMENT.test(text)) {
+    return { kind: "direct", reason: "management_command" };
+  }
+  if (input.planOnly || PLAN_ONLY.test(text)) {
+    return { kind: "direct", reason: "plan_only" };
+  }
+  if (SOCIAL.test(text)) {
+    return { kind: "direct", reason: "social_conversation" };
+  }
+  if (isPureQuestion(text)) {
+    return { kind: "direct", reason: "pure_question" };
+  }
+  if (ONE_COMMAND.test(text) && !hasCompoundWork(text)) {
+    return { kind: "direct", reason: "one_command_operation" };
+  }
+  if (!hasActionableIntent(text)) {
+    return { kind: "direct", reason: "non_actionable_request" };
+  }
+  if (input.mode === "preferred" && !hasComplexShape(text)) {
+    return { kind: "direct", reason: "simple_request" };
+  }
+  return {
+    kind: "durable_plan",
+    reason:
+      input.mode === "preferred"
+        ? "eligible_complex_request"
+        : "eligible_actionable_request",
+    mode: input.mode,
+  };
+}
+
+function isPureQuestion(text: string): boolean {
+  if (ACTION_REQUEST_QUESTION.test(text)) return false;
+  if (QUESTION_LEAD.test(text) || AUXILIARY_QUESTION.test(text)) return true;
+  return text.endsWith("?") && !IMPERATIVE_ACTION.test(text);
+}
+
+function hasActionableIntent(text: string): boolean {
+  if (
+    IMPERATIVE_ACTION.test(text) ||
+    DO_IMPERATIVE.test(text) ||
+    ACTION_REQUEST_QUESTION.test(text)
+  ) {
+    return true;
+  }
+  if (!REQUEST_CONTEXT.test(text)) return false;
+  ACTION.lastIndex = 0;
+  return ACTION.test(text);
+}
+
+function hasComplexShape(text: string): boolean {
+  return COMPLEX_SHAPE.test(text) || hasCompoundWork(text);
+}
+
+function hasCompoundWork(text: string): boolean {
+  if (ORDERED_WORK.test(text)) return true;
+  ACTION.lastIndex = 0;
+  const actions = new Set<string>();
+  for (const match of text.matchAll(ACTION))
+    actions.add(match[0].toLowerCase());
+  return actions.size >= 2 && /\b(?:and|plus|then|while)\b/i.test(text);
+}
+
+export class WorkflowRoutingMetrics {
+  private decisions = 0;
+  private eligible = 0;
+  private hostStarted = 0;
+  private policyObserved = 0;
+  private routingUnconfirmed = 0;
+  private readonly directReasons: Record<string, number> = Object.create(null);
+
+  recordDecision(decision: WorkflowRoutingDecision): void {
+    this.decisions++;
+    if (decision.kind === "durable_plan") {
+      this.eligible++;
+      return;
+    }
+    this.directReasons[decision.reason] =
+      (this.directReasons[decision.reason] ?? 0) + 1;
+  }
+
+  recordHostStarted(): void {
+    this.hostStarted++;
+  }
+
+  recordPolicyObserved(): void {
+    this.policyObserved++;
+  }
+
+  recordRoutingUnconfirmed(): void {
+    this.routingUnconfirmed++;
+  }
+
+  snapshot(): WorkflowRoutingMetricsSnapshot {
+    const policyDecisions = this.policyObserved + this.routingUnconfirmed;
+    return {
+      decisions: this.decisions,
+      eligible: this.eligible,
+      hostStarted: this.hostStarted,
+      policyObserved: this.policyObserved,
+      routingUnconfirmed: this.routingUnconfirmed,
+      unconfirmedRate:
+        policyDecisions === 0 ? 0 : this.routingUnconfirmed / policyDecisions,
+      directReasons: { ...this.directReasons },
+    };
+  }
+}

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -79,6 +79,10 @@ import {
   DurableWorkflowProjectionRepository,
   type WorkflowProjection,
 } from "./workflow-projection-repository";
+import type {
+  WorkflowRoutingHost,
+  WorkflowRoutingStartResult,
+} from "./workflow-routing-runtime";
 
 const WORKFLOW_SESSION_SCOPE_MESSAGE =
   "Workflow jobs are scoped to the current parent session and do not survive reload/resume/new/quit.";
@@ -116,6 +120,7 @@ const workflowPlanParameterSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+const MAX_EAGER_WORKFLOW_TASK_BYTES = 262_144;
 
 function workflowNotFoundMessage(workflowId: string): string {
   return (
@@ -233,7 +238,7 @@ export function formatWorkflowNotificationSummary(
 export function registerWorkflowTool(
   pi: ExtensionAPI,
   sessionScope?: SessionScope,
-): void {
+): WorkflowRoutingHost {
   debugLog("info", "workflow_registered", {});
   const owner = (): SessionOwnerToken | undefined =>
     sessionScope
@@ -317,6 +322,7 @@ export function registerWorkflowTool(
       label,
       schema,
       thinkingLevel,
+      structuredOutputOnly,
       onProgress,
       onCancellationSnapshot,
     }) => {
@@ -336,6 +342,9 @@ export function registerWorkflowTool(
           onProgress?.({ kind: "log", message: msg, label, liveUsage });
         }
       };
+      if (structuredOutputOnly && isolation !== "in-process") {
+        throw new Error("structured-output-only agents must run in-process");
+      }
 
       const tryProcess = isolation !== "in-process";
       if (tryProcess) {
@@ -422,6 +431,7 @@ export function registerWorkflowTool(
         cancellationSource: "workflow",
         thinkingLevel,
         owner: childOwner,
+        structuredOutputOnly,
         ...(isolation === "in-process" && schema !== undefined
           ? { workflowStructuredOutputSchema: schema }
           : {}),
@@ -631,7 +641,7 @@ export function registerWorkflowTool(
     };
   }
 
-  pi.registerTool({
+  const workflowToolDefinition = {
     name: "workflow",
     label: "Workflow",
     description: [
@@ -1280,7 +1290,8 @@ export function registerWorkflowTool(
         };
       }
     },
-  });
+  };
+  pi.registerTool(workflowToolDefinition);
 
   // ── get_workflow_status ──
   pi.registerTool({
@@ -2597,4 +2608,124 @@ export function registerWorkflowTool(
     const h = Math.floor(m / 60);
     return `${h}h ${m % 60}m`;
   }
+
+  async function hasActiveWorkflow(): Promise<boolean> {
+    if (workflowJobsForOwner(owner()).some((job) => job.status === "running")) {
+      return true;
+    }
+    return (await listDurableWorkflowProjections()).some(
+      (projection) => projection.terminal === undefined,
+    );
+  }
+
+  return {
+    hasActiveWorkflow,
+    planAndStart: async (task, ctx, signal) => {
+      const planner = makeRunAgent(ctx, createDurableWorkflowRunId(), owner());
+      const plan = await buildEagerWorkflowPlan(planner, task, signal);
+      const result = await workflowToolDefinition.execute(
+        "workflow-routing",
+        { plan, durable: true },
+        signal,
+        undefined,
+        ctx,
+      );
+      if (result.isError) {
+        const details = result.details as { error?: unknown } | undefined;
+        throw new Error(
+          typeof details?.error === "string"
+            ? details.error
+            : "durable workflow plan did not start",
+        );
+      }
+      return routingStartResult(result.details);
+    },
+  };
+
+  function routingStartResult(details: unknown): WorkflowRoutingStartResult {
+    if (!details || typeof details !== "object") {
+      throw new Error("durable workflow start returned no details");
+    }
+    const value = details as Record<string, unknown>;
+    const requiredStrings = ["workflowId", "name"] as const;
+    const requiredNumbers = [
+      "revision",
+      "runEpoch",
+      "ownerGeneration",
+      "leaseEpoch",
+    ] as const;
+    for (const key of requiredStrings) {
+      if (typeof value[key] !== "string") {
+        throw new Error(`durable workflow start returned invalid ${key}`);
+      }
+    }
+    for (const key of requiredNumbers) {
+      if (!Number.isSafeInteger(value[key])) {
+        throw new Error(`durable workflow start returned invalid ${key}`);
+      }
+    }
+    return {
+      status: "started",
+      workflowId: value.workflowId as string,
+      name: value.name as string,
+      revision: value.revision as number,
+      runEpoch: value.runEpoch as number,
+      ownerGeneration: value.ownerGeneration as number,
+      leaseEpoch: value.leaseEpoch as number,
+    };
+  }
+}
+
+export async function buildEagerWorkflowPlan(
+  planner: WorkflowAgentRunner,
+  task: string,
+  signal?: AbortSignal,
+): Promise<WorkflowPlan> {
+  if (!task.trim()) throw new Error("workflow planner task must be nonempty");
+  if (Buffer.byteLength(task, "utf8") > MAX_EAGER_WORKFLOW_TASK_BYTES) {
+    throw new Error(
+      `workflow planner task exceeds ${MAX_EAGER_WORKFLOW_TASK_BYTES} bytes`,
+    );
+  }
+  let priorError: string | undefined;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const correction =
+      priorError === undefined
+        ? ""
+        : `\nThe prior plan was rejected: ${priorError}\nCorrect that exact error.`;
+    const result = await planner({
+      prompt: [
+        "Turn the parent request below into a bounded durable workflow plan.",
+        "Call structured_output exactly once with a schemaVersion 1 plan.",
+        "Use stable identifier IDs, sequential phases, and only in-process tasks.",
+        "Create multiple tasks only where work is independently agent-worthy.",
+        "Each task prompt must be self-contained. Do not perform the work.",
+        correction,
+        "",
+        "Parent request:",
+        task,
+      ].join("\n"),
+      isolation: "in-process",
+      label: "workflow planner",
+      schema: workflowPlanParameterSchema,
+      structuredOutputOnly: true,
+      signal,
+    });
+    try {
+      if (result.isError) {
+        throw new Error(result.errorMessage || result.output);
+      }
+      const capture = result.workflowStructuredOutput;
+      if (!capture?.called) {
+        throw new Error("workflow planner did not call structured_output");
+      }
+      validateWorkflowPlan(capture.value);
+      return capture.value;
+    } catch (error) {
+      priorError = error instanceof Error ? error.message : String(error);
+    }
+  }
+  throw new Error(
+    `workflow planner failed after one correction attempt: ${priorError}`,
+  );
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -4,3 +4,5 @@ export * from "./workflow-jobs";
 export * from "./workflow-ui";
 export * from "./workflow-tree-ui";
 export { registerWorkflowTool } from "./workflow-tool";
+export * from "./workflow-routing";
+export * from "./workflow-routing-runtime";

--- a/tests/readme-surface.test.ts
+++ b/tests/readme-surface.test.ts
@@ -47,7 +47,7 @@ describe("README public surface", () => {
     );
 
     expect(tools).toHaveLength(21);
-    expect(commands).toHaveLength(9);
+    expect(commands).toHaveLength(10);
     for (const name of tools) {
       expect(toolInventory, `Missing tool inventory row for ${name}`).toContain(
         `| \`${name}\``,

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -106,6 +106,23 @@ describe("extension registration", () => {
     });
   });
 
+  it("registers opt-in eager routing only for the parent runtime", () => {
+    const api = mockApi();
+
+    registerExtension(api as any);
+
+    expect(api.registerFlag).toHaveBeenCalledWith("workflow-eager", {
+      description: "Route eligible parent requests to durable workflow plans",
+      type: "string",
+      default: "off",
+    });
+    expect(api.on).toHaveBeenCalledWith("input", expect.any(Function));
+    expect(api.registerCommand).toHaveBeenCalledWith(
+      "workflow-plan",
+      expect.any(Object),
+    );
+  });
+
   it("appends the bundled prompt when --orchestrator is enabled", async () => {
     const api = mockApi({
       getFlag: vi.fn((name: string) => name === "orchestrator"),
@@ -174,6 +191,10 @@ describe("extension registration", () => {
     expect(api.registerShortcut).toHaveBeenCalledWith(
       "ctrl+alt+a",
       expect.any(Object),
+    );
+    expect(api.registerFlag).not.toHaveBeenCalledWith(
+      "workflow-eager",
+      expect.anything(),
     );
     expect(api.on.mock.calls.map(([event]) => event)).toEqual(
       expect.arrayContaining([

--- a/tests/thinking-level-effective.test.ts
+++ b/tests/thinking-level-effective.test.ts
@@ -102,6 +102,24 @@ describe("startSubagentJob effective thinking level", () => {
     expect(result.thinkingLevel).toBeUndefined();
   });
 
+  it("allows only structured output for schema-only children", async () => {
+    const session = createSession("medium");
+    mockCreateAgentSession.mockResolvedValue({ session });
+
+    const prepared = await startSubagentJob({
+      ...params(),
+      workflowStructuredOutputSchema: { type: "object" },
+      structuredOutputOnly: true,
+    });
+    expect(mockBuildSessionOptions.mock.calls[0][1]).toMatchObject({
+      tools: ["structured_output"],
+      customTools: [expect.objectContaining({ name: "structured_output" })],
+    });
+
+    prepared.disposeBeforeStart();
+    await prepared.jobPromise;
+  });
+
   it("disposes a prepared session without starting its prompt", async () => {
     const session = createSession("medium");
     mockCreateAgentSession.mockResolvedValue({ session });

--- a/tests/workflow-routing-host.test.ts
+++ b/tests/workflow-routing-host.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildEagerWorkflowPlan } from "../src/workflow-tool";
+import type { WorkflowAgentRunner } from "../src/workflow-core";
+
+const usage = {
+  input: 1,
+  output: 1,
+  cacheRead: 0,
+  cacheWrite: 0,
+  cost: 0,
+  turns: 1,
+};
+
+const validPlan = {
+  schemaVersion: 1 as const,
+  name: "routed-plan",
+  phases: [
+    {
+      id: "phase-a",
+      mode: "sequential" as const,
+      tasks: [
+        {
+          id: "task-a",
+          prompt: "Perform the first independent slice.",
+          isolation: "in-process" as const,
+        },
+      ],
+    },
+  ],
+};
+
+function captured(value: unknown) {
+  return {
+    isError: false as const,
+    output: "",
+    usage,
+    workflowStructuredOutput: { called: true, value },
+  };
+}
+
+describe("eager workflow planner", () => {
+  it("allows one correction and validates before returning", async () => {
+    const prompts: string[] = [];
+    const planner: WorkflowAgentRunner = vi.fn(async (request) => {
+      prompts.push(request.prompt);
+      return prompts.length === 1
+        ? captured({
+            ...validPlan,
+            phases: [{ ...validPlan.phases[0], mode: "parallel" }],
+          })
+        : captured(validPlan);
+    });
+
+    await expect(
+      buildEagerWorkflowPlan(planner, "Implement two independent slices"),
+    ).resolves.toEqual(validPlan);
+    expect(planner).toHaveBeenCalledTimes(2);
+    expect(prompts[0]).toContain("only in-process tasks");
+    expect(prompts[1]).toContain('plan.phases[0].mode must be "sequential"');
+    expect((planner as any).mock.calls[0][0].isolation).toBe("in-process");
+    expect((planner as any).mock.calls[0][0].structuredOutputOnly).toBe(true);
+  });
+
+  it("fails exactly after a missing structured output and one correction", async () => {
+    const planner: WorkflowAgentRunner = vi.fn(async () => ({
+      isError: false as const,
+      output: "plain text",
+      usage,
+      workflowStructuredOutput: { called: false, value: undefined },
+    }));
+
+    await expect(
+      buildEagerWorkflowPlan(planner, "Refactor the repository"),
+    ).rejects.toThrow(
+      "workflow planner failed after one correction attempt: workflow planner did not call structured_output",
+    );
+    expect(planner).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects process isolation after the bounded correction", async () => {
+    const processPlan = {
+      ...validPlan,
+      phases: [
+        {
+          ...validPlan.phases[0],
+          tasks: [
+            {
+              ...validPlan.phases[0].tasks[0],
+              isolation: "process",
+            },
+          ],
+        },
+      ],
+    };
+    const planner: WorkflowAgentRunner = vi.fn(async () =>
+      captured(processPlan),
+    );
+
+    await expect(
+      buildEagerWorkflowPlan(planner, "Implement process work"),
+    ).rejects.toThrow(
+      'plan.phases[0].tasks[0].isolation must be omitted or "in-process"',
+    );
+    expect(planner).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects oversized tasks before planner dispatch", async () => {
+    const planner: WorkflowAgentRunner = vi.fn(async () => captured(validPlan));
+
+    await expect(
+      buildEagerWorkflowPlan(planner, "x".repeat(262_145)),
+    ).rejects.toThrow("workflow planner task exceeds 262144 bytes");
+    expect(planner).not.toHaveBeenCalled();
+  });
+});

--- a/tests/workflow-routing-runtime.test.ts
+++ b/tests/workflow-routing-runtime.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerWorkflowRouting,
+  type WorkflowRoutingHost,
+} from "../src/workflow-routing-runtime";
+
+const started = {
+  status: "started" as const,
+  workflowId: "durable-route-1",
+  name: "route-plan",
+  revision: 2,
+  runEpoch: 3,
+  ownerGeneration: 4,
+  leaseEpoch: 5,
+};
+
+function setup(mode: string, host?: WorkflowRoutingHost, rejectInput = false) {
+  const handlers = new Map<string, (...args: any[]) => any>();
+  const commands = new Map<string, any>();
+  const messages: Array<{ message: any; options: any }> = [];
+  const pi = {
+    getFlag: vi.fn((name: string) =>
+      name === "workflow-eager" ? mode : undefined,
+    ),
+    on: vi.fn((event: string, handler: (...args: any[]) => any) => {
+      if (rejectInput && event === "input") {
+        throw new Error("input interception unsupported");
+      }
+      handlers.set(event, handler);
+    }),
+    registerCommand: vi.fn((name: string, command: any) => {
+      commands.set(name, command);
+    }),
+    sendMessage: vi.fn((message: any, options: any) => {
+      messages.push({ message, options });
+    }),
+  };
+  const metrics = registerWorkflowRouting(pi as any, host);
+  return { handlers, commands, messages, metrics };
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    isIdle: () => true,
+    signal: undefined,
+    ui: { notify: vi.fn() },
+    ...overrides,
+  } as any;
+}
+
+afterEach(() => {
+  delete process.env.PI_SUBAGENTURA_CHILD;
+});
+
+describe("workflow eager routing runtime", () => {
+  it("keeps the default-off host lane on the direct path", async () => {
+    const host = {
+      hasActiveWorkflow: vi.fn(async () => false),
+      planAndStart: vi.fn(async () => started),
+    };
+    const { handlers, messages } = setup("off", host);
+    const getBranch = vi.fn(() => {
+      throw new Error("off mode inspected session state");
+    });
+
+    await expect(
+      handlers.get("input")!(
+        { text: "Refactor the repository in multiple phases" },
+        context({ sessionManager: { getBranch } }),
+      ),
+    ).resolves.toEqual({ action: "continue" });
+    expect(getBranch).not.toHaveBeenCalled();
+    expect(host.hasActiveWorkflow).not.toHaveBeenCalled();
+    expect(host.planAndStart).not.toHaveBeenCalled();
+    expect(messages).toEqual([]);
+  });
+
+  it("starts an eligible host route before handling the input turn", async () => {
+    const host = {
+      hasActiveWorkflow: vi.fn(async () => false),
+      planAndStart: vi.fn(async () => started),
+    };
+    const { handlers, messages, metrics } = setup("preferred", host);
+    const ctx = context();
+
+    await expect(
+      handlers.get("input")!(
+        { text: "Audit the repository in multiple phases" },
+        ctx,
+      ),
+    ).resolves.toEqual({ action: "handled" });
+    expect(host.planAndStart).toHaveBeenCalledWith(
+      "Audit the repository in multiple phases",
+      ctx,
+      undefined,
+    );
+    expect(messages).toEqual([
+      expect.objectContaining({
+        message: expect.objectContaining({
+          customType: "workflow-routing",
+          details: expect.objectContaining({
+            lane: "host_enforced",
+            workflowId: "durable-route-1",
+          }),
+        }),
+        options: { triggerTurn: false },
+      }),
+    ]);
+    expect(metrics.snapshot().hostStarted).toBe(1);
+  });
+
+  it("suppresses active workflows and streaming continuations", async () => {
+    const activeHost = {
+      hasActiveWorkflow: vi.fn(async () => true),
+      planAndStart: vi.fn(async () => started),
+    };
+    const active = setup("always", activeHost);
+    await expect(
+      active.handlers.get("input")!(
+        { text: "Implement the feature" },
+        context(),
+      ),
+    ).resolves.toEqual({ action: "continue" });
+
+    const idleHost = {
+      hasActiveWorkflow: vi.fn(async () => false),
+      planAndStart: vi.fn(async () => started),
+    };
+    const streaming = setup("always", idleHost);
+    await expect(
+      streaming.handlers.get("input")!(
+        { text: "Implement the feature", streamingBehavior: "followUp" },
+        context(),
+      ),
+    ).resolves.toEqual({ action: "continue" });
+    expect(activeHost.planAndStart).not.toHaveBeenCalled();
+    expect(idleHost.planAndStart).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the response to a parent clarification question", async () => {
+    const host = {
+      hasActiveWorkflow: vi.fn(async () => false),
+      planAndStart: vi.fn(async () => started),
+    };
+    const { handlers } = setup("always", host);
+    const ctx = context({
+      sessionManager: {
+        getBranch: () => [
+          {
+            type: "message",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Which database should I use?" }],
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      handlers.get("input")!(
+        { text: "Use PostgreSQL and keep the existing schema" },
+        ctx,
+      ),
+    ).resolves.toEqual({ action: "continue" });
+    expect(host.planAndStart).not.toHaveBeenCalled();
+  });
+
+  it("handles host failures with the exact cause and declarative command", async () => {
+    const host = {
+      hasActiveWorkflow: vi.fn(async () => false),
+      planAndStart: vi.fn(async () => {
+        throw new Error("plan.phases[0].mode must be sequential");
+      }),
+    };
+    const { handlers, messages } = setup("always", host);
+
+    await expect(
+      handlers.get("input")!({ text: "Implement the feature" }, context()),
+    ).resolves.toEqual({ action: "handled" });
+    expect(messages[0]?.message.content).toContain(
+      "plan.phases[0].mode must be sequential",
+    );
+    expect(messages[0]?.message.content).toContain(
+      "/workflow-plan create <task>",
+    );
+    expect(messages[0]?.message.content).not.toContain("/workflow <task>");
+  });
+
+  it("runs /workflow-plan create through the same host path", async () => {
+    const host = {
+      hasActiveWorkflow: vi.fn(async () => false),
+      planAndStart: vi.fn(async () => started),
+    };
+    const { commands, messages } = setup("off", host);
+    const ctx = context();
+
+    await commands.get("workflow-plan").handler("create migrate storage", ctx);
+    expect(host.planAndStart).toHaveBeenCalledWith(
+      "migrate storage",
+      ctx,
+      undefined,
+    );
+    expect(messages[0]?.message.details.lane).toBe("host_command");
+  });
+
+  it("reports an unobserved model-policy route as routing_unconfirmed", async () => {
+    const { handlers, messages, metrics } = setup("preferred");
+    const result = await handlers.get("before_agent_start")!(
+      {
+        prompt: "Audit the repository in multiple phases",
+        systemPrompt: "base",
+      },
+      context(),
+    );
+    expect(result.systemPrompt).toContain(
+      "at most one corrected workflow call",
+    );
+    expect(result.systemPrompt).toContain(
+      "do not describe this route as host-enforced",
+    );
+
+    handlers.get("agent_settled")!({}, context());
+    expect(messages[0]?.message.details).toMatchObject({
+      lane: "model_policy",
+      status: "routing_unconfirmed",
+    });
+    expect(metrics.snapshot().routingUnconfirmed).toBe(1);
+  });
+
+  it("falls back honestly when input interception is unavailable", async () => {
+    const host = {
+      hasActiveWorkflow: vi.fn(async () => false),
+      planAndStart: vi.fn(async () => started),
+    };
+    const { handlers, messages } = setup("always", host, true);
+
+    const result = await handlers.get("before_agent_start")!(
+      { prompt: "Implement the feature", systemPrompt: "base" },
+      context(),
+    );
+    expect(result.systemPrompt).toContain(
+      "do not describe this route as host-enforced",
+    );
+    handlers.get("agent_settled")!({}, context());
+    expect(messages[0]?.message.details).toMatchObject({
+      lane: "model_policy",
+      status: "routing_unconfirmed",
+      capabilityReason: "input interception unsupported",
+    });
+    expect(host.planAndStart).not.toHaveBeenCalled();
+  });
+
+  it("suppresses active workflow continuations in the policy fallback", async () => {
+    const host = {
+      hasActiveWorkflow: vi.fn(async () => true),
+      planAndStart: vi.fn(async () => started),
+    };
+    const { handlers, messages } = setup("always", host, true);
+
+    await expect(
+      handlers.get("before_agent_start")!(
+        { prompt: "Implement the feature", systemPrompt: "base" },
+        context(),
+      ),
+    ).resolves.toBeUndefined();
+    handlers.get("agent_settled")!({}, context());
+    expect(messages).toEqual([]);
+    expect(host.planAndStart).not.toHaveBeenCalled();
+  });
+
+  it("observes at most two compliant policy workflow calls", async () => {
+    const { handlers, messages, metrics } = setup("always");
+    await handlers.get("before_agent_start")!(
+      { prompt: "Implement the feature", systemPrompt: "base" },
+      context(),
+    );
+    const first = {
+      toolCallId: "first",
+      toolName: "workflow",
+      input: { durable: true, plan: { schemaVersion: 1 } },
+    };
+    expect(handlers.get("tool_call")!(first, context())).toBeUndefined();
+    expect(
+      handlers.get("tool_call")!(
+        { ...first, toolCallId: "parallel" },
+        context(),
+      ),
+    ).toEqual({
+      block: true,
+      reason:
+        "A workflow plan call is already running or succeeded; a correction is not allowed.",
+    });
+    handlers.get("tool_execution_end")!(
+      { toolCallId: "first", toolName: "workflow", isError: true },
+      context(),
+    );
+    const second = { ...first, toolCallId: "second" };
+    expect(handlers.get("tool_call")!(second, context())).toBeUndefined();
+    expect(
+      handlers.get("tool_call")!({ ...first, toolCallId: "third" }, context()),
+    ).toEqual({
+      block: true,
+      reason: "Automatic workflow plan correction limit reached (two calls).",
+    });
+    handlers.get("agent_settled")!({}, context());
+    expect(messages).toEqual([]);
+    expect(metrics.snapshot().policyObserved).toBe(1);
+  });
+
+  it("blocks direct tools and legacy workflow fallback in the policy lane", async () => {
+    const { handlers, metrics } = setup("always");
+    await handlers.get("before_agent_start")!(
+      { prompt: "Implement the feature", systemPrompt: "base" },
+      context(),
+    );
+
+    expect(
+      handlers.get("tool_call")!(
+        { toolCallId: "read", toolName: "read", input: { path: "src" } },
+        context(),
+      ),
+    ).toMatchObject({ block: true });
+    expect(
+      handlers.get("tool_call")!(
+        {
+          toolCallId: "legacy",
+          toolName: "workflow",
+          input: { script: "legacy" },
+        },
+        context(),
+      ),
+    ).toEqual({
+      block: true,
+      reason:
+        "Automatic routing requires the workflow tool with plan and durable:true; legacy workflow execution is disabled.",
+    });
+    expect(
+      handlers.get("tool_call")!(
+        {
+          toolCallId: "corrected",
+          toolName: "workflow",
+          input: { durable: true, plan: { schemaVersion: 1 } },
+        },
+        context(),
+      ),
+    ).toBeUndefined();
+    expect(metrics.snapshot().policyObserved).toBe(1);
+  });
+});

--- a/tests/workflow-routing.test.ts
+++ b/tests/workflow-routing.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideWorkflowRouting,
+  parseWorkflowEagerMode,
+  WorkflowRoutingMetrics,
+  WORKFLOW_EAGER_DEFAULT,
+  type WorkflowEagerMode,
+  type WorkflowRoutingInput,
+} from "../src/workflow-routing";
+
+function decide(
+  mode: WorkflowEagerMode,
+  text: string,
+  overrides: Partial<WorkflowRoutingInput> = {},
+) {
+  return decideWorkflowRouting({ mode, text, ...overrides });
+}
+
+describe("workflow eager routing policy", () => {
+  it("defaults off and rejects unknown flag values", () => {
+    expect(WORKFLOW_EAGER_DEFAULT).toBe("off");
+    expect(parseWorkflowEagerMode(undefined)).toBe("off");
+    expect(parseWorkflowEagerMode(false)).toBe("off");
+    expect(parseWorkflowEagerMode("preferred")).toBe("preferred");
+    expect(parseWorkflowEagerMode("always")).toBe("always");
+    expect(() => parseWorkflowEagerMode("sometimes")).toThrow(
+      "workflow-eager must be off, preferred, or always",
+    );
+  });
+
+  it("routes only multi-slice or phased work in preferred mode", () => {
+    expect(decide("preferred", "Fix the parser bug")).toEqual({
+      kind: "direct",
+      reason: "simple_request",
+    });
+    expect(decide("preferred", "Fix one workflow bug")).toEqual({
+      kind: "direct",
+      reason: "simple_request",
+    });
+    expect(
+      decide(
+        "preferred",
+        "Investigate the parser and then update the callers and tests",
+      ),
+    ).toMatchObject({ kind: "durable_plan", mode: "preferred" });
+    expect(
+      decide(
+        "preferred",
+        "Refactor authentication across the codebase in multiple phases",
+      ),
+    ).toMatchObject({ kind: "durable_plan", mode: "preferred" });
+    expect(
+      decide(
+        "preferred",
+        "Refactor authentication across the repository. Do not change the public API.",
+      ),
+    ).toMatchObject({ kind: "durable_plan", mode: "preferred" });
+    expect(
+      decide(
+        "preferred",
+        "Do a repository-wide audit and then fix the discovered issues",
+      ),
+    ).toMatchObject({ kind: "durable_plan", mode: "preferred" });
+    expect(
+      decide("preferred", "Run npm test and then fix the failures"),
+    ).toMatchObject({ kind: "durable_plan", mode: "preferred" });
+    expect(
+      decide(
+        "preferred",
+        "I need you to write tests across the repository in multiple phases",
+      ),
+    ).toMatchObject({ kind: "durable_plan", mode: "preferred" });
+  });
+
+  it("routes remaining actionable work in always mode", () => {
+    expect(decide("always", "Fix the parser bug")).toMatchObject({
+      kind: "durable_plan",
+      mode: "always",
+      reason: "eligible_actionable_request",
+    });
+  });
+
+  it.each([
+    ["", "empty_request"],
+    ["Thanks!", "social_conversation"],
+    ["Why does this parser use a cache?", "pure_question"],
+    ["What should we refactor first?", "pure_question"],
+    ["Do you think we should refactor this?", "pure_question"],
+    ["Write a plan only; do not implement it", "plan_only"],
+    ["/workflow-status active", "management_command"],
+    ["Run the typecheck", "one_command_operation"],
+    ["Run npm test", "one_command_operation"],
+    ["Can you run npm test?", "one_command_operation"],
+    [
+      "The repository uses review gates across multiple phases",
+      "non_actionable_request",
+    ],
+    ["PostgreSQL is our primary database", "non_actionable_request"],
+  ])("suppresses %j in always mode as %s", (text, reason) => {
+    expect(decide("always", text)).toEqual({ kind: "direct", reason });
+  });
+
+  it.each([
+    ["childContext", "child_context"],
+    ["hasActiveWorkflow", "active_workflow"],
+    ["awaitingUserInput", "awaiting_user_input"],
+    ["managementCommand", "management_command"],
+    ["planOnly", "plan_only"],
+  ] as const)("honors the explicit %s suppression", (key, reason) => {
+    expect(decide("always", "Implement the feature", { [key]: true })).toEqual({
+      kind: "direct",
+      reason,
+    });
+  });
+
+  it("keeps all natural requests direct while disabled", () => {
+    expect(decide("off", "Refactor everything in multiple phases")).toEqual({
+      kind: "direct",
+      reason: "routing_disabled",
+    });
+  });
+
+  it("keeps the local preferred-mode fixture at zero false positives", () => {
+    const fixtures = [
+      { text: "Fix one parser bug", route: false },
+      { text: "Fix one workflow bug", route: false },
+      { text: "Explain the workflow architecture", route: false },
+      { text: "Run npm test", route: false },
+      { text: "Write a plan only and do not implement it", route: false },
+      {
+        text: "Audit the repository across multiple subsystems",
+        route: true,
+      },
+      {
+        text: "Investigate the parser and then update its callers and tests",
+        route: true,
+      },
+      {
+        text: "Migrate storage across services in multiple phases",
+        route: true,
+      },
+    ];
+    const actual = fixtures.map(
+      ({ text }) => decide("preferred", text).kind === "durable_plan",
+    );
+    const falsePositives = actual.filter(
+      (routed, index) => routed && !fixtures[index]?.route,
+    );
+
+    expect(actual).toEqual(fixtures.map(({ route }) => route));
+    expect(falsePositives).toHaveLength(0);
+  });
+
+  it("records local rollout facts without external telemetry", () => {
+    const metrics = new WorkflowRoutingMetrics();
+    metrics.recordDecision(decide("preferred", "Fix one bug"));
+    metrics.recordDecision(
+      decide("preferred", "Audit the repository in multiple phases"),
+    );
+    metrics.recordHostStarted();
+    metrics.recordPolicyObserved();
+    metrics.recordRoutingUnconfirmed();
+
+    expect(metrics.snapshot()).toEqual({
+      decisions: 2,
+      eligible: 1,
+      hostStarted: 1,
+      policyObserved: 1,
+      routingUnconfirmed: 1,
+      unconfirmedRate: 0.5,
+      directReasons: { simple_request: 1 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements `plan.md` Milestone 2B as a bounded preview on top of merged Milestones 0–2:

- adds `--workflow-eager=off|preferred|always`, defaulting to `off`;
- classifies parent requests before dispatch and applies mandatory suppression for child turns, active workflows, continuations, questions, social/plan-only/management requests, and one-command operations;
- creates, validates, commits, and starts sequential in-process durable plans in the same input turn through the existing owner-fenced controller;
- confines the planner to the `structured_output` tool, one initial attempt, and one correction;
- provides `/workflow-plan create <task>` as the explicit host-owned path;
- downgrades honestly to a bounded model-policy lane with `routing_unconfirmed` when input interception cannot be registered;
- records local routing decisions, starts, observed policy calls, and unconfirmed rate without external telemetry.

Later milestones remain deliberately deferred: terminal outbox/delivery, parallel durable execution, process-child adoption, durable JavaScript, mutations/reminders, trusted approvals, and quota/retention hardening.

## Verification

- `npm run typecheck` — passed
- `npm test` — 67 files, 1519 tests passed
- `npm run format:check` — passed
- `npm run pack:check` — passed
- CLI smoke: `npx pi -e ./src/subagent.ts --help` exposes `--workflow-eager`
- Runtime smoke: off/preferred/question/always decisions returned the expected direct/durable lanes

## Known test boundary

The repository `npm test` command intentionally excludes tmux, zellij, and terminal E2E suites.