### PR TITLE
fix: rename sub-agent footer status to alive

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -173,7 +173,7 @@ function mergeFooterContributions(
       if (contribution.kind === "subagent") total += contribution.count;
     }
     if (total === 0) return undefined;
-    return `⚡ ${total} sub-agent${total > 1 ? "s" : ""} active`;
+    return `⚡ ${total} sub-agent${total > 1 ? "s" : ""} alive`;
   }
   if (key === WORKFLOW_FOOTER_KEY) {
     let total = 0;
@@ -236,7 +236,7 @@ function updateFooterStatus(
 }
 
 /**
- * Repaint the "N sub-agents active" footer, scoped to `owner` when supplied.
+ * Repaint the "N sub-agents alive" footer, scoped to `owner` when supplied.
  *
  * Liveness is decided here rather than at the call sites: callers pass the raw
  * active token, so a token whose lifecycle already ended reads as "this session

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -409,7 +409,7 @@ describe("session handler lifecycle callbacks", () => {
     updateRunningSubagentFooter(sharedUi, sessionOwner(a.sessionScope));
     expect(sharedUi.setStatus).toHaveBeenLastCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent active",
+      "⚡ 1 sub-agent alive",
     );
 
     a.handlers.get("session_shutdown")![0]({ reason: "quit" }, aCtx);
@@ -437,7 +437,7 @@ describe("session handler lifecycle callbacks", () => {
 
     expect(ui.setStatus).toHaveBeenLastCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent active",
+      "⚡ 1 sub-agent alive",
     );
   });
 

--- a/tests/subagent-interactive-default.test.ts
+++ b/tests/subagent-interactive-default.test.ts
@@ -345,7 +345,7 @@ describe("subagent_interactive tool lifecycle", () => {
 
     expect(ctx.ui.setStatus).toHaveBeenCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent active",
+      "⚡ 1 sub-agent alive",
     );
   });
 
@@ -381,7 +381,7 @@ describe("subagent_interactive tool lifecycle", () => {
 
     expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent active",
+      "⚡ 1 sub-agent alive",
     );
   });
 

--- a/tests/subagent-notify.test.ts
+++ b/tests/subagent-notify.test.ts
@@ -385,7 +385,7 @@ describe("notifyOnComplete", () => {
 
           expect(ctx.ui.setStatus).toHaveBeenCalledWith(
             "subagentura-running",
-            "⚡ 1 sub-agent active",
+            "⚡ 1 sub-agent alive",
           );
 
           control.resolve(SUCCESS_RESULT);

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -319,7 +319,7 @@ describe("pollArtifactChanges", () => {
     const footerCalls = sharedUi.setStatus.mock.calls.filter(
       ([key]) => key === "subagentura-running",
     );
-    expect(footerCalls.at(-1)?.[1]).toBe("⚡ 1 sub-agent active");
+    expect(footerCalls.at(-1)?.[1]).toBe("⚡ 1 sub-agent alive");
   });
 
   it("aggregates workflow footer contributions across owners sharing one UI", async () => {
@@ -538,7 +538,7 @@ describe("pollArtifactChanges", () => {
     expect(rows).toHaveLength(1);
     expect(uiA.setStatus).toHaveBeenCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent active",
+      "⚡ 1 sub-agent alive",
     );
   });
 
@@ -909,7 +909,7 @@ describe("pollArtifactChanges", () => {
 
     expect(setStatus).toHaveBeenCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent active",
+      "⚡ 1 sub-agent alive",
     );
   });
 
@@ -1971,7 +1971,7 @@ describe("pollArtifactChanges", () => {
 
       expect(setStatus).toHaveBeenCalledWith(
         "subagentura-running",
-        "⚡ 2 sub-agents active",
+        "⚡ 2 sub-agents alive",
       );
       expect(setWidget).toHaveBeenCalledWith(
         "subagentura-activity",
@@ -2048,7 +2048,7 @@ describe("pollArtifactChanges", () => {
       expect(state.status).toBe("idle");
       expect(setStatus).toHaveBeenCalledWith(
         "subagentura-running",
-        "⚡ 1 sub-agent active",
+        "⚡ 1 sub-agent alive",
       );
       const widgetRows = setWidget.mock.calls[0][1] as string[];
       expect(widgetRows).toContain(
@@ -2145,7 +2145,7 @@ describe("pollArtifactChanges", () => {
 
       expect(setStatus).toHaveBeenCalledWith(
         "subagentura-running",
-        "⚡ 3 sub-agents active",
+        "⚡ 3 sub-agents alive",
       );
       const widgetArgs = setWidget.mock.calls[0];
       expect(widgetArgs[1].length).toBe(2);

--- a/tests/subagent-session-log.test.ts
+++ b/tests/subagent-session-log.test.ts
@@ -530,7 +530,7 @@ describe("session-log tail-read", () => {
     // Footer status shows count.
     expect(setStatus).toHaveBeenCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent active",
+      "⚡ 1 sub-agent alive",
     );
     // Widget shows the activity row. Workflow widget is also cleared in the same poll.
     const activityWidgetCall = setWidget.mock.calls.find(

--- a/tests/workflow-supervisor.integration.test.ts
+++ b/tests/workflow-supervisor.integration.test.ts
@@ -367,7 +367,7 @@ describe("workflow supervisor integration", () => {
     // workflow agent label passed through to launchInteractiveSubagent).
     expect((rows as string[]).join("\n")).toContain("reviewer");
     expect((rows as string[]).join("\n")).not.toContain("sibling-agent");
-    expect(lastFooter(a.ui)).toBe("⚡ 1 sub-agent active");
+    expect(lastFooter(a.ui)).toBe("⚡ 1 sub-agent alive");
     // B's surfaces are untouched by A's tick.
     expect(lastWidgetRows(b.ui)).toBe("never-painted");
 


### PR DESCRIPTION
## Summary
- change the sub-agent footer wording from “active” to “alive”
- update focused footer expectations across lifecycle and polling tests

## Verification
- npm run typecheck
- npm test
- npm run format:check
- npm run pack:check