### PR TITLE
feat: prefix subagent completion messages with display names

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "src/artifact-poller.ts",
     "src/child-protocol.ts",
     "src/completion-turn.ts",
+    "src/completion-presentation.ts",
     "src/delivery.ts",
     "src/completion-coordinator.ts",
     "src/completion-ledger.ts",

--- a/src/completion-coordinator.ts
+++ b/src/completion-coordinator.ts
@@ -8,6 +8,7 @@ import {
   sessionLedgerPath,
 } from "./completion-ledger";
 import { Text } from "@earendil-works/pi-tui";
+import { formatCompletionMessage } from "./completion-presentation";
 import { MAX_TURN_ID_LENGTH } from "./artifact";
 import {
   getActiveSessionOwner,
@@ -1610,8 +1611,8 @@ export function registerCompletionCoordinator(
           const identity = record.turnId
             ? `${JSON.stringify(record.sourceId)}, turn ${JSON.stringify(record.turnId)}`
             : JSON.stringify(record.sourceId);
-          const references = options.expanded
-            ? `\n${record.references
+          const details = options.expanded
+            ? ` (${identity})\n${record.references
                 .map(
                   (reference) =>
                     `  ${JSON.stringify(reference.label)}: ${JSON.stringify(reference.value)}`,
@@ -1621,7 +1622,7 @@ export function registerCompletionCoordinator(
           return new Text(
             theme.fg(
               record.status === "error" ? "error" : "dim",
-              `${icon} ${JSON.stringify(record.label)} ${record.status} (${identity})${references}`,
+              `${formatCompletionMessage(record.label, `${icon} ${record.status}`)}${details}`,
             ),
             0,
             0,

--- a/src/completion-presentation.ts
+++ b/src/completion-presentation.ts
@@ -1,0 +1,20 @@
+export const MAX_COMPLETION_DISPLAY_LABEL_LENGTH = 160;
+
+/** Normalize an optional human-facing label without exposing technical IDs. */
+export function completionDisplayLabel(
+  value: unknown,
+  fallback = "sub-agent",
+): string {
+  if (typeof value !== "string") return fallback;
+  const label = value.trim().replace(/[\r\n]+/g, " ");
+  if (label.length === 0) return fallback;
+  return label.slice(0, MAX_COMPLETION_DISPLAY_LABEL_LENGTH);
+}
+
+export function formatCompletionMessage(
+  label: unknown,
+  text: string,
+  fallback = "sub-agent",
+): string {
+  return `from: ${completionDisplayLabel(label, fallback)}, ${text}`;
+}

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -1,3 +1,7 @@
+import {
+  completionDisplayLabel,
+  formatCompletionMessage,
+} from "./completion-presentation";
 import { createHash } from "node:crypto";
 import {
   appendFileSync,
@@ -47,7 +51,6 @@ export const MAX_OUTPUT_BYTES = 32 * 1024;
 export const MAX_FLUSH_BYTES = 64 * 1024;
 /** Maximum immutable output snapshot accepted from the artifact protocol. */
 export const MAX_ARTIFACT_OUTPUT_BYTES = 1024 * 1024;
-const MAX_FORMATTED_IDENTIFIER = 96;
 interface DeliveryGlobalState {
   __piSubagenturaInteractiveRegistry?: Map<string, InteractiveSubagentState>;
   __piSubagenturaSessionManager?: { getEntries?: () => unknown[] };
@@ -97,12 +100,6 @@ function appendRunningJobsNote(
 ): string {
   const note = runningInProcessJobsNote(owner);
   return note ? `${content}\n${note}` : content;
-}
-
-function boundedIdentifier(value: unknown, fallback: string): string {
-  if (typeof value !== "string" || value.length === 0) return fallback;
-  const sanitized = sanitizeOutput(value.slice(0, MAX_FORMATTED_IDENTIFIER));
-  return sanitized.replace(/[\r\n]/g, " ");
 }
 
 function truncateUtf8(value: string, maxBytes: number): string {
@@ -363,9 +360,9 @@ function pointer(intent: PersistedDeliveryIntent): string {
 
 function formatIntent(
   intent: PersistedDeliveryIntent,
+  displayLabel: string,
   owner?: SessionOwnerToken,
 ): string {
-  const header = `[Sub-agent ${boundedIdentifier(intent.subagentId, "unknown")}, turn ${boundedIdentifier(intent.turnId, "unknown")}, ${intent.status}]`;
   const output = intent.mode === "inject" ? readBoundedOutput(intent) : null;
   const message =
     typeof intent.message === "string" ? sanitizeOutput(intent.message) : "";
@@ -380,13 +377,16 @@ function formatIntent(
           ? `\n${message}`
           : "\n(no immutable output available)"
         : `\n<untrusted-subagent-output>\n${output || "(empty output)"}\n</untrusted-subagent-output>`;
-  return appendRunningJobsNote(
-    truncateUtf8(`${header}${body}\n${pointer(intent)}`, MAX_FLUSH_BYTES),
-    owner,
+  const content = formatCompletionMessage(
+    displayLabel,
+    `[${intent.status}]${body}\n${pointer(intent)}`,
+    "interactive sub-agent",
   );
+  return appendRunningJobsNote(truncateUtf8(content, MAX_FLUSH_BYTES), owner);
 }
 
 function publishCoordinatedInteractiveCompletion(
+  state: InteractiveSubagentState,
   intent: PersistedDeliveryIntent,
   owner?: SessionOwnerToken,
 ): void {
@@ -416,7 +416,7 @@ function publishCoordinatedInteractiveCompletion(
       source: "interactive",
       sourceId: intent.subagentId,
       turnId: intent.turnId,
-      label: `Sub-agent ${boundedIdentifier(intent.subagentId, "unknown")}`,
+      label: completionDisplayLabel(state.name, "interactive sub-agent"),
       status: intent.status,
       policy: intent.completionPolicy,
       ...(intent.completionGroupId
@@ -446,10 +446,14 @@ export function flushDeliveries(
     for (const intent of state.pendingDeliveries ?? []) {
       if (intent.state === "dispatchAttempted") continue;
       if (intent.completionPolicy) {
-        publishCoordinatedInteractiveCompletion(intent, owner);
+        publishCoordinatedInteractiveCompletion(state, intent, owner);
         continue;
       }
-      llm.push({ state, intent, content: formatIntent(intent, owner) });
+      llm.push({
+        state,
+        intent,
+        content: formatIntent(intent, state.name, owner),
+      });
     }
   }
   reconcileAllDeliveryReceipts(owner);
@@ -502,8 +506,8 @@ export function flushDeliveries(
   }
   notifyCompletionDelivery(
     ui,
-    selected.map(({ intent }) => ({
-      label: `Sub-agent ${boundedIdentifier(intent.subagentId, "unknown")}`,
+    selected.map(({ state, intent }) => ({
+      label: completionDisplayLabel(state.name, "interactive sub-agent"),
       mode: intent.mode,
       triggerTurn: intent.triggerTurn,
       status: intent.status,

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,3 +1,4 @@
+import { formatCompletionMessage } from "./completion-presentation";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -375,14 +376,12 @@ export function notifyCompletionDelivery(
       notice.triggerTurn,
       "delivered",
     );
-    return `${notice.label} (${notice.status}). ${behavior}`;
+    return formatCompletionMessage(
+      notice.label,
+      `(${notice.status}). ${behavior}`,
+    );
   });
-  const message =
-    lines.length === 1
-      ? lines[0]
-      : `${lines.length} sub-agent completions delivered:\n${lines
-          .map((line) => `- ${line}`)
-          .join("\n")}`;
+  const message = lines.join("\n");
   const level = notices.some(({ status }) => status === "error")
     ? "error"
     : notices.some(({ status }) => status === "cancelled")
@@ -395,7 +394,7 @@ export function notifyCompletionDelivery(
   }
 }
 
-function buildNotifySummary(jobId: string, result: SubagentResult): string {
+function buildNotifySummary(result: SubagentResult): string {
   const status = result.isError ? "❌" : "✅";
   const msg = result.isError
     ? result.errorMessage || result.output.slice(0, 200).replace(/\s+/g, " ")
@@ -404,7 +403,7 @@ function buildNotifySummary(jobId: string, result: SubagentResult): string {
   const sanitized = sanitizeOutput(msg);
 
   const usageStr = formatUsage(result.usage);
-  const summary = `${status} Job ${jobId} ${sanitized.slice(0, 300)}`;
+  const summary = `${status} ${sanitized.slice(0, 300)}`;
   if (usageStr) {
     return `${summary} (${usageStr})`;
   }
@@ -535,7 +534,7 @@ export function notifyInProcessCompletionWithoutDelivery(
   const mode = jobState.notifyOnComplete ?? "inject";
   notifyCompletionDelivery(target.ui, [
     {
-      label: `Job ${jobState.id}`,
+      label: "in-process sub-agent",
       mode,
       triggerTurn: completionTriggersTurn(mode, jobState.triggerTurnOnComplete),
       status: result.isError ? "error" : "done",
@@ -610,9 +609,12 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
   for (const pending of queue) {
     if (!sameDeliveryOwner(pending, deliveryOwner)) continue;
     if (pending.kind === "overflow") {
-      let content =
+      let content = formatCompletionMessage(
+        undefined,
         "⚠️ In-process completion delivery overflowed its bounded queue." +
-        `\nCompletion identity ledger: ${pending.overflowPath}`;
+          `\nCompletion identity ledger: ${pending.overflowPath}`,
+        "in-process sub-agent",
+      );
       content = appendRunningJobsNote(content, effectiveOwner);
       const itemBytes = Buffer.byteLength(content, "utf8");
       if (llm.length > 0 && bytes + itemBytes > MAX_IN_PROCESS_FLUSH_BYTES)
@@ -634,13 +636,18 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
       mode,
       jobState.triggerTurnOnComplete,
     );
-    const summary = buildNotifySummary(jobState.id, result);
+    const summary = buildNotifySummary(result);
     let content =
       mode === "inject"
         ? `${summary}\n[Untrusted sub-agent output]\n${sanitizeOutput(result.output) || "(sub-agent produced no output)"}`
         : isOrchestratorV2Enabled(target.pi)
           ? `${summary}\nResult remains in compatibility job ${jobState.id}. Surface its status without calling in-process tools in Orchestratorv2 mode.`
           : `${summary}\nResult retained in job ${jobState.id}; use get_subagent_result for details.`;
+    content = formatCompletionMessage(
+      undefined,
+      content,
+      "in-process sub-agent",
+    );
     content = appendRunningJobsNote(content, effectiveOwner);
     const itemBytes = Buffer.byteLength(content, "utf8");
     if (llm.length > 0 && bytes + itemBytes > MAX_IN_PROCESS_FLUSH_BYTES) break;
@@ -693,7 +700,7 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
     llm.map(({ pending, mode, trigger, status }) => ({
       label:
         pending.kind === "completion"
-          ? `Job ${pending.jobState.id}`
+          ? "in-process sub-agent"
           : "In-process completion overflow",
       mode,
       triggerTurn: trigger,
@@ -816,7 +823,11 @@ function buildArtifactMessage(
   state: InteractiveSubagentState,
   event: SubagentEvent,
 ): string {
-  const header = `${iconFor(event)} ${state.name} (${state.id}) — ${labelFor(event)}`;
+  const header = formatCompletionMessage(
+    state.name,
+    `${iconFor(event)} ${labelFor(event)}`,
+    "interactive sub-agent",
+  );
   const outputPath = join(state.artifactDir, "output.md");
   const logPath = join(state.artifactDir, "events.ndjson");
   const pointer = `\nOutput: ${outputPath}\nActivity log: ${logPath}`;

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -534,7 +534,7 @@ export function notifyInProcessCompletionWithoutDelivery(
   const mode = jobState.notifyOnComplete ?? "inject";
   notifyCompletionDelivery(target.ui, [
     {
-      label: "in-process sub-agent",
+      label: `Job ${jobState.id}`,
       mode,
       triggerTurn: completionTriggersTurn(mode, jobState.triggerTurnOnComplete),
       status: result.isError ? "error" : "done",
@@ -637,6 +637,7 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
       jobState.triggerTurnOnComplete,
     );
     const summary = buildNotifySummary(result);
+    const displayLabel = `Job ${jobState.id}`;
     let content =
       mode === "inject"
         ? `${summary}\n[Untrusted sub-agent output]\n${sanitizeOutput(result.output) || "(sub-agent produced no output)"}`
@@ -644,7 +645,7 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
           ? `${summary}\nResult remains in compatibility job ${jobState.id}. Surface its status without calling in-process tools in Orchestratorv2 mode.`
           : `${summary}\nResult retained in job ${jobState.id}; use get_subagent_result for details.`;
     content = formatCompletionMessage(
-      undefined,
+      displayLabel,
       content,
       "in-process sub-agent",
     );
@@ -700,7 +701,7 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
     llm.map(({ pending, mode, trigger, status }) => ({
       label:
         pending.kind === "completion"
-          ? "in-process sub-agent"
+          ? `Job ${pending.jobState.id}`
           : "In-process completion overflow",
       mode,
       triggerTurn: trigger,

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -340,7 +340,7 @@ function publishInProcessCompletion(
       completionId: `job:${jobState.id}`,
       source: "in-process",
       sourceId: jobState.id,
-      label: `Job ${jobState.id}`,
+      label: "in-process sub-agent",
       status: result.cancelled
         ? "cancelled"
         : result.isError

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -340,7 +340,7 @@ function publishInProcessCompletion(
       completionId: `job:${jobState.id}`,
       source: "in-process",
       sourceId: jobState.id,
-      label: "in-process sub-agent",
+      label: `Job ${jobState.id}`,
       status: result.cancelled
         ? "cancelled"
         : result.isError

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -44,6 +44,10 @@ import {
 import { renderProgress } from "./workflow-ui";
 import { awaitInteractiveResult, stringify } from "./workflow-worker";
 import { sanitizeOutput } from "./notifications";
+import {
+  completionDisplayLabel,
+  formatCompletionMessage,
+} from "./completion-presentation";
 import { showWorkflowTree } from "./workflow-tree-ui";
 import {
   WorkflowPickerComponent,
@@ -73,7 +77,6 @@ import {
   reserveCompletionGroup,
   releaseCompletionGroup,
   consumeCompletionSource,
-  MAX_COMPLETION_LABEL_LENGTH,
   publishCompletion,
   registerCompletionMember,
   resolveCompletionPolicy,
@@ -391,19 +394,7 @@ export function registerWorkflowTool(
   }
 
   function workflowCompletionLabel(job: WorkflowJobState): string {
-    const prefix = "Workflow ";
-    const suffix = ` (${job.id})`;
-    const nameLimit = Math.max(
-      0,
-      MAX_COMPLETION_LABEL_LENGTH - prefix.length - suffix.length,
-    );
-    const displayName =
-      job.name.length <= nameLimit
-        ? job.name
-        : nameLimit <= 1
-          ? job.name.slice(0, nameLimit)
-          : `${job.name.slice(0, nameLimit - 1)}…`;
-    return `${prefix}${displayName}${suffix}`;
+    return completionDisplayLabel(job.name, "workflow");
   }
 
   function notifyWorkflowCompletion(job: WorkflowJobState): boolean {
@@ -448,7 +439,11 @@ export function registerWorkflowTool(
     const icon = presentation.icon || (job.status === "done" ? "✅" : "❌");
     const rawSummary = formatWorkflowNotificationSummary(job);
     const summary = truncateWorkflowNotification(sanitizeOutput(rawSummary));
-    let content = `${icon} Workflow "${job.name}" (${job.id}) ${presentation.label} — ${summary}`;
+    let content = formatCompletionMessage(
+      completionDisplayLabel(job.name, "workflow"),
+      `${icon} ${presentation.label} — ${summary}`,
+      "workflow",
+    );
     if (run) {
       content += isOrchestratorV2Enabled(pi)
         ? "\n\nThis completion came from the separate workflow compatibility mode. Surface its status without calling workflow tools in Orchestratorv2 mode."

--- a/tests/completion-coordinator.test.ts
+++ b/tests/completion-coordinator.test.ts
@@ -144,6 +144,28 @@ describe("completion coordinator", () => {
     }
   });
 
+  it("hides technical IDs in collapsed completion entries", () => {
+    const setupResult = setup();
+    scope = setupResult.scope;
+    const renderer = setupResult.pi.registerEntryRenderer.mock.calls.find(
+      ([type]) => type === "subagentura-completion",
+    )?.[1];
+    expect(renderer).toBeTypeOf("function");
+    const theme = { fg: (_color: string, text: string) => text };
+    const entry = { data: record("worker", { label: "Reviewer" }) };
+    const collapsed = renderer(entry, { expanded: false }, theme)
+      .render(200)
+      .join("\n")
+      .trimEnd();
+    expect(collapsed).toBe("from: Reviewer, ✓ done");
+    expect(collapsed).not.toContain("worker");
+    expect(collapsed).not.toContain("turn-worker");
+    const expanded = renderer(entry, { expanded: true }, theme)
+      .render(200)
+      .join("\n");
+    expect(expanded).toContain('("worker", turn "turn-worker")');
+  });
+
   it("notifies the user once and sends one independent reference manifest", () => {
     const setupResult = setup();
     scope = setupResult.scope;

--- a/tests/completion-presentation.test.ts
+++ b/tests/completion-presentation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  completionDisplayLabel,
+  formatCompletionMessage,
+} from "../src/completion-presentation";
+
+describe("completion presentation", () => {
+  it("starts notifications with the display label", () => {
+    expect(
+      formatCompletionMessage("workflow-lifecycle-review", "completed"),
+    ).toBe("from: workflow-lifecycle-review, completed");
+  });
+
+  it("uses a bounded safe fallback for unnamed sources", () => {
+    expect(formatCompletionMessage(undefined, "completed")).toBe(
+      "from: sub-agent, completed",
+    );
+    expect(completionDisplayLabel("line one\nline two", "fallback")).toBe(
+      "line one line two",
+    );
+    expect(completionDisplayLabel("x".repeat(500), "fallback").length).toBe(
+      160,
+    );
+  });
+
+  it("does not make duplicate labels part of source identity", () => {
+    const first = formatCompletionMessage("reviewer", "first");
+    const second = formatCompletionMessage("reviewer", "second");
+
+    expect(first).toBe("from: reviewer, first");
+    expect(second).toBe("from: reviewer, second");
+  });
+});

--- a/tests/notifications-unit.test.ts
+++ b/tests/notifications-unit.test.ts
@@ -97,6 +97,9 @@ describe("in-process completion delivery queue", () => {
     deliverNotification(job, SUCCESS_RESULT);
 
     expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage.mock.calls[0][0].content).toMatch(
+      /^from: in-process sub-agent, /,
+    );
     expect(sendMessage.mock.calls[0][0].content).not.toContain(
       SUCCESS_RESULT.output,
     );
@@ -406,7 +409,7 @@ describe("artifact notification compatibility", () => {
       }),
     ).toBe(true);
     expect(sendMessage.mock.calls[0][0].content).toContain(
-      "✅ Reviewer (child-1) — done (exit 0)",
+      "from: Reviewer, ✅ done (exit 0)",
     );
     expect(sendMessage.mock.calls[0][1]).toMatchObject({
       deliverAs: "followUp",
@@ -490,15 +493,34 @@ describe("artifact notification compatibility", () => {
     }
 
     expect(sendMessage.mock.calls.map((call) => call[0].content)).toEqual([
-      expect.stringContaining("▶ Reviewer (child-1) — started"),
-      expect.stringContaining("🚫 Reviewer (child-1) — cancelled"),
-      expect.stringContaining("❌ Reviewer (child-1) — process exited (1)"),
-      expect.stringContaining("▶ Reviewer (child-1) — started"),
-      expect.stringContaining("▶ Reviewer (child-1) — activity"),
-      expect.stringContaining("❌ Reviewer (child-1) — done (exit 1)"),
-      expect.stringContaining("❌ Reviewer (child-1) — error"),
-      expect.stringContaining("✅ Reviewer (child-1) — process exited (0)"),
-      expect.stringContaining("❌ Reviewer (child-1) — error"),
+      "from: Reviewer, ▶ started\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, 🚫 cancelled\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, ❌ process exited (1)\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, ▶ started\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, ▶ activity\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, ❌ done (exit 1)\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, ❌ error\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, ✅ process exited (0)\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
+      "from: Reviewer, ❌ error\n" +
+        "unknown error\n" +
+        "Output: /tmp/artifacts/child-1/output.md\n" +
+        "Activity log: /tmp/artifacts/child-1/events.ndjson",
     ]);
   });
 

--- a/tests/notifications-unit.test.ts
+++ b/tests/notifications-unit.test.ts
@@ -98,13 +98,28 @@ describe("in-process completion delivery queue", () => {
 
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(sendMessage.mock.calls[0][0].content).toMatch(
-      /^from: in-process sub-agent, /,
+      /^from: Job test-job-1, /,
     );
     expect(sendMessage.mock.calls[0][0].content).not.toContain(
       SUCCESS_RESULT.output,
     );
     expect(sendMessage.mock.calls[0][0].details.mode).toBe("notify");
     expect(job.notificationDelivered).toBe(true);
+  });
+
+  it("keeps job IDs in distinct in-process completion labels", () => {
+    const sendMessage = vi.fn();
+    (globalThis as any).__piSubagenturaPiRef = { sendMessage };
+    const first = makeJobState({ id: "job-a" });
+    const second = makeJobState({ id: "job-b" });
+
+    deliverNotification(first, SUCCESS_RESULT);
+    deliverNotification(second, SUCCESS_RESULT);
+
+    expect(sendMessage.mock.calls.map(([message]) => message.content)).toEqual([
+      expect.stringMatching(/^from: Job job-a, /),
+      expect.stringMatching(/^from: Job job-b, /),
+    ]);
   });
 
   it("reports other running in-process jobs in completion messages", () => {

--- a/tests/pi-session-delivery.integration.test.ts
+++ b/tests/pi-session-delivery.integration.test.ts
@@ -211,7 +211,9 @@ describe("coordinated completion delivery", () => {
     expect(providerContext).toContain("Completed background work");
     expect(providerContext).toContain("outputs/event-a.md");
     expect(providerContext).toContain("events.ndjson");
-    expect(providerContext).not.toContain("subagentura-completion");
+    expect(JSON.stringify(harness.contexts[0].messages)).not.toContain(
+      "subagentura-completion",
+    );
     expect(providerContext).not.toContain("untrusted-subagent-output");
     harness.completeNext();
     await harness.session.waitForIdle();

--- a/tests/terminal-e2e/terminal.test.ts
+++ b/tests/terminal-e2e/terminal.test.ts
@@ -232,7 +232,7 @@ describe("real Pi terminal E2E", () => {
         "async completion",
       );
       await harness.waitForScreen(
-        (screen) => /✓ "Job [a-f0-9]{16}" done/.test(screen),
+        (screen) => /from: in-process sub-agent, ✓ done/.test(screen),
         "async completion TUI notice",
       );
       await harness.waitForScreen(

--- a/tests/terminal-e2e/terminal.test.ts
+++ b/tests/terminal-e2e/terminal.test.ts
@@ -232,7 +232,7 @@ describe("real Pi terminal E2E", () => {
         "async completion",
       );
       await harness.waitForScreen(
-        (screen) => /from: in-process sub-agent, ✓ done/.test(screen),
+        (screen) => /from: Job [a-f0-9]{16}, ✓ done/.test(screen),
         "async completion TUI notice",
       );
       await harness.waitForScreen(

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -3211,6 +3211,9 @@ describe("registerWorkflowTool", () => {
         }),
         { deliverAs: "followUp", triggerTurn: true },
       );
+      expect(staleSendMessage.mock.calls[0][0].content).toContain(
+        "from: notify, ",
+      );
       expect(sendMessage).not.toHaveBeenCalled();
       expect(staleSendMessage.mock.calls[0][0].content).not.toContain(
         "final result",


### PR DESCRIPTION
## Summary
- prefix interactive, workflow, and in-process completion notifications with `from: <display name>,`
- use interactive/workflow display names while retaining `Job <jobId>` for in-process completions so concurrent one-shot jobs remain distinguishable
- keep routing IDs structured; hide them from collapsed interactive/workflow completion entries
- bound and normalize display labels with focused regression coverage

## Verification
- npm run typecheck
- npm test (71 files, 1671 tests)
- npm run format:check
- npm run pack:check
- targeted terminal E2E completion-label test
- GitHub Actions CI passed for Pi 0.80.6 and latest