### PR TITLE
fix: reduce high-concurrency input lag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y tmux
 
+      # Pi 0.80.6 uses fd and ripgrep to discover the explicitly loaded
+      # resources shown in the terminal startup screen. The harness asserts
+      # that both the fixture provider and extension were loaded.
+      - name: Install terminal E2E search tools
+        if: matrix.pi-version == '0.80.6'
+        run: |
+          sudo apt-get install -y fd-find ripgrep
+          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+          fd --version
+          rg --version
+
       # zellij is not in apt, so pull the prebuilt musl binary from the release
       # the backend is verified against. Without a real zellij on PATH the whole
       # zellij suite is mocked, which is exactly how a `dump-screen` argv that

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -21,11 +21,12 @@ import {
   isCompletionEvent,
   readEventBatch,
   removeInteractiveState,
-  updateInteractiveState,
+  updateInteractiveStates,
   type CompletionEvent,
   type CompletionOutcome,
   type SubagentArtifact,
   type SubagentEvent,
+  type InteractiveSubagentPersistedStateV2,
 } from "./artifact";
 import {
   deriveInteractiveSubagentStatusFromLifecycle,
@@ -370,6 +371,40 @@ function pollOwnerKey(owner: SessionOwnerToken | undefined): string {
   return owner ? `${owner.id}:${owner.generation}` : "unscoped";
 }
 
+function persistPolledState(
+  state: InteractiveSubagentState,
+  entry: InteractiveSubagentPersistedStateV2,
+): void {
+  entry.eventByteCursor = state.eventByteCursor ?? 0;
+  entry.sessionByteCursor =
+    state.sessionObservedByteCursor ?? state.lastDeliveredSessionByte ?? 0;
+  entry.sessionPartialLineStart = state.sessionPartialLineStart ?? null;
+  entry.activeTurnId = state.activeTurnId;
+  entry.pendingDeliveries = state.pendingDeliveries ?? [];
+  entry.deliveryReceipts = state.deliveryReceipts ?? [];
+  entry.lifecycle = state.lifecycle;
+}
+
+function persistPolledStates(
+  states: readonly InteractiveSubagentState[],
+): void {
+  const statesByCwd = new Map<string, InteractiveSubagentState[]>();
+  for (const state of states) {
+    const grouped = statesByCwd.get(state.cwd) ?? [];
+    grouped.push(state);
+    statesByCwd.set(state.cwd, grouped);
+  }
+  for (const [cwd, grouped] of statesByCwd) {
+    updateInteractiveStates(
+      cwd,
+      grouped.map((state) => ({
+        id: state.id,
+        update: (entry) => persistPolledState(state, entry),
+      })),
+    );
+  }
+}
+
 /**
  * Poll the artifact directory of every running interactive sub-agent and fire a
  * pointer-only notification for any new events that match the spawner's cadence.
@@ -446,6 +481,7 @@ async function runPollArtifactChanges(
     const ui =
       ownerContext?.ui ??
       (g2.__piSubagenturaUi as ExtensionUIContext | undefined);
+    const persistedStates: InteractiveSubagentState[] = [];
     for (const [state, paneLiveness] of liveness) {
       if (stateMap.get(state.id) !== state) continue;
       // Cancelled is terminal. Unknown means pane liveness is unavailable, so keep polling
@@ -485,24 +521,28 @@ async function runPollArtifactChanges(
           (ev as unknown as { eventId?: string }).eventId ??
           `legacy-${record.startOffset}`;
         const status = deliveryStatusFromEvent(ev);
-        enqueueDelivery(state, {
-          deliveryId: deliveryIdFor({
-            parentSessionId: state.parentSessionId ?? "pi",
+        enqueueDelivery(
+          state,
+          {
+            deliveryId: deliveryIdFor({
+              parentSessionId: state.parentSessionId ?? "pi",
+              subagentId: state.id,
+              turnId,
+              mode,
+            }),
             subagentId: state.id,
             turnId,
+            eventId,
             mode,
-          }),
-          subagentId: state.id,
-          turnId,
-          eventId,
-          mode,
-          triggerTurn,
-          status,
-          artifactDir: state.artifactDir,
-          output: v2?.output,
-          message: deliveryMessageFromEvent(ev),
-          state: "queued",
-        });
+            triggerTurn,
+            status,
+            artifactDir: state.artifactDir,
+            output: v2?.output,
+            message: deliveryMessageFromEvent(ev),
+            state: "queued",
+          },
+          { persist: false },
+        );
       }
       for (const issue of batch.issues) {
         if (state.completionOwner === "workflow") continue;
@@ -512,29 +552,27 @@ async function runPollArtifactChanges(
             ? state.triggerTurnOnComplete !== false
             : state.triggerTurnOnComplete === true;
         const identity = `record-overflow-${issue.startOffset}`;
-        enqueueDelivery(state, {
-          deliveryId: deliveryIdFor({
-            parentSessionId: state.parentSessionId ?? "pi",
+        enqueueDelivery(
+          state,
+          {
+            deliveryId: deliveryIdFor({
+              parentSessionId: state.parentSessionId ?? "pi",
+              subagentId: state.id,
+              turnId: identity,
+              mode,
+            }),
             subagentId: state.id,
             turnId: identity,
+            eventId: identity,
             mode,
-          }),
-          subagentId: state.id,
-          turnId: identity,
-          eventId: identity,
-          mode,
-          triggerTurn,
-          status: "error",
-          artifactDir: state.artifactDir,
-          message: `Artifact record at byte ${issue.startOffset} exceeded the ${issue.maxBytes}-byte limit and was skipped.`,
-          state: "queued",
-        });
-      }
-      if (batch.issues.length > 0 && state.parentSessionId) {
-        updateInteractiveState(state.cwd, state.id, (entry) => {
-          entry.pendingDeliveries = state.pendingDeliveries ?? [];
-          entry.deliveryReceipts = state.deliveryReceipts ?? [];
-        });
+            triggerTurn,
+            status: "error",
+            artifactDir: state.artifactDir,
+            message: `Artifact record at byte ${issue.startOffset} exceeded the ${issue.maxBytes}-byte limit and was skipped.`,
+            state: "queued",
+          },
+          { persist: false },
+        );
       }
       nextCursor = batch.endOffset;
       state.eventByteCursor = nextCursor;
@@ -550,21 +588,11 @@ async function runPollArtifactChanges(
           state.exitCode = lifecycle.completionExitCode;
         }
       }
-      if (state.parentSessionId) {
-        updateInteractiveState(state.cwd, state.id, (entry) => {
-          entry.eventByteCursor = nextCursor;
-          entry.sessionByteCursor =
-            state.sessionObservedByteCursor ??
-            state.lastDeliveredSessionByte ??
-            0;
-          entry.sessionPartialLineStart = state.sessionPartialLineStart ?? null;
-          entry.activeTurnId = state.activeTurnId;
-          entry.pendingDeliveries = state.pendingDeliveries ?? [];
-          entry.deliveryReceipts = state.deliveryReceipts ?? [];
-          entry.lifecycle = state.lifecycle;
-        });
-      }
+      if (state.parentSessionId) persistedStates.push(state);
     }
+    // Queue state and its advanced byte cursor reach disk atomically. A crash
+    // before this write replays the old cursor; deterministic delivery ids dedupe it.
+    persistPolledStates(persistedStates);
     // One clock for both widgets so their coarse elapsed buckets stay aligned.
     const now = Date.now();
     const widgetRows = projectActivityWidgetRows(ui, owner, now);

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -1943,18 +1943,37 @@ export function appendInteractiveState(
   });
 }
 
+export interface InteractiveStateUpdate {
+  id: string;
+  update: (entry: InteractiveSubagentPersistedStateV2) => void;
+}
+
+/** Apply multiple state mutations under one lock and publish one atomic file. */
+export function updateInteractiveStates(
+  cwd: string,
+  updates: readonly InteractiveStateUpdate[],
+): void {
+  if (updates.length === 0) return;
+  withInteractiveStateLock(cwd, () => {
+    const current = loadInteractiveStates(cwd);
+    if (!current) return;
+    let changed = false;
+    for (const update of updates) {
+      const entry = current.states[update.id];
+      if (!entry) continue;
+      update.update(entry);
+      changed = true;
+    }
+    if (changed) writeInteractiveStatesUnlocked(cwd, current);
+  });
+}
+
 export function updateInteractiveState(
   cwd: string,
   id: string,
   update: (entry: InteractiveSubagentPersistedStateV2) => void,
 ): void {
-  withInteractiveStateLock(cwd, () => {
-    const current = loadInteractiveStates(cwd);
-    const entry = current?.states[id];
-    if (!current || !entry) return;
-    update(entry);
-    writeInteractiveStatesUnlocked(cwd, current);
-  });
+  updateInteractiveStates(cwd, [{ id, update }]);
 }
 /**
  * Convenience: load + drop entry by id + save. No-op if absent or file missing.

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -17,8 +17,9 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import {
   MAX_DELIVERY_RECEIPTS,
-  updateInteractiveState,
+  updateInteractiveStates,
   type PersistedDeliveryIntent,
+  type InteractiveSubagentPersistedStateV2,
 } from "./artifact";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 import { notifyCompletionDelivery, sanitizeOutput } from "./notifications";
@@ -134,19 +135,42 @@ export function deliveryIdFor(params: {
     .slice(0, 32);
 }
 
+function copyDeliveryState(
+  state: InteractiveSubagentState,
+  entry: InteractiveSubagentPersistedStateV2,
+): void {
+  entry.eventByteCursor = state.eventByteCursor ?? 0;
+  entry.sessionByteCursor =
+    state.sessionObservedByteCursor ?? state.lastDeliveredSessionByte ?? 0;
+  entry.sessionPartialLineStart = state.sessionPartialLineStart ?? null;
+  entry.activeTurnId = state.activeTurnId;
+  entry.pendingDeliveries = state.pendingDeliveries ?? [];
+  entry.deliveryReceipts = state.deliveryReceipts ?? [];
+  entry.lifecycle = state.lifecycle;
+}
+
+function persistStates(states: readonly InteractiveSubagentState[]): void {
+  const statesByCwd = new Map<string, Map<string, InteractiveSubagentState>>();
+  for (const state of states) {
+    compactDeliveryReceipts(state);
+    if (!state.parentSessionId) continue;
+    const grouped = statesByCwd.get(state.cwd) ?? new Map();
+    grouped.set(state.id, state);
+    statesByCwd.set(state.cwd, grouped);
+  }
+  for (const [cwd, grouped] of statesByCwd) {
+    updateInteractiveStates(
+      cwd,
+      [...grouped.values()].map((state) => ({
+        id: state.id,
+        update: (entry) => copyDeliveryState(state, entry),
+      })),
+    );
+  }
+}
+
 function persistState(state: InteractiveSubagentState): void {
-  compactDeliveryReceipts(state);
-  if (!state.parentSessionId) return;
-  updateInteractiveState(state.cwd, state.id, (entry) => {
-    entry.eventByteCursor = state.eventByteCursor ?? 0;
-    entry.sessionByteCursor =
-      state.sessionObservedByteCursor ?? state.lastDeliveredSessionByte ?? 0;
-    entry.sessionPartialLineStart = state.sessionPartialLineStart ?? null;
-    entry.activeTurnId = state.activeTurnId;
-    entry.pendingDeliveries = state.pendingDeliveries ?? [];
-    entry.deliveryReceipts = state.deliveryReceipts ?? [];
-    entry.lifecycle = state.lifecycle;
-  });
+  persistStates([state]);
 }
 
 function queueBytes(queue: PersistedDeliveryIntent[]): number {
@@ -229,6 +253,7 @@ function collapseOldestIntent(state: InteractiveSubagentState): void {
 export function enqueueDelivery(
   state: InteractiveSubagentState,
   intent: PersistedDeliveryIntent,
+  options: { persist?: boolean } = {},
 ): void {
   if (typeof intent.message !== "string") {
     intent.message = undefined;
@@ -256,7 +281,7 @@ export function enqueueDelivery(
   ) {
     collapseOldestIntent(state);
   }
-  persistState(state);
+  if (options.persist !== false) persistState(state);
 }
 
 /** Mark a completion as handled by the parent tool without sending it to LLM context. */
@@ -418,10 +443,8 @@ export function flushDeliveries(
       status: intent.status,
     })),
   );
