### PR TITLE
fix: make completion consumption selectors type-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit `group` completion seals when the spawning parent turn settles and releases one aggregate manifest only after every caller-registered member is terminal; `done`, `error`, and `cancelled` all satisfy the barrier. An entirely consumed group creates no empty continuation, and workflow-owned children remain suppressed in favor of the background workflow aggregate.
 - Interactive coordinated policy, group membership, intents, and receipts rehydrate only into the matching parent session. In-process jobs and background workflows remain session scoped.
 - Consumption receipts prefer parent-session entries. When `appendEntry` is unavailable or fails, receipts append losslessly to a private, session-scoped append-only ledger keyed by parent session identity; fixed snapshots and bounded streaming reads preserve memory bounds while retaining late-published receipts.
+- Completion-consumption selectors now use explicit source variants: interactive turn receipts require `turnId`, source-level interactive receipts use `scope: "source"`, and in-process/workflow receipts remain source-scoped. Legacy interactive receipts without `scope` are migrated safely without matching turn-scoped completions.
 
 ### Fixed
 

--- a/src/completion-coordinator.ts
+++ b/src/completion-coordinator.ts
@@ -111,15 +111,51 @@ export function resolveCompletionPolicy(
   return { policy, groupId, legacy: false };
 }
 
-export interface CompletionConsumption {
+interface CompletionConsumptionBase {
   schemaVersion: typeof COMPLETION_RECORD_SCHEMA_VERSION;
-  completionIds?: string[];
-  source?: CompletionSource;
-  sourceId?: string;
-  turnId?: string;
   consumedAt: number;
   reason: "manual" | "manifest" | "lifecycle";
 }
+
+export interface InteractiveTurnConsumption extends CompletionConsumptionBase {
+  source: "interactive";
+  sourceId: string;
+  turnId: string;
+  scope?: never;
+}
+
+export interface InteractiveSourceConsumption extends CompletionConsumptionBase {
+  source: "interactive";
+  sourceId: string;
+  scope: "source";
+  turnId?: never;
+}
+
+export interface NonInteractiveCompletionConsumption extends CompletionConsumptionBase {
+  source: "in-process" | "workflow";
+  sourceId: string;
+  turnId?: never;
+  scope?: never;
+}
+
+export interface CompletionIdsConsumption extends CompletionConsumptionBase {
+  completionIds: string[];
+  source?: never;
+  sourceId?: never;
+  turnId?: never;
+  scope?: never;
+}
+
+export type CompletionConsumption =
+  | InteractiveTurnConsumption
+  | InteractiveSourceConsumption
+  | NonInteractiveCompletionConsumption
+  | CompletionIdsConsumption;
+
+export type CompletionConsumptionSelector =
+  | Pick<InteractiveTurnConsumption, "source" | "sourceId" | "turnId">
+  | Pick<InteractiveSourceConsumption, "source" | "sourceId" | "scope">
+  | Pick<NonInteractiveCompletionConsumption, "source" | "sourceId">;
 
 export interface CompletionExpectation {
   completionId: string;
@@ -429,14 +465,32 @@ function normalizeConsumption(
     turnId = data.turnId;
   }
 
+  const hasScope = Object.hasOwn(data, "scope");
+  let scope: "source" | undefined;
+  if (hasScope) {
+    if (data.scope !== "source") return undefined;
+    scope = "source";
+  }
+
   const hasIdSelector = (completionIds?.length ?? 0) > 0;
   const hasSourceSelector =
-    source !== undefined || sourceId !== undefined || turnId !== undefined;
+    source !== undefined ||
+    sourceId !== undefined ||
+    turnId !== undefined ||
+    scope !== undefined;
   if (
     (hasIdSelector && hasSourceSelector) ||
     (hasSourceSelector && (source === undefined || sourceId === undefined)) ||
     (!hasIdSelector && !hasSourceSelector)
   ) {
+    return undefined;
+  }
+  if (source === "interactive") {
+    // Older source-only receipts omitted scope; migrate them to the explicit
+    // source selector while never treating them as a turn wildcard.
+    if (turnId === undefined && scope === undefined) scope = "source";
+    if (turnId !== undefined && scope !== undefined) return undefined;
+  } else if (turnId !== undefined || scope !== undefined) {
     return undefined;
   }
 
@@ -454,15 +508,19 @@ function normalizeConsumption(
   ) {
     return undefined;
   }
-  return {
-    schemaVersion: COMPLETION_RECORD_SCHEMA_VERSION,
-    ...(completionIds !== undefined ? { completionIds } : {}),
-    ...(source !== undefined ? { source } : {}),
-    ...(sourceId !== undefined ? { sourceId } : {}),
-    ...(turnId !== undefined ? { turnId } : {}),
+  const base = {
+    schemaVersion:
+      COMPLETION_RECORD_SCHEMA_VERSION as typeof COMPLETION_RECORD_SCHEMA_VERSION,
     consumedAt: data.consumedAt,
     reason: data.reason,
-  };
+  } as const;
+  if (completionIds !== undefined) return { ...base, completionIds };
+  if (source === "interactive") {
+    return turnId !== undefined
+      ? { ...base, source, sourceId: sourceId!, turnId }
+      : { ...base, source, sourceId: sourceId!, scope: "source" as const };
+  }
+  return { ...base, source: source!, sourceId: sourceId! };
 }
 
 function consumptionFromEntry(
@@ -478,17 +536,21 @@ function matchesConsumption(
   record: CompletionRecord,
   consumption: CompletionConsumption,
 ): boolean {
-  if (consumption.completionIds?.includes(record.completionId)) return true;
-  if (!consumption.source || !consumption.sourceId) return false;
+  if ("completionIds" in consumption) {
+    return consumption.completionIds.includes(record.completionId);
+  }
   if (
     record.source !== consumption.source ||
     record.sourceId !== consumption.sourceId
   ) {
     return false;
   }
-  return record.turnId === undefined
-    ? consumption.turnId === undefined
-    : consumption.turnId === record.turnId;
+  if (consumption.source === "interactive") {
+    return "scope" in consumption
+      ? record.turnId === undefined
+      : record.turnId === consumption.turnId;
+  }
+  return record.turnId === undefined;
 }
 
 function entriesFor(state: CompletionCoordinatorState): unknown[] {
@@ -748,17 +810,21 @@ function expectationMatchesConsumption(
   expectation: CompletionExpectation,
   consumption: CompletionConsumption,
 ): boolean {
-  if (consumption.completionIds?.includes(expectation.completionId))
-    return true;
+  if ("completionIds" in consumption) {
+    return consumption.completionIds.includes(expectation.completionId);
+  }
   if (
     consumption.source !== expectation.source ||
     consumption.sourceId !== expectation.sourceId
   ) {
     return false;
   }
-  return expectation.turnId === undefined
-    ? consumption.turnId === undefined
-    : consumption.turnId === expectation.turnId;
+  if (consumption.source === "interactive") {
+    return "scope" in consumption
+      ? expectation.turnId === undefined
+      : consumption.turnId === expectation.turnId;
+  }
+  return expectation.turnId === undefined;
 }
 
 function reconcileFallbackConsumptions(
@@ -871,17 +937,24 @@ function reconcileFallbackConsumptions(
 
 function fallbackConsumptionMatches(
   state: CompletionCoordinatorState,
-  source: CompletionSource,
-  sourceId: string,
-  turnId: string | undefined,
+  selector: CompletionConsumptionSelector,
 ): boolean {
   return state.sourceConsumptions.some((consumption) => {
-    if (consumption.source !== source || consumption.sourceId !== sourceId) {
+    if (!("source" in consumption)) return false;
+    if (
+      consumption.source !== selector.source ||
+      consumption.sourceId !== selector.sourceId
+    ) {
       return false;
     }
-    return turnId === undefined
-      ? consumption.turnId === undefined
-      : consumption.turnId === turnId;
+    if (selector.source === "interactive") {
+      return "scope" in selector
+        ? "scope" in consumption
+          ? consumption.scope === "source"
+          : false
+        : "turnId" in consumption && consumption.turnId === selector.turnId;
+    }
+    return true;
   });
 }
 
@@ -1832,37 +1905,31 @@ export function publishCompletion(
 
 export function consumeCompletionSource(
   pi: ExtensionAPI,
-  source: CompletionSource,
-  sourceId: string,
+  selector: CompletionConsumptionSelector,
   owner?: SessionOwnerToken,
-  turnId?: string,
 ): void {
   const state = getState(owner);
   if (!state || state.pi !== pi) return;
   reconcileState(state);
-  const normalizedSourceId = sourceId.slice(0, MAX_SOURCE_ID_LENGTH);
-  const normalizedTurnId = turnId?.slice(0, MAX_TURN_ID_LENGTH);
-  if (
-    state.sourceConsumptions.some(
-      (consumption) =>
-        consumption.source === source &&
-        consumption.sourceId === normalizedSourceId &&
-        consumption.turnId === normalizedTurnId,
-    ) ||
-    fallbackConsumptionMatches(
-      state,
-      source,
-      normalizedSourceId,
-      normalizedTurnId,
-    )
-  ) {
-    return;
-  }
+  const normalizedSourceId = selector.sourceId.slice(0, MAX_SOURCE_ID_LENGTH);
+  const normalizedSelector: CompletionConsumptionSelector =
+    selector.source === "interactive"
+      ? "scope" in selector
+        ? {
+            source: "interactive",
+            sourceId: normalizedSourceId,
+            scope: "source",
+          }
+        : {
+            source: "interactive",
+            sourceId: normalizedSourceId,
+            turnId: selector.turnId.slice(0, MAX_TURN_ID_LENGTH),
+          }
+      : { source: selector.source, sourceId: normalizedSourceId };
+  if (fallbackConsumptionMatches(state, normalizedSelector)) return;
   appendConsumption(state, {
     schemaVersion: COMPLETION_RECORD_SCHEMA_VERSION,
-    source,
-    sourceId: normalizedSourceId,
-    ...(normalizedTurnId ? { turnId: normalizedTurnId } : {}),
+    ...normalizedSelector,
     consumedAt: Date.now(),
     reason: "manual",
   });

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -1154,7 +1154,11 @@ function registerGetSubagentResultTool(
       }
 
       if (job.status === "cancelled") {
-        consumeCompletionSource(pi, "in-process", job.id, execution.owner);
+        consumeCompletionSource(
+          pi,
+          { source: "in-process", sourceId: job.id },
+          execution.owner,
+        );
         return {
           content: [
             {
@@ -1278,7 +1282,11 @@ function registerGetSubagentResultTool(
       const result = waitResult.value!;
       // Only set resultRetrieved after successful completion (not on abort)
       job.resultRetrieved = true;
-      consumeCompletionSource(pi, "in-process", job.id, execution.owner);
+      consumeCompletionSource(
+        pi,
+        { source: "in-process", sourceId: job.id },
+        execution.owner,
+      );
       if (job.cleanupAfterCollection) {
         job.cleanupAfterCollection = false;
         scheduleJobCleanup(job.id, true, undefined, execution.owner);

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -1252,10 +1252,12 @@ export function registerInteractiveSubagentTools(
       if (wantsOutput && output !== null && selectedCompletion) {
         consumeCompletionSource(
           pi,
-          "interactive",
-          params.id,
+          {
+            source: "interactive",
+            sourceId: params.id,
+            turnId: selectedCompletion.turnId,
+          },
           registration?.scope ? sessionOwner(registration.scope) : undefined,
-          selectedCompletion.turnId,
         );
       }
       return {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -993,7 +993,11 @@ export function registerWorkflowTool(
         const outputBudget = st.snapshot?.budgetTotal;
         const usageDetails = usage ? { usage } : {};
         st.resultRetrieved = true;
-        consumeCompletionSource(pi, "workflow", st.id, workflowOwner);
+        consumeCompletionSource(
+          pi,
+          { source: "workflow", sourceId: st.id },
+          workflowOwner,
+        );
         return {
           content: [
             {
@@ -1026,7 +1030,11 @@ export function registerWorkflowTool(
       );
       const usage = presentWorkflowUsage(run.usage);
       st.resultRetrieved = true;
-      consumeCompletionSource(pi, "workflow", st.id, workflowOwner);
+      consumeCompletionSource(
+        pi,
+        { source: "workflow", sourceId: st.id },
+        workflowOwner,
+      );
       return {
         content: [
           {

--- a/tests/completion-consumption-types.test-d.ts
+++ b/tests/completion-consumption-types.test-d.ts
@@ -1,0 +1,59 @@
+import type { CompletionConsumption } from "../src/completion-coordinator";
+
+const interactiveTurnReceipt: CompletionConsumption = {
+  schemaVersion: 1,
+  source: "interactive",
+  sourceId: "agent",
+  turnId: "turn-1",
+  consumedAt: 1,
+  reason: "manual",
+};
+
+const sourceReceipt: CompletionConsumption = {
+  schemaVersion: 1,
+  source: "interactive",
+  sourceId: "agent",
+  scope: "source",
+  consumedAt: 1,
+  reason: "manual",
+};
+
+const inProcessReceipt: CompletionConsumption = {
+  schemaVersion: 1,
+  source: "in-process",
+  sourceId: "job",
+  consumedAt: 1,
+  reason: "manual",
+};
+
+const workflowReceipt: CompletionConsumption = {
+  schemaVersion: 1,
+  source: "workflow",
+  sourceId: "workflow",
+  consumedAt: 1,
+  reason: "manual",
+};
+
+void interactiveTurnReceipt;
+void sourceReceipt;
+void inProcessReceipt;
+void workflowReceipt;
+
+// @ts-expect-error Interactive turn-scoped receipts must identify their turn.
+const missingInteractiveTurn: CompletionConsumption = {
+  schemaVersion: 1,
+  source: "interactive",
+  sourceId: "agent",
+  consumedAt: 1,
+  reason: "manual",
+};
+
+// @ts-expect-error Non-interactive receipts are source-scoped and do not accept turnId.
+const inProcessTurn: CompletionConsumption = {
+  schemaVersion: 1,
+  source: "in-process",
+  sourceId: "job",
+  turnId: "turn-1",
+  consumedAt: 1,
+  reason: "manual",
+};

--- a/tests/completion-coordinator.test.ts
+++ b/tests/completion-coordinator.test.ts
@@ -309,10 +309,8 @@ describe("completion coordinator", () => {
 
     consumeCompletionSource(
       setupResult.pi as never,
-      "interactive",
-      "a",
+      { source: "interactive", sourceId: "a", turnId: "turn-a" },
       sessionOwner(scope),
-      "turn-a",
     );
     publishCompletion(record("a"), sessionOwner(scope));
     flushCompletionManifests(sessionOwner(scope));
@@ -328,10 +326,8 @@ describe("completion coordinator", () => {
     for (let index = 0; index < 2; index++) {
       consumeCompletionSource(
         setupResult.pi as never,
-        "interactive",
-        "a",
+        { source: "interactive", sourceId: "a", turnId: "turn-a" },
         sessionOwner(scope),
-        "turn-a",
       );
     }
 
@@ -365,18 +361,14 @@ describe("completion coordinator", () => {
     publishCompletion(record("a", group), sessionOwner(scope));
     consumeCompletionSource(
       setupResult.pi as never,
-      "interactive",
-      "a",
+      { source: "interactive", sourceId: "a", turnId: "turn-a" },
       sessionOwner(scope),
-      "turn-a",
     );
     publishCompletion(record("b", group), sessionOwner(scope));
     consumeCompletionSource(
       setupResult.pi as never,
-      "interactive",
-      "b",
+      { source: "interactive", sourceId: "b", turnId: "turn-b" },
       sessionOwner(scope),
-      "turn-b",
     );
     flushCompletionManifests(sessionOwner(scope));
 
@@ -887,10 +879,12 @@ describe("completion coordinator", () => {
       expect(() =>
         consumeCompletionSource(
           setupResult.pi as never,
-          "interactive",
-          "consumed",
+          {
+            source: "interactive",
+            sourceId: "consumed",
+            turnId: "turn-consumed",
+          },
           sessionOwner(scope),
-          "turn-consumed",
         ),
       ).not.toThrow();
       publishCompletion(
@@ -1001,6 +995,75 @@ describe("completion coordinator", () => {
     );
   });
 
+  it("ignores malformed persisted consumption selectors", () => {
+    const setupResult = setup();
+    scope = setupResult.scope;
+    const owner = sessionOwner(scope);
+    const ledgerPath = sessionLedgerPath(
+      setupResult.ledgerRoot,
+      "parent-session",
+      "subagentura-completion-consumed",
+    );
+    mkdirSync(join(setupResult.ledgerRoot, ".pi"), { recursive: true });
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        source: "interactive",
+        sourceId: "malformed",
+        scope: "turn",
+        consumedAt: 1,
+        reason: "manual",
+      })}\n`,
+      { mode: 0o600 },
+    );
+    registerCompletionExpectations(
+      [
+        {
+          completionId: "completion-malformed",
+          source: "interactive",
+          sourceId: "malformed",
+          turnId: "turn-malformed",
+        },
+      ],
+      owner,
+    );
+    publishCompletion(record("malformed", { turnId: "turn-malformed" }), owner);
+    flushCompletionManifests(owner);
+    expect(manifests(setupResult.pi)[0]?.[0].details.completionIds).toEqual([
+      "completion-malformed",
+    ]);
+  });
+
+  it("does not let an explicit source receipt consume a turn-scoped completion", () => {
+    const setupResult = setup();
+    scope = setupResult.scope;
+    const owner = sessionOwner(scope);
+    consumeCompletionSource(
+      setupResult.pi as never,
+      { source: "interactive", sourceId: "source-selector", scope: "source" },
+      owner,
+    );
+    publishCompletion(
+      record("source-selector", {
+        completionId: "source-selector-unscoped",
+        turnId: undefined,
+      }),
+      owner,
+    );
+    publishCompletion(
+      record("source-selector", {
+        completionId: "source-selector-turn",
+        turnId: "turn-selector",
+      }),
+      owner,
+    );
+    flushCompletionManifests(owner);
+    expect(manifests(setupResult.pi)[0]?.[0].details.completionIds).toEqual([
+      "source-selector-turn",
+    ]);
+  });
+
   it("records a specific turn after an earlier source-only consumption", () => {
     const setupResult = setup();
     scope = setupResult.scope;
@@ -1008,16 +1071,17 @@ describe("completion coordinator", () => {
 
     consumeCompletionSource(
       setupResult.pi as never,
-      "interactive",
-      "reused-source",
+      { source: "interactive", sourceId: "reused-source", scope: "source" },
       owner,
     );
     consumeCompletionSource(
       setupResult.pi as never,
-      "interactive",
-      "reused-source",
+      {
+        source: "interactive",
+        sourceId: "reused-source",
+        turnId: "later-turn",
+      },
       owner,
-      "later-turn",
     );
 
     const receipts = setupResult.entries.filter(
@@ -1026,6 +1090,7 @@ describe("completion coordinator", () => {
         entry.customType === "subagentura-completion-consumed",
     );
     expect(receipts).toHaveLength(2);
+    expect(receipts[0]).toHaveProperty("data.scope", "source");
     expect(receipts[1]).toHaveProperty("data.turnId", "later-turn");
   });
 
@@ -1044,19 +1109,16 @@ describe("completion coordinator", () => {
     try {
       for (let index = 0; index < 513; index++) {
         const sourceId = `receipt-${index}`;
-        const turnId = `turn-${index}`;
         consumeCompletionSource(
           setupResult.pi as never,
-          "in-process",
-          sourceId,
+          { source: "in-process", sourceId },
           sessionOwner(scope),
-          turnId,
         );
         publishCompletion(
           record(sourceId, {
             source: "in-process",
             completionId: `receipt-completion-${index}`,
-            turnId,
+            turnId: undefined,
           }),
           sessionOwner(scope),
         );
@@ -1296,7 +1358,6 @@ describe("completion coordinator", () => {
             completionId: "recovered-completion",
             source: "in-process",
             sourceId: "recovered",
-            turnId: "recovered-turn",
           },
         ],
         owner,
@@ -1308,7 +1369,6 @@ describe("completion coordinator", () => {
           schemaVersion: 1,
           source: "in-process",
           sourceId: "recovered",
-          turnId: "recovered-turn",
           consumedAt: 1,
           reason: "manual",
         })}\n`,
@@ -1319,7 +1379,7 @@ describe("completion coordinator", () => {
         record("recovered", {
           source: "in-process",
           completionId: "recovered-completion",
-          turnId: "recovered-turn",
+          turnId: undefined,
         }),
         owner,
       );


### PR DESCRIPTION
## Summary
- model completion-consumption receipts as source-specific discriminated unions
- require `turnId` for interactive turn receipts and make source-level scope explicit
- reject malformed or non-interactive turn-scoped persisted receipts without wildcard matching
- add runtime and compile-time regression coverage

## Verification
- `npm run typecheck`
- `npm test` (1663 tests)
- `npm run format:check`
- `npm run pack:check`

Base: `master`, matching the parent/base of the Orchestratorv2 completion-coordination PR.