### PR TITLE
fix(orchestratorv2): enforce router boundaries

### DIFF
--- a/ORCHESTRATOR_V2_SYSTEM_PROMPT.md
+++ b/ORCHESTRATOR_V2_SYSTEM_PROMPT.md
@@ -20,9 +20,9 @@ A child-originated side topic is not a new assignment. Surface the concern to th
 
 ## Responsibilities and confirmation
 
-Give every new child an explicit initial responsibility, using the existing routing description and aliases when appropriate. A child may propose a responsibility change, but it cannot redefine itself. Present the proposal and require confirmation before calling `update_orchestrator_agent_description` with `confirmed: true`.
+Give every new child an explicit initial responsibility, using the existing routing description and aliases when appropriate. A child may propose a responsibility change, but it cannot redefine itself. First call `update_orchestrator_agent_description` with `confirmed: false` to create a pending exact change. Present the returned confirmation token and require the user to send that exact token in a new message. Only then retry the exact change with `confirmed: true` and `confirmationToken`.
 
-Routing metadata is bounded and must never be evicted automatically. If an insert is blocked at capacity, surface the blocker and ask the user which stale entry may be retired. Call `remove_orchestrator_agent_description` with `confirmed: true` only after explicit user confirmation, then retry the metadata update. Removing routing metadata does not cancel the child or delete artifacts.
+Routing metadata is bounded and must never be evicted automatically. If an initial insert is blocked at capacity, the new child is cancelled. Surface the blocker and ask the user which stale entry may be retired. Request a pending removal with `confirmed: false`, present its token, and retry with `confirmed: true` plus `confirmationToken` only after the user sends that token. Then retry the spawn. Removing routing metadata does not cancel an existing child or delete artifacts.
 
 ## Context contract
 
@@ -42,6 +42,6 @@ Surface only substantial additional information, blockers or errors, completion,
 
 ## Control boundary and legacy mode
 
-This control-only role is prompt policy, not a security boundary. Host tool allowlisting is not enforced in Phase 1, so exposed tools are not proof of permission or isolation.
+When `--orchestratorv2` is enabled, the extension enforces the control-only boundary with an active-tool allowlist. Built-in repository tools, workflows, and in-process worker tools are unavailable to the parent model. Interactive routing, metadata, artifact, model-discovery, supervision, and cancellation surfaces remain available.
 
 The existing `--orchestrator` prompt and workflow path are separate and unchanged. Users should enable one orchestration mode at a time. Enabling both flags is unsupported user configuration and may append conflicting prompts; do not silently normalize that choice.

--- a/README.md
+++ b/README.md
@@ -219,16 +219,19 @@ pi --orchestratorv2
 
 This flag appends `ORCHESTRATOR_V2_SYSTEM_PROMPT.md`; it does not select or
 verify the parent model. Select the intended Luna-compatible model separately,
-and do not enable `--orchestrator` and `--orchestratorv2` together. The thin
-router delegates only through attachable interactive children and uses
-project-local confirmed descriptions and aliases to route continuations.
+and do not enable `--orchestrator` and `--orchestratorv2` together. The mode uses
+an active-tool allowlist that excludes built-in repository tools, workflows, and
+in-process workers. It delegates only through attachable interactive children
+and uses project-local confirmed descriptions and aliases to route
+continuations.
 
 Routing metadata is capped at 128 records and is never evicted automatically.
-If stale history reaches that cap, inspect it with `list_orchestrator_agents`,
-ask the user which entry may be retired, and call
-`remove_orchestrator_agent_description` with `confirmed: true` before retrying
-the metadata update. Removal changes only routing metadata; it does not cancel
-a child or delete its artifacts.
+If initial metadata cannot be persisted, the newly launched child is cancelled.
+To update or remove metadata, first call the relevant tool with
+`confirmed: false`, show the server-issued token to the user, and wait for the
+user to send that exact token in a new message. Retry the exact change with
+`confirmed: true` and `confirmationToken`. Removal changes only routing
+metadata; it does not cancel an existing child or delete its artifacts.
 
 ## Cancellation context snapshots (opt-in)
 

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -88,6 +88,19 @@ const ORCHESTRATOR_V2_SYSTEM_PROMPT = readFileSync(
   new URL("../ORCHESTRATOR_V2_SYSTEM_PROMPT.md", import.meta.url),
   "utf8",
 ).trim();
