### PR TITLE
docs: promote orchestratorv2 routing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A separate prompt-directed `--orchestratorv2` thin-router mode with bounded project-local responsibility metadata, runtime-authoritative interactive-agent routing, and legacy interactive-session compatibility.
+- Promoted `--orchestratorv2` as a routing-first interactive mode. Its prompt
+  guides the parent to route work to attachable interactive subagents, ask for
+  clarification when a request is ambiguous or a narrow request has no matching
+  child, and leave
+  specialist work to those children. Compatibility workflow and in-process tools
+  remain registered; this is prompt guidance rather than an enforced boundary.
 - Orchestratorv2 routing now treats the current parent branch as the sole authority ledger and the project-local JSON file as repairable untrusted cache data, preventing child-written records from becoming actionable, consuming authority capacity, blocking approved writes, or hiding authoritative stale records.
 - Idle Orchestratorv2 completions now use process-global, run-bound durable wake state with bounded prompt and acknowledgement retries, exact settled-run acknowledgement, and session-replacement recovery without changing delivery behavior in other modes.
 - Explicit `completionPolicy: "each" | "group"` coordination for asynchronous sub-agents and background workflows, with caller-declared bounded `completionGroupId` barriers, human-input priority, manual-result consumption, and compact reference manifests. Relatedness is never inferred from same-turn launch or task text.
@@ -19,7 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Asynchronous completion now defaults to coordinated `each` delivery: each terminal result is immediately eligible, while results that finish while the parent is busy coalesce into one safe-idle compact continuation without injecting full child output.
 - Explicit `group` completion seals when the spawning parent turn settles and releases one aggregate manifest only after every caller-registered member is terminal; `done`, `error`, and `cancelled` all satisfy the barrier. An entirely consumed group creates no empty continuation, and workflow-owned children remain suppressed in favor of the background workflow aggregate.
-- Interactive coordinated policy, group membership, intents, and receipts rehydrate only into the matching parent session. In-process jobs and background workflows remain session scoped.
+- Documented the durability boundary: interactive artifacts, routing state, pending
+  deliveries, and receipts persist and rehydrate within the matching parent
+  session. Delivery is bounded and at-least-once; in-process jobs and background
+  workflows remain session scoped.
 - Consumption receipts prefer parent-session entries. When `appendEntry` is unavailable or fails, receipts append losslessly to a private, session-scoped append-only ledger keyed by parent session identity; fixed snapshots and bounded streaming reads preserve memory bounds while retaining late-published receipts.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@ Give the parent Pi agent one task and let it build the team. pi-subagentura adds
 reusable multi-agent workflows, lightweight background delegation, and real
 child Pi sessions you can watch, attach to, and continue in tmux or Zellij.
 
-Start Pi with the bundled orchestrator guidance and describe the outcome you
-want. The parent can turn that request into a saved workflow, run its agents in
-the background, and keep their intermediate results out of the parent context.
+For routing-first delegation, start Pi with `--orchestratorv2`. The prompt
+guides the parent to route clear work to attachable interactive subagents, ask
+for clarification when a request is ambiguous or a narrow request has no matching
+child, and leave specialist repository work to those children. Compatibility
+workflow and in-process tools remain registered.
+
+For reusable workflows, start Pi with the bundled orchestration guidance and
+describe the outcome you want. The parent can turn that request into a saved
+workflow, run its agents in the background, and keep their intermediate results
+out of the parent context.
 
 ## Installation
 
@@ -43,6 +50,17 @@ pi install git:github.com/lmn451/pi-subagentura
 ```
 
 ## Quick start
+
+For routing-first interactive delegation:
+
+```text
+pi --orchestratorv2
+Review the authentication layer across the API and database boundaries.
+```
+
+The parent routes work to attachable interactive subagents and asks for
+clarification when a request is ambiguous or a narrow request has no matching
+child. For reusable workflows, use the workflow-oriented `--orchestrator` mode:
 
 ```text
 pi --orchestrator
@@ -89,6 +107,10 @@ See the [workflow guide](./docs/workflows.md) and
 
 ## Why use it?
 
+- Route work to attachable interactive specialists with `--orchestratorv2`
+- Resume interactive artifacts, routing state, pending deliveries, and receipts
+  within the matching parent session; delivery is bounded and at-least-once,
+  while in-process jobs and background workflows remain session-scoped
 - Watch a real child Pi session and its tool activity live in tmux or zellij
 - Supervise a bounded recursive tree of interactive children and grandchildren
 - Focus or capture a descendant pane locally, or attach from another terminal
@@ -224,6 +246,17 @@ tools remain registered for compatibility, while the Orchestratorv2 prompt
 directs the parent to delegate only through attachable interactive children and
 use the parent session's authoritative routing ledger together with the
 project-local routing cache.
+
+The v2 prompt gives the parent a lightweight routing role: it routes clear work
+to attachable interactive subagents, can split broad requests across specialists,
+and asks for clarification when a request is ambiguous or a narrow request has no
+matching child. The parent is instructed to leave specialist repository work to
+those children; this is prompt guidance, not an enforced routing boundary.
+
+For interactive children in the matching parent session, artifacts, routing state,
+pending deliveries, and receipts persist and rehydrate across same-session
+restart, reload, and resume paths. Delivery is bounded and at-least-once; in-process
+jobs and background workflows remain session-scoped.
 
 Orchestratorv2 adds exactly two routing-metadata tools:
 `list_orchestrator_agents` and `update_orchestrator_agent_description`.


### PR DESCRIPTION
## Summary

- Promote `--orchestratorv2` in the README Quick Start and main feature narrative.
- Explain the prompt-directed thin-router behavior: route clear work to attachable interactive subagents and ask for clarification on ambiguous or narrow no-match requests.
- State plainly that the parent is instructed not to perform specialist work, while compatibility workflow and in-process tools remain registered and no host-level routing security boundary is enforced.
- Document the bounded durability guarantee: interactive artifacts, routing state, pending delivery intents, and receipts persist/rehydrate within the matching parent session; delivery is bounded and at-least-once; in-process/background workflow jobs are session-scoped.
- Update the Unreleased changelog with the user-facing mode and durability boundary.

This is a docs-only stacked follow-up to #100, targeting `feat/orchestratorv2-completion-coordination` so it integrates with the complete Orchestratorv2/completion-delivery implementation without including unrelated feature commits.

## Verification

- `npm run typecheck`
- `npm test` (70 files, 1661 tests)
- `npm run format:check`
- `npm run pack:check`
- `npm test -- --run tests/readme-surface.test.ts`

Changed files: `README.md`, `CHANGELOG.md`.
