### PR TITLE
feat(workflow): add finite high default output budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Workflow output budgets now default to the finite `100_000_000_000` completed output tokens. This is a high safety ceiling with significant cost/runtime risk; existing explicit overrides and independent safeguards are unchanged.
+
 ## [3.4.2] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ results stay in workflow variables outside the parent model context. Only the
 workflow completion enters coordinated parent delivery; the retained final
 result is available through `get_workflow_result`.
 
+An omitted workflow `budget` defaults to the finite `100_000_000_000` completed
+output tokens. This is a high safety ceiling with significant cost/runtime risk,
+not a spending recommendation; use a lower explicit budget when practical.
+Existing agent/item caps, concurrency, timeouts, cancellation, and errors still apply.
+
 Workflow scripts are trusted agent-authored JavaScript. The VM improves
 determinism but is not a security boundary, so never run untrusted JavaScript.
 Background workflow jobs are scoped to the current parent session and are

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -20,6 +20,8 @@ export const INTERACTIVE_POLL_MS = 1000;
 export const INTERACTIVE_DEAD_GRACE_TICKS = 3;
 export const WORKFLOW_SYNC_TIMEOUT_MS = 30_000;
 export const WORKFLOW_WALL_TIMEOUT_MS = 100 * 60 * 60_000;
+/** Finite high default; callers should pass lower explicit budgets when practical. */
+export const DEFAULT_WORKFLOW_OUTPUT_BUDGET = 100_000_000_000;
 
 export function defaultConcurrency(): number {
   const n = cpus()?.length ?? 4;

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -8,6 +8,7 @@ import {
 import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
 import { runWorkflow } from "./workflow-worker";
 import {
+  DEFAULT_WORKFLOW_OUTPUT_BUDGET,
   type RunWorkflowOptions,
   type WorkflowAgentRunner,
   type WorkflowAgentRecord,
@@ -278,7 +279,7 @@ export function startWorkflowJob(
       agentsSpawned: 0,
       errorCount: 0,
       tokensSpent: 0,
-      budgetTotal: opts.budgetTotal ?? null,
+      budgetTotal: opts.budgetTotal ?? DEFAULT_WORKFLOW_OUTPUT_BUDGET,
       usage: zeroWorkflowUsage(),
       phases: [],
       agentRecords: [],

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -13,6 +13,7 @@ import {
   registerInteractiveSubagentState,
 } from "./interactive-tmux";
 import {
+  DEFAULT_WORKFLOW_OUTPUT_BUDGET,
   MAX_ITEMS_PER_CALL,
   INTERACTIVE_POLL_MS,
   MAX_TOTAL_AGENTS,
@@ -675,7 +676,7 @@ export function registerWorkflowTool(
       const baseOpts = (workflowId: string) => ({
         args: params.args,
         cwd: ctx.cwd,
-        budgetTotal: params.budget ?? null,
+        budgetTotal: params.budget ?? DEFAULT_WORKFLOW_OUTPUT_BUDGET,
         runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
         loadWorkflow: (n: string) => loadWorkflowScript(n),
       });
@@ -834,7 +835,7 @@ export function registerWorkflowTool(
         const msg = err instanceof Error ? err.message : String(err);
         const usage = workflowErrorUsage(err);
         const usageDetails = usage ? { usage } : {};
-        const budgetTotal = params.budget ?? null;
+        const budgetTotal = params.budget ?? DEFAULT_WORKFLOW_OUTPUT_BUDGET;
         return {
           content: [
             {
@@ -1290,7 +1291,7 @@ export function registerWorkflowTool(
         (workflowId) => ({
           args: argsValue,
           cwd: ctx.cwd,
-          budgetTotal: null,
+          budgetTotal: DEFAULT_WORKFLOW_OUTPUT_BUDGET,
           runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
           loadWorkflow: (n: string) => loadWorkflowScript(n),
         }),

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -15,6 +15,7 @@ import {
 import { debugLog, usageFromAssistantMessages } from "./helpers";
 import type { SubagentResult, Usage } from "./helpers";
 import {
+  DEFAULT_WORKFLOW_OUTPUT_BUDGET,
   INTERACTIVE_DEAD_GRACE_TICKS,
   INTERACTIVE_POLL_MS,
   MAX_ITEMS_PER_CALL,
@@ -199,7 +200,7 @@ export async function runWorkflow(
     ),
     loadWorkflow: opts.loadWorkflow,
     cwd: opts.cwd ?? process.cwd(),
-    budgetTotal: opts.budgetTotal ?? null,
+    budgetTotal: opts.budgetTotal ?? DEFAULT_WORKFLOW_OUTPUT_BUDGET,
     counters: {
       agentsSpawned: 0,
       errorCount: 0,

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_WORKFLOW_OUTPUT_BUDGET,
   MAX_ITEMS_PER_CALL,
   WORKFLOW_WALL_TIMEOUT_MS,
   MAX_WORKFLOW_AGENT_RECORDS,
@@ -419,6 +420,20 @@ describe("agent() + budget", () => {
     });
     expect(r.result).toBe("hello");
     expect(r.agentsSpawned).toBe(1);
+  });
+
+  it("uses the finite 100B output budget when omitted", async () => {
+    const result = await runWorkflow(
+      meta + `return { total: budget.total, remaining: budget.remaining() };`,
+      { runAgent: echoRunner() },
+    );
+
+    expect(DEFAULT_WORKFLOW_OUTPUT_BUDGET).toBe(100_000_000_000);
+    expect(Number.isSafeInteger(DEFAULT_WORKFLOW_OUTPUT_BUDGET)).toBe(true);
+    expect(result.result).toEqual({
+      total: DEFAULT_WORKFLOW_OUTPUT_BUDGET,
+      remaining: DEFAULT_WORKFLOW_OUTPUT_BUDGET,
+    });
   });
 
   it("waits for unawaited agent work before completing", async () => {
@@ -2853,6 +2868,7 @@ describe("registerWorkflowTool", () => {
     const job = workflowJobRegistry.get(started.details.workflowId)!;
     expect(started.details.status).toBe("started");
     expect(job.executionMode).toBe("async");
+    expect(job.snapshot.budgetTotal).toBe(DEFAULT_WORKFLOW_OUTPUT_BUDGET);
     await job.promise;
   });
 


### PR DESCRIPTION
## Summary

- raise the existing omitted workflow output-budget default to finite `100_000_000_000` completed output tokens
- use that same default for runtime execution, initial job snapshots, sync/background tool runs, and saved workflow commands
- keep all existing explicit override semantics and independent safety behavior unchanged

## Risk

100B is a high safety ceiling, not a spending recommendation. Allowing a workflow to approach it can create significant model cost and runtime; callers should pass a lower explicit budget when practical.

## Scope

This intentionally does **not** add new budget validation, range machinery, architecture, worker-thread behavior, or public type changes. Existing agent/item caps, concurrency, timeouts, cancellation, soft parallel overshoot, and resource-error behavior are unchanged.

## Verification

- `npm run typecheck`
- `npm test` — 71 files, 1,678 tests passed
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`

Focused regression assertions verify the exact safe-integer 100B default at the workflow runtime boundary and in the initial background job snapshot.
