### PR TITLE
feat: show grouped completion progress

### DIFF
--- a/src/completion-coordinator.ts
+++ b/src/completion-coordinator.ts
@@ -65,6 +65,10 @@ export interface CompletionRecord {
   status: CompletionStatus;
   policy: CompletionPolicy;
   groupId?: string;
+  /** Number of registered group members still awaiting terminal completion. */
+  groupRemaining?: number;
+  /** Indicates that this member completed the sealed group barrier. */
+  groupComplete?: boolean;
   references: CompletionReference[];
   completedAt: number;
   /** Monotonic publication sequence used to retire spilled session entries. */
@@ -309,7 +313,24 @@ function normalizeRecord(value: unknown): CompletionRecord {
   if (raw.policy === "group" && !groupId) {
     throw new Error("Grouped completion requires groupId");
   }
-  if (raw.policy === "each" && groupId) {
+  const groupRemaining =
+    typeof raw.groupRemaining === "number" &&
+    Number.isSafeInteger(raw.groupRemaining) &&
+    raw.groupRemaining >= 0 &&
+    raw.groupRemaining <= MAX_GROUP_MEMBERS
+      ? raw.groupRemaining
+      : undefined;
+  if (raw.groupRemaining !== undefined && groupRemaining === undefined) {
+    throw new Error("Invalid grouped completion progress");
+  }
+  const groupComplete = raw.groupComplete === true ? true : undefined;
+  if (raw.groupComplete !== undefined && groupComplete === undefined) {
+    throw new Error("Invalid grouped completion state");
+  }
+  if (
+    raw.policy === "each" &&
+    (groupId || groupRemaining !== undefined || groupComplete !== undefined)
+  ) {
     throw new Error("Independent completion cannot have group metadata");
   }
   const references = Array.isArray(raw.references)
@@ -362,6 +383,8 @@ function normalizeRecord(value: unknown): CompletionRecord {
     status: raw.status,
     policy: raw.policy,
     ...(groupId ? { groupId } : {}),
+    ...(groupRemaining !== undefined ? { groupRemaining } : {}),
+    ...(groupComplete === true ? { groupComplete } : {}),
     references,
     completedAt,
     ...(sequence !== undefined ? { sequence } : {}),
@@ -1611,6 +1634,11 @@ export function registerCompletionCoordinator(
           const identity = record.turnId
             ? `${JSON.stringify(record.sourceId)}, turn ${JSON.stringify(record.turnId)}`
             : JSON.stringify(record.sourceId);
+          const progress = record.groupComplete
+            ? "; group complete"
+            : record.groupRemaining !== undefined
+              ? `; waiting for ${record.groupRemaining} more`
+              : "";
           const details = options.expanded
             ? ` (${identity})\n${record.references
                 .map(
@@ -1622,7 +1650,7 @@ export function registerCompletionCoordinator(
           return new Text(
             theme.fg(
               record.status === "error" ? "error" : "dim",
-              `${formatCompletionMessage(record.label, `${icon} ${record.status}`)}${details}`,
+              `${formatCompletionMessage(record.label, `${icon} ${record.status}${progress}`)}${details}`,
             ),
             0,
             0,
@@ -1871,11 +1899,23 @@ export function publishCompletion(
         group = state.groups.get(record.groupId!);
       }
       if (!group) throw new Error("Completion group registration failed");
+      delete record.groupRemaining;
+      delete record.groupComplete;
       if (group.terminalMembers.has(memberKey)) {
         record = { ...record, policy: "each" };
         delete record.groupId;
+        delete record.groupRemaining;
+        delete record.groupComplete;
       } else {
         group.terminalMembers.add(memberKey);
+        if (groupIsReady(state, record)) {
+          record = { ...record, groupComplete: true };
+        } else {
+          record = {
+            ...record,
+            groupRemaining: group.members.size - group.terminalMembers.size,
+          };
+        }
       }
     } catch (error) {
       debugLog("warn", "completion_publication_rejected", {

--- a/tests/completion-coordinator.test.ts
+++ b/tests/completion-coordinator.test.ts
@@ -325,6 +325,103 @@ describe("completion coordinator", () => {
     );
   });
 
+  it("renders grouped progress for each terminal member before the final manifest", () => {
+    const setupResult = setup();
+    scope = setupResult.scope;
+    const owner = sessionOwner(scope);
+    const group = { policy: "group" as const, groupId: "progress-group" };
+    for (const id of ["a", "b", "c"]) {
+      registerCompletionMember(
+        "interactive",
+        id,
+        "group",
+        group.groupId,
+        owner,
+      );
+    }
+    const renderer = setupResult.pi.registerEntryRenderer.mock.calls.find(
+      ([type]) => type === "subagentura-completion",
+    )?.[1];
+    const theme = { fg: (_color: string, text: string) => text };
+    const render = (entry: any) =>
+      renderer(entry, { expanded: false }, theme)
+        .render(200)
+        .join("\n")
+        .trimEnd();
+    scope.parentStreaming = true;
+
+    publishCompletion(record("a", group), owner);
+    const first = userCompletions(setupResult.entries)[0];
+    expect(first.data.groupRemaining).toBe(2);
+    expect(render(first)).toContain(
+      "from: Agent a, ✓ done; waiting for 2 more",
+    );
+
+    publishCompletion(record("b", { ...group, status: "error" }), owner);
+    const second = userCompletions(setupResult.entries)[1];
+    expect(second.data.groupRemaining).toBe(1);
+    expect(render(second)).toContain(
+      "from: Agent b, ✕ error; waiting for 1 more",
+    );
+
+    sealCompletionGroups(owner);
+    publishCompletion(record("c", { ...group, status: "cancelled" }), owner);
+    const final = userCompletions(setupResult.entries)[2];
+    expect(final.data.groupRemaining).toBeUndefined();
+    expect(final.data.groupComplete).toBe(true);
+    expect(render(final)).toBe("from: Agent c, ○ cancelled; group complete");
+
+    scope.parentStreaming = false;
+    flushCompletionManifests(owner);
+    expect(manifests(setupResult.pi)).toHaveLength(1);
+    expect(manifests(setupResult.pi)[0][0].details.groups).toEqual([
+      "progress-group",
+    ]);
+  });
+
+  it("preserves grouped progress across coordinator reload and ignores duplicate terminals", () => {
+    const setupResult = setup();
+    scope = setupResult.scope;
+    const owner = sessionOwner(scope);
+    const group = { policy: "group" as const, groupId: "reload-group" };
+    for (const id of ["a", "b", "c"]) {
+      registerCompletionMember(
+        "interactive",
+        id,
+        "group",
+        group.groupId,
+        owner,
+      );
+    }
+    publishCompletion(record("a", group), owner);
+    const first = userCompletions(setupResult.entries)[0];
+    expect(first.data.groupRemaining).toBe(2);
+
+    publishCompletion(
+      record("a", {
+        ...group,
+        completionId: "duplicate-a",
+        turnId: "duplicate-a-turn",
+      }),
+      owner,
+    );
+    const duplicate = userCompletions(setupResult.entries)[1];
+    expect(duplicate.data.policy).toBe("each");
+    expect(duplicate.data.groupRemaining).toBeUndefined();
+    expect(duplicate.data.groupComplete).toBeUndefined();
+
+    clearCompletionCoordinator(owner);
+    registerCompletionCoordinator(setupResult.pi as never, scope);
+    registerCompletionMember("interactive", "b", "group", group.groupId, owner);
+    registerCompletionMember("interactive", "c", "group", group.groupId, owner);
+    expect(userCompletions(setupResult.entries)[0].data.groupRemaining).toBe(2);
+
+    publishCompletion(record("b", { ...group, status: "error" }), owner);
+    expect(
+      userCompletions(setupResult.entries).at(-1).data.groupRemaining,
+    ).toBe(1);
+  });
+
   it("marks manually collected results consumed before later publication", () => {
     const setupResult = setup();
     scope = setupResult.scope;


### PR DESCRIPTION
## Summary
- show grouped terminal members with the exact number still pending
- identify the final sealed member with a group-complete status
- preserve aggregate manifests, selectors, reload reconciliation, duplicate guards, and each-policy behavior

## Verification
- npm run typecheck
- npm test (71 files, 1679 tests)
- npm run format:check
- npm run pack:check
- git diff --check