### PR TITLE
fix: quiet directly aborted child turns

### DIFF
--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -118,6 +118,7 @@ export type SubagentEventV2 =
       source: CompletionSource;
       cancellationOrigin?: ParentCancellationOrigin;
       cancellationLifecycleReason?: ParentCancellationLifecycleReason;
+      agentStopReason?: "error" | "aborted";
       output?: OutputSnapshot;
       outputError?: OutputSnapshotError;
       exitCode?: number;
@@ -559,6 +560,7 @@ export function appendCompletionEvent(
     exitCode?: number;
     message?: string;
     errorMessage?: string;
+    agentStopReason?: "error" | "aborted";
     eventId?: string;
     ts?: number;
   },
@@ -588,6 +590,13 @@ export function appendCompletionEvent(
             params.cancellationLifecycleReason,
           )
         : undefined;
+    const agentStopReason =
+      params.source === "agent_settled" &&
+      params.outcome === "error" &&
+      (params.agentStopReason === "error" ||
+        params.agentStopReason === "aborted")
+        ? params.agentStopReason
+        : undefined;
     const event: CompletionEventV2 = {
       version: 2,
       eventId,
@@ -603,6 +612,7 @@ export function appendCompletionEvent(
       ...(errorMessage ? { errorMessage } : {}),
       ...(cancellationOrigin ? { cancellationOrigin } : {}),
       ...(cancellationLifecycleReason ? { cancellationLifecycleReason } : {}),
+      ...(agentStopReason ? { agentStopReason } : {}),
     };
     appendEvent(art, event);
     return event;
@@ -861,6 +871,12 @@ function normalizeEvent(
             obj.cancellationLifecycleReason,
           )
         : undefined;
+    const agentStopReason =
+      obj.source === "agent_settled" &&
+      obj.outcome === "error" &&
+      (obj.agentStopReason === "error" || obj.agentStopReason === "aborted")
+        ? obj.agentStopReason
+        : undefined;
     return {
       event: {
         ...base,
@@ -876,6 +892,7 @@ function normalizeEvent(
         summary,
         cancellationOrigin,
         cancellationLifecycleReason,
+        ...(agentStopReason ? { agentStopReason } : {}),
       },
       legacy: false,
     };

--- a/src/child-protocol.ts
+++ b/src/child-protocol.ts
@@ -179,6 +179,7 @@ export function registerChildProtocol(pi: ExtensionAPI): void {
     const assistant = [...latestAgentMessages]
       .reverse()
       .find((message: any) => message?.role === "assistant") as any;
+    const stopReason = assistant?.stopReason;
     const errorMessage =
       typeof assistant?.errorMessage === "string"
         ? assistant.errorMessage
@@ -194,6 +195,10 @@ export function registerChildProtocol(pi: ExtensionAPI): void {
       exitCode: failed ? 1 : 0,
       errorMessage,
       message: errorMessage,
+      agentStopReason:
+        stopReason === "error" || stopReason === "aborted"
+          ? stopReason
+          : undefined,
     });
   });
 }

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -751,9 +751,19 @@ function markOverflowDelivered(
 
 // ── Interactive artifact notification helpers ───────────────────
 
+/** True only for a child-local aborted settlement that is intentionally quiet. */
+export function isQuietChildInterruption(event: SubagentEvent): boolean {
+  return (
+    event.type === "completion" &&
+    event.source === "agent_settled" &&
+    event.outcome === "error" &&
+    event.agentStopReason === "aborted"
+  );
+}
+
 /** True when the event should trigger a wakeup notification to the parent. */
 export function shouldNotify(event: SubagentEvent): boolean {
-  return isCompletionEvent(event);
+  return isCompletionEvent(event) && !isQuietChildInterruption(event);
 }
 
 export function sanitizeOutput(text: string): string {

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -371,6 +371,54 @@ describe("artifact", () => {
     expect(supervisorEvent).not.toHaveProperty("cancellationLifecycleReason");
   });
 
+  it("preserves valid agent stop reasons only for child settlement errors", () => {
+    const art = artifactPath(root, "agent-stop-reason");
+    const aborted = appendCompletionEvent(art, {
+      turnId: "aborted-turn",
+      outcome: "error",
+      source: "agent_settled",
+      agentStopReason: "aborted",
+    });
+    const providerError = appendCompletionEvent(art, {
+      turnId: "provider-error-turn",
+      outcome: "error",
+      source: "agent_settled",
+      agentStopReason: "error",
+    });
+    const successful = appendCompletionEvent(art, {
+      turnId: "successful-turn",
+      outcome: "done",
+      source: "agent_settled",
+      agentStopReason: "aborted",
+    });
+    const parent = appendCompletionEvent(art, {
+      turnId: "parent-turn",
+      outcome: "cancelled",
+      source: "parent",
+      agentStopReason: "aborted",
+    });
+
+    expect(aborted).toMatchObject({ agentStopReason: "aborted" });
+    expect(providerError).toMatchObject({ agentStopReason: "error" });
+    expect(successful).not.toHaveProperty("agentStopReason");
+    expect(parent).not.toHaveProperty("agentStopReason");
+
+    appendFileSync(
+      art.statusFile,
+      JSON.stringify({
+        version: 2,
+        eventId: "malformed-stop-reason",
+        turnId: "malformed-stop-turn",
+        ts: 3,
+        type: "completion",
+        outcome: "error",
+        source: "agent_settled",
+        agentStopReason: "aborted-by-user",
+      }) + "\n",
+    );
+    expect(readEvents(art).at(-1)).not.toHaveProperty("agentStopReason");
+  });
+
   it("reports one deterministic issue for an oversized physical record", () => {
     const art = artifactPath(root, "ultra-oversized-event");
     ensureArtifactDir(art);

--- a/tests/child-protocol.test.ts
+++ b/tests/child-protocol.test.ts
@@ -90,6 +90,7 @@ describe("child protocol lifecycle", () => {
       outcome: "done",
       source: "agent_settled",
     });
+    expect(events.at(-1)).not.toHaveProperty("agentStopReason");
   });
 
   it("records an error completion and supports getBranch fallback", () => {
@@ -124,6 +125,45 @@ describe("child protocol lifecycle", () => {
       outcome: "error",
       exitCode: 1,
       errorMessage: "provider failed",
+      agentStopReason: "error",
+    });
+  });
+
+  it("records an aborted assistant settlement as a quietable error", () => {
+    const handlers = registerHandlers();
+    const entries: any[] = [];
+    const ctx = { sessionManager: { getEntries: () => entries } };
+
+    handlers.get("before_agent_start")!({}, ctx);
+    entries.push({
+      id: "user-aborted",
+      type: "message",
+      message: { role: "user" },
+    });
+    handlers.get("turn_start")!({ timestamp: 100 }, ctx);
+    vi.runAllTimers();
+    handlers.get("before_provider_request")!({}, ctx);
+    handlers.get("agent_end")!(
+      {
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "aborted",
+            errorMessage: "Operation aborted",
+          },
+        ],
+      },
+      ctx,
+    );
+    handlers.get("agent_settled")!({}, ctx);
+
+    expect(readEvents(artifactPath(root, "child")).at(-1)).toMatchObject({
+      type: "completion",
+      turnId: "user-aborted",
+      outcome: "error",
+      source: "agent_settled",
+      agentStopReason: "aborted",
+      errorMessage: "Operation aborted",
     });
   });
 

