### PR TITLE
chore(release): prepare v3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.2] - 2026-08-28
+
+### Added
+
+- Added an annotated Orchestratorv2 thin-router walkthrough showing a parent session creating a child session and that child coordinating two interactive specialists.
+- Added credit and replay links for [vibe-replay](https://github.com/tuo-lei/vibe-replay).
+
 ## [3.4.0] - 2026-08-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-subagentura",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-subagentura",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-subagentura",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Reusable agent workflows and observable, attachable sub-agents for the Pi coding agent",
   "author": "lmn451",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `pi-subagentura` from `3.4.1` to `3.4.2`
- record the Orchestratorv2 replay walkthrough and vibe-replay credit in the changelog

## Verification

- `npm run typecheck`
- `npm test` (71 files, 1677 tests)
- `npm run format:check`
- `npm run pack:check`
- packed tarball version verified as `3.4.2`

After merge, tag the exact `master` commit as `v3.4.2` to trigger the publish workflow.