-  for (const { state, intent } of selected) {
-    intent.state = "dispatchAttempted";
-    persistState(state);
-  }
+  for (const { intent } of selected) intent.state = "dispatchAttempted";
+  persistStates(selected.map(({ state }) => state));
   reconcileAllDeliveryReceipts(owner);
 }
 
@@ -442,11 +465,11 @@ function deliveryIdsFromEntry(entry: unknown): unknown[] | undefined {
   return Array.isArray(ids) ? ids : undefined;
 }
 
-export function reconcileDeliveryReceipts(
+function reconcileDeliveryReceiptsInMemory(
   state: InteractiveSubagentState,
   entries: unknown[],
   owner?: SessionOwnerToken,
-): void {
+): boolean {
   compactDeliveryReceipts(state);
   const seen = new Set<string>();
   for (const entry of entries) {
@@ -471,9 +494,18 @@ export function reconcileDeliveryReceipts(
   state.pendingDeliveries = (state.pendingDeliveries ?? []).filter(
     (intent) => !seen.has(intent.deliveryId),
   );
-  if (!changed) return;
-  compactDeliveryReceipts(state);
-  persistState(state);
+  if (changed) compactDeliveryReceipts(state);
+  return changed;
+}
+
+export function reconcileDeliveryReceipts(
+  state: InteractiveSubagentState,
+  entries: unknown[],
+  owner?: SessionOwnerToken,
+): void {
+  if (reconcileDeliveryReceiptsInMemory(state, entries, owner)) {
+    persistState(state);
+  }
 }
 
 export function reconcileAllDeliveryReceipts(owner?: SessionOwnerToken): void {
@@ -481,8 +513,12 @@ export function reconcileAllDeliveryReceipts(owner?: SessionOwnerToken): void {
     ? resolveLiveSessionScope(owner)?.sessionManager?.getEntries?.()
     : deliveryGlobals().__piSubagenturaSessionManager?.getEntries?.();
   if (!Array.isArray(entries)) return;
+  const changedStates: InteractiveSubagentState[] = [];
   for (const state of interactiveStatesForOwner(owner)) {
     if (!interactiveStateBelongsToOwner(state, owner)) continue;
-    reconcileDeliveryReceipts(state, entries, owner);
+    if (reconcileDeliveryReceiptsInMemory(state, entries, owner)) {
+      changedStates.push(state);
+    }
   }
+  persistStates(changedStates);
 }

--- a/src/multiplexer-tmux.ts
+++ b/src/multiplexer-tmux.ts
@@ -106,12 +106,19 @@ function parsePaneListing(output: string): ReadonlySet<string> {
   return new Set(paneIds);
 }
 
+const PANE_LIVENESS_CACHE_MS = 500;
+
 export class TmuxMultiplexer implements Multiplexer {
   readonly name = "tmux" as const;
   readonly capabilities = MUX_CAPABILITIES.tmux;
 
   /** Shared detached session used when the parent is outside tmux. */
   private detachedSessionName?: string;
+  private paneListingInFlight?: Promise<ReadonlySet<string> | undefined>;
+  private paneListingCache?: {
+    at: number;
+    panes: ReadonlySet<string> | undefined;
+  };
 
   /**
    * True iff the `tmux` binary is on PATH. Does NOT require the parent
@@ -356,9 +363,13 @@ export class TmuxMultiplexer implements Multiplexer {
     }
   }
 
-  getPaneLivenessAsync(paneId: string): Promise<PaneLiveness> {
-    if (!/^%\d+$/.test(paneId)) return Promise.resolve("unknown");
-    return new Promise((resolve) => {
+  private listPanesAsync(): Promise<ReadonlySet<string> | undefined> {
+    const cached = this.paneListingCache;
+    if (cached && Date.now() - cached.at < PANE_LIVENESS_CACHE_MS) {
+      return Promise.resolve(cached.panes);
+    }
+    if (this.paneListingInFlight) return this.paneListingInFlight;
+    const request = new Promise<ReadonlySet<string> | undefined>((resolve) => {
       try {
         execFile(
           "tmux",
@@ -366,20 +377,34 @@ export class TmuxMultiplexer implements Multiplexer {
           { encoding: "utf8", timeout: 5000 },
           (error, stdout) => {
             if (error) {
-              resolve("unknown");
+              resolve(undefined);
               return;
             }
             try {
-              resolve(parsePaneListing(stdout).has(paneId) ? "alive" : "dead");
+              resolve(parsePaneListing(stdout));
             } catch {
-              resolve("unknown");
+              resolve(undefined);
             }
           },
         );
       } catch {
-        resolve("unknown");
+        resolve(undefined);
       }
     });
+    this.paneListingInFlight = request;
+    void request.then((panes) => {
+      this.paneListingCache = { at: Date.now(), panes };
+      if (this.paneListingInFlight === request) {
+        this.paneListingInFlight = undefined;
+      }
+    });
+    return request;
+  }
+
+  async getPaneLivenessAsync(paneId: string): Promise<PaneLiveness> {
+    if (!/^%\d+$/.test(paneId)) return "unknown";
+    const panes = await this.listPanesAsync();
+    return panes ? (panes.has(paneId) ? "alive" : "dead") : "unknown";
   }
 
   sendKeys(paneId: string, text: string): void {

--- a/src/multiplexer-zellij.ts
+++ b/src/multiplexer-zellij.ts
@@ -144,9 +144,21 @@ class BoundedByteTail {
   }
 }
 
+const PANE_LIVENESS_CACHE_MS = 500;
+
+interface ZellijPaneListingProbe {
+  cachedAt?: number;
+  panes?: readonly ZellijPaneRow[];
+  inFlight?: Promise<readonly ZellijPaneRow[] | undefined>;
+}
+
 export class ZellijMultiplexer implements Multiplexer {
   readonly name = "zellij" as const;
   readonly capabilities = MUX_CAPABILITIES.zellij;
+  private readonly paneListingProbes = new Map<
+    string,
+    ZellijPaneListingProbe
+  >();
 
   /**
    * True iff `zellij` is on PATH. Binary-only — symmetric with
@@ -401,40 +413,63 @@ export class ZellijMultiplexer implements Multiplexer {
     }
   }
 
-  getPaneLivenessAsync(
+  private listPanesAsync(
+    session?: string,
+  ): Promise<readonly ZellijPaneRow[] | undefined> {
+    const key = session ?? "";
+    const probe = this.paneListingProbes.get(key) ?? {};
+    this.paneListingProbes.set(key, probe);
+    if (
+      probe.cachedAt !== undefined &&
+      Date.now() - probe.cachedAt < PANE_LIVENESS_CACHE_MS
+    ) {
+      return Promise.resolve(probe.panes);
+    }
+    if (probe.inFlight) return probe.inFlight;
+    const request = new Promise<readonly ZellijPaneRow[] | undefined>(
+      (resolve) => {
+        try {
+          execFile(
+            "zellij",
+            [...this.sessionFlag(session), "action", "list-panes", "--json"],
+            { encoding: "utf8", timeout: 5000 },
+            (error, stdout) => {
+              if (error) {
+                resolve(undefined);
+                return;
+              }
+              try {
+                resolve(parsePaneListing(stdout));
+              } catch {
+                resolve(undefined);
+              }
+            },
+          );
+        } catch {
+          resolve(undefined);
+        }
+      },
+    );
+    probe.inFlight = request;
+    void request.then((panes) => {
+      probe.cachedAt = Date.now();
+      probe.panes = panes;
+      if (probe.inFlight === request) probe.inFlight = undefined;
+    });
+    return request;
+  }
+
+  async getPaneLivenessAsync(
     paneId: string,
     session?: string,
   ): Promise<PaneLiveness> {
     const target = normalizePaneId(paneId);
-    if (!/^\d+$/.test(target)) return Promise.resolve("unknown");
-    return new Promise((resolve) => {
-      try {
-        execFile(
-          "zellij",
-          [...this.sessionFlag(session), "action", "list-panes", "--json"],
-          { encoding: "utf8", timeout: 5000 },
-          (error, stdout) => {
-            if (error) {
-              resolve("unknown");
-              return;
-            }
-            try {
-              resolve(
-                parsePaneListing(stdout).some((pane) =>
-                  this.paneRowMatches(pane, target),
-                )
-                  ? "alive"
-                  : "dead",
-              );
-            } catch {
-              resolve("unknown");
-            }
-          },
-        );
-      } catch {
-        resolve("unknown");
-      }
-    });
+    if (!/^\d+$/.test(target)) return "unknown";
+    const panes = await this.listPanesAsync(session);
+    if (!panes) return "unknown";
+    return panes.some((pane) => this.paneRowMatches(pane, target))
+      ? "alive"
+      : "dead";
   }
 
   /**

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -19,7 +19,7 @@ export const MAX_WORKFLOW_DEPTH = 1; // workflow() composition is one level deep
 export const INTERACTIVE_POLL_MS = 1000;
 export const INTERACTIVE_DEAD_GRACE_TICKS = 3;
 export const WORKFLOW_SYNC_TIMEOUT_MS = 30_000;
-export const WORKFLOW_WALL_TIMEOUT_MS = 30 * 60_000;
+export const WORKFLOW_WALL_TIMEOUT_MS = 100 * 60 * 60_000;
 
 export function defaultConcurrency(): number {
   const n = cpus()?.length ?? 4;
@@ -455,7 +455,7 @@ export interface RunWorkflowOptions {
   processConcurrency?: number;
   /** Resolve a saved workflow script by name, for `workflow(name, args)` composition. */
   loadWorkflow?: (name: string) => string | null;
-  /** Hard wall-clock cap for the workflow VM worker. Defaults to 30 minutes. */
+  /** Hard wall-clock cap for the workflow VM worker. Defaults to 100 hours. */
   workflowTimeoutMs?: number;
 }
 

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -3,10 +3,12 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   assertNever,
+  eventLogEndOffset,
   isTurnTerminal,
-  readEvents,
+  readEventBatch,
   readOutput,
   readOutputForTurnId,
+  type SubagentArtifact,
   type SubagentEvent,
   type TurnTerminalEvent,
 } from "./artifact";
@@ -45,7 +47,7 @@ import {
 import { workflowStringify } from "./workflow-script";
 import {
   cancelInteractiveSubagent,
-  isPaneAlive,
+  isPaneAliveAsync,
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
@@ -736,32 +738,52 @@ function parseUsageFromSessionFile(sessionFile: string | undefined): Usage {
   }
 }
 
-function findCurrentTurnTerminal(
-  events: SubagentEvent[],
+interface InteractiveResultEventCursor {
+  byteOffset: number;
+  activeTurnId?: string;
+  sawTurnStart: boolean;
+  terminal: TurnTerminalEvent | null;
+}
+
+function foldInteractiveResultEvent(
+  cursor: InteractiveResultEventCursor,
+  event: SubagentEvent,
+): void {
+  if (event.type === "turn_started") {
+    cursor.sawTurnStart = true;
+    cursor.activeTurnId = event.turnId;
+    cursor.terminal = null;
+    return;
+  }
+  if (cursor.sawTurnStart) {
+    if (event.type === "completion" && event.turnId === cursor.activeTurnId) {
+      cursor.terminal = event;
+    }
+    return;
+  }
+  if (isTurnTerminal(event)) cursor.terminal = event;
+}
+
+function readCurrentTurnTerminal(
+  art: SubagentArtifact,
+  cursor: InteractiveResultEventCursor,
 ): TurnTerminalEvent | null {
-  let latestTurnStart = -1;
-  let latestTurnId: string | undefined;
-  for (let index = 0; index < events.length; index++) {
-    const event = events[index];
-    if (event.type === "turn_started") {
-      latestTurnStart = index;
-      latestTurnId = event.turnId;
+  if (eventLogEndOffset(art) < cursor.byteOffset) {
+    cursor.byteOffset = 0;
+    cursor.activeTurnId = undefined;
+    cursor.sawTurnStart = false;
+    cursor.terminal = null;
+  }
+  for (;;) {
+    const batch = readEventBatch(art, cursor.byteOffset);
+    for (const record of batch.records) {
+      foldInteractiveResultEvent(cursor, record.event);
     }
+    if (batch.endOffset <= cursor.byteOffset) break;
+    cursor.byteOffset = batch.endOffset;
+    if (cursor.byteOffset >= eventLogEndOffset(art)) break;
   }
-  if (latestTurnStart >= 0) {
-    for (let index = events.length - 1; index > latestTurnStart; index--) {
-      const event = events[index];
-      if (event.type === "completion" && event.turnId === latestTurnId) {
-        return event;
-      }
-    }
-    return null;
-  }
-  for (let index = events.length - 1; index >= 0; index--) {
-    const event = events[index];
-    if (isTurnTerminal(event)) return event;
-  }
-  return null;
+  return cursor.terminal;
 }
 
 /**
@@ -776,7 +798,13 @@ export async function awaitInteractiveResult(
 ): Promise<SubagentResult> {
   const art = artifactFor(state);
   let deadTicks = 0;
+  const eventCursor: InteractiveResultEventCursor = {
+    byteOffset: 0,
+    sawTurnStart: false,
+    terminal: null,
+  };
   for (;;) {
+    let terminal: TurnTerminalEvent | null;
     if (signal?.aborted) {
       try {
         const cancelled = cancelInteractiveSubagent(
@@ -798,8 +826,7 @@ export async function awaitInteractiveResult(
         errorMessage: "aborted",
       };
     }
-    const events = readEvents(art);
-    const terminal = findCurrentTurnTerminal(events);
+    terminal = readCurrentTurnTerminal(art, eventCursor);
     if (terminal) {
       const usage = parseUsageFromSessionFile(state.sessionFile);
       switch (terminal.type) {
@@ -851,7 +878,7 @@ export async function awaitInteractiveResult(
     // No terminal event yet — if the pane has died, give it a few grace ticks for a final flush.
     let alive = true;
     try {
-      alive = isPaneAlive(state);
+      alive = await isPaneAliveAsync(state);
     } catch {
       alive = false;
     }

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -46,6 +46,7 @@ import {
   stateFilePath,
   writeOutput,
   withInteractiveStateLock,
+  updateInteractiveStates,
   type InteractiveSubagentPersistedStateV2,
   type SubagentEvent,
 } from "../src/artifact";
@@ -1129,6 +1130,35 @@ describe("persisted interactive state helpers", () => {
     appendInteractiveState(root, updated);
 
     expect(loadInteractiveStates(root)?.states["abc12345"]?.paneId).toBe("%99");
+  });
+
+  it("updates multiple interactive states in one batch", () => {
+    appendInteractiveState(root, SAMPLE);
+    appendInteractiveState(root, {
+      ...SAMPLE,
+      id: "def67890",
+      artifactDir: "/tmp/artifacts/def67890",
+    });
+
+    updateInteractiveStates(root, [
+      {
+        id: SAMPLE.id,
+        update: (entry) => {
+          entry.eventByteCursor = 10;
+        },
+      },
+      {
+        id: "def67890",
+        update: (entry) => {
+          entry.eventByteCursor = 20;
+        },
+      },
+      { id: "missing", update: () => expect.unreachable() },
+    ]);
+
+    const states = loadInteractiveStates(root)?.states;
+    expect(states?.[SAMPLE.id].eventByteCursor).toBe(10);
+    expect(states?.def67890.eventByteCursor).toBe(20);
   });
 
   it("preserves updates from concurrent parents using the same cwd", () => {

--- a/tests/multiplexer-tmux.test.ts
+++ b/tests/multiplexer-tmux.test.ts
@@ -620,6 +620,36 @@ describe("multiplexer-tmux", () => {
     ).resolves.toBe("alive");
   });
 
+  it("coalesces concurrent async pane liveness probes", async () => {
+    vi.resetModules();
+    const execFile = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) => setTimeout(() => callback(null, "%1\n%2\n"), 0),
+    );
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(),
+      execFile,
+    }));
+    const { TmuxMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-tmux")
+    >("../src/multiplexer-tmux");
+    const mux = new TmuxMultiplexer();
+
+    await expect(
+      Promise.all([
+        mux.getPaneLivenessAsync("%1"),
+        mux.getPaneLivenessAsync("%2"),
+        mux.getPaneLivenessAsync("%3"),
+      ]),
+    ).resolves.toEqual(["alive", "alive", "dead"]);
+    await expect(mux.getPaneLivenessAsync("%1")).resolves.toBe("alive");
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
   it("treats a successful blank listing as dead", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", () => ({

--- a/tests/multiplexer-zellij.test.ts
+++ b/tests/multiplexer-zellij.test.ts
@@ -406,6 +406,43 @@ describe("multiplexer-zellij", () => {
     ).resolves.toBe("alive");
   });
 
+  it("coalesces concurrent async probes within one zellij session", async () => {
+    vi.resetModules();
+    const execFile = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        _options: object,
+        callback: (error: Error | null, stdout: string) => void,
+      ) =>
+        setTimeout(
+          () => callback(null, JSON.stringify([{ id: 1 }, { id: 2 }])),
+          0,
+        ),
+    );
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(),
+      execFile,
+      spawn: vi.fn(),
+    }));
+    const { ZellijMultiplexer } = await importFresh<
+      typeof import("../src/multiplexer-zellij")
+    >("../src/multiplexer-zellij");
+    const mux = new ZellijMultiplexer();
+
+    await expect(
+      Promise.all([
+        mux.getPaneLivenessAsync("1", "shared"),
+        mux.getPaneLivenessAsync("2", "shared"),
+        mux.getPaneLivenessAsync("3", "shared"),
+      ]),
+    ).resolves.toEqual(["alive", "alive", "dead"]);
+    await expect(mux.getPaneLivenessAsync("1", "shared")).resolves.toBe(
+      "alive",
+    );
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
   /* ------------------------------------------------------------------ */
   /*  sendKeys + sendEnter                                               */
   /* ------------------------------------------------------------------ */

--- a/tests/performance-regression.test.ts
+++ b/tests/performance-regression.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { appendInteractiveState } from "../src/artifact";
+import {
+  interactiveSubagentRegistry,
+  type InteractiveSubagentState,
+} from "../src/interactive-tmux";
+import { __setTmuxMultiplexer } from "../src/multiplexer";
+import { pollArtifactChanges } from "../src/artifact-poller";
+import { clearSessionScopes, registerSessionScope } from "../src/session-scope";
+import { awaitInteractiveResult } from "../src/workflow-worker";
+
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+function interactiveState(
+  id: string,
+  cwd: string,
+  parentSessionId?: string,
+): InteractiveSubagentState {
+  const artifactDir = join(cwd, id);
+  mkdirSync(artifactDir, { recursive: true });
+  return {
+    id,
+    name: id,
+    task: "performance regression",
+    paneId: `%${id.replace(/\D/g, "") || "1"}`,
+    mux: "tmux",
+    sessionFile: join(artifactDir, "session.jsonl"),
+    cwd,
+    startedAt: Date.now(),
+    status: "running",
+    attachCommand: "tmux attach -t test",
+    selectPaneCommand: "tmux select-pane -t test",
+    launchScriptFile: join(artifactDir, "launch.sh"),
+    artifactDir,
+    parentSessionId,
+  };
+}
+
+afterEach(() => {
+  __setTmuxMultiplexer(undefined);
+  interactiveSubagentRegistry.clear();
+  clearSessionScopes();
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("high-concurrency input latency regressions", () => {
+  it("does not block the parent event loop on workflow pane liveness", async () => {
+    const cwd = temporaryDirectory("subagentura-workflow-latency-");
+    const state = interactiveState("agent-1", cwd);
+    const eventsFile = join(state.artifactDir, "events.ndjson");
+    writeFileSync(
+      eventsFile,
+      `${JSON.stringify({ ts: 1, type: "started", status: "running" })}\n`,
+    );
+    const synchronousProbe = vi.fn(() => {
+      const deadline = performance.now() + 250;
+      while (performance.now() < deadline) {
+        // Model a slow synchronous tmux/zellij subprocess on Pi's main thread.
+      }
+      return "alive" as const;
+    });
+    const asynchronousProbe = vi.fn(async () => "alive" as const);
+    __setTmuxMultiplexer({
+      getPaneLiveness: synchronousProbe,
+      getPaneLivenessAsync: asynchronousProbe,
+    } as never);
+
+    const startedAt = performance.now();
+    let inputDelayMs = Number.POSITIVE_INFINITY;
+    setTimeout(() => {
+      inputDelayMs = performance.now() - startedAt;
+      appendFileSync(
+        eventsFile,
+        `${JSON.stringify({ ts: 2, type: "done", status: "done", exitCode: 0 })}\n`,
+      );
+    }, 0);
+
+    await awaitInteractiveResult(state, undefined, 1);
+
+    expect(inputDelayMs).toBeLessThan(125);
+    expect(synchronousProbe).not.toHaveBeenCalled();
+    expect(asynchronousProbe).toHaveBeenCalled();
+  });
+
+  it("persists a 200-subagent poll without quadratic input delay", async () => {
+    const cwd = temporaryDirectory("subagentura-poller-latency-");
+    const owner = { id: 901, generation: 1 };
+    const pi = { sendMessage: vi.fn() };
+    const scope = registerSessionScope({ ...owner, pi: pi as never });
+    const parentSessionId = "performance-parent";
+    const count = 200;
+
+    for (let index = 0; index < count; index++) {
+      const state = interactiveState(
+        `agent-${index + 1}`,
+        cwd,
+        parentSessionId,
+      );
+      appendInteractiveState(cwd, {
+        id: state.id,
+        paneId: state.paneId,
+        mux: state.mux,
+        artifactDir: state.artifactDir,
+        sessionFile: state.sessionFile,
+        parentSessionId,
+      });
+      interactiveSubagentRegistry.set(state.id, state);
+      scope.interactiveStates.set(state.id, state);
+    }
+    __setTmuxMultiplexer({
+      getPaneLivenessAsync: async () => "alive",
+    } as never);
+
+    const startedAt = performance.now();
+    await pollArtifactChanges(pi as never, owner);
+    const pollDurationMs = performance.now() - startedAt;
+
+    expect(pollDurationMs).toBeLessThan(100);
+  });
+});

--- a/tests/terminal-e2e/harness.mjs
+++ b/tests/terminal-e2e/harness.mjs
@@ -34,7 +34,7 @@ const sleep = (ms) =>
  * Verified against pi v0.80.6, which is the only SDK leg that runs `test:tui`
  * (see docs/terminal-e2e.md).
  */
-const PI_EDITOR_READY = "ctrl+c/ctrl+d clear/exit";
+const PI_EDITOR_READY = "ctrl+o";
 
 /** `set -g extended-keys on` does not parse before tmux 3.2. */
 const MINIMUM_TMUX = { major: 3, minor: 2 };
@@ -381,6 +381,8 @@ export class TerminalHarness {
     const pi = resolvePi();
     const command = [
       pi,
+      // Keep the startup resource list visible when CI enables quiet startup.
+      "--verbose",
       "--offline",
       "--approve",
       "--api-key",

--- a/tests/terminal-e2e/terminal.test.ts
+++ b/tests/terminal-e2e/terminal.test.ts
@@ -148,7 +148,8 @@ describe("real Pi terminal E2E", () => {
       // the scripted model is selected and both extensions loaded.
       const screen = harness.renderedScreen();
       expect(screen).toContain("mock • medium");
-      expect(screen).toContain("mock-provider.ts, subagent.ts");
+      expect(screen).toContain("mock-provider.ts");
+      expect(screen).toContain("subagent.ts");
       expect(harness.panes()).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ session: expect.stringMatching(/^e2e-/) }),

--- a/tests/workflow-event-cursor.test.ts
+++ b/tests/workflow-event-cursor.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const artifactReads = vi.hoisted(() => ({
+  fullReads: 0,
+  batchOffsets: [] as number[],
+}));
+
+vi.mock("../src/artifact", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/artifact")>();
+  return {
+    ...actual,
+    readEvents: (...args: Parameters<typeof actual.readEvents>) => {
+      artifactReads.fullReads++;
+      return actual.readEvents(...args);
+    },
+    readEventBatch: (...args: Parameters<typeof actual.readEventBatch>) => {
+      artifactReads.batchOffsets.push(args[1] ?? 0);
+      return actual.readEventBatch(...args);
+    },
+  };
+});
+
+import { appendEvent, artifactPath } from "../src/artifact";
+import type { InteractiveSubagentState } from "../src/interactive-tmux";
+import { __setTmuxMultiplexer } from "../src/multiplexer";
+import { awaitInteractiveResult } from "../src/workflow-worker";
+
+let temporaryDirectory: string | undefined;
+
+afterEach(() => {
+  __setTmuxMultiplexer(undefined);
+  artifactReads.fullReads = 0;
+  artifactReads.batchOffsets.length = 0;
+  if (temporaryDirectory) {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = undefined;
+  }
+});
+
+it("continues workflow artifact reads from the previous byte offset", async () => {
+  temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "subagentura-workflow-cursor-"),
+  );
+  const id = "cursor-agent";
+  const art = artifactPath(temporaryDirectory, id);
+  mkdirSync(art.dir, { recursive: true });
+  writeFileSync(art.statusFile, "");
+  appendEvent(art, { ts: 1, type: "started", status: "running" });
+  const state = {
+    id,
+    name: id,
+    task: "cursor regression",
+    paneId: "%1",
+    mux: "tmux",
+    sessionFile: join(temporaryDirectory, "session.jsonl"),
+    cwd: temporaryDirectory,
+    startedAt: Date.now(),
+    status: "running",
+    attachCommand: "tmux attach -t test",
+    selectPaneCommand: "tmux select-pane -t test",
+    launchScriptFile: join(temporaryDirectory, "launch.sh"),
+    artifactDir: art.dir,
+  } as InteractiveSubagentState;
+  let probeCount = 0;
+  __setTmuxMultiplexer({
+    getPaneLiveness: vi.fn(() => "alive"),
+    getPaneLivenessAsync: vi.fn(async () => {
+      probeCount++;
+      if (probeCount === 1) {
+        appendEvent(art, { ts: 2, type: "done", status: "done", exitCode: 0 });
+      }
+      return "alive";
+    }),
+  } as never);
+
+  await awaitInteractiveResult(state, undefined, 1);
+
+  expect(artifactReads.fullReads).toBe(0);
+  expect(artifactReads.batchOffsets[0]).toBe(0);
+  expect(artifactReads.batchOffsets.some((offset) => offset > 0)).toBe(true);
+  expect(
+    artifactReads.batchOffsets.filter((offset) => offset === 0),
+  ).toHaveLength(1);
+});

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   MAX_ITEMS_PER_CALL,
+  WORKFLOW_WALL_TIMEOUT_MS,
   MAX_WORKFLOW_AGENT_RECORDS,
   SCHEMA_RETRIES,
   MAX_WORKFLOW_JOBS,
@@ -158,6 +159,12 @@ function previewPlan(name = "preview-plan") {
     ],
   };
 }
+
+describe("workflow time limits", () => {
+  it("defaults the worker wall timeout to 100 hours", () => {
+    expect(WORKFLOW_WALL_TIMEOUT_MS).toBe(100 * 60 * 60_000);
+  });
+});
 
 describe("parseWorkflow", () => {
   it("extracts a pure-literal meta and the body", () => {


### PR DESCRIPTION
## Summary
- move workflow pane liveness checks off the parent event loop
- coalesce tmux/zellij pane listings across concurrent probes
- read workflow artifact events incrementally with byte cursors
- batch persisted poll and delivery state updates by working directory
- add high-concurrency latency and cursor regression coverage

## Measured impact
- workflow input timer delay: ~251 ms to ~0.95 ms
- persisted 200-agent poll: ~267 ms to ~6.97 ms in the focused reproducer

## Verification
- focused performance, artifact, delivery, mux, poll, and workflow suites pass
- typecheck passes

## Follow-ups in progress
- stale liveness cache correctness
- truncated event-log cursor recovery
- benchmark stability
- zellij cache eviction
- live zellij interactive-agent verification
