### PR TITLE
fix: clear routing cache on new sessions

### DIFF
--- a/src/orchestrator-routing.ts
+++ b/src/orchestrator-routing.ts
@@ -210,6 +210,17 @@ export function orchestratorRoutingFilePath(cwd: string): string {
   return join(cwd, ".pi", "subagentura-routing.json");
 }
 
+/** Delete the project-local routing cache for an intentional fresh session. */
+export function deleteOrchestratorRoutingFile(cwd: string): void {
+  withInteractiveStateLock(cwd, () => {
+    try {
+      rmSync(orchestratorRoutingFilePath(cwd), { force: true });
+    } catch {
+      /* Best effort, matching interactive state cleanup semantics. */
+    }
+  });
+}
+
 export function routingProjectId(cwd: string): string {
   if (
     typeof cwd !== "string" ||

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -38,7 +38,10 @@ import {
   type ParsedSpawnTreeContext,
 } from "./spawn-tree-context";
 import { rehydrateInteractiveSubagents } from "./rehydrate";
-import { loadOrchestratorRoutingMetadata } from "./orchestrator-routing";
+import {
+  deleteOrchestratorRoutingFile,
+  loadOrchestratorRoutingMetadata,
+} from "./orchestrator-routing";
 import {
   cancelInteractiveSubagentByState,
   removeInteractiveSubagentState,
@@ -384,6 +387,7 @@ export function registerSessionHandlers(
       if (event?.reason === "new" && ctx?.cwd) {
         try {
           deleteInteractiveStatesFile(ctx.cwd);
+          deleteOrchestratorRoutingFile(ctx.cwd);
         } catch {
           /* best effort */
         }

--- a/tests/subagent-session-shutdown-state.test.ts
+++ b/tests/subagent-session-shutdown-state.test.ts
@@ -5,9 +5,13 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { appendInteractiveState, loadInteractiveStates } from "../src/artifact";
+import {
+  orchestratorRoutingFilePath,
+  upsertOrchestratorRoutingEntry,
+} from "../src/orchestrator-routing";
 import {
   interactiveSubagentRegistry,
   registerInteractiveSubagentState,
@@ -145,6 +149,25 @@ describe("session_shutdown clean-slate on /new and quit", () => {
     expect(loadInteractiveStates(cwd)).toBeNull();
     expect(peer.scope.interactiveStates.size).toBe(0);
     expect(interactiveSubagentRegistry.has(peerState.id)).toBe(false);
+  });
+
+  it("deletes routing metadata on /new shutdown", async () => {
+    upsertOrchestratorRoutingEntry(cwd, {
+      childId: "0123456789abcdef",
+      description: "Own the routing cleanup regression",
+      provenance: "user",
+    });
+    const routingFile = orchestratorRoutingFilePath(cwd);
+    expect(existsSync(routingFile)).toBe(true);
+
+    const extension = await setupExtension();
+    const ctx = startSession(extension, "new");
+    extension.shutdownHandlers.at(-1)!(
+      { type: "session_shutdown", reason: "new" },
+      ctx,
+    );
+
+    expect(existsSync(routingFile)).toBe(false);
   });
 
   it("session_shutdown with reason='quit' KEEPS the state file (rehydrate depends on it)", async () => {


### PR DESCRIPTION
## Summary
- delete the project-local Orchestratorv2 routing cache during intentional `/new` shutdown
- preserve existing interactive state cleanup behavior
- add regression coverage

## Verification
- `npm run typecheck`
- `npm test` (70 files, 1664 tests)
- `npm run format:check`
- `npm run pack:check`

Proposed patch release: 3.4.1

Not merged or published.