+const ORCHESTRATOR_V2_ACTIVE_TOOLS = [
+  "cancel_interactive_subagent",
+  "cleanup_subagent_artifacts",
+  "get_interactive_subagent_status",
+  "list_available_models",
+  "list_orchestrator_agents",
+  "list_subagent_artifacts",
+  "read_subagent_artifact",
+  "remove_orchestrator_agent_description",
+  "send_interactive_subagent_message",
+  "subagent_interactive",
+  "update_orchestrator_agent_description",
+];
 
 export default function (pi: ExtensionAPI) {
   if (process.env.PI_SUBAGENTURA_CHILD === "1") {
@@ -117,12 +130,14 @@ export default function (pi: ExtensionAPI) {
     type: "boolean",
     default: false,
   });
+  const orchestratorV2Enabled = pi.getFlag("orchestratorv2") === true;
   pi.on("before_agent_start", (event) => {
     const prompts: string[] = [];
     if (pi.getFlag("orchestrator") === true) {
       prompts.push(ORCHESTRATOR_SYSTEM_PROMPT);
     }
     if (pi.getFlag("orchestratorv2") === true) {
+      pi.setActiveTools(ORCHESTRATOR_V2_ACTIVE_TOOLS);
       prompts.push(ORCHESTRATOR_V2_SYSTEM_PROMPT);
     }
     if (prompts.length === 0) return;
@@ -135,11 +150,19 @@ export default function (pi: ExtensionAPI) {
   registerInteractiveSubagentTools(pi, sessionScope);
   registerOrchestratorTools(pi, sessionScope);
   registerInteractiveSupervisor(pi, sessionScope);
-  registerWorkflowTool(pi, sessionScope);
-  registerInProcessSubagentTools(pi, sessionScope);
-  registerInProcessMaintenanceTools(pi, sessionScope);
+  if (orchestratorV2Enabled) {
+    registerSubagentArtifactsCleanupTool(pi, sessionScope);
+    registerSubagentModelListTool(pi);
+  } else {
+    registerWorkflowTool(pi, sessionScope);
+    registerInProcessSubagentTools(pi, sessionScope);
+    registerInProcessMaintenanceTools(pi, sessionScope);
+  }
   // ── Cancel-all-flows shortcut and command ──────────────────────
   registerCancelAllFlows(pi, sessionScope);
+  if (orchestratorV2Enabled) {
+    pi.setActiveTools(ORCHESTRATOR_V2_ACTIVE_TOOLS);
+  }
 }
 
 /**

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -71,7 +71,9 @@ function formatFollowupPreview(message: string): string {
 
 type InitialRoutingMetadataResult =
   | { status: "persisted"; entry: OrchestratorRoutingEntry }
-  | { status: "warning"; error: string };
+  | { status: "error"; error: string };
+
+const INITIAL_ROUTING_CLEANUP_ATTEMPTS = 2;
 
 function persistInitialRoutingMetadata(params: {
   cwd: string;
@@ -82,7 +84,7 @@ function persistInitialRoutingMetadata(params: {
   if (params.description === undefined) return undefined;
   if (!isValidSubagentId(params.childId)) {
     return {
-      status: "warning",
+      status: "error",
       error: `spawn returned invalid child id ${params.childId}`,
     };
   }
@@ -99,10 +101,28 @@ function persistInitialRoutingMetadata(params: {
     return { status: "persisted", entry };
   } catch (error) {
     return {
-      status: "warning",
+      status: "error",
       error: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function cancelAfterInitialRoutingFailure(
+  state: InteractiveSubagentState,
+): string | undefined {
+  let cleanupError: string | undefined;
+  for (let attempt = 0; attempt < INITIAL_ROUTING_CLEANUP_ATTEMPTS; attempt++) {
+    try {
+      cancelInteractiveSubagent(state.id, "cancel_interactive_subagent", state);
+      return undefined;
+    } catch (error) {
+      cleanupError = error instanceof Error ? error.message : String(error);
+    }
+  }
+  // Cancellation marks the state before pane teardown. If teardown never
+  // succeeds, keep the registry honest and allow an explicit cancellation retry.
+  state.status = "unknown";
+  return cleanupError ?? "interactive sub-agent cleanup failed";
 }
 
 function validateInitialRoutingMetadata(
@@ -364,6 +384,36 @@ export function registerInteractiveSubagentTools(
           description: params.routingDescription,
           aliases: params.routingAliases,
         });
+        if (routingMetadata?.status === "error") {
+          const cleanupError = cancelAfterInitialRoutingFailure(state);
+          updateRunningSubagentFooter(
+            ctx.ui,
+            registration.scope ? sessionOwner(registration.scope) : undefined,
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  (cleanupError
+                    ? `Interactive sub-agent ${state.id} could not be confirmed stopped after its initial routing metadata failed to persist: ${routingMetadata.error}`
+                    : `Interactive sub-agent ${state.id} was cancelled because its initial routing metadata could not be persisted: ${routingMetadata.error}`) +
+                  (cleanupError
+                    ? `\nPane cleanup also failed: ${cleanupError}`
+                    : ""),
+              },
+            ],
+            details: {
+              status: cleanupError
+                ? "routing_metadata_cleanup_error"
+                : "routing_metadata_error",
+              id: state.id,
+              error: routingMetadata.error,
+              ...(cleanupError === undefined ? {} : { cleanupError }),
+            },
+            isError: true,
+          };
+        }
         updateRunningSubagentFooter(
           ctx.ui,
           registration.scope ? sessionOwner(registration.scope) : undefined,
@@ -378,11 +428,6 @@ export function registerInteractiveSubagentTools(
         }
         locationLines.push(`Focus: ${state.selectPaneCommand}`);
         locationLines.push(`Session: ${state.sessionFile}`);
-        if (routingMetadata?.status === "warning") {
-          locationLines.push(
-            `Warning: initial routing metadata was not persisted: ${routingMetadata.error}`,
-          );
-        }
         return {
           content: [
             {

--- a/src/tools/orchestrator.ts
+++ b/src/tools/orchestrator.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
@@ -17,6 +18,25 @@ import {
 } from "../session-scope";
 
 const CHILD_ID_PATTERN = "^[a-f0-9]{16}$";
+const CONFIRMATION_TOKEN_PREFIX = "orchestrator-confirm:";
+const CONFIRMATION_TOKEN_MAX_BYTES = 128;
+const CONFIRMATION_TTL_MS = 10 * 60 * 1000;
+const MAX_PENDING_CONFIRMATIONS = 32;
+
+type ConfirmationAction = "update" | "remove";
+
+interface PendingConfirmation {
+  action: ConfirmationAction;
+  childId: string;
+  payload: string;
+  generation: number;
+  createdAt: number;
+}
+
+const pendingConfirmations = new WeakMap<
+  SessionScope,
+  Map<string, PendingConfirmation>
+>();
 
 const ListOrchestratorAgentsParams = Type.Object({});
 
@@ -46,10 +66,18 @@ const UpdateOrchestratorAgentDescriptionParams = Type.Object({
   provenance: Type.Optional(
     Type.Union([Type.Literal("user"), Type.Literal("luna")]),
   ),
-  confirmed: Type.Literal(true, {
+  confirmed: Type.Boolean({
     description:
-      "Must be true after the user or Luna has confirmed this metadata update",
+      "False requests a server-issued confirmation token. True applies the exact pending update only after the latest user message contains that token.",
   }),
+  confirmationToken: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: CONFIRMATION_TOKEN_MAX_BYTES,
+      description:
+        "Server-issued token from the pending update. The latest user message must contain it before confirmed=true succeeds.",
+    }),
+  ),
 });
 
 const RemoveOrchestratorAgentDescriptionParams = Type.Object({
@@ -57,10 +85,18 @@ const RemoveOrchestratorAgentDescriptionParams = Type.Object({
     pattern: CHILD_ID_PATTERN,
     description: "Interactive child ID whose routing metadata is removed",
   }),
-  confirmed: Type.Literal(true, {
+  confirmed: Type.Boolean({
     description:
-      "Must be true after the user has confirmed permanent metadata removal",
+      "False requests a server-issued confirmation token. True removes the exact pending entry only after the latest user message contains that token.",
   }),
+  confirmationToken: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: CONFIRMATION_TOKEN_MAX_BYTES,
+      description:
+        "Server-issued token from the pending removal. The latest user message must contain it before confirmed=true succeeds.",
+    }),
+  ),
 });
 
 export function registerOrchestratorTools(
@@ -126,6 +162,21 @@ export function registerOrchestratorTools(
         };
       }
 
+      const confirmation = confirmOrRequestChange({
+        scope,
+        ctx,
+        action: "update",
+        childId: params.childId,
+        payload: JSON.stringify({
+          description: params.description,
+          aliases: params.aliases,
+          provenance: params.provenance,
+        }),
+        confirmed: params.confirmed,
+        confirmationToken: params.confirmationToken,
+      });
+      if (confirmation) return confirmation;
+
       try {
         const existing = listOrchestratorRoutingEntries(ctx.cwd).find(
           (entry) => entry.childId === params.childId,
@@ -170,22 +221,22 @@ export function registerOrchestratorTools(
       const scope = resolveToolSessionScope(toolToken);
       if (!scope) return sessionUnavailableResult();
       try {
+        const existing = listOrchestratorRoutingEntries(ctx.cwd).find(
+          (entry) => entry.childId === params.childId,
+        );
+        if (!existing) return routingEntryNotFoundResult(params.childId);
+        const confirmation = confirmOrRequestChange({
+          scope,
+          ctx,
+          action: "remove",
+          childId: params.childId,
+          payload: JSON.stringify(existing),
+          confirmed: params.confirmed,
+          confirmationToken: params.confirmationToken,
+        });
+        if (confirmation) return confirmation;
         const entry = removeOrchestratorRoutingEntry(ctx.cwd, params.childId);
-        if (!entry) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `No routing metadata exists for interactive child ${params.childId}.`,
-              },
-            ],
-            details: {
-              status: "not_found",
-              childId: params.childId,
-            },
-            isError: true,
-          };
-        }
+        if (!entry) return routingEntryNotFoundResult(params.childId);
         return {
           content: [
             {
@@ -200,6 +251,178 @@ export function registerOrchestratorTools(
       }
     },
   });
+}
+
+function confirmationMap(
+  scope: SessionScope,
+): Map<string, PendingConfirmation> {
+  let entries = pendingConfirmations.get(scope);
+  if (!entries) {
+    entries = new Map();
+    pendingConfirmations.set(scope, entries);
+  }
+  return entries;
+}
+
+function prunePendingConfirmations(
+  entries: Map<string, PendingConfirmation>,
+  now: number,
+): void {
+  for (const [token, pending] of entries) {
+    if (now - pending.createdAt > CONFIRMATION_TTL_MS) entries.delete(token);
+  }
+}
+
+function confirmOrRequestChange(params: {
+  scope: SessionScope;
+  ctx: unknown;
+  action: ConfirmationAction;
+  childId: string;
+  payload: string;
+  confirmed: boolean;
+  confirmationToken?: string;
+}) {
+  const entries = confirmationMap(params.scope);
+  const now = Date.now();
+  prunePendingConfirmations(entries, now);
+  if (!params.confirmed) {
+    while (entries.size >= MAX_PENDING_CONFIRMATIONS) {
+      const oldest = entries.keys().next().value as string | undefined;
+      if (!oldest) break;
+      entries.delete(oldest);
+    }
+    const confirmationToken = `${CONFIRMATION_TOKEN_PREFIX}${randomUUID()}`;
+    entries.set(confirmationToken, {
+      action: params.action,
+      childId: params.childId,
+      payload: params.payload,
+      generation: params.scope.generation,
+      createdAt: now,
+    });
+    return confirmationRequiredResult(
+      params.action,
+      params.childId,
+      confirmationToken,
+    );
+  }
+
+  const token = params.confirmationToken;
+  const pending = token ? entries.get(token) : undefined;
+  if (
+    !token ||
+    !pending ||
+    pending.action !== params.action ||
+    pending.childId !== params.childId ||
+    pending.payload !== params.payload ||
+    pending.generation !== params.scope.generation
+  ) {
+    return confirmationErrorResult(
+      "confirmation_invalid",
+      params.action,
+      params.childId,
+      "No matching pending confirmation exists for this exact change.",
+    );
+  }
+
+  const userText = latestUserMessageText(params.ctx);
+  if (!userText?.includes(token)) {
+    return confirmationErrorResult(
+      "user_confirmation_required",
+      params.action,
+      params.childId,
+      `The latest user message must contain the exact token ${token}.`,
+    );
+  }
+  entries.delete(token);
+  return undefined;
+}
+
+function latestUserMessageText(ctx: unknown): string | undefined {
+  if (!ctx || typeof ctx !== "object") return undefined;
+  const sessionManager = (ctx as { sessionManager?: unknown }).sessionManager;
+  if (!sessionManager || typeof sessionManager !== "object") return undefined;
+  const getBranch = (sessionManager as { getBranch?: unknown }).getBranch;
+  if (typeof getBranch !== "function") return undefined;
+  let branch: unknown;
+  try {
+    branch = getBranch.call(sessionManager);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(branch)) return undefined;
+  for (let index = branch.length - 1; index >= 0; index--) {
+    const entry = branch[index];
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as { type?: unknown; message?: unknown };
+    if (record.type !== "message") continue;
+    const message = record.message;
+    if (!message || typeof message !== "object") continue;
+    const userMessage = message as { role?: unknown; content?: unknown };
+    if (userMessage.role !== "user") continue;
+    return textContent(userMessage.content);
+  }
+  return undefined;
+}
+
+function textContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (!part || typeof part !== "object") return "";
+      const text = (part as { text?: unknown }).text;
+      return typeof text === "string" ? text : "";
+    })
+    .join("\n");
+}
+
+function confirmationRequiredResult(
+  action: ConfirmationAction,
+  childId: string,
+  confirmationToken: string,
+) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `User confirmation is required. Ask the user to send the exact token ${confirmationToken}, then retry this exact ${action} with confirmed=true and confirmationToken.`,
+      },
+    ],
+    details: {
+      status: "confirmation_required",
+      action,
+      childId,
+      confirmationToken,
+    },
+    isError: true,
+  };
+}
+
+function confirmationErrorResult(
+  status: "confirmation_invalid" | "user_confirmation_required",
+  action: ConfirmationAction,
+  childId: string,
+  message: string,
+) {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    details: { status, action, childId },
+    isError: true,
+  };
+}
+
+function routingEntryNotFoundResult(childId: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `No routing metadata exists for interactive child ${childId}.`,
+      },
+    ],
+    details: { status: "not_found", childId },
+    isError: true,
+  };
 }
 
 function optionalAliases(

--- a/task.md
+++ b/task.md
@@ -1,0 +1,30 @@
+# Orchestratorv2 hardening task
+
+## Source findings
+
+This branch handles findings 1, 3, 4, and 5 from the Orchestratorv2 verification. Finding 2 is explicitly out of scope because it is not considered a bug at this point.
+
+1. **Router-only and workflow separation are prompt-only.** `--orchestratorv2` appends a system prompt, but the parent still registers workflow and in-process worker tools. The mode needs a runtime tool boundary, not only model compliance.
+2. **No change requested.** Follow-up routing is model-directed and does not require a fresh registry lookup or deterministic responsibility matching. This is accepted for now.
+3. **Metadata confirmation is asserted by the model.** The update and removal schemas accept `confirmed: true`, but the runtime does not prove that the user confirmed the exact pending change. Add a user-bound confirmation flow.
+4. **A child can remain live when initial metadata persistence fails.** Spawning currently succeeds and returns a warning after the child has already launched. Make the operation fail closed by cancelling the launched child when requested routing metadata cannot be persisted.
+5. **Tests overstate end-to-end coverage.** Existing scenario tests mainly exercise registered tools with mocked launch and pane operations, and prompt text is used as evidence for router behavior. Add coverage through the extension's public registration boundary that verifies the restricted tool surface and the failure behavior above. Keep real-project acceptance validation in the verification record.
+
+## Intended outcome
+
+- In `--orchestratorv2` mode, register only the extension tools needed for interactive routing, metadata management, model discovery, artifact access/cleanup, supervision, and cancellation. Enforce an active-tool allowlist so built-in repository tools, workflows, and in-process workers are unavailable to the parent model.
+- Require a server-issued pending confirmation token and a subsequent user message containing that token before responsibility metadata can be updated or removed.
+- If initial routing metadata persistence fails after launch, cancel the new child and return an error rather than a usable live runtime.
+- Add regression tests for each changed behavior and a real Pi CLI integration path that observes the provider-visible tool surface, appended prompt, and routing registry tool result.
+- Run `npm run typecheck`, `npm test`, `npm run format:check`, and `npm run pack:check` before committing.
+
+## Follow-up review findings
+
+- Cleanup originally attempted cancellation only once. Because pane liveness or teardown can throw after marking the runtime cancelled, cleanup now retries once and leaves the runtime `unknown` and explicitly retryable if both attempts fail.
+- A full pending-confirmation set originally risked evicting its oldest token before validating that token. Capacity eviction now applies only when issuing a new token, and a regression test confirms the oldest of 32 pending changes remains confirmable.
+
+## Verification record
+
+- The real Pi CLI integration observed the exact provider-visible Orchestratorv2 tool allowlist, the appended v2 system prompt, and the public `list_orchestrator_agents` result. Built-in repository tools, workflow tools, and in-process worker tools were absent.
+- Focused reviewer re-validation passed 44 tests, typecheck, and `git diff --check` with both follow-up findings closed.
+- Final repository verification passed `npm run typecheck`, all 1,545 tests across 69 files, `npm run format:check`, `npm run pack:check`, and `git diff --check`.

--- a/tests/orchestrator-cli.integration.test.ts
+++ b/tests/orchestrator-cli.integration.test.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PI_CLI = join(
+  ROOT,
+  "node_modules",
+  "@earendil-works",
+  "pi-coding-agent",
+  "dist",
+  "cli.js",
+);
+const EXPECTED_TOOLS = [
+  "cancel_interactive_subagent",
+  "cleanup_subagent_artifacts",
+  "get_interactive_subagent_status",
+  "list_available_models",
+  "list_orchestrator_agents",
+  "list_subagent_artifacts",
+  "read_subagent_artifact",
+  "remove_orchestrator_agent_description",
+  "send_interactive_subagent_message",
+  "subagent_interactive",
+  "update_orchestrator_agent_description",
+].sort();
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("Orchestratorv2 real Pi CLI boundary", () => {
+  it("exposes only router-safe tools and appends the v2 prompt", () => {
+    const root = mkdtempSync(join(tmpdir(), "orchestrator-cli-"));
+    roots.push(root);
+    const providerLog = join(root, "provider.ndjson");
+
+    execFileSync(
+      process.execPath,
+      [
+        PI_CLI,
+        "--offline",
+        "--approve",
+        "--api-key",
+        "subagentura-e2e-test-key",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+        "--no-context-files",
+        "--no-session",
+        "--mode",
+        "json",
+        "--print",
+        "-e",
+        join(ROOT, "src", "subagent.ts"),
+        "-e",
+        join(ROOT, "tests", "terminal-e2e", "fixtures", "mock-provider.ts"),
+        "--model",
+        "subagentura-e2e/mock",
+        "--orchestratorv2=true",
+        "[E2E:ORCHESTRATOR_BOUNDARY] Report the active router surface.",
+      ],
+      {
+        cwd: root,
+        env: {
+          ...process.env,
+          HOME: root,
+          PI_CODING_AGENT_DIR: join(root, ".pi-agent"),
+          SUBAGENTURA_E2E_LOG: providerLog,
+          HTTP_PROXY: "http://127.0.0.1:1",
+          HTTPS_PROXY: "http://127.0.0.1:1",
+          ALL_PROXY: "http://127.0.0.1:1",
+          NO_PROXY: "",
+        },
+        encoding: "utf8",
+        timeout: 30_000,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    const events = readFileSync(providerLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const request = events.find(
+      (event) =>
+        event.marker === "[E2E:ORCHESTRATOR_BOUNDARY]" &&
+        event.beforeStage === "initial",
+    );
+    const completion = events.find(
+      (event) =>
+        event.marker === "[E2E:ORCHESTRATOR_BOUNDARY]" &&
+        event.afterStage === "complete",
+    );
+
+    expect(request?.contextToolNames).toEqual(EXPECTED_TOOLS);
+    expect(completion?.contextHasOrchestratorV2Prompt).toBe(true);
+    expect(completion?.routingListObserved).toBe(true);
+  });
+});

--- a/tests/orchestrator-scenarios.test.ts
+++ b/tests/orchestrator-scenarios.test.ts
@@ -12,18 +12,22 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Schema from "typebox/schema";
 
-const { mockLaunchInteractiveSubagent, mockSendCommandToPane } = vi.hoisted(
-  () => ({
-    mockLaunchInteractiveSubagent: vi.fn(),
-    mockSendCommandToPane: vi.fn(),
-  }),
-);
+const {
+  mockCancelInteractiveSubagent,
+  mockLaunchInteractiveSubagent,
+  mockSendCommandToPane,
+} = vi.hoisted(() => ({
+  mockCancelInteractiveSubagent: vi.fn(),
+  mockLaunchInteractiveSubagent: vi.fn(),
+  mockSendCommandToPane: vi.fn(),
+}));
 
 vi.mock("../src/interactive-tmux", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../src/interactive-tmux")>();
   return {
     ...actual,
+    cancelInteractiveSubagent: mockCancelInteractiveSubagent,
     launchInteractiveSubagent: mockLaunchInteractiveSubagent,
     sendCommandToPane: mockSendCommandToPane,
   };
@@ -82,6 +86,7 @@ function mockApi(orchestratorv2 = false) {
     ),
     sendMessage: vi.fn(),
     sendUserMessage: vi.fn(),
+    setActiveTools: vi.fn(),
     on: vi.fn(),
   };
 }
@@ -122,6 +127,19 @@ function setupScenario(orchestratorv2 = false): ScenarioEnvironment {
   scope.ui = ctx.ui as never;
   scope.sessionManager = ctx.sessionManager;
   return { api, ctx, root, scope };
+}
+
+function fillRoutingCapacity(root: string) {
+  const historical = Array.from(
+    { length: MAX_ORCHESTRATOR_ROUTING_RECORDS },
+    (_, index) => ({
+      childId: index.toString(16).padStart(16, "0"),
+      description: `Historical responsibility ${index}`,
+      updatedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+    }),
+  );
+  saveOrchestratorRoutingEntries(root, historical);
+  return historical;
 }
 
 function makeRuntimeState(
@@ -198,6 +216,16 @@ beforeEach(() => {
     getPaneLivenessAsync: vi.fn().mockResolvedValue("alive"),
   } as never);
   mockSendCommandToPane.mockReturnValue(undefined);
+  mockCancelInteractiveSubagent.mockImplementation(
+    (
+      _id: string,
+      _source: string,
+      state: InteractiveSubagentState | undefined,
+    ) => {
+      if (state) state.status = "cancelled";
+      return state;
+    },
+  );
   mockLaunchInteractiveSubagent.mockImplementation((params: any) => {
     const id = launchIds.shift();
     if (!id) throw new Error("scenario did not reserve a child id");
@@ -260,17 +288,9 @@ describe("Orchestratorv2 thin-router scenarios", () => {
     ]);
   });
 
-  it("recovers a full routing overlay through confirmed removal and update", async () => {
+  it("fails closed and cancels the child when initial routing metadata cannot be persisted", async () => {
     const environment = setupScenario(true);
-    const historical = Array.from(
-      { length: MAX_ORCHESTRATOR_ROUTING_RECORDS },
-      (_, index) => ({
-        childId: index.toString(16).padStart(16, "0"),
-        description: `Historical responsibility ${index}`,
-        updatedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
-      }),
-    );
-    saveOrchestratorRoutingEntries(environment.root, historical);
+    const historical = fillRoutingCapacity(environment.root);
     const routingFile = orchestratorRoutingFilePath(environment.root);
     const beforeSpawn = readFileSync(routingFile, "utf8");
     const spawn = registeredTool(environment.api, "subagent_interactive");
@@ -286,51 +306,106 @@ describe("Orchestratorv2 thin-router scenarios", () => {
       environment.ctx,
     );
 
-    expect(spawned.isError).not.toBe(true);
-    expect(spawned.details.routingMetadata).toMatchObject({
-      status: "warning",
+    expect(spawned.isError).toBe(true);
+    expect(spawned.details).toMatchObject({
+      status: "routing_metadata_error",
+      id: CHILD_A,
       error: expect.stringContaining("routing record count exceeds"),
     });
     expect(readFileSync(routingFile, "utf8")).toBe(beforeSpawn);
     expect(environment.scope.interactiveStates.has(CHILD_A)).toBe(true);
+    expect(environment.scope.interactiveStates.get(CHILD_A)?.status).toBe(
+      "cancelled",
+    );
+    expect(mockCancelInteractiveSubagent).toHaveBeenCalledWith(
+      CHILD_A,
+      "cancel_interactive_subagent",
+      expect.objectContaining({ id: CHILD_A }),
+    );
+    expect(listOrchestratorRoutingEntries(environment.root)).toEqual(
+      historical,
+    );
+  });
 
-    const remove = registeredTool(
-      environment.api,
-      "remove_orchestrator_agent_description",
-    );
-    const removed = await executeTool(
-      remove,
-      { childId: historical[0].childId, confirmed: true },
-      environment.ctx,
-    );
-    expect(removed.details.status).toBe("removed");
+  it("retries transient child cleanup failures after routing metadata persistence fails", async () => {
+    const environment = setupScenario(true);
+    fillRoutingCapacity(environment.root);
+    mockCancelInteractiveSubagent
+      .mockImplementationOnce(
+        (
+          _id: string,
+          _source: string,
+          state: InteractiveSubagentState | undefined,
+        ) => {
+          if (state) state.status = "cancelled";
+          throw new Error("transient pane kill failure");
+        },
+      )
+      .mockImplementationOnce(
+        (
+          _id: string,
+          _source: string,
+          state: InteractiveSubagentState | undefined,
+        ) => {
+          if (state) state.status = "cancelled";
+          return state;
+        },
+      );
+    const spawn = registeredTool(environment.api, "subagent_interactive");
 
-    const update = registeredTool(
-      environment.api,
-      "update_orchestrator_agent_description",
-    );
-    const updated = await executeTool(
-      update,
+    const spawned = await executeTool(
+      spawn,
       {
-        childId: CHILD_A,
-        description: "Own post-capacity work",
-        aliases: ["capacity-recovery"],
-        confirmed: true,
+        task: "Own work after a transient cleanup failure",
+        routingDescription: "Own transient cleanup recovery",
       },
       environment.ctx,
     );
 
-    expect(updated.details.status).toBe("updated");
-    const entries = listOrchestratorRoutingEntries(environment.root);
-    expect(entries).toHaveLength(MAX_ORCHESTRATOR_ROUTING_RECORDS);
-    expect(entries).toContainEqual(
-      expect.objectContaining({
-        childId: CHILD_A,
-        description: "Own post-capacity work",
-        aliases: ["capacity-recovery"],
-      }),
+    expect(mockCancelInteractiveSubagent).toHaveBeenCalledTimes(2);
+    expect(spawned.details).toMatchObject({
+      status: "routing_metadata_error",
+      id: CHILD_A,
+    });
+    expect(environment.scope.interactiveStates.get(CHILD_A)?.status).toBe(
+      "cancelled",
     );
-    expect(entries).not.toContainEqual(historical[0]);
+  });
+
+  it("keeps cleanup failures retryable instead of reporting a live child as cancelled", async () => {
+    const environment = setupScenario(true);
+    fillRoutingCapacity(environment.root);
+    mockCancelInteractiveSubagent.mockImplementation(
+      (
+        _id: string,
+        _source: string,
+        state: InteractiveSubagentState | undefined,
+      ) => {
+        if (state) state.status = "cancelled";
+        throw new Error("pane kill failure");
+      },
+    );
+    const spawn = registeredTool(environment.api, "subagent_interactive");
+
+    const spawned = await executeTool(
+      spawn,
+      {
+        task: "Own work after an unrecoverable cleanup failure",
+        routingDescription: "Own cleanup failure recovery",
+      },
+      environment.ctx,
+    );
+
+    expect(mockCancelInteractiveSubagent).toHaveBeenCalledTimes(2);
+    expect(spawned.details).toMatchObject({
+      status: "routing_metadata_cleanup_error",
+      id: CHILD_A,
+      cleanupError: "pane kill failure",
+    });
+    expect(spawned.content[0].text).toContain("could not be confirmed stopped");
+    expect(environment.scope.interactiveStates.get(CHILD_A)?.status).toBe(
+      "unknown",
+    );
   });
 
   it("lists A and B with current pointers and delegates to the selected child without creating a new one", async () => {

--- a/tests/orchestrator-tools.test.ts
+++ b/tests/orchestrator-tools.test.ts
@@ -99,6 +99,23 @@ function tool(api: ReturnType<typeof mockApi>, name: string): any {
   })?.[0];
 }
 
+function toolContext(root: string, userText?: string) {
+  return {
+    cwd: root,
+    sessionManager: {
+      getBranch: () =>
+        userText === undefined
+          ? []
+          : [
+              {
+                type: "message",
+                message: { role: "user", content: userText },
+              },
+            ],
+    },
+  };
+}
+
 describe("Orchestratorv2 compact agent projection", () => {
   beforeEach(() => {
     __setTmuxMultiplexer({
@@ -259,7 +276,7 @@ describe("Orchestratorv2 metadata tools", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it("registers list, update, and confirmed removal definitions", () => {
+  it("registers list, update, and user-bound confirmation definitions", () => {
     const api = mockApi();
     const scope = startedScope(api, 1, "parent-a");
 
@@ -269,13 +286,15 @@ describe("Orchestratorv2 metadata tools", () => {
     expect(tool(api, "list_orchestrator_agents")).toBeDefined();
     const update = tool(api, "update_orchestrator_agent_description");
     expect(update).toBeDefined();
-    expect(update.parameters.properties.confirmed.const).toBe(true);
+    expect(update.parameters.properties.confirmed.type).toBe("boolean");
+    expect(update.parameters.properties.confirmationToken.type).toBe("string");
     expect(update.parameters.required).toEqual(
       expect.arrayContaining(["childId", "description", "confirmed"]),
     );
     const remove = tool(api, "remove_orchestrator_agent_description");
     expect(remove).toBeDefined();
-    expect(remove.parameters.properties.confirmed.const).toBe(true);
+    expect(remove.parameters.properties.confirmed.type).toBe("boolean");
+    expect(remove.parameters.properties.confirmationToken.type).toBe("string");
     expect(remove.parameters.required).toEqual(["childId", "confirmed"]);
   });
 
@@ -380,7 +399,7 @@ describe("Orchestratorv2 metadata tools", () => {
     });
   });
 
-  it("updates confirmed metadata for a child in the current session scope", async () => {
+  it("updates metadata only after the exact pending token appears in a user message", async () => {
     upsertOrchestratorRoutingEntry(
       root,
       routingEntry(CHILD_A, { aliases: ["old"], provenance: "user" }),
@@ -390,21 +409,47 @@ describe("Orchestratorv2 metadata tools", () => {
     registerState(scope, CHILD_A);
     registerOrchestratorTools(api as never, scope);
 
-    const result = await tool(
-      api,
-      "update_orchestrator_agent_description",
-    ).execute(
+    const update = tool(api, "update_orchestrator_agent_description");
+    const requested = await update.execute(
       "update-1",
       {
         childId: CHILD_A,
         description: "Own the public API and release compatibility",
         aliases: ["api", "release"],
         provenance: "luna",
-        confirmed: true,
+        confirmed: false,
       },
       undefined,
       undefined,
-      { cwd: root },
+      toolContext(root),
+    );
+
+    expect(requested.isError).toBe(true);
+    expect(requested.details).toMatchObject({
+      status: "confirmation_required",
+      action: "update",
+      childId: CHILD_A,
+      confirmationToken: expect.any(String),
+    });
+    expect(listOrchestratorRoutingEntries(root)[0]).toMatchObject({
+      aliases: ["old"],
+      provenance: "user",
+    });
+
+    const confirmationToken = requested.details.confirmationToken;
+    const result = await update.execute(
+      "update-2",
+      {
+        childId: CHILD_A,
+        description: "Own the public API and release compatibility",
+        aliases: ["api", "release"],
+        provenance: "luna",
+        confirmed: true,
+        confirmationToken,
+      },
+      undefined,
+      undefined,
+      toolContext(root, `I confirm ${confirmationToken}`),
     );
 
     expect(result.isError).toBeFalsy();
@@ -428,7 +473,134 @@ describe("Orchestratorv2 metadata tools", () => {
     ]);
   });
 
-  it("removes confirmed metadata without touching the live runtime", async () => {
+  it("rejects model-asserted confirmation without a matching user message", async () => {
+    const api = mockApi();
+    const scope = startedScope(api, 1, "parent-a");
+    registerState(scope, CHILD_A);
+    registerOrchestratorTools(api as never, scope);
+    const update = tool(api, "update_orchestrator_agent_description");
+    const requested = await update.execute(
+      "update-request",
+      {
+        childId: CHILD_A,
+        description: "Own authentication",
+        confirmed: false,
+      },
+      undefined,
+      undefined,
+      toolContext(root),
+    );
+
+    const result = await update.execute(
+      "update-unconfirmed",
+      {
+        childId: CHILD_A,
+        description: "Own authentication",
+        confirmed: true,
+        confirmationToken: requested.details.confirmationToken,
+      },
+      undefined,
+      undefined,
+      toolContext(root, "Yes, make the change"),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.details).toMatchObject({
+      status: "user_confirmation_required",
+      action: "update",
+      childId: CHILD_A,
+    });
+    expect(listOrchestratorRoutingEntries(root)).toEqual([]);
+  });
+
+  it("rejects a token when the confirmed update differs from the pending change", async () => {
+    const api = mockApi();
+    const scope = startedScope(api, 1, "parent-a");
+    registerState(scope, CHILD_A);
+    registerOrchestratorTools(api as never, scope);
+    const update = tool(api, "update_orchestrator_agent_description");
+    const requested = await update.execute(
+      "update-request",
+      {
+        childId: CHILD_A,
+        description: "Own authentication",
+        confirmed: false,
+      },
+      undefined,
+      undefined,
+      toolContext(root),
+    );
+    const confirmationToken = requested.details.confirmationToken;
+
+    const result = await update.execute(
+      "update-mismatch",
+      {
+        childId: CHILD_A,
+        description: "Own checkout instead",
+        confirmed: true,
+        confirmationToken,
+      },
+      undefined,
+      undefined,
+      toolContext(root, `Confirm ${confirmationToken}`),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.details).toMatchObject({
+      status: "confirmation_invalid",
+      action: "update",
+      childId: CHILD_A,
+    });
+    expect(listOrchestratorRoutingEntries(root)).toEqual([]);
+  });
+
+  it("does not evict a valid oldest confirmation while checking a full pending set", async () => {
+    const api = mockApi();
+    const scope = startedScope(api, 1, "parent-a");
+    registerState(scope, CHILD_A);
+    registerOrchestratorTools(api as never, scope);
+    const update = tool(api, "update_orchestrator_agent_description");
+    let oldestToken = "";
+
+    for (let index = 0; index < 32; index++) {
+      const requested = await update.execute(
+        `update-request-${index}`,
+        {
+          childId: CHILD_A,
+          description: `Own responsibility ${index}`,
+          confirmed: false,
+        },
+        undefined,
+        undefined,
+        toolContext(root),
+      );
+      if (index === 0) oldestToken = requested.details.confirmationToken;
+    }
+
+    const result = await update.execute(
+      "update-confirm-oldest",
+      {
+        childId: CHILD_A,
+        description: "Own responsibility 0",
+        confirmed: true,
+        confirmationToken: oldestToken,
+      },
+      undefined,
+      undefined,
+      toolContext(root, `Confirm ${oldestToken}`),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.details).toMatchObject({
+      status: "updated",
+      entry: {
+        childId: CHILD_A,
+        description: "Own responsibility 0",
+      },
+    });
+  });
+
+  it("removes metadata only after user-bound confirmation without touching the live runtime", async () => {
     const original = routingEntry(CHILD_A);
     upsertOrchestratorRoutingEntry(root, original);
     const api = mockApi();
@@ -437,12 +609,30 @@ describe("Orchestratorv2 metadata tools", () => {
     registerOrchestratorTools(api as never, scope);
     const remove = tool(api, "remove_orchestrator_agent_description");
 
+    const requested = await remove.execute(
+      "remove-request",
+      { childId: CHILD_A, confirmed: false },
+      undefined,
+      undefined,
+      toolContext(root),
+    );
+    expect(requested.details).toMatchObject({
+      status: "confirmation_required",
+      action: "remove",
+      childId: CHILD_A,
+      confirmationToken: expect.any(String),
+    });
+
     const result = await remove.execute(
-      "remove-stale",
-      { childId: CHILD_A, confirmed: true },
+      "remove-confirmed",
+      {
+        childId: CHILD_A,
+        confirmed: true,
+        confirmationToken: requested.details.confirmationToken,
+      },
       undefined,
       undefined,
-      { cwd: root },
+      toolContext(root, `Confirm ${requested.details.confirmationToken}`),
     );
 
     expect(result.isError).toBeFalsy();
@@ -460,10 +650,10 @@ describe("Orchestratorv2 metadata tools", () => {
 
     const missing = await remove.execute(
       "remove-missing",
-      { childId: CHILD_A, confirmed: true },
+      { childId: CHILD_A, confirmed: false },
       undefined,
       undefined,
-      { cwd: root },
+      toolContext(root),
     );
     expect(missing.isError).toBe(true);
     expect(missing.details).toEqual({

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -55,6 +55,7 @@ function mockApi(overrides: Record<string, any> = {}) {
     registerCommand: vi.fn(),
     registerShortcut: vi.fn(),
     getFlag: vi.fn().mockReturnValue(false),
+    setActiveTools: vi.fn(),
     on: vi.fn(),
     ...overrides,
   };
@@ -125,6 +126,28 @@ describe("extension registration", () => {
     });
   });
 
+  it("registers only router-safe tools when --orchestratorv2 is enabled", () => {
+    const api = mockApi({
+      getFlag: vi.fn((name: string) => name === "orchestratorv2"),
+    });
+
+    registerExtension(api as any);
+
+    expect(getRegisteredToolNames(api)).toEqual(
+      [...INTERACTIVE_TOOL_NAMES, ...ORCHESTRATOR_TOOL_NAMES].sort(),
+    );
+    expect(getRegisteredToolNames(api)).not.toEqual(
+      expect.arrayContaining(IN_PROCESS_TOOL_NAMES),
+    );
+    expect(getRegisteredToolNames(api)).not.toEqual(
+      expect.arrayContaining(WORKFLOW_TOOL_NAMES),
+    );
+    expect(getRegisteredToolNames(api)).not.toContain("prune_subagent_jobs");
+    expect(api.setActiveTools).toHaveBeenCalledWith(
+      [...INTERACTIVE_TOOL_NAMES, ...ORCHESTRATOR_TOOL_NAMES].sort(),
+    );
+  });
+
   it("appends the bundled prompt when --orchestrator is enabled", async () => {
     const api = mockApi({
       getFlag: vi.fn((name: string) => name === "orchestrator"),
@@ -163,7 +186,12 @@ describe("extension registration", () => {
     expect(result.systemPrompt).not.toContain("# Orchestrator System Prompt");
     expect(result.systemPrompt).toContain("send_interactive_subagent_message");
     expect(result.systemPrompt).toContain("includeContext");
-    expect(result.systemPrompt).toContain("not a security boundary");
+    expect(result.systemPrompt).toContain(
+      "enforces the control-only boundary with an active-tool allowlist",
+    );
+    expect(result.systemPrompt).toContain(
+      "Built-in repository tools, workflows, and in-process worker tools are unavailable",
+    );
     expect(result.systemPrompt).toContain(
       "An exact or continuation match is not routable",
     );

--- a/tests/subagent-interactive-default.test.ts
+++ b/tests/subagent-interactive-default.test.ts
@@ -395,7 +395,7 @@ describe("subagent_interactive tool lifecycle", () => {
     expect(mockUpsertOrchestratorRoutingEntry).not.toHaveBeenCalled();
   });
 
-  it("reports routing persistence failure without pretending the child failed", async () => {
+  it("cancels a spawned child when its routing metadata cannot persist", async () => {
     const toolDef = getInteractiveToolDef(api);
     const state = {
       ...mockInteractiveState(),
@@ -419,23 +419,19 @@ describe("subagent_interactive tool lifecycle", () => {
       mockCtx(),
     );
 
-    expect(result.isError).not.toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.details).toMatchObject({
       id: state.id,
-      status: "started",
-      routingMetadata: {
-        status: "warning",
-        error: "routing record count exceeds 128",
-      },
+      status: "routing_metadata_error",
+      error: "routing record count exceeds 128",
     });
     expect(result.content[0].text).toContain(
-      `Interactive sub-agent ${state.id} started`,
+      `Interactive sub-agent ${state.id} was cancelled`,
     );
-    expect(result.content[0].text).toContain(
-      "Warning: initial routing metadata was not persisted: routing record count exceeds 128",
-    );
-    expect(result.content[0].text).not.toContain(
-      "Failed to start interactive sub-agent",
+    expect(mockCancelInteractiveSubagent).toHaveBeenCalledWith(
+      state.id,
+      "cancel_interactive_subagent",
+      state,
     );
   });
 

--- a/tests/terminal-e2e/fixtures/mock-provider.ts
+++ b/tests/terminal-e2e/fixtures/mock-provider.ts
@@ -157,6 +157,7 @@ const KNOWN_MARKERS = new Set([
   "[E2E:INTERACTIVE_FOLLOWUP_PARENT]",
   "[E2E:INTERACTIVE_CANCEL_PARENT]",
   "[E2E:INTERACTIVE_ERROR_PARENT]",
+  "[E2E:ORCHESTRATOR_BOUNDARY]",
   "[E2E:CANCEL]",
   "[E2E:ERROR]",
   "[E2E:CHILD_SMOKE]",
@@ -464,6 +465,52 @@ async function runRequest(
   let state: State = previous ?? { stage: "initial", requestSeq: 0 };
   if (state.stage === "complete" && !marker.includes("WORKFLOW_ASYNC")) {
     throw new Error(`duplicate request for completed marker ${marker}`);
+  }
+  if (marker === "[E2E:ORCHESTRATOR_BOUNDARY]") {
+    const tools = context.tools?.map((tool) => tool.name).sort() ?? [];
+    if (state.stage === "initial") {
+      const call = toolCall(
+        "e2e-orchestrator-list-1",
+        "list_orchestrator_agents",
+        {},
+      );
+      const final = message([call], "toolUse");
+      states.set(marker, {
+        stage: "toolIssued",
+        requestSeq,
+        toolCallId: call.id,
+      });
+      emit(stream, toolEvents(final), final);
+      return;
+    }
+    if (!toolResultId || toolResultId !== state.toolCallId) {
+      throw new Error(
+        `invalid Orchestratorv2 transition: expected tool result ${state.toolCallId ?? "none"}`,
+      );
+    }
+    const routingResult = toolResultText(context, "list_orchestrator_agents");
+    const final = message([
+      {
+        type: "text",
+        text: `Orchestrator active tools: ${tools.join(", ")}. Routing registry checked.`,
+      },
+    ]);
+    states.set(marker, { stage: "complete", requestSeq });
+    emit(stream, textEvents(final), final);
+    diagnostic({
+      marker,
+      requestSeq,
+      afterStage: "complete",
+      eventType: "done",
+      contextHasOrchestratorV2Prompt:
+        context.systemPrompt?.includes(
+          "# Orchestratorv2 Thin Router System Prompt",
+        ) ?? false,
+      routingListObserved:
+        routingResult.includes('"routingMetadataStatus":"missing"') &&
+        routingResult.includes('"agents":[]'),
+    });
+    return;
   }
   if (
     marker === "[E2E:ERROR]" ||


### PR DESCRIPTION
## Summary

- enforce a runtime Orchestratorv2 active-tool allowlist so the parent remains a router instead of a worker
- require server-issued, user-bound confirmation tokens for routing metadata updates and removals
- fail closed when initial routing metadata persistence fails, including retryable pane cleanup handling
- add real Pi CLI integration coverage for the provider-visible tool boundary and public registry interface
- document the findings, scope, follow-up review, and verification in `task.md`

## Scope

Finding 2 from the verification is intentionally unchanged. Follow-up routing remains model-directed at this stage.

## Verification

- `npm run typecheck`
- `npm test` with 1,545 tests across 69 files
- `npm run format:check`
- `npm run pack:check`
- real Pi CLI integration exercising `--orchestratorv2=true`
- focused reviewer re-validation after follow-up fixes