--- a/tests/notifications-unit.test.ts
+++ b/tests/notifications-unit.test.ts
@@ -411,6 +411,45 @@ describe("artifact notification compatibility", () => {
     ).toBe(true);
   });
 
+  it("quietens only aborted child settlement errors", () => {
+    const base = {
+      version: 2 as const,
+      eventId: "event-aborted",
+      turnId: "turn-aborted",
+      ts: 2,
+      type: "completion" as const,
+      status: "error" as const,
+      outcome: "error" as const,
+      source: "agent_settled" as const,
+    };
+
+    expect(shouldNotify({ ...base, agentStopReason: "aborted" })).toBe(false);
+    expect(shouldNotify({ ...base, agentStopReason: "error" })).toBe(true);
+    expect(shouldNotify(base)).toBe(true);
+    expect(
+      shouldNotify({
+        ...base,
+        source: "parent",
+        agentStopReason: "aborted",
+      }),
+    ).toBe(true);
+    expect(
+      shouldNotify({
+        ...base,
+        source: "explicit",
+        agentStopReason: "aborted",
+      }),
+    ).toBe(true);
+    expect(
+      shouldNotify({
+        ...base,
+        type: "completion",
+        source: "process_exit",
+        agentStopReason: "aborted",
+      }),
+    ).toBe(true);
+  });
+
   it("builds and sends pointer notifications for legacy terminal events", () => {
     const sendMessage = vi.fn();
     const pi = { sendMessage };

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -166,6 +166,82 @@ describe("pollArtifactChanges", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("skips aborted child settlement but delivers the next turn", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const item = makeState();
+    item.state.parentSessionId = "session-aborted";
+    item.state.cwd = join(item.artifactDir, "..");
+    const art = artifactPath(item.state.cwd, item.id);
+    appendCompletionEvent(art, {
+      turnId: "aborted-turn",
+      outcome: "error",
+      source: "agent_settled",
+      agentStopReason: "aborted",
+    });
+    mod.interactiveSubagentRegistry.set(item.id, item.state);
+
+    const owner = { id: 601, generation: 1 };
+    const sendMessage = vi.fn();
+    const ui = {
+      notify: vi.fn(),
+      setStatus: vi.fn(),
+      setWidget: vi.fn(),
+    };
+    const scope = registerSessionScope({
+      ...owner,
+      pi: { sendMessage } as any,
+      ui: ui as any,
+      sessionManager: {
+        getSessionId: () => "session-aborted",
+        getEntries: () => [],
+      },
+    });
+    scope.interactiveStates.set(item.id, item.state);
+    multiplexer.__setTmuxMultiplexer({
+      getPaneLivenessAsync: async () => "alive",
+    } as any);
+
+    const abortedCursor = eventLogEndOffset(art);
+    await mod.pollArtifactChanges({} as any, owner);
+
+    expect(item.state.eventByteCursor).toBe(abortedCursor);
+    expect(item.state.status).toBe("idle");
+    expect(item.state.pendingDeliveries).toEqual([]);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(ui.notify).not.toHaveBeenCalled();
+
+    appendEvent(art, {
+      version: 2,
+      eventId: "next-turn-start",
+      turnId: "clarification-turn",
+      ts: 2,
+      type: "turn_started",
+      status: "running",
+    });
+    writeOutput(art, "clarification output");
+    appendCompletionEvent(art, {
+      turnId: "clarification-turn",
+      outcome: "done",
+      source: "agent_settled",
+    });
+
+    await mod.pollArtifactChanges({} as any, owner);
+
+    expect(item.state.eventByteCursor).toBe(eventLogEndOffset(art));
+    expect(item.state.status).toBe("idle");
+    expect(item.state.pendingDeliveries).toHaveLength(1);
+    expect(item.state.pendingDeliveries?.[0]).toMatchObject({
+      turnId: "clarification-turn",
+      status: "done",
+    });
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMessage.mock.calls[0][0].content).not.toContain("aborted-turn");
+    expect(ui.notify).toHaveBeenCalledOnce();
+    expect(ui.notify.mock.calls[0][0]).not.toContain("aborted");
+  });
+
   it("polls and dispatches only interactive states owned by the supplied context", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");


### PR DESCRIPTION
## Summary
- retain `agentStopReason` on child settlement error completions
- suppress automatic delivery only for directly aborted child turns
- keep child lifecycle reusable and deliver later clarification turns normally

## Verification
- npm run typecheck
- npm test
- npm run format:check
- npm run pack:check
- git diff --check