### PR TITLE
feat(workflow): align ralplan independent review contract

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -95,32 +95,41 @@ records, while `/workflow-tree` displays the latest 20 and reports omissions.
 
 ### `ralplan-consensus.mjs`
 
-A Planner → Architect → Critic loop that asks agents to write review artifacts
-and a final plan.
+A compact SHORT-only Planner → Architect → Critic loop. Architect and Critic
+are isolated sequential reviewers of the same immutable Planner snapshot. Critic
+never receives Architect output and still runs after Architect rejection. Every
+terminal result is pending approval and execution-halted; consensus is not an
+execution recommendation. A final consolidation agent may write Markdown after
+both explicit approvals, but Phase 1 does not verify that artifact.
 
-| Argument        | Required | Meaning                               |
-| --------------- | -------- | ------------------------------------- |
-| `idea`          | yes      | Planning problem                      |
-| `maxIterations` | no       | Positive iteration cap; defaults to 3 |
-| `artifactsDir`  | no       | Output directory; defaults to `plans` |
+| Argument             | Required | Meaning                                 |
+| -------------------- | -------- | --------------------------------------- |
+| `idea`               | yes      | Planning problem                        |
+| `maxIterations`      | no       | Round cap, clamped to 1–5 (default 5)   |
+| `artifactsDir`       | no       | Output directory; defaults to `plans`   |
+| `executeOnConsensus` | no       | Deprecated compatibility input; ignored |
 
 ### `ralplan-occ.mjs`
 
-An OCC-style RALPLAN flow with a short-prompt gate, deliberate-mode checks,
-per-reviewer model routing, and explicit approval markers. It never executes
-the resulting plan.
+The canonical OCC-facing RALPLAN flow with a short-prompt gate, deliberate-mode
+hard gates, and optional per-reviewer model routing. Both reviewers inspect one
+fixed Planner snapshot independently. It never executes the resulting plan.
 
-| Argument             | Required | Meaning                                                   |
-| -------------------- | -------- | --------------------------------------------------------- |
-| `idea`               | yes      | Planning problem                                          |
-| `deliberate`         | no       | `true`, `false`, or `"auto"` risk-triggered mode          |
-| `maxIterations`      | no       | Iteration cap from 1 to 5; defaults to 5                  |
-| `artifactsDir`       | no       | Final-plan directory; defaults to `.omc/plans`            |
-| `draftsDir`          | no       | Draft directory; defaults to `.omc/drafts`                |
-| `planName`           | no       | Final plan basename; defaults to `ralplan`                |
-| `architectModel`     | no       | Model id passed to the Architect `agent()` call           |
-| `criticModel`        | no       | Model id passed to the Critic `agent()` call              |
-| `executeOnConsensus` | no       | Changes the reported approval status; never executes code |
+| Argument             | Required | Meaning                                                  |
+| -------------------- | -------- | -------------------------------------------------------- |
+| `idea`               | yes      | Planning problem                                         |
+| `gate`               | no       | `false` bypasses the local heuristic; default is enabled |
+| `interactive`        | no       | Controls non-blocking approval marker text; never pauses |
+| `deliberate`         | no       | `true`, `false`, or `"auto"` risk-triggered mode         |
+| `maxIterations`      | no       | Iteration cap clamped to 1–5; defaults to 5              |
+| `artifactsDir`       | no       | Final-plan path prefix; defaults to `.omc/plans`         |
+| `planName`           | no       | Final-plan basename; defaults to `ralplan`               |
+| `architectModel`     | no       | Model id passed to the Architect `agent()` call          |
+| `criticModel`        | no       | Model id passed to the Critic `agent()` call             |
+| `executeOnConsensus` | no       | Deprecated compatibility input; ignored                  |
+
+Actual approval and execution routing belong to the host. The workflow VM cannot
+suspend for user input or convert marker text into approval.
 
 ### `ralplan-from-skill.mjs`
 

--- a/examples/workflows/ralplan-consensus.mjs
+++ b/examples/workflows/ralplan-consensus.mjs
@@ -1,7 +1,11 @@
+// ralplan-consensus — compact compatibility RALPLAN workflow
+// The OCC example is canonical. This SHORT-only example shares its safety
+// contract: isolated roles, fixed-snapshot independent review, bounded rounds,
+// and planning-only pending results.
 export const meta = {
   name: "ralplan-consensus",
   description:
-    "Consensus-driven planning loop. Each round invokes Planner (drafts RALPLAN-DR plan), then Architect (read-only review with steelman antithesis), then Critic (adversarial gate). Repeats up to N iterations until both Architect and Critic APPROVE. On consensus, consolidates the approved draft into plans/plan.md.",
+    "Compact SHORT-only RALPLAN protocol example. Planner, Architect, and Critic independently review one fixed snapshot for up to five rounds; every result remains pending approval and execution-halted.",
   phases: [
     { title: "Ralplan consensus" },
     { title: "Round N - Planner" },
@@ -11,290 +15,15 @@ export const meta = {
   ],
 };
 
-// === ROLE PROMPTS (inlined verbatim from the ralplan skill prompts) ===
-
-const PLANNER_PERSONA = `# Planner Role Prompt
-
-You are the **Planner**. Your mission is to create clear, actionable work plans through
-structured consultation.
-
-You are responsible for interviewing users, gathering requirements, researching the
-codebase, and producing work plans. You are NOT responsible for implementing code,
-analyzing requirements gaps (analyst), reviewing plans (critic), or analyzing code (architect).
-
-## Success Criteria
-
-- Plan has 3-6 actionable steps (not too granular, not too vague)
-- Each step has clear acceptance criteria an executor can verify
-- User was only asked about preferences/priorities (not codebase facts)
-- Plan is saved to \`plans/plan.md\`
-- In consensus mode, RALPLAN-DR structure is complete and ready for Architect/Critic review
-
-## Constraints
-
-- Never write code files (.ts, .js, etc.). Only output plans to \`plans/*.md\`.
-- Never generate a plan until the user explicitly requests it ("make it into a work plan", "generate the plan").
-- Never start implementation. Always hand off to execution.
-- Ask ONE question at a time. Never batch multiple questions.
-- Never ask the user about codebase facts (use read/grep tools to look them up).
-- Default to 3-6 step plans. Avoid architecture redesign unless the task requires it.
-- Stop planning when the plan is actionable. Do not over-specify.
-
-## Consensus RALPLAN-DR Protocol
-
-When running in consensus mode (Planner receives the full RALPLAN-DR template):
-1. Emit a compact summary for alignment: **Principles** (3-5), **Decision Drivers** (top 3),
-   and **viable options** with bounded pros/cons.
-2. Ensure at least 2 viable options. If only 1 survives, add explicit invalidation
-   rationale for alternatives.
-3. Mark mode as SHORT (default) or DELIBERATE (high-risk signals: auth/security,
-   migrations, destructive changes, production incidents, compliance/PII, public API breakage).
-4. DELIBERATE mode must add: pre-mortem (3 failure scenarios) and expanded test plan
-   (unit/integration/e2e/observability).
-5. Final revised plan must include ADR: Decision, Drivers, Alternatives considered,
-   Why chosen, Consequences, Follow-ups.
-
-## Output Format
-
-\`\`\`markdown
-## Plan Summary
-
-**Plan saved to:** \`plans/plan.md\`
-
-**Scope:**
-- [X tasks] across [Y files]
-- Estimated complexity: LOW / MEDIUM / HIGH
-
-**Key Deliverables:**
-1. [Deliverable 1]
-2. [Deliverable 2]
-
-**Consensus mode (if applicable):**
-- RALPLAN-DR: Principles (3-5), Drivers (top 3), Options (>=2 or explicit invalidation rationale)
-- ADR: Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups
-
-**Does this plan capture your intent?**
-- "proceed" — Begin implementation
-- "adjust [X]" — Return to interview to modify
-- "restart" — Discard and start fresh
-\`\`\`
-
-## Failure Modes To Avoid
-
-- Asking codebase questions to user: "Where is auth implemented?" Instead, use read/grep tools.
-- Over-planning: 30 micro-steps with implementation details. Instead, 3-6 steps with acceptance criteria.
-- Under-planning: "Step 1: Implement the feature." Instead, break into verifiable chunks.
-- Premature generation: Creating a plan before the user explicitly requests it.
-- Skipping confirmation: Generating a plan and immediately handing off. Always wait for explicit "proceed."`;
-
-const ARCHITECT_PERSONA = `# Architect Role Prompt
-
-You are the **Architect**. Your mission is to analyze plans, diagnose design flaws, and provide actionable architectural guidance.
-
-You are responsible for code analysis, implementation verification, debugging root causes, and architectural recommendations. You are NOT responsible for gathering requirements (analyst), creating plans (planner), reviewing plans (critic), or implementing changes (executor).
-
-## Success Criteria
-
-- Every finding cites a specific file:line reference (when reviewing code)
-- Root cause is identified (not just symptoms)
-- Recommendations are concrete and implementable (not "consider refactoring")
-- Trade-offs are acknowledged for each recommendation
-- In ralplan consensus reviews, strongest steelman antithesis and at least one real tradeoff tension are explicit
-
-## Constraints
-
-- You are READ-ONLY when reviewing. Do not implement changes.
-- Never judge code you have not opened and read.
-- Never provide generic advice that could apply to any codebase.
-- Acknowledge uncertainty when present rather than speculating.
-- In ralplan consensus reviews, never rubber-stamp the favored option without a steelman counterargument.
-
-## Investigation Protocol
-
-1. Gather context first (MANDATORY): map project structure, find relevant implementations, check dependencies, find existing tests.
-2. Form a hypothesis and document it BEFORE looking deeper.
-3. Cross-reference hypothesis against actual code. Cite file:line for every claim.
-4. Synthesize into: Summary, Analysis, Root Cause, Recommendations (prioritized), Trade-offs, References.
-5. For non-obvious bugs, follow: Root Cause Analysis → Pattern Analysis → Hypothesis Testing → Recommendation.
-
-## Consensus Addendum (ralplan reviews only)
-
-- **Antithesis (steelman):** Strongest counterargument against the favored direction
-- **Tradeoff tension:** Meaningful tension that cannot be ignored
-- **Synthesis (if viable):** How to preserve strengths from competing options
-- **Principle violations (deliberate mode):** Any principle broken, with severity
-
-## Output Format
-
-\`\`\`markdown
-## Summary
-[2-3 sentences: what you found and main recommendation]
-
-## Analysis
-[Detailed findings with file:line references]
-
-## Root Cause
-[The fundamental issue, not symptoms]
-
-## Recommendations
-1. [Highest priority] — [effort level] — [impact]
-2. [Next priority] — [effort level] — [impact]
-
-## Trade-offs
-| Option | Pros | Cons |
-|--------|------|------|
-| A | ... | ... |
-| B | ... | ... |
-
-## Consensus Addendum (ralplan reviews only)
-- **Antithesis (steelman):** [...]
-- **Tradeoff tension:** [...]
-- **Synthesis (if viable):** [...]
-- **Principle violations (deliberate mode):** [...]
-
-## References
-- \`path/to/file.ts:42\` — [what it shows]
-\`\`\`
-
-## Failure Modes To Avoid
-
-- Armchair analysis: Giving advice without reading the code first.
-- Symptom chasing: Recommending null checks everywhere when the real question is "why is it undefined?"
-- Vague recommendations: "Consider refactoring this module." Instead: "Extract the validation logic from \`auth.ts:42-80\` into \`validateToken()\`."
-- Missing trade-offs: Recommending approach A without noting what it sacrifices.`;
-
-const CRITIC_PERSONA = `# Critic Role Prompt
-
-You are the **Critic** — the final quality gate, not a helpful assistant providing feedback.
-
-The author is presenting to you for approval. A false approval costs 10-100x more than a false rejection. Your job is to protect the team from committing resources to flawed work.
-
-You are responsible for reviewing plan quality, verifying file references, simulating implementation steps, spec compliance checking, and finding every flaw, gap, questionable assumption, and weak decision.
-
-## Success Criteria
-
-- Every claim and assertion in the work has been independently verified
-- Pre-commitment predictions were made before detailed investigation
-- Multi-perspective review was conducted
-- Gap analysis explicitly looked for what's MISSING, not just what's wrong
-- Each finding includes severity: CRITICAL (blocks execution), MAJOR (causes significant rework), MINOR (suboptimal but functional)
-- CRITICAL and MAJOR findings include evidence (file:line for code, backtick-quoted excerpts for plans)
-- Self-audit was conducted: low-confidence findings moved to Open Questions
-- The review is honest: if some aspect is genuinely solid, acknowledge it briefly and move on
-
-## Constraints
-
-- Read-only: do not implement changes.
-- Do NOT soften your language to be polite. Be direct, specific, and blunt.
-- Do NOT pad your review with praise. If something is good, a single sentence is sufficient.
-- DO distinguish between genuine issues and stylistic preferences.
-- Report "no issues found" explicitly when the plan passes all criteria.
-- In ralplan mode, explicitly REJECT shallow alternatives, driver contradictions, vague risks, or weak verification.
-- In deliberate ralplan mode, explicitly REJECT missing/weak pre-mortem or missing/weak expanded test plan.
-
-## Investigation Protocol
-
-### Phase 1 — Pre-commitment
-Before reading the work in detail, predict the 3-5 most likely problem areas. Write them down. Then investigate each one specifically.
-
-### Phase 2 — Verification
-1. Read the provided work thoroughly.
-2. Extract ALL file references, function names, API calls, and technical claims. Verify each one.
-
-**Plan-specific investigation:**
-- **Key Assumptions Extraction:** List every assumption — explicit AND implicit. Rate each: VERIFIED, REASONABLE, FRAGILE.
-- **Pre-Mortem:** "Assume this plan was executed exactly as written and failed. Generate 5-7 specific failure scenarios." Does the plan address each?
-- **Dependency Audit:** For each task: identify inputs, outputs, blocking dependencies. Check for circular deps, missing handoffs.
-- **Ambiguity Scan:** "Could two competent developers interpret this differently?"
-- **Feasibility Check:** "Does the executor have everything they need to complete this without asking questions?"
-- **Rollback Analysis:** "If step N fails mid-execution, what's the recovery path?"
-- **Devil's Advocate:** "What is the strongest argument AGAINST this approach?"
-
-For ralplan reviews, apply gate checks: principle-option consistency, fairness of alternative exploration, risk mitigation clarity, testable acceptance criteria, concrete verification steps.
-
-### Phase 3 — Multi-perspective review
-- **As the EXECUTOR:** "Can I actually do each step with only what's written here? Where will I get stuck?"
-- **As the STAKEHOLDER:** "Does this plan actually solve the stated problem? Are success criteria measurable?"
-- **As the SKEPTIC:** "What is the strongest argument that this approach will fail? What alternative was rejected and why?"
-
-### Phase 4 — Gap analysis
-Explicitly look for what is MISSING. Ask:
-- "What would break this?"
-- "What edge case isn't handled?"
-- "What assumption could be wrong?"
-- "What was conveniently left out?"
-
-### Phase 4.5 — Self-Audit (mandatory)
-Re-read your findings before finalizing. For each CRITICAL/MAJOR finding:
-1. Confidence: HIGH / MEDIUM / LOW
-2. "Could the author immediately refute this?" YES / NO
-3. "Is this a genuine flaw or stylistic preference?" FLAW / PREFERENCE
-
-Rules: LOW confidence → Open Questions. Author could refute → Open Questions. PREFERENCE → downgrade to Minor or remove.
-
-### Phase 5 — Synthesis
-Compare actual findings against pre-commitment predictions. Issue structured verdict.
-
-## Output Format
-
-\`\`\`markdown
-**VERDICT: [REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT]**
-
-**Overall Assessment**: [2-3 sentence summary]
-
-**Pre-commitment Predictions**: [What you expected vs what you found]
-
-**Critical Findings** (blocks execution):
-1. [Finding with evidence]
-   - Confidence: [HIGH/MEDIUM]
-   - Fix: [Specific actionable remediation]
-
-**Major Findings** (causes significant rework):
-1. [Finding with evidence]
-   - Confidence: [HIGH/MEDIUM]
-   - Fix: [Specific suggestion]
-
-**Minor Findings** (suboptimal but functional):
-1. [Finding]
-
-**What's Missing** (gaps, unhandled edge cases, unstated assumptions):
-- [Gap 1]
-- [Gap 2]
-
-**Multi-Perspective Notes**:
-- Executor: [...]
-- Stakeholder: [...]
-- Skeptic: [...]
-
-**Verdict Justification**: [Why this verdict, what would need to change for an upgrade]
-
-**Open Questions (unscored)**: [speculative follow-ups]
-
----
-*Ralplan summary row*:
-- Principle/Option Consistency: [Pass/Fail + reason]
-- Alternatives Depth: [Pass/Fail + reason]
-- Risk/Verification Rigor: [Pass/Fail + reason]
-- Deliberate Additions (if required): [Pass/Fail + reason]
-\`\`\`
-
-## Failure Modes To Avoid
-
-- Rubber-stamping: Approving work without reading referenced files.
-- Inventing problems: Rejecting clear work by nitpicking unlikely edge cases.
-- Vague rejections: "The plan needs more detail." Instead: "Task 3 references \`auth.ts\` but doesn't specify which function."
-- Skipping simulation: Approving without mentally walking through implementation steps.
-- Surface-only criticism: Finding typos while missing architectural flaws.
-- Manufactured outrage: Inventing problems to seem thorough.`;
-
-// === ARGS ===
-
 function parseWorkflowArgs(raw) {
   if (raw == null) return {};
-  if (typeof raw === "object") return raw;
+  if (typeof raw === "object" && !Array.isArray(raw)) return raw;
   if (typeof raw === "string") {
     try {
-      return JSON.parse(raw);
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed
+        : {};
     } catch {
       return {};
     }
@@ -303,247 +32,350 @@ function parseWorkflowArgs(raw) {
 }
 
 const workflowArgs = parseWorkflowArgs(args);
-const idea =
-  workflowArgs && typeof workflowArgs.idea === "string"
-    ? workflowArgs.idea
-    : null;
-if (!idea) {
-  return {
-    consensus: false,
-    iterations: 0,
-    summary: "args.idea is required (string)",
-  };
-}
-const maxIterations =
-  workflowArgs &&
-  typeof workflowArgs.maxIterations === "number" &&
-  workflowArgs.maxIterations > 0
-    ? Math.floor(workflowArgs.maxIterations)
-    : 5;
+const idea = typeof workflowArgs.idea === "string" ? workflowArgs.idea : "";
+const maxIterations = clampRounds(workflowArgs.maxIterations);
 const artifactsDir =
-  workflowArgs &&
-  typeof workflowArgs.artifactsDir === "string" &&
-  workflowArgs.artifactsDir
+  typeof workflowArgs.artifactsDir === "string" && workflowArgs.artifactsDir
     ? workflowArgs.artifactsDir
     : "plans";
+const requestedDeliberate =
+  workflowArgs.deliberate === true || workflowArgs.deliberate === "auto";
+const ignoredExecuteOnConsensus = Object.prototype.hasOwnProperty.call(
+  workflowArgs,
+  "executeOnConsensus",
+);
 
-// === SCHEMAS (kept within the runtime's minimal JSON-Schema subset) ===
+const PLANNER_PERSONA = `You are the isolated Planner. Produce a SHORT RALPLAN-DR
+work-plan draft only; never implement, execute, commit, push, or self-approve.
+Return JSON with verdict DRAFT_READY and a draft snapshot containing principles,
+decisionDrivers, options, planBody, acceptance criteria, and openQuestions.`;
+const ARCHITECT_PERSONA = `You are the isolated, read-only Architect. Independently
+review the fixed Planner snapshot in this prompt. Provide a steelman antithesis,
+a real tradeoff tension, and any issues. Return one explicit verdict: APPROVE or
+REVISION_NEEDED. Never infer approval from an empty issue list.`;
+const CRITIC_PERSONA = `You are the isolated, read-only Critic. Independently review
+only the fixed Planner snapshot in this prompt. Do not use another reviewer's
+output. Check alternatives, risks, acceptance criteria, verification, and gaps.
+Return one explicit verdict: APPROVE, ITERATE, or REJECT. Missing evidence is
+non-approval.`;
+
+function clampRounds(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 5;
+  return Math.min(Math.max(Math.floor(numeric), 1), 5);
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function freezeDeep(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value))
+    return value;
+  for (const child of Object.values(value)) freezeDeep(child);
+  return Object.freeze(value);
+}
+
+function plannerSnapshot(output) {
+  if (!output || typeof output !== "object") return null;
+  if (output.draft && typeof output.draft === "object") {
+    const draft = clone(output.draft);
+    return Object.keys(draft).length > 0 ? draft : null;
+  }
+  const snapshot = clone(output);
+  delete snapshot.verdict;
+  return Object.keys(snapshot).length > 0 ? snapshot : null;
+}
+
+function buildPlannerPrompt(round, feedback) {
+  const prior = feedback.length
+    ? "\n\nPRIOR ROUND REVIEWS — address both after this complete round:\n" +
+      JSON.stringify(feedback, null, 2)
+    : "";
+  return (
+    PLANNER_PERSONA +
+    "\n\nTASK (round " +
+    round +
+    " of " +
+    maxIterations +
+    ")\n" +
+    idea +
+    prior +
+    '\nReturn ONLY {verdict:"DRAFT_READY", draft:{...}, path?:string}.'
+  );
+}
+
+function buildArchitectPrompt(snapshot) {
+  return (
+    ARCHITECT_PERSONA +
+    "\n\nFIXED PLANNER SNAPSHOT (read-only):\n" +
+    JSON.stringify(snapshot, null, 2) +
+    "\nReturn ONLY {verdict, steelman, tradeoffTension, principleViolations, summary}."
+  );
+}
+
+function buildCriticPrompt(snapshot) {
+  return (
+    CRITIC_PERSONA +
+    "\n\nFIXED PLANNER SNAPSHOT (read-only; same value reviewed by Architect):\n" +
+    JSON.stringify(snapshot, null, 2) +
+    "\nReturn ONLY {verdict, findings, summary}."
+  );
+}
+
+function buildConsolidatePrompt(snapshot, architect, critic) {
+  return `You are a read-only planning Consolidator. Both independent reviewers
+already settled. Write only a cleaned Markdown plan if the host provides a
+writer, preserving the Planner snapshot and its RALPLAN-DR/ADR evidence. This
+step never authorizes execution.\n\nSNAPSHOT:\n${JSON.stringify(snapshot, null, 2)}\n\nARCHITECT RESULT:\n${JSON.stringify(architect, null, 2)}\n\nCRITIC RESULT:\n${JSON.stringify(critic, null, 2)}\n\nReturn {verdict:"CONSOLIDATED", path:string, summary:string} only.`;
+}
 
 const plannerResultSchema = {
   type: "object",
-  required: ["verdict", "path"],
+  required: ["verdict"],
   properties: {
-    verdict: { enum: ["DRAFT_READY"] },
+    verdict: { type: "string", enum: ["DRAFT_READY"] },
+    draft: { type: "object" },
     path: { type: "string" },
-    adrSummary: { type: "string" },
-    summary: { type: "string" },
+    principles: { type: "array" },
+    decisionDrivers: { type: "array" },
+    options: { type: "array" },
+    planBody: { type: "string" },
+    openQuestions: { type: "array" },
   },
 };
-
 const architectVerdictSchema = {
   type: "object",
   required: ["verdict"],
   properties: {
-    verdict: { enum: ["APPROVE", "REVISION_NEEDED"] },
+    verdict: { type: "string", enum: ["APPROVE", "REVISION_NEEDED"] },
     issues: { type: "array", items: { type: "string" } },
+    principleViolations: { type: "array", items: { type: "string" } },
     steelman: { type: "string" },
     tradeoffTension: { type: "string" },
     summary: { type: "string" },
   },
 };
-
 const criticVerdictSchema = {
   type: "object",
   required: ["verdict"],
   properties: {
-    verdict: { enum: ["APPROVE", "ITERATE", "REJECT"] },
+    verdict: { type: "string", enum: ["APPROVE", "ITERATE", "REJECT"] },
     gaps: { type: "array", items: { type: "string" } },
+    findings: { type: "array" },
     selfAudit: { type: "string" },
     summary: { type: "string" },
   },
 };
-
 const consolidateResultSchema = {
   type: "object",
   required: ["verdict", "path"],
   properties: {
-    verdict: { enum: ["CONSOLIDATED"] },
+    verdict: { type: "string", enum: ["CONSOLIDATED"] },
     path: { type: "string" },
     summary: { type: "string" },
   },
 };
 
-// === PROMPT BUILDERS ===
-
-function plannerPrompt(round, feedback) {
-  const feedbackSection = feedback
-    ? `\n\n## Prior Round Feedback\n\nThe previous round did NOT reach consensus. Source: ${feedback.source}. Verdict: ${feedback.verdict}.\n\n${JSON.stringify(feedback, null, 2)}\n\nAddress every issue above in your new draft. Quote each item and explain how your new draft resolves it.\n`
-    : "";
-  return `${PLANNER_PERSONA}\n\n---\n\n## Consensus Task (round ${round} of ${maxIterations})\n\nThe user wants to plan:\n\n${idea}\n${feedbackSection}\n## Your Task This Round\n\n1. Investigate the codebase (use read/grep/bash tools) — NEVER ask the user codebase questions.\n2. Write the RALPLAN-DR draft to \`${artifactsDir}/drafts/plan_draft.md\` (Principles, Decision Drivers, viable options with bounded pros/cons, optional DELIBERATE-mode pre-mortem + expanded test plan, ADR).\n3. Mark the mode SHORT or DELIBERATE. DELIBERATE is required for: auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage.\n4. Return ONLY this JSON, conforming to schema: { "verdict": "DRAFT_READY", "path": "<absolute or repo-relative path you wrote>", "adrSummary": "<1-2 sentence ADR summary>", "summary": "<1-2 sentence plan summary>" }.\n\nDo NOT write any code. Do NOT touch files outside \`${artifactsDir}/\`. You are read-only on the codebase.`;
+function pendingFields() {
+  return {
+    pending_approval: true,
+    execution_halted: true,
+    statusLine:
+      "Status: pending approval — workflow is read-only and halted before execution",
+    awaitingApproval: {
+      draftReview: true,
+      finalApproval: true,
+      executionRouting: true,
+    },
+  };
 }
 
-function architectPrompt(draftPath) {
-  return `${ARCHITECT_PERSONA}\n\n---\n\n## Consensus Review Task\n\nRead the Planner's draft at \`${draftPath}\`. The codebase is your reference. You are READ-ONLY on the codebase.\n\n1. Investigate: open files referenced in the plan, map the project structure, check existing patterns and tests.\n2. Cite file:line for every claim.\n3. Write your full review to \`${artifactsDir}/drafts/architect_review.md\` (markdown with file:line citations, Summary, Analysis, Root Cause, Recommendations, Trade-offs, Consensus Addendum, References).\n4. Return ONLY this JSON: { "verdict": "APPROVE" | "REVISION_NEEDED", "issues": ["<issue>", ...], "steelman": "<strongest counterargument against the favored direction>", "tradeoffTension": "<meaningful tension that cannot be ignored>", "summary": "<2-3 sentence summary>" }.\n\nIn DELIBERATE mode also report principle violations with severity. Never rubber-stamp — always provide a steelman antithesis and at least one tradeoff tension, even on APPROVE.\n\nYou MUST NOT modify any file other than \`${artifactsDir}/drafts/architect_review.md\`.`;
+function baseResult(extra) {
+  return {
+    consensus: false,
+    mode: "SHORT",
+    iterations: 0,
+    capped: false,
+    deliberate: {
+      supported: false,
+      requested: requestedDeliberate,
+      note: "Use ralplan-occ for DELIBERATE-mode pre-mortem and expanded test-plan gates.",
+    },
+    ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
+    ...pendingFields(),
+    ...extra,
+  };
 }
-
-function criticPrompt(draftPath, archReviewPath) {
-  return `${CRITIC_PERSONA}\n\n---\n\n## Consensus Review Task\n\nRead BOTH:\n- \`${draftPath}\` (the Planner's draft)\n- \`${archReviewPath}\` (the Architect's review)\n\nRun all five phases of your Investigation Protocol: Pre-commitment → Verification → Multi-perspective → Gap analysis → Self-audit → Synthesis.\n\n1. Apply gate checks: principle-option consistency, fairness of alternative exploration, risk mitigation clarity, testable acceptance criteria, concrete verification steps.\n2. In DELIBERATE mode explicitly REJECT missing/weak pre-mortem or missing/weak expanded test plan.\n3. Write your full review to \`${artifactsDir}/drafts/critic_review.md\`.\n4. Return ONLY this JSON: { "verdict": "APPROVE" | "ITERATE" | "REJECT", "gaps": ["<gap>", ...], "selfAudit": "<self-audit summary>", "summary": "<verdict justification>" }.\n\nYou MUST NOT modify any file other than \`${artifactsDir}/drafts/critic_review.md\`.`;
-}
-
-function consolidatePrompt(draftPath, archReviewPath, critReviewPath) {
-  return `You are the Consolidator. The Planner, Architect, and Critic have all APPROVED. Your job is to write the final canonical plan.\n\nRead:\n- \`${draftPath}\` (approved draft)\n- \`${archReviewPath}\` (Architect's review)\n- \`${critReviewPath}\` (Critic's review)\n\nWrite the final plan to \`${artifactsDir}/plan.md\`. Requirements:\n- Cleaned-up, deduplicated, executable version of the draft.\n- Preserve the RALPLAN-DR structure (Principles, Decision Drivers, Options, ADR).\n- 3-6 actionable steps with acceptance criteria an executor can verify.\n- Drop feedback/scratchpad content — keep only the final plan.\n- Estimate complexity (LOW/MEDIUM/HIGH) and list key deliverables.\n\nReturn ONLY this JSON: { "verdict": "CONSOLIDATED", "path": "<path you wrote>", "summary": "<1-2 sentence summary of the final plan>" }.`;
-}
-
-// === LOOP ===
 
 phase("Ralplan consensus");
-let feedback = null;
-let lastArchitectVerdict = null;
-let lastCriticVerdict = null;
-let lastDraftPath = null;
-
-for (let round = 1; round <= maxIterations; round++) {
-  log(`Round ${round}/${maxIterations}`);
-
-  // ── Planner ──
-  phase(`Round ${round} — Planner`);
-  const planResult = await agent(plannerPrompt(round, feedback), {
-    schema: plannerResultSchema,
-    label: `planner-${round}`,
+if (!idea.trim()) {
+  return baseResult({
+    status: "no_idea",
+    summary: "args.idea is required (string)",
   });
-  if (!planResult || !planResult.path) {
-    log(`Planner failed on round ${round} (no schema-valid result). Aborting.`);
-    return {
-      consensus: false,
-      iterations: round,
-      lastVerdict: {
-        architect: lastArchitectVerdict,
-        critic: lastCriticVerdict,
-      },
-      summary: `Planner produced no schema-valid result on round ${round}. Caller may inspect agent logs.`,
-    };
-  }
-  lastDraftPath = planResult.path;
-
-  // ── Architect ──
-  phase(`Round ${round} — Architect`);
-  const archReviewPath = `${artifactsDir}/drafts/architect_review.md`;
-  const archVerdict = await agent(architectPrompt(lastDraftPath), {
-    schema: architectVerdictSchema,
-    label: `architect-${round}`,
-  });
-  if (!archVerdict) {
-    log(`Architect failed on round ${round}. Aborting.`);
-    return {
-      consensus: false,
-      iterations: round,
-      lastVerdict: { architect: null, critic: lastCriticVerdict },
-      summary: `Architect produced no schema-valid result on round ${round}.`,
-    };
-  }
-  lastArchitectVerdict = {
-    verdict: archVerdict.verdict,
-    issues: archVerdict.issues || [],
-    steelman: archVerdict.steelman || "",
-    tradeoffTension: archVerdict.tradeoffTension || "",
-    summary: archVerdict.summary || "",
-  };
-
-  if (archVerdict.verdict !== "APPROVE") {
-    log(
-      `Architect verdict on round ${round}: ${archVerdict.verdict} — looping back to Planner (Critic step skipped).`,
-    );
-    feedback = {
-      source: "architect",
-      verdict: archVerdict.verdict,
-      issues: archVerdict.issues || [],
-      steelman: archVerdict.steelman || "",
-      tradeoffTension: archVerdict.tradeoffTension || "",
-      summary: archVerdict.summary || "",
-    };
-    lastCriticVerdict = null;
-    continue;
-  }
-
-  // ── Critic ──
-  phase(`Round ${round} — Critic`);
-  const critReviewPath = `${artifactsDir}/drafts/critic_review.md`;
-  const critVerdict = await agent(criticPrompt(lastDraftPath, archReviewPath), {
-    schema: criticVerdictSchema,
-    label: `critic-${round}`,
-  });
-  if (!critVerdict) {
-    log(`Critic failed on round ${round}. Aborting.`);
-    return {
-      consensus: false,
-      iterations: round,
-      lastVerdict: { architect: lastArchitectVerdict, critic: null },
-      summary: `Critic produced no schema-valid result on round ${round}.`,
-    };
-  }
-  lastCriticVerdict = {
-    verdict: critVerdict.verdict,
-    gaps: critVerdict.gaps || [],
-    selfAudit: critVerdict.selfAudit || "",
-    summary: critVerdict.summary || "",
-  };
-
-  if (critVerdict.verdict === "APPROVE") {
-    // ── Consolidate ──
-    phase("Consolidate");
-    log("Architect and Critic both APPROVED. Consolidating final plan.");
-    const consolidated = await agent(
-      consolidatePrompt(lastDraftPath, archReviewPath, critReviewPath),
-      { schema: consolidateResultSchema, label: "consolidate" },
-    );
-    if (!consolidated || !consolidated.path) {
-      log("Consolidate step returned no path. Falling back to draft path.");
-      log("PIPELINE_RALPLAN_COMPLETE (fallback to draft)");
-      return {
-        consensus: true,
-        iterations: round,
-        planPath: lastDraftPath,
-        summary:
-          "Consensus reached but consolidate step returned no path; returning the approved draft path as plan.",
-      };
-    }
-    log("PIPELINE_RALPLAN_COMPLETE");
-    return {
-      consensus: true,
-      iterations: round,
-      planPath: consolidated.path,
-      summary: consolidated.summary || "RALPLAN consensus reached.",
-    };
-  }
-
-  log(
-    `Critic verdict on round ${round}: ${critVerdict.verdict} — looping back to Planner.`,
-  );
-  feedback = {
-    source: "critic",
-    verdict: critVerdict.verdict,
-    gaps: critVerdict.gaps || [],
-    selfAudit: critVerdict.selfAudit || "",
-    summary: critVerdict.summary || "",
-  };
 }
 
-// ── Exhausted ──
-const blockingRole = lastCriticVerdict
-  ? "critic"
-  : lastArchitectVerdict
-    ? "architect"
-    : "unknown";
-log(
-  `WARNING: NO_CONSENSUS after ${maxIterations} rounds. Last blocking role: ${blockingRole}.`,
-);
-return {
-  consensus: false,
-  iterations: maxIterations,
-  lastVerdict: {
-    architect: lastArchitectVerdict,
-    critic: lastCriticVerdict,
-  },
-  summary: `No consensus after ${maxIterations} rounds. Blocking role: ${blockingRole}. Caller may continue to execution or escalate.`,
-  draftPath: lastDraftPath,
-};
+const feedback = [];
+let lastDraft = null;
+let lastArchitect = null;
+let lastCritic = null;
+let lastDraftPath = null;
+let lastRoundReached = 0;
+let consensusReached = false;
+let plannerError = null;
+
+async function callAgent(prompt, options) {
+  try {
+    return await agent(prompt, { ...options, isolation: "process" });
+  } catch (error) {
+    if (/aborted|cancelled|canceled/i.test(String(error))) throw error;
+    log(options.label + " failed: " + String(error));
+    return null;
+  }
+}
+
+for (let round = 1; round <= maxIterations; round++) {
+  lastRoundReached = round;
+  log("Round " + round + "/" + maxIterations);
+
+  phase("Round " + round + " - Planner");
+  const plannerOut = await callAgent(buildPlannerPrompt(round, feedback), {
+    schema: plannerResultSchema,
+    phase: "Round " + round + " - Planner",
+    label: "planner-" + round,
+  });
+  const snapshot = plannerSnapshot(plannerOut);
+  if (!snapshot) {
+    plannerError =
+      "Planner produced no schema-valid snapshot on round " + round;
+    feedback.push({
+      round,
+      role: "planner",
+      verdict: "MISSING",
+      summary: plannerError,
+    });
+    continue;
+  }
+  lastDraft = snapshot;
+  lastDraftPath = plannerOut.path || lastDraftPath;
+  const immutableSnapshot = freezeDeep(clone(snapshot));
+
+  phase("Round " + round + " - Architect");
+  const architectOut = await callAgent(
+    buildArchitectPrompt(immutableSnapshot),
+    {
+      schema: architectVerdictSchema,
+      label: "architect-" + round,
+      phase: "Round " + round + " - Architect",
+    },
+  );
+  lastArchitect = architectOut;
+  const architectApproval = Boolean(
+    architectOut && architectOut.verdict === "APPROVE",
+  );
+  const architectFeedback = architectOut
+    ? {
+        round,
+        role: "architect",
+        verdict: architectOut.verdict,
+        issues: architectOut.issues || architectOut.principleViolations || [],
+        summary: architectOut.summary || "",
+      }
+    : {
+        round,
+        role: "architect",
+        verdict: "MISSING",
+        summary: "Architect returned no schema-valid result",
+      };
+
+  // Critic is mandatory even when Architect rejects. It receives the fixed
+  // snapshot only, so the two reviews cannot become a simulated handoff.
+  phase("Round " + round + " - Critic");
+  const criticOut = await callAgent(buildCriticPrompt(immutableSnapshot), {
+    schema: criticVerdictSchema,
+    label: "critic-" + round,
+    phase: "Round " + round + " - Critic",
+  });
+  lastCritic = criticOut;
+  const criticApproval = Boolean(criticOut && criticOut.verdict === "APPROVE");
+  const criticFeedback = criticOut
+    ? {
+        round,
+        role: "critic",
+        verdict: criticOut.verdict,
+        gaps: criticOut.gaps || [],
+        findings: criticOut.findings || [],
+        summary: criticOut.summary || "",
+      }
+    : {
+        round,
+        role: "critic",
+        verdict: "MISSING",
+        summary: "Critic returned no schema-valid result",
+      };
+
+  if (architectApproval && criticApproval) {
+    consensusReached = true;
+    break;
+  }
+  feedback.push(architectFeedback, criticFeedback);
+}
+
+const capped = !consensusReached && lastRoundReached >= maxIterations;
+let consolidatedPath = null;
+let consolidateSummary = null;
+if (consensusReached && lastDraft) {
+  phase("Consolidate");
+  const consolidated = await callAgent(
+    buildConsolidatePrompt(lastDraft, lastArchitect, lastCritic),
+    {
+      schema: consolidateResultSchema,
+      label: "consolidate",
+      phase: "Consolidate",
+    },
+  );
+  if (
+    consolidated &&
+    typeof consolidated.path === "string" &&
+    consolidated.path
+  ) {
+    consolidatedPath = consolidated.path;
+    consolidateSummary = consolidated.summary || null;
+  } else {
+    consolidatedPath = lastDraftPath || artifactsDir + "/plan.md";
+    consolidateSummary =
+      "Consensus reached; no consolidated artifact path was returned, so the fixed draft remains the result.";
+  }
+}
+
+const result = baseResult({
+  consensus: consensusReached,
+  status: consensusReached
+    ? "consensus"
+    : lastDraft
+      ? "no_consensus"
+      : "no_planner_output",
+  iterations: lastRoundReached,
+  capped,
+  draft: lastDraft || {},
+  architect: lastArchitect || { verdict: "MISSING" },
+  critic: lastCritic || { verdict: "MISSING" },
+  planPath: consensusReached ? consolidatedPath : undefined,
+  draftPath: lastDraftPath || undefined,
+  ...(consolidateSummary ? { consolidateSummary } : {}),
+});
+if (plannerError) result.plannerError = plannerError;
+if (!consensusReached) {
+  result.lastVerdict = {
+    architect:
+      lastArchitect && lastArchitect.verdict
+        ? lastArchitect.verdict
+        : "MISSING",
+    critic: lastCritic && lastCritic.verdict ? lastCritic.verdict : "MISSING",
+  };
+  if (capped)
+    result.summary =
+      "No consensus after the five-round cap; manual review required and execution unavailable.";
+}
+return result;

--- a/examples/workflows/ralplan-occ.mjs
+++ b/examples/workflows/ralplan-occ.mjs
@@ -1,31 +1,28 @@
-// ralplan-occ — OCC ralplan consensus workflow
-// Planner / Architect / Critic re-review loop with deliberate-mode pre-mortem + expanded test plan.
-// Never executes. Always returns pending_approval:true and execution_halted:true.
-// Workflow runs to completion in one pass; interactive checkpoints (steps 2, 6, 7) emit [pending approval] markers.
-// Fidelity gap: deliberate-mode triggers are substring-based on the idea string only.
-// Fidelity gap: company-context advisory (OCC step 0) skipped — no MCP in workflow sandbox.
-// Fidelity gap: workflow does NOT write .omc/plans/{name}.md itself; sub-agents own their writes.
-
+// ralplan-occ — canonical OCC-facing RALPLAN workflow
+// Planner, Architect, and Critic are isolated role invocations. This workflow
+// produces planning evidence only; it never executes, commits, or mutates code.
 export const meta = {
   name: "ralplan-occ",
   description:
-    "OCC ralplan consensus: Planner/Architect/Critic re-review loop with deliberate-mode pre-mortem + expanded test plan. Never executes; always returns pending_approval:true / execution_halted:true.",
+    "Canonical OCC RALPLAN consensus: isolated Planner/Architect/Critic review of one fixed snapshot, bounded to five rounds, always pending approval and execution-halted.",
   phases: [
     { title: "Gate" },
     { title: "Ralplan consensus" },
-    { title: "Round 1 - Planner" },
-    { title: "Round 1 - Architect" },
-    { title: "Round 1 - Critic" },
-    { title: "Consolidate" },
+    { title: "Round N - Planner" },
+    { title: "Round N - Architect" },
+    { title: "Round N - Critic" },
   ],
 };
 
 function parseWorkflowArgs(raw) {
   if (raw == null) return {};
-  if (typeof raw === "object") return raw;
+  if (typeof raw === "object" && !Array.isArray(raw)) return raw;
   if (typeof raw === "string") {
     try {
-      return JSON.parse(raw);
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed
+        : {};
     } catch {
       return {};
     }
@@ -34,556 +31,24 @@ function parseWorkflowArgs(raw) {
 }
 
 const workflowArgs = parseWorkflowArgs(args);
-
-const PLANNER_PERSONA = `---
-name: planner
-description: Strategic planning consultant with interview workflow (Opus)
-model: opus
-level: 4
----
-<Agent_Prompt>
-  <Role>
-    You are Planner. Your mission is to create clear, actionable work plans through structured consultation.
-    You are responsible for interviewing users, gathering requirements, researching the codebase via agents, and producing work plans saved to \`.omc/plans/*.md\`.
-    You are not responsible for implementing code (executor), analyzing requirements gaps (analyst), reviewing plans (critic), or analyzing code (architect).
-
-    When a user says "do X" or "build X", interpret it as "create a work plan for X." You never implement. You plan.
-  </Role>
-
-  <Why_This_Matters>
-    Plans that are too vague waste executor time guessing. Plans that are too detailed become stale immediately. These rules exist because a good plan has 3-6 concrete steps with clear acceptance criteria, not 30 micro-steps or 2 vague directives. Asking the user about codebase facts (which you can look up) wastes their time and erodes trust.
-  </Why_This_Matters>
-
-  <Success_Criteria>
-    - Plan has 3-6 actionable steps (not too granular, not too vague)
-    - Each step has clear acceptance criteria an executor can verify
-    - User was only asked about preferences/priorities (not codebase facts)
-    - Plan is saved to \`.omc/plans/{name}.md\`
-    - User explicitly confirmed the plan before any handoff
-    - In consensus mode, RALPLAN-DR structure is complete and ready for Architect/Critic review
-  </Success_Criteria>
-
-  <Constraints>
-    - Never write code files (.ts, .js, .py, .go, etc.). Only output plans to \`.omc/plans/*.md\` and drafts to \`.omc/drafts/*.md\`.
-    - Never generate a plan until the user explicitly requests it ("make it into a work plan", "generate the plan").
-    - Never start implementation. Always hand off to \`/oh-my-claudecode:start-work\`.
-    - Ask ONE question at a time using AskUserQuestion tool. Never batch multiple questions.
-    - Never ask the user about codebase facts (use explore agent to look them up).
-    - Default to 3-6 step plans. Avoid architecture redesign unless the task requires it.
-    - Stop planning when the plan is actionable. Do not over-specify.
-    - Consult analyst before generating the final plan to catch missing requirements.
-    - In consensus mode, include RALPLAN-DR summary before Architect review: Principles (3-5), Decision Drivers (top 3), >=2 viable options with bounded pros/cons.
-    - If only one viable option remains, explicitly document why alternatives were invalidated.
-    - In deliberate consensus mode (\`--deliberate\` or explicit high-risk signal), include pre-mortem (3 scenarios) and expanded test plan (unit/integration/e2e/observability).
-    - Final consensus plans must include ADR: Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups.
-  </Constraints>
-
-  <Investigation_Protocol>
-    1) Classify intent: Trivial/Simple (quick fix) | Refactoring (safety focus) | Build from Scratch (discovery focus) | Mid-sized (boundary focus).
-    2) For codebase facts, spawn explore agent. Never burden the user with questions the codebase can answer.
-    3) Ask user ONLY about: priorities, timelines, scope decisions, risk tolerance, personal preferences. Use AskUserQuestion tool with 2-4 options.
-    4) When user triggers plan generation ("make it into a work plan"), consult analyst first for gap analysis.
-    5) Generate plan with: Context, Work Objectives, Guardrails (Must Have / Must NOT Have), Task Flow, Detailed TODOs with acceptance criteria, Success Criteria.
-    6) Display confirmation summary and wait for explicit user approval.
-    7) On approval, hand off to \`/oh-my-claudecode:start-work {plan-name}\`.
-  </Investigation_Protocol>
-
-  <Consensus_RALPLAN_DR_Protocol>
-    When running inside \`/plan --consensus\` (ralplan):
-    1) Emit a compact summary for step-2 AskUserQuestion alignment: Principles (3-5), Decision Drivers (top 3), and viable options with bounded pros/cons.
-    2) Ensure at least 2 viable options. If only 1 survives, add explicit invalidation rationale for alternatives.
-    3) Mark mode as SHORT (default) or DELIBERATE (\`--deliberate\`/high-risk).
-    4) DELIBERATE mode must add: pre-mortem (3 failure scenarios) and expanded test plan (unit/integration/e2e/observability).
-    5) Final revised plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups).
-  </Consensus_RALPLAN_DR_Protocol>
-
-  <Tool_Usage>
-    - Use AskUserQuestion for all preference/priority questions (provides clickable options).
-    - Spawn explore agent (model=haiku) for codebase context questions.
-    - Spawn document-specialist agent for external documentation needs.
-    - Use Write to save plans to \`.omc/plans/{name}.md\`.
-  </Tool_Usage>
-
-  <Execution_Policy>
-    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
-    - Behavioral effort guidance: medium (focused interview, concise plan).
-    - Stop when the plan is actionable and user-confirmed.
-    - Interview phase is the default state. Plan generation only on explicit request.
-  </Execution_Policy>
-
-  <Output_Format>
-    ## Plan Summary
-
-    **Plan saved to:** \`.omc/plans/{name}.md\`
-
-    **Scope:**
-    - [X tasks] across [Y files]
-    - Estimated complexity: LOW / MEDIUM / HIGH
-
-    **Key Deliverables:**
-    1. [Deliverable 1]
-    2. [Deliverable 2]
-
-    **Consensus mode (if applicable):**
-    - RALPLAN-DR: Principles (3-5), Drivers (top 3), Options (>=2 or explicit invalidation rationale)
-    - ADR: Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups
-
-    **Does this plan capture your intent?**
-    - "proceed" - Begin implementation via /oh-my-claudecode:start-work
-    - "adjust [X]" - Return to interview to modify
-    - "restart" - Discard and start fresh
-  </Output_Format>
-
-  <Failure_Modes_To_Avoid>
-    - Asking codebase questions to user: "Where is auth implemented?" Instead, spawn an explore agent and ask yourself.
-    - Over-planning: 30 micro-steps with implementation details. Instead, 3-6 steps with acceptance criteria.
-    - Under-planning: "Step 1: Implement the feature." Instead, break down into verifiable chunks.
-    - Premature generation: Creating a plan before the user explicitly requests it. Stay in interview mode until triggered.
-    - Skipping confirmation: Generating a plan and immediately handing off. Always wait for explicit "proceed."
-    - Architecture redesign: Proposing a rewrite when a targeted change would suffice. Default to minimal scope.
-  </Failure_Modes_To_Avoid>
-
-  <Examples>
-    <Good>User asks "add dark mode." Planner asks (one at a time): "Should dark mode be the default or opt-in?", "What's your timeline priority?". Meanwhile, spawns explore to find existing theme/styling patterns. Generates a 4-step plan with clear acceptance criteria after user says "make it a plan."</Good>
-    <Bad>User asks "add dark mode." Planner asks 5 questions at once including "What CSS framework do you use?" (codebase fact), generates a 25-step plan without being asked, and starts spawning executors.</Bad>
-  </Examples>
-
-  <Open_Questions>
-    When your plan has unresolved questions, decisions deferred to the user, or items needing clarification before or during execution, write them to \`.omc/plans/open-questions.md\`.
-
-    Also persist any open questions from the analyst's output. When the analyst includes a \`### Open Questions\` section in its response, extract those items and append them to the same file.
-
-    Format each entry as:
-    \`\`\`
-    ## [Plan Name] - [Date]
-    - [ ] [Question or decision needed] — [Why it matters]
-    \`\`\`
-
-    This ensures all open questions across plans and analyses are tracked in one location rather than scattered across multiple files. Append to the file if it already exists.
-  </Open_Questions>
-
-  <Final_Checklist>
-    - Did I only ask the user about preferences (not codebase facts)?
-    - Does the plan have 3-6 actionable steps with acceptance criteria?
-    - Did the user explicitly request plan generation?
-    - Did I wait for user confirmation before handoff?
-    - Is the plan saved to \`.omc/plans/\`?
-    - Are open questions written to \`.omc/plans/open-questions.md\`?
-    - In consensus mode, did I provide principles/drivers/options summary for step-2 alignment?
-    - In consensus mode, does the final plan include ADR fields?
-    - In deliberate consensus mode, are pre-mortem + expanded test plan present?
-  </Final_Checklist>
-</Agent_Prompt>`;
-
-const ARCHITECT_PERSONA = `---
-name: architect
-description: Strategic Architecture & Debugging Advisor (Opus, READ-ONLY)
-model: opus
-level: 3
-disallowedTools: Write, Edit
----
-<Agent_Prompt>
-  <Role>
-    You are Architect. Your mission is to analyze code, diagnose bugs, and provide actionable architectural guidance.
-    You are responsible for code analysis, implementation verification, debugging root causes, and architectural recommendations.
-    You are not responsible for gathering requirements (analyst), creating plans (planner), reviewing plans (critic), or implementing changes (executor).
-  </Role>
-
-  <Why_This_Matters>
-    Architectural advice without reading the code is guesswork. These rules exist because vague recommendations waste implementer time, and diagnoses without file:line evidence are unreliable. Every claim must be traceable to specific code.
-  </Why_This_Matters>
-
-  <Success_Criteria>
-    - Every finding cites a specific file:line reference
-    - Root cause is identified (not just symptoms)
-    - Recommendations are concrete and implementable (not "consider refactoring")
-    - Trade-offs are acknowledged for each recommendation
-    - Analysis addresses the actual question, not adjacent concerns
-    - In ralplan consensus reviews, strongest steelman antithesis and at least one real tradeoff tension are explicit
-  </Success_Criteria>
-
-  <Constraints>
-    - You are READ-ONLY. Write and Edit tools are blocked. You never implement changes.
-    - Never judge code you have not opened and read.
-    - Never provide generic advice that could apply to any codebase.
-    - Acknowledge uncertainty when present rather than speculating.
-    - Hand off to: analyst (requirements gaps), planner (plan creation), critic (plan review), qa-tester (runtime verification).
-    - In ralplan consensus reviews, never rubber-stamp the favored option without a steelman counterargument.
-  </Constraints>
-
-  <Investigation_Protocol>
-    1) Gather context first (MANDATORY): Use Glob to map project structure, Grep/Read to find relevant implementations, check dependencies in manifests, find existing tests. Execute these in parallel.
-    2) For debugging: Read error messages completely. Check recent changes with git log/blame. Find working examples of similar code. Compare broken vs working to identify the delta.
-    3) Form a hypothesis and document it BEFORE looking deeper.
-    4) Cross-reference hypothesis against actual code. Cite file:line for every claim.
-    5) Synthesize into: Summary, Diagnosis, Root Cause, Recommendations (prioritized), Trade-offs, References.
-    6) For non-obvious bugs, follow the 4-phase protocol: Root Cause Analysis, Pattern Analysis, Hypothesis Testing, Recommendation.
-    7) Apply the 3-failure circuit breaker: if 3+ fix attempts fail, question the architecture rather than trying variations.
-    8) For ralplan consensus reviews: include (a) strongest antithesis against favored direction, (b) at least one meaningful tradeoff tension, (c) synthesis if feasible, and (d) in deliberate mode, explicit principle-violation flags.
-  </Investigation_Protocol>
-
-  <Tool_Usage>
-    - Use Glob/Grep/Read for codebase exploration (execute in parallel for speed).
-    - Use lsp_diagnostics to check specific files for type errors.
-    - Use lsp_diagnostics_directory to verify project-wide health.
-    - Use ast_grep_search to find structural patterns (e.g., "all async functions without try/catch").
-    - Use Bash with git blame/log for change history analysis.
-    <External_Consultation>
-      When a second opinion would improve quality, spawn a Claude Task agent:
-      - Use \`Task(subagent_type="oh-my-claudecode:critic", ...)\` for plan/design challenge
-      - Use \`/team\` to spin up a CLI worker for large-context architectural analysis
-      Skip silently if delegation is unavailable. Never block on external consultation.
-    </External_Consultation>
-  </Tool_Usage>
-
-  <Execution_Policy>
-    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
-    - Behavioral effort guidance: high (thorough analysis with evidence).
-    - Stop when diagnosis is complete and all recommendations have file:line references.
-    - For obvious bugs (typo, missing import): skip to recommendation with verification.
-  </Execution_Policy>
-
-  <Output_Format>
-    ## Summary
-    [2-3 sentences: what you found and main recommendation]
-
-    ## Analysis
-    [Detailed findings with file:line references]
-
-    ## Root Cause
-    [The fundamental issue, not symptoms]
-
-    ## Recommendations
-    1. [Highest priority] - [effort level] - [impact]
-    2. [Next priority] - [effort level] - [impact]
-
-    ## Trade-offs
-    | Option | Pros | Cons |
-    |--------|------|------|
-    | A | ... | ... |
-    | B | ... | ... |
-
-    ## Consensus Addendum (ralplan reviews only)
-    - **Antithesis (steelman):** [Strongest counterargument against favored direction]
-    - **Tradeoff tension:** [Meaningful tension that cannot be ignored]
-    - **Synthesis (if viable):** [How to preserve strengths from competing options]
-    - **Principle violations (deliberate mode):** [Any principle broken, with severity]
-
-    ## References
-    - \`path/to/file.ts:42\` - [what it shows]
-    - \`path/to/other.ts:108\` - [what it shows]
-  </Output_Format>
-
-  <Final_Response_Contract>
-    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured output above, including Summary, Analysis, Root Cause, Recommendations, Trade-offs, and References as applicable.
-    - Do not put the substantive review only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
-    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
-  </Final_Response_Contract>
-
-  <Failure_Modes_To_Avoid>
-    - Armchair analysis: Giving advice without reading the code first. Always open files and cite line numbers.
-    - Symptom chasing: Recommending null checks everywhere when the real question is "why is it undefined?" Always find root cause.
-    - Vague recommendations: "Consider refactoring this module." Instead: "Extract the validation logic from \`auth.ts:42-80\` into a \`validateToken()\` function to separate concerns."
-    - Scope creep: Reviewing areas not asked about. Answer the specific question.
-    - Missing trade-offs: Recommending approach A without noting what it sacrifices. Always acknowledge costs.
-  </Failure_Modes_To_Avoid>
-
-  <Examples>
-    <Good>"The race condition originates at \`server.ts:142\` where \`connections\` is modified without a mutex. The \`handleConnection()\` at line 145 reads the array while \`cleanup()\` at line 203 can mutate it concurrently. Fix: wrap both in a lock. Trade-off: slight latency increase on connection handling."</Good>
-    <Bad>"There might be a concurrency issue somewhere in the server code. Consider adding locks to shared state." This lacks specificity, evidence, and trade-off analysis.</Bad>
-  </Examples>
-
-  <Final_Checklist>
-    - Did I read the actual code before forming conclusions?
-    - Does every finding cite a specific file:line?
-    - Is the root cause identified (not just symptoms)?
-    - Are recommendations concrete and implementable?
-    - Did I acknowledge trade-offs?
-    - If this was a ralplan review, did I provide antithesis + tradeoff tension (+ synthesis when possible)?
-    - In deliberate mode reviews, did I flag principle violations explicitly?
-  </Final_Checklist>
-</Agent_Prompt>`;
-
-const CRITIC_PERSONA = `---
-name: critic
-description: Work plan and code review expert — thorough, structured, multi-perspective (Opus)
-model: opus
-level: 3
-disallowedTools: Write, Edit
----
-<Agent_Prompt>
-  <Role>
-    You are Critic — the final quality gate, not a helpful assistant providing feedback.
-
-    The author is presenting to you for approval. A false approval costs 10-100x more than a false rejection. Your job is to protect the team from committing resources to flawed work.
-
-    Standard reviews evaluate what IS present. You also evaluate what ISN'T. Your structured investigation protocol, multi-perspective analysis, and explicit gap analysis consistently surface issues that single-pass reviews miss.
-
-    You are responsible for reviewing plan quality, verifying file references, simulating implementation steps, spec compliance checking, and finding every flaw, gap, questionable assumption, and weak decision in the provided work.
-    You are not responsible for gathering requirements (analyst), creating plans (planner), analyzing code (architect), or implementing changes (executor).
-  </Role>
-
-  <Why_This_Matters>
-    Standard reviews under-report gaps because reviewers default to evaluating what's present rather than what's absent. A/B testing showed that structured gap analysis ("What's Missing") surfaces dozens of items that unstructured reviews produce zero of — not because reviewers can't find them, but because they aren't prompted to look.
-
-    Multi-perspective investigation (security, new-hire, ops angles for code; executor, stakeholder, skeptic angles for plans) further expands coverage by forcing the reviewer to examine the work through lenses they wouldn't naturally adopt. Each perspective reveals a different class of issue.
-
-    Every undetected flaw that reaches implementation costs 10-100x more to fix later. Historical data shows plans average 7 rejections before being actionable — your thoroughness here is the highest-leverage review in the entire pipeline.
-  </Why_This_Matters>
-
-  <Success_Criteria>
-    - Every claim and assertion in the work has been independently verified against the actual codebase
-    - Pre-commitment predictions were made before detailed investigation (activates deliberate search)
-    - Multi-perspective review was conducted (security/new-hire/ops for code; executor/stakeholder/skeptic for plans)
-    - For plans: key assumptions extracted and rated, pre-mortem run, ambiguity scanned, dependencies audited
-    - Gap analysis explicitly looked for what's MISSING, not just what's wrong
-    - Each finding includes a severity rating: CRITICAL (blocks execution), MAJOR (causes significant rework), MINOR (suboptimal but functional)
-    - CRITICAL and MAJOR findings include evidence (file:line for code, backtick-quoted excerpts for plans)
-    - Self-audit was conducted: low-confidence and refutable findings moved to Open Questions
-    - Realist Check was conducted: CRITICAL/MAJOR findings pressure-tested for real-world severity
-    - Escalation to ADVERSARIAL mode was considered and applied when warranted
-    - Concrete, actionable fixes are provided for every CRITICAL and MAJOR finding
-    - In ralplan reviews, principle-option consistency and verification rigor are explicitly gated
-    - The review is honest: if some aspect is genuinely solid, acknowledge it briefly and move on
-  </Success_Criteria>
-
-  <Constraints>
-    - Read-only: Write and Edit tools are blocked.
-    - When receiving ONLY a file path as input, this is valid. Accept and proceed to read and evaluate.
-    - When receiving a YAML file, reject it (not a valid plan format).
-    - Do NOT soften your language to be polite. Be direct, specific, and blunt.
-    - Do NOT pad your review with praise. If something is good, a single sentence acknowledging it is sufficient.
-    - DO distinguish between genuine issues and stylistic preferences. Flag style concerns separately and at lower severity.
-    - Report "no issues found" explicitly when the plan passes all criteria. Do not invent problems.
-    - Hand off to: planner (plan needs revision), analyst (requirements unclear), architect (code analysis needed), executor (code changes needed), security-reviewer (deep security audit needed).
-    - In ralplan mode, explicitly REJECT shallow alternatives, driver contradictions, vague risks, or weak verification.
-    - In deliberate ralplan mode, explicitly REJECT missing/weak pre-mortem or missing/weak expanded test plan (unit/integration/e2e/observability).
-  </Constraints>
-
-  <Investigation_Protocol>
-    Phase 1 — Pre-commitment:
-    Before reading the work in detail, based on the type of work (plan/code/analysis) and its domain, predict the 3-5 most likely problem areas. Write them down. Then investigate each one specifically. This activates deliberate search rather than passive reading.
-
-    Phase 2 — Verification:
-    1) Read the provided work thoroughly.
-    2) Extract ALL file references, function names, API calls, and technical claims. Verify each one by reading the actual source.
-
-    CODE-SPECIFIC INVESTIGATION (use when reviewing code):
-    - Trace execution paths, especially error paths and edge cases.
-    - Check for off-by-one errors, race conditions, missing null checks, incorrect type assumptions, and security oversights.
-
-    PLAN-SPECIFIC INVESTIGATION (use when reviewing plans/proposals/specs):
-    - Step 1 — Key Assumptions Extraction: List every assumption the plan makes — explicit AND implicit. Rate each: VERIFIED (evidence in codebase/docs), REASONABLE (plausible but untested), FRAGILE (could easily be wrong). Fragile assumptions are your highest-priority targets.
-    - Step 2 — Pre-Mortem: "Assume this plan was executed exactly as written and failed. Generate 5-7 specific, concrete failure scenarios." Then check: does the plan address each failure scenario? If not, it's a finding.
-    - Step 3 — Dependency Audit: For each task/step: identify inputs, outputs, and blocking dependencies. Check for: circular dependencies, missing handoffs, implicit ordering assumptions, resource conflicts.
-    - Step 4 — Ambiguity Scan: For each step, ask: "Could two competent developers interpret this differently?" If yes, document both interpretations and the risk of the wrong one being chosen.
-    - Step 5 — Feasibility Check: For each step: "Does the executor have everything they need (access, knowledge, tools, permissions, context) to complete this without asking questions?"
-    - Step 6 — Rollback Analysis: "If step N fails mid-execution, what's the recovery path? Is it documented or assumed?"
-    - Devil's Advocate for Key Decisions: For each major decision or approach choice in the plan: "What is the strongest argument AGAINST this approach? What alternative was likely considered and rejected? If you cannot construct a strong counter-argument, the decision may be sound. If you can, the plan should address why it was rejected."
-
-    ANALYSIS-SPECIFIC INVESTIGATION (use when reviewing analysis/reasoning):
-    - Identify logical leaps, unsupported conclusions, and assumptions stated as facts.
-
-    For ALL types: simulate implementation of EVERY task (not just 2-3). Ask: "Would a developer following only this plan succeed, or would they hit an undocumented wall?"
-
-    For ralplan reviews, apply gate checks: principle-option consistency, fairness of alternative exploration, risk mitigation clarity, testable acceptance criteria, and concrete verification steps.
-    If deliberate mode is active, verify pre-mortem (3 scenarios) quality and expanded test plan coverage (unit/integration/e2e/observability).
-
-    Phase 3 — Multi-perspective review:
-
-    CODE-SPECIFIC PERSPECTIVES (use when reviewing code):
-    - As a SECURITY ENGINEER: What trust boundaries are crossed? What input isn't validated? What could be exploited?
-    - As a NEW HIRE: Could someone unfamiliar with this codebase follow this work? What context is assumed but not stated?
-    - As an OPS ENGINEER: What happens at scale? Under load? When dependencies fail? What's the blast radius of a failure?
-
-    PLAN-SPECIFIC PERSPECTIVES (use when reviewing plans/proposals/specs):
-    - As the EXECUTOR: "Can I actually do each step with only what's written here? Where will I get stuck and need to ask questions? What implicit knowledge am I expected to have?"
-    - As the STAKEHOLDER: "Does this plan actually solve the stated problem? Are the success criteria measurable and meaningful, or are they vanity metrics? Is the scope appropriate?"
-    - As the SKEPTIC: "What is the strongest argument that this approach will fail? What alternative was likely considered and rejected? Is the rejection rationale sound, or was it hand-waved?"
-
-    For mixed artifacts (plans with code, code with design rationale), use BOTH sets of perspectives.
-
-    Phase 4 — Gap analysis:
-    Explicitly look for what is MISSING. Ask:
-    - "What would break this?"
-    - "What edge case isn't handled?"
-    - "What assumption could be wrong?"
-    - "What was conveniently left out?"
-
-    Phase 4.5 — Self-Audit (mandatory):
-    Re-read your findings before finalizing. For each CRITICAL/MAJOR finding:
-    1. Confidence: HIGH / MEDIUM / LOW
-    2. "Could the author immediately refute this with context I might be missing?" YES / NO
-    3. "Is this a genuine flaw or a stylistic preference?" FLAW / PREFERENCE
-
-    Rules:
-    - LOW confidence → move to Open Questions
-    - Author could refute + no hard evidence → move to Open Questions
-    - PREFERENCE → downgrade to Minor or remove
-
-    Phase 4.75 — Realist Check (mandatory):
-    For each CRITICAL and MAJOR finding that survived Self-Audit, pressure-test the severity:
-    1. "What is the realistic worst case — not the theoretical maximum, but what would actually happen?"
-    2. "What mitigating factors exist that the review might be ignoring (existing tests, deployment gates, monitoring, feature flags)?"
-    3. "How quickly would this be detected in practice — immediately, within hours, or silently?"
-    4. "Am I inflating severity because I found momentum during the review (hunting mode bias)?"
-
-    Recalibration rules:
-    - If realistic worst case is minor inconvenience with easy rollback → downgrade CRITICAL to MAJOR
-    - If mitigating factors substantially contain the blast radius → downgrade CRITICAL to MAJOR or MAJOR to MINOR
-    - If detection time is fast and fix is straightforward → note this in the finding (it's still a finding, but context matters)
-    - If the finding survives all four questions at its current severity → it's correctly rated, keep it
-    - NEVER downgrade a finding that involves data loss, security breach, or financial impact — those earn their severity
-    - Every downgrade MUST include a "Mitigated by: ..." statement explaining what real-world factor justifies the lower severity. No downgrade without an explicit mitigation rationale.
-
-    Report any recalibrations in the Verdict Justification (e.g., "Realist check downgraded finding #2 from CRITICAL to MAJOR — mitigated by the fact that the affected endpoint handles <1% of traffic and has retry logic upstream").
-
-    ESCALATION — Adaptive Harshness:
-    Start in THOROUGH mode (precise, evidence-driven, measured). If during Phases 2-4 you discover:
-    - Any CRITICAL finding, OR
-    - 3+ MAJOR findings, OR
-    - A pattern suggesting systemic issues (not isolated mistakes)
-    Then escalate to ADVERSARIAL mode for the remainder of the review:
-    - Assume there are more hidden problems — actively hunt for them
-    - Challenge every design decision, not just the obviously flawed ones
-    - Apply "guilty until proven innocent" to remaining unchecked claims
-    - Expand scope: check adjacent code/steps that weren't originally in scope but could be affected
-    Report which mode you operated in and why in the Verdict Justification.
-
-    Phase 5 — Synthesis:
-    Compare actual findings against pre-commitment predictions. Synthesize into structured verdict with severity ratings.
-  </Investigation_Protocol>
-
-  <Evidence_Requirements>
-    For code reviews: Every finding at CRITICAL or MAJOR severity MUST include a file:line reference or concrete evidence. Findings without evidence are opinions, not findings.
-
-    For plan reviews: Every finding at CRITICAL or MAJOR severity MUST include concrete evidence. Acceptable plan evidence includes:
-    - Direct quotes from the plan showing the gap or contradiction (backtick-quoted)
-    - References to specific steps/sections by number or name
-    - Codebase references that contradict plan assumptions (file:line)
-    - Prior art references (existing code that the plan fails to account for)
-    - Specific examples that demonstrate why a step is ambiguous or infeasible
-    Format: Use backtick-quoted plan excerpts as evidence markers.
-    Example: Step 3 says \`"migrate user sessions"\` but doesn't specify whether active sessions are preserved or invalidated — see \`sessions.ts:47\` where \`SessionStore.flush()\` destroys all active sessions.
-  </Evidence_Requirements>
-
-  <Tool_Usage>
-    - Use Read to load the plan file and all referenced files.
-    - Use Grep/Glob aggressively to verify claims about the codebase. Do not trust any assertion — verify it yourself.
-    - Use Bash with git commands to verify branch/commit references, check file history, and validate that referenced code hasn't changed.
-    - Use LSP tools (lsp_hover, lsp_goto_definition, lsp_find_references, lsp_diagnostics) when available to verify type correctness.
-    - Read broadly around referenced code — understand callers and the broader system context, not just the function in isolation.
-  </Tool_Usage>
-
-  <Execution_Policy>
-    - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
-    - Behavioral effort guidance: maximum. This is thorough review. Leave no stone unturned.
-    - Do NOT stop at the first few findings. Work typically has layered issues — surface problems mask deeper structural ones.
-    - Time-box per-finding verification but DO NOT skip verification entirely.
-    - If the work is genuinely excellent and you cannot find significant issues after thorough investigation, say so clearly — a clean bill of health from you carries real signal.
-    - For spec compliance reviews, use the compliance matrix format (Requirement | Status | Notes).
-  </Execution_Policy>
-
-  <Output_Format>
-    **VERDICT: [REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT]**
-
-    **Overall Assessment**: [2-3 sentence summary]
-
-    **Pre-commitment Predictions**: [What you expected to find vs what you actually found]
-
-    **Critical Findings** (blocks execution):
-    1. [Finding with file:line or backtick-quoted evidence]
-       - Confidence: [HIGH/MEDIUM]
-       - Why this matters: [Impact]
-       - Fix: [Specific actionable remediation]
-
-    **Major Findings** (causes significant rework):
-    1. [Finding with evidence]
-       - Confidence: [HIGH/MEDIUM]
-       - Why this matters: [Impact]
-       - Fix: [Specific suggestion]
-
-    **Minor Findings** (suboptimal but functional):
-    1. [Finding]
-
-    **What's Missing** (gaps, unhandled edge cases, unstated assumptions):
-    - [Gap 1]
-    - [Gap 2]
-
-    **Ambiguity Risks** (plan reviews only — statements with multiple valid interpretations):
-    - [Quote from plan] → Interpretation A: ... / Interpretation B: ...
-      - Risk if wrong interpretation chosen: [consequence]
-
-    **Multi-Perspective Notes** (concerns not captured above):
-    - Security: [...] (or Executor: [...] for plans)
-    - New-hire: [...] (or Stakeholder: [...] for plans)
-    - Ops: [...] (or Skeptic: [...] for plans)
-
-    **Verdict Justification**: [Why this verdict, what would need to change for an upgrade. State whether review escalated to ADVERSARIAL mode and why. Include any Realist Check recalibrations.]
-
-    **Open Questions (unscored)**: [speculative follow-ups AND low-confidence findings moved here by self-audit]
-
-    ---
-
-    *Ralplan summary row (if applicable)*:
-    - Principle/Option Consistency: [Pass/Fail + reason]
-    - Alternatives Depth: [Pass/Fail + reason]
-    - Risk/Verification Rigor: [Pass/Fail + reason]
-    - Deliberate Additions (if required): [Pass/Fail + reason]
-  </Output_Format>
-
-  <Final_Response_Contract>
-    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured verdict above, beginning with **VERDICT:** and including findings, gaps, justification, open questions, and the ralplan summary row when applicable.
-    - Do not put the substantive critique only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
-    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
-  </Final_Response_Contract>
-
-  <Failure_Modes_To_Avoid>
-    - Rubber-stamping: Approving work without reading referenced files. Always verify file references exist and contain what the plan claims.
-    - Inventing problems: Rejecting clear work by nitpicking unlikely edge cases. If the work is actionable, say ACCEPT.
-    - Vague rejections: "The plan needs more detail." Instead: "Task 3 references \`auth.ts\` but doesn't specify which function to modify. Add: modify \`validateToken()\` at line 42."
-    - Skipping simulation: Approving without mentally walking through implementation steps. Always simulate every task.
-    - Confusing certainty levels: Treating a minor ambiguity the same as a critical missing requirement. Differentiate severity.
-    - Letting weak deliberation pass: Never approve plans with shallow alternatives, driver contradictions, vague risks, or weak verification.
-    - Ignoring deliberate-mode requirements: Never approve deliberate ralplan output without a credible pre-mortem and expanded test plan.
-    - Surface-only criticism: Finding typos and formatting issues while missing architectural flaws. Prioritize substance over style.
-    - Manufactured outrage: Inventing problems to seem thorough. If something is correct, it's correct. Your credibility depends on accuracy.
-    - Skipping gap analysis: Reviewing only what's present without asking "what's missing?" This is the single biggest differentiator of thorough review.
-    - Single-perspective tunnel vision: Only reviewing from your default angle. The multi-perspective protocol exists because each lens reveals different issues.
-    - Findings without evidence: Asserting a problem exists without citing the file and line or a backtick-quoted excerpt. Opinions are not findings.
-    - False positives from low confidence: Asserting findings you aren't sure about in scored sections. Use the self-audit to gate these.
-  </Failure_Modes_To_Avoid>
-
-  <Examples>
-    <Good>Critic makes pre-commitment predictions ("auth plans commonly miss session invalidation and token refresh edge cases"), reads the plan, verifies every file reference, discovers \`validateSession()\` was renamed to \`verifySession()\` two weeks ago via git log. Reports as CRITICAL with commit reference and fix. Gap analysis surfaces missing rate-limiting. Multi-perspective: new-hire angle reveals undocumented dependency on Redis.</Good>
-    <Good>Critic reviews a code implementation, traces execution paths, and finds the happy path works but error handling silently swallows a specific exception type (file:line cited). Ops perspective: no circuit breaker for external API. Security perspective: error responses leak internal stack traces. What's Missing: no retry backoff, no metrics emission on failure. One CRITICAL found, so review escalates to ADVERSARIAL mode and discovers two additional issues in adjacent modules.</Good>
-    <Good>Critic reviews a migration plan, extracts 7 key assumptions (3 FRAGILE), runs pre-mortem generating 6 failure scenarios. Plan addresses 2 of 6. Ambiguity scan finds Step 4 can be interpreted two ways — one interpretation breaks the rollback path. Reports with backtick-quoted plan excerpts as evidence. Executor perspective: "Step 5 requires DBA access that the assigned developer doesn't have."</Good>
-    <Bad>Critic reads the plan title, doesn't open any files, says "OKAY, looks comprehensive." Plan turns out to reference a file that was deleted 3 weeks ago.</Bad>
-    <Bad>Critic says "This plan looks mostly fine with some minor issues." No structure, no evidence, no gap analysis — this is the rubber-stamp the critic exists to prevent.</Bad>
-    <Bad>Critic finds 2 minor typos, reports REJECT. Severity calibration failure — typos are MINOR, not grounds for rejection.</Bad>
-  </Examples>
-
-  <Final_Checklist>
-    - Did I make pre-commitment predictions before diving in?
-    - Did I read every file referenced in the plan?
-    - Did I verify every technical claim against actual source code?
-    - Did I simulate implementation of every task?
-    - Did I identify what's MISSING, not just what's wrong?
-    - Did I review from the appropriate perspectives (security/new-hire/ops for code; executor/stakeholder/skeptic for plans)?
-    - For plans: did I extract key assumptions, run a pre-mortem, and scan for ambiguity?
-    - Does every CRITICAL/MAJOR finding have evidence (file:line for code, back quotes for plans)?
-    - Did I run the self-audit and move low-confidence findings to Open Questions?
-    - Did I run the Realist Check and pressure-test CRITICAL/MAJOR severity labels?
-    - Did I check whether escalation to ADVERSARIAL mode was warranted?
-    - Is my verdict clearly stated (REJECT/REVISE/ACCEPT-WITH-RESERVATIONS/ACCEPT)?
-    - Are my severity ratings calibrated correctly?
-    - Are my fixes specific and actionable, not vague suggestions?
-    - Did I differentiate certainty levels for my findings?
-    - For ralplan reviews, did I verify principle-option consistency and alternative quality?
-    - For deliberate mode, did I enforce pre-mortem + expanded test plan quality?
-    - Did I resist the urge to either rubber-stamp or manufacture outrage?
-  </Final_Checklist>
-</Agent_Prompt>`;
+const PLANNER_PERSONA = `You are the isolated Planner in a RALPLAN workflow.
+Create or revise a plan; never implement code, execute a skill, commit, push, or
+approve your own work. Return structured JSON only. Include RALPLAN-DR:
+3-5 principles, exactly 3 decision drivers, at least 2 viable options with
+bounded pros/cons, and an actionable 3-6 step plan with acceptance criteria.
+The host workflow, not the Planner, owns approval and execution routing.`;
+const ARCHITECT_PERSONA = `You are the isolated Architect, a read-only technical
+reviewer. Review only the Planner snapshot supplied in this prompt. You are not
+the Planner or Critic, and you must not implement changes. Independently state
+the strongest steelman antithesis, a meaningful tradeoff tension, and explicit
+architectural principle violations. Approval is never inferred from an empty
+violations list: return exactly one explicit verdict, APPROVE or REVISION_NEEDED.`;
+const CRITIC_PERSONA = `You are the isolated Critic and final quality gate. Review
+only the fixed Planner snapshot supplied in this prompt, independently of every
+other review. You do not receive or rely on Architect output. Check alternatives,
+risk mitigation, acceptance criteria, verification, gaps, and deliberate-mode
+requirements. Return exactly one explicit verdict: APPROVE, ITERATE, or REJECT.
+Missing, invalid, or uncertain evidence is non-approval.`;
 
 const HIGH_RISK_TRIGGERS = [
   "auth",
@@ -598,7 +63,6 @@ const HIGH_RISK_TRIGGERS = [
   "production",
   "destroy",
   "delete",
-  "rm",
   "compliance",
   "pii",
   "gdpr",
@@ -606,15 +70,21 @@ const HIGH_RISK_TRIGGERS = [
   "public api",
   "breaking change",
 ];
-const EXEC_KEYWORDS = ["ralph", "autopilot", "team", "ultrawork", "ultrapilot"];
+const EXECUTION_KEYWORDS = [
+  "ralph",
+  "autopilot",
+  "team",
+  "ultrawork",
+  "ultrapilot",
+];
 
-function checkGate(args) {
-  const text = String((args && args.idea) || "");
+function checkGate(idea) {
+  const text = String(idea || "");
   const lower = text.toLowerCase();
   const words = text.trim().split(/\s+/).filter(Boolean);
-  for (const p of ["force:", "!"]) {
-    if (lower.startsWith(p))
-      return { gated: false, reason: "escape prefix " + p };
+  for (const prefix of ["force:", "!"]) {
+    if (lower.startsWith(prefix))
+      return { gated: false, reason: "escape prefix " + prefix };
   }
   if (words.length > 15)
     return { gated: false, reason: "word count above threshold" };
@@ -630,327 +100,331 @@ function checkGate(args) {
     /^\s*\d+\.\s/m,
     /\b(?:TypeError|ReferenceError|SyntaxError|ENOENT|EACCES)\b/,
   ];
-  for (const re of anchors) {
-    if (re.test(text))
+  for (const anchor of anchors) {
+    if (anchor.test(text))
       return { gated: false, reason: "concrete anchor present" };
   }
-  const matched = EXEC_KEYWORDS.filter(function (k) {
-    return new RegExp("\\b" + k + "\\b").test(lower);
-  });
-  const note = matched.length
+  const matched = EXECUTION_KEYWORDS.filter((keyword) =>
+    new RegExp("\\b" + keyword + "\\b").test(lower),
+  );
+  const reason = matched.length
     ? "prompt has " +
       words.length +
       " words and execution keyword (" +
       matched.join(",") +
-      "); use force: or ! to bypass, or include a file path / issue number / symbol / test command / numbered step"
-    : "prompt has " +
-      words.length +
-      " words and no concrete anchors; use force: or ! to bypass, or include a file path / issue number / symbol / test command / numbered step";
-  return { gated: true, reason: note };
+      ")"
+    : "prompt has " + words.length + " words and no concrete anchors";
+  return { gated: true, reason };
 }
 
-function isDeliberate(idea, args) {
-  if (args && args.deliberate === true) return true;
-  if (args && args.deliberate === "auto") {
+function isDeliberate(idea, input) {
+  if (input.deliberate === true) return true;
+  if (input.deliberate === "auto") {
     const lower = String(idea || "").toLowerCase();
-    return HIGH_RISK_TRIGGERS.some(function (t) {
-      return lower.includes(t);
-    });
+    return HIGH_RISK_TRIGGERS.some((trigger) => lower.includes(trigger));
   }
   return false;
 }
 
-function mapCriticVerdict(v) {
-  if (v === "ACCEPT" || v === "ACCEPT-WITH-RESERVATIONS") return "APPROVE";
-  if (v === "REVISE") return "ITERATE";
-  if (v === "REJECT") return "REJECT";
-  return "ITERATE";
+function clampRounds(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 5;
+  return Math.min(Math.max(Math.floor(numeric), 1), 5);
 }
 
-function buildPlannerPrompt(idea, mode, feedback, round) {
-  const previousFeedback =
-    feedback && feedback.length
-      ? "\n\nPRIOR ROUND FEEDBACK (round " +
-        feedback[feedback.length - 1].round +
-        "):\n" +
-        feedback
-          .map(function (f) {
-            return "- [" + f.role + "] " + (f.summary || "");
-          })
-          .join("\n")
-      : "";
-  const deliberateBlock =
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function freezeDeep(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value))
+    return value;
+  for (const child of Object.values(value)) freezeDeep(child);
+  return Object.freeze(value);
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function deliberateValidation(draft, mode) {
+  if (mode !== "DELIBERATE") return { valid: true, issues: [] };
+  const issues = [];
+  const scenarios = draft && draft.preMortem;
+  if (!Array.isArray(scenarios) || scenarios.length !== 3) {
+    issues.push("preMortem must contain exactly 3 scenarios");
+  } else {
+    const fields = [
+      "trigger",
+      "blastRadius",
+      "earlySignal",
+      "mitigation",
+      "detection",
+    ];
+    scenarios.forEach((scenario, index) => {
+      for (const field of fields) {
+        if (!scenario || !nonEmpty(scenario[field]))
+          issues.push("preMortem[" + index + "]." + field + " is required");
+      }
+    });
+  }
+  const testPlan = draft && draft.expandedTestPlan;
+  for (const pillar of ["unit", "integration", "e2e", "observability"]) {
+    if (
+      !testPlan ||
+      !Array.isArray(testPlan[pillar]) ||
+      testPlan[pillar].length === 0 ||
+      testPlan[pillar].some((item) => !nonEmpty(item))
+    ) {
+      issues.push(
+        "expandedTestPlan." + pillar + " must contain actionable entries",
+      );
+    }
+  }
+  return { valid: issues.length === 0, issues };
+}
+
+function plannerSnapshot(output) {
+  if (!output || typeof output !== "object") return null;
+  if (output.draft && typeof output.draft === "object") {
+    const draft = clone(output.draft);
+    return Object.keys(draft).length > 0 ? draft : null;
+  }
+  const draft = clone(output);
+  delete draft.verdict;
+  return Object.keys(draft).length > 0 ? draft : null;
+}
+
+function buildPlannerPrompt(idea, mode, feedback, round, maxRounds) {
+  const prior = feedback.length
+    ? "\n\nPRIOR ROUND REVIEWS (address both independently):\n" +
+      JSON.stringify(feedback, null, 2)
+    : "";
+  const deliberate =
     mode === "DELIBERATE"
-      ? "\n\nDELIBERATE MODE ACTIVE — additionally include:\n\n## PRE-MORTEM (exactly 3 failure scenarios)\nFor each scenario:\n- Trigger: what initiates the failure\n- Blast radius: how far the damage extends\n- Early signal: what we would see first\n- Mitigation: how the plan prevents/contains it\n- Detection: how we would know it is happening\n\n## EXPANDED TEST PLAN\nCover all four pillars with concrete file paths and runner commands:\n- Unit tests (specific files, functions, vitest/jest commands)\n- Integration tests (cross-module, DB or external API scenarios)\n- End-to-end tests (full user flows, browser/CLI commands)\n- Observability (metrics, logs, traces, alerts — what to emit, where to alert)\n"
+      ? "\nDELIBERATE HARD REQUIREMENTS: preMortem must have exactly 3 actionable scenarios with trigger, blastRadius, earlySignal, mitigation, detection. expandedTestPlan must contain non-empty unit, integration, e2e, and observability arrays."
       : "";
   return (
     PLANNER_PERSONA +
-    "\n\n---\n\nTASK\nIdea: " +
+    "\n\nTASK\nIdea: " +
     idea +
     "\nMode: " +
     mode +
     "\nRound: " +
     round +
-    " of up to 5" +
-    previousFeedback +
-    "\n\nProduce a JSON object that matches the required schema:\n- principles: 3-5 guiding principles for this plan\n- decisionDrivers: exactly the top 3 drivers (ranked)\n- options: >=2 viable options, each with bounded pros/cons\n- invalidatedOptions: names of options considered and rejected, with rationale (omit if >=2 survive)\n- planBody: the full plan markdown including Guardrails, Task Flow, Detailed TODOs with acceptance criteria, and Success Criteria" +
-    (deliberateBlock
-      ? "\n- preMortem: array of exactly 3 failure scenarios"
-      : "") +
-    (deliberateBlock
-      ? "\n- expandedTestPlan: object with unit/integration/e2e/observability arrays"
-      : "") +
-    "\n- openQuestions: array of unresolved questions / deferred decisions\n\nMark mode as " +
-    mode +
-    " in the principles block header. Do not write code files. Do not start implementation. Output ONLY the JSON object." +
-    deliberateBlock
+    " of " +
+    maxRounds +
+    prior +
+    deliberate +
+    '\nReturn JSON {verdict:"DRAFT_READY", draft:{principles, decisionDrivers, options, planBody, openQuestions, ...}} only.'
   );
 }
 
-function buildArchitectPrompt(draft, mode) {
-  const deliberateNote =
+function buildArchitectPrompt(snapshot, mode) {
+  const deliberate =
     mode === "DELIBERATE"
-      ? "\n\nDELIBERATE MODE: flag any principle violation in the Consensus Addendum; do not pass silently. If the pre-mortem has fewer than 3 scenarios or the expanded test plan omits unit/integration/e2e/observability, name those gaps explicitly as principle violations. Empty principleViolations array means Architect approves proceeding to Critic."
+      ? "\nIn DELIBERATE mode, treat missing or weak preMortem/test-plan fields as explicit principle violations."
       : "";
   return (
     ARCHITECT_PERSONA +
-    "\n\n---\n\nTASK\nReview the following draft plan for architectural soundness." +
-    deliberateNote +
-    "\n\nDRAFT PLAN (JSON):\n" +
-    JSON.stringify(draft, null, 2) +
-    "\n\nProduce a JSON object that matches the schema:\n- summary: 1-2 sentence overall read\n- steelman: the STRONGEST argument against the favored direction (do NOT rubber-stamp)\n- tradeoffTension: at least one meaningful tradeoff that cannot be ignored\n- synthesis: if viable, how to preserve strengths from competing options; else null\n- principleViolations: array of strings naming any principle broken; empty array means Architect approves proceeding to Critic\n\nBe specific. Cite plan sections by quote. Output ONLY the JSON object."
+    "\n\nFIXED PLANNER SNAPSHOT (read-only; do not alter):\n" +
+    JSON.stringify(snapshot, null, 2) +
+    deliberate +
+    "\nReturn JSON {verdict, steelman, tradeoffTension, synthesis, principleViolations, summary} only."
   );
 }
 
-function buildCriticPrompt(draft, architectReview, mode) {
-  const deliberateGate =
+function buildCriticPrompt(snapshot, mode) {
+  const deliberate =
     mode === "DELIBERATE"
-      ? "\n\nDELIBERATE-MODE HARD GATES (REJECT if violated):\n- preMortem has fewer than 3 scenarios or any scenario lacks mitigation\n- expandedTestPlan omits any of unit / integration / e2e / observability"
+      ? "\nDELIBERATE HARD GATES: reject missing/weak preMortem or any missing unit, integration, e2e, or observability test pillar."
       : "";
   return (
     CRITIC_PERSONA +
-    "\n\n---\n\nTASK\nApply ralplan gate checks: principle-option consistency, fair alternatives, risk mitigation clarity, testable acceptance criteria, concrete verification steps." +
-    deliberateGate +
-    "\n\nDRAFT PLAN (JSON):\n" +
-    JSON.stringify(draft, null, 2) +
-    "\n\nARCHITECT REVIEW (JSON):\n" +
-    JSON.stringify(architectReview, null, 2) +
-    "\n\nProduce a JSON object that matches the schema:\n- verdict: one of REJECT | REVISE | ACCEPT-WITH-RESERVATIONS | ACCEPT\n- summary: 2-3 sentence overall assessment\n- findings: array of { severity: CRITICAL|MAJOR|MINOR, area, evidence } — evidence is backtick-quoted plan excerpt\n- preMortemStatus: present-3 | weak | missing\n- testPlanStatus: complete | weak | missing\n\nUse VERDICT line as the first character of summary for traceability. Output ONLY the JSON object."
+    "\n\nFIXED PLANNER SNAPSHOT (read-only; same value reviewed by Architect):\n" +
+    JSON.stringify(snapshot, null, 2) +
+    deliberate +
+    "\nReturn JSON {verdict, findings, summary, preMortemStatus, testPlanStatus} only."
   );
 }
 
 const PLANNER_SCHEMA = {
   type: "object",
+  required: ["verdict"],
   properties: {
-    principles: {
-      type: "array",
-      items: { type: "string" },
-      minItems: 3,
-      maxItems: 5,
-    },
-    decisionDrivers: {
-      type: "array",
-      items: { type: "string" },
-      minItems: 3,
-      maxItems: 3,
-    },
-    options: {
-      type: "array",
-      minItems: 2,
-      items: {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-          pros: { type: "array", items: { type: "string" } },
-          cons: { type: "array", items: { type: "string" } },
-        },
-        required: ["name", "pros", "cons"],
-      },
-    },
-    invalidatedOptions: { type: "array", items: { type: "string" } },
+    verdict: { type: "string", enum: ["DRAFT_READY"] },
+    draft: { type: "object" },
+    principles: { type: "array", items: { type: "string" } },
+    decisionDrivers: { type: "array", items: { type: "string" } },
+    options: { type: "array" },
     planBody: { type: "string" },
-    preMortem: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          trigger: { type: "string" },
-          blastRadius: { type: "string" },
-          earlySignal: { type: "string" },
-          mitigation: { type: "string" },
-          detection: { type: "string" },
-        },
-        required: [
-          "trigger",
-          "blastRadius",
-          "earlySignal",
-          "mitigation",
-          "detection",
-        ],
-      },
-    },
-    expandedTestPlan: {
-      type: "object",
-      properties: {
-        unit: { type: "array", items: { type: "string" } },
-        integration: { type: "array", items: { type: "string" } },
-        e2e: { type: "array", items: { type: "string" } },
-        observability: { type: "array", items: { type: "string" } },
-      },
-    },
     openQuestions: { type: "array", items: { type: "string" } },
   },
-  required: ["principles", "decisionDrivers", "options", "planBody"],
 };
-
 const ARCHITECT_SCHEMA = {
   type: "object",
+  required: ["verdict", "steelman", "tradeoffTension", "principleViolations"],
   properties: {
-    summary: { type: "string" },
+    verdict: { type: "string", enum: ["APPROVE", "REVISION_NEEDED"] },
     steelman: { type: "string" },
     tradeoffTension: { type: "string" },
     synthesis: { type: "string" },
     principleViolations: { type: "array", items: { type: "string" } },
+    summary: { type: "string" },
   },
-  required: ["steelman", "tradeoffTension"],
 };
-
 const CRITIC_SCHEMA = {
   type: "object",
+  required: ["verdict", "findings", "summary"],
   properties: {
-    verdict: {
-      type: "string",
-      enum: ["REJECT", "REVISE", "ACCEPT-WITH-RESERVATIONS", "ACCEPT"],
-    },
+    verdict: { type: "string", enum: ["APPROVE", "ITERATE", "REJECT"] },
+    findings: { type: "array" },
     summary: { type: "string" },
-    findings: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          severity: { type: "string", enum: ["CRITICAL", "MAJOR", "MINOR"] },
-          area: { type: "string" },
-          evidence: { type: "string" },
-        },
-        required: ["severity", "area", "evidence"],
-      },
-    },
-    preMortemStatus: { type: "string", enum: ["present-3", "weak", "missing"] },
-    testPlanStatus: { type: "string", enum: ["complete", "weak", "missing"] },
+    preMortemStatus: { type: "string" },
+    testPlanStatus: { type: "string" },
   },
-  required: ["verdict", "findings"],
 };
 
-// Main execution
-phase("Gate");
-const gateResult = checkGate(workflowArgs);
-const idea0 = String((workflowArgs && workflowArgs.idea) || "");
-const promptWords = idea0.trim().split(/\s+/).filter(Boolean).length;
-const lowerIdea = idea0.toLowerCase();
-const hadEscapePrefix =
-  lowerIdea.startsWith("force:") || lowerIdea.startsWith("!");
-const hadAnchor =
-  !gateResult.gated && /concrete anchor/.test(gateResult.reason);
+const idea = String(workflowArgs.idea || "");
+const interactive = workflowArgs.interactive !== false;
+const gateEnabled = workflowArgs.gate !== false;
+const mode = isDeliberate(idea, workflowArgs) ? "DELIBERATE" : "SHORT";
+const maxRounds = clampRounds(workflowArgs.maxIterations);
+const ignoredExecuteOnConsensus = Object.prototype.hasOwnProperty.call(
+  workflowArgs,
+  "executeOnConsensus",
+);
 
-if (gateResult.gated) {
-  log("[pending approval] gate redirect to ralplan -- " + gateResult.reason);
-  log("status=redirected; awaiting user approval for execution routing");
+function pendingFields() {
   return {
-    gated: true,
-    redirect: "ralplan",
-    reason: gateResult.reason,
-    algorithm: "ralplan-consensus-v1",
-    gate: {
-      triggered: true,
-      reason: gateResult.reason,
-      promptWords: promptWords,
-      hadAnchor: hadAnchor,
-      hadEscapePrefix: hadEscapePrefix,
-    },
-    mode: "SHORT",
-    iterations: 0,
-    capped: false,
     pending_approval: true,
     execution_halted: true,
-    statusLine: "Status: pending approval -- workflow halted before execution",
+    statusLine:
+      "Status: pending approval — workflow is read-only and halted before execution",
     awaitingApproval: {
       draftReview: true,
       finalApproval: true,
       executionRouting: true,
     },
-    recommendedExecution: {
-      skill: "oh-my-claudecode:team",
-      reason:
-        "Gate redirected short prompt to ralplan consensus. Run via team (parallel) for isolated review streams; workflow itself never executes.",
-    },
   };
+}
+
+function emitCheckpoint(message) {
+  if (interactive) log("[pending approval] " + message);
+}
+
+function emptyResult(status, extra) {
+  return {
+    status,
+    consensus: false,
+    algorithm: "ralplan-occ-v1",
+    mode,
+    iterations: 0,
+    capped: false,
+    gate: {
+      enabled: gateEnabled,
+      triggered: false,
+      reason: "gate bypassed or passed",
+    },
+    interactive: { enabled: interactive, markersEmitted: interactive },
+    ...pendingFields(),
+    ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
+    ...extra,
+  };
+}
+
+phase("Gate");
+if (!idea.trim()) {
+  log("no idea provided; planning cannot proceed");
+  return emptyResult("no_idea", {
+    gate: {
+      enabled: gateEnabled,
+      triggered: false,
+      reason: "idea is required",
+    },
+  });
+}
+const gateResult = gateEnabled
+  ? checkGate(idea)
+  : { gated: false, reason: "gate disabled by caller" };
+if (gateResult.gated) {
+  emitCheckpoint(
+    "gate requires explicit planning invocation: " + gateResult.reason,
+  );
+  return emptyResult("gated", {
+    gated: true,
+    redirect: "ralplan",
+    gate: { enabled: true, triggered: true, reason: gateResult.reason },
+    mode: "SHORT",
+    interactive: { enabled: interactive, markersEmitted: interactive },
+    statusLine:
+      "Status: pending approval — gate redirected to explicit RALPLAN invocation",
+  });
 }
 
 phase("Ralplan consensus");
-const idea = idea0;
-if (!idea.trim()) {
-  log("no idea provided; aborting");
-  return {
-    status: "no_idea",
-    pending_approval: true,
-    execution_halted: true,
-    statusLine: "Status: pending approval -- workflow halted before execution",
-  };
+if (interactive) {
+  emitCheckpoint("draft review checkpoint is non-blocking in the workflow VM");
+  emitCheckpoint("final approval and execution routing belong to the host");
 }
-
-const mode = isDeliberate(idea, workflowArgs) ? "DELIBERATE" : "SHORT";
-const maxIter = Math.min(
-  Math.max(Number((workflowArgs && workflowArgs.maxIterations) || 5), 1),
-  5,
-);
-log("mode=" + mode + "; maxIterations=" + maxIter);
-
-const artifactsDir =
-  (workflowArgs && workflowArgs.artifactsDir) || ".omc/plans";
-const draftsDir = (workflowArgs && workflowArgs.draftsDir) || ".omc/drafts";
-const planName = (workflowArgs && workflowArgs.planName) || "ralplan";
-const planPath = artifactsDir + "/" + planName + ".md";
-
 log(
-  "[pending approval] draft review checkpoint (Proceed / Request changes / Skip review) -- awaiting user approval",
-);
-log(
-  "[pending approval] final plan approval (Approve via team / Approve via ralph / Compact / Request changes / Reject) -- awaiting user approval",
-);
-log(
-  "[pending approval] execution routing (team vs ralph) -- awaiting user approval",
+  "mode=" +
+    mode +
+    "; maxRounds=" +
+    maxRounds +
+    "; gate=" +
+    (gateEnabled ? "enabled" : "disabled"),
 );
 
 const feedback = [];
 let lastDraft = null;
 let lastArchitect = null;
 let lastCritic = null;
-let lastVerdict = null;
 let lastRoundReached = 0;
-let capped = false;
+let consensusReached = false;
+let deliberateResult = { valid: mode !== "DELIBERATE", issues: [] };
+let plannerError = null;
 
-for (let iteration = 1; iteration <= maxIter; iteration++) {
-  lastRoundReached = iteration;
+async function callAgent(prompt, options) {
+  try {
+    return await agent(prompt, { ...options, isolation: "process" });
+  } catch (error) {
+    if (/aborted|cancelled|canceled/i.test(String(error))) throw error;
+    log(options.label + " failed: " + String(error));
+    return null;
+  }
+}
 
-  phase("Round " + iteration + " - Planner");
-  const plannerOut = await agent(
-    buildPlannerPrompt(idea, mode, feedback, iteration),
+for (let round = 1; round <= maxRounds; round++) {
+  lastRoundReached = round;
+  phase("Round " + round + " - Planner");
+  const plannerOut = await callAgent(
+    buildPlannerPrompt(idea, mode, feedback, round, maxRounds),
     {
       schema: PLANNER_SCHEMA,
-      phase: "Round " + iteration + " - Planner",
+      phase: "Round " + round + " - Planner",
       label: "planner",
     },
   );
-  if (!plannerOut) {
-    log("planner returned null on round " + iteration + "; aborting consensus");
-    break;
+  const snapshot = plannerSnapshot(plannerOut);
+  if (!snapshot) {
+    plannerError =
+      "Planner returned no schema-valid snapshot on round " + round;
+    feedback.push({
+      round,
+      role: "planner",
+      verdict: "MISSING",
+      summary: plannerError,
+    });
+    continue;
   }
-  lastDraft = plannerOut;
+  lastDraft = snapshot;
+  deliberateResult = deliberateValidation(snapshot, mode);
 
-  phase("Round " + iteration + " - Architect");
+  phase("Round " + round + " - Architect");
   const architectOptions = {
     schema: ARCHITECT_SCHEMA,
-    phase: "Round " + iteration + " - Architect",
+    phase: "Round " + round + " - Architect",
     label: "architect",
   };
   if (
@@ -959,60 +433,34 @@ for (let iteration = 1; iteration <= maxIter; iteration++) {
   ) {
     architectOptions.model = workflowArgs.architectModel;
   }
-  const archOut = await agent(
-    buildArchitectPrompt(lastDraft, mode),
+  const immutableSnapshot = freezeDeep(clone(snapshot));
+  const architectOut = await callAgent(
+    buildArchitectPrompt(immutableSnapshot, mode),
     architectOptions,
   );
-  if (!archOut) {
-    log(
-      "architect returned null on round " +
-        iteration +
-        "; routing back to planner",
-    );
-    feedback.push({
-      round: iteration,
-      role: "architect",
-      summary: "architect returned null",
-      steelman: "",
-      tradeoffTension: "",
-    });
-    if (iteration === maxIter) capped = true;
-    continue;
-  }
-  lastArchitect = archOut;
+  lastArchitect = architectOut;
+  const architectApproval = Boolean(
+    architectOut && architectOut.verdict === "APPROVE",
+  );
+  const architectFeedback = architectOut
+    ? {
+        round,
+        role: "architect",
+        verdict: architectOut.verdict,
+        summary: architectOut.summary || "",
+        issues: architectOut.principleViolations || [],
+      }
+    : {
+        round,
+        role: "architect",
+        verdict: "MISSING",
+        summary: "Architect returned no schema-valid result",
+      };
 
-  // Architect non-APPROVE signal: principleViolations non-empty (deliberate mode primarily,
-  // but architect is instructed to populate this for any blocking structural issue).
-  if (
-    Array.isArray(archOut.principleViolations) &&
-    archOut.principleViolations.length > 0
-  ) {
-    log(
-      "architect flagged " +
-        archOut.principleViolations.length +
-        " principle violation(s); routing back to planner without Critic",
-    );
-    feedback.push({
-      round: iteration,
-      role: "architect",
-      summary:
-        "steelman=" +
-        (archOut.steelman || "") +
-        "; tradeoffTension=" +
-        (archOut.tradeoffTension || "") +
-        "; principleViolations=" +
-        archOut.principleViolations.join(" | "),
-      steelman: archOut.steelman,
-      tradeoffTension: archOut.tradeoffTension,
-    });
-    if (iteration === maxIter) capped = true;
-    continue;
-  }
-
-  phase("Round " + iteration + " - Critic");
+  phase("Round " + round + " - Critic");
   const criticOptions = {
     schema: CRITIC_SCHEMA,
-    phase: "Round " + iteration + " - Critic",
+    phase: "Round " + round + " - Critic",
     label: "critic",
   };
   if (
@@ -1021,162 +469,85 @@ for (let iteration = 1; iteration <= maxIter; iteration++) {
   ) {
     criticOptions.model = workflowArgs.criticModel;
   }
-  const critOut = await agent(
-    buildCriticPrompt(lastDraft, lastArchitect, mode),
+  // Deliberately pass only the immutable Planner snapshot. Architect output is
+  // recorded for the next Planner, never used as Critic input.
+  const criticOut = await callAgent(
+    buildCriticPrompt(immutableSnapshot, mode),
     criticOptions,
   );
-  if (!critOut) {
-    log(
-      "critic returned null on round " +
-        iteration +
-        "; routing back to planner",
-    );
-    feedback.push({
-      round: iteration,
-      role: "critic",
-      summary: "critic returned null",
-    });
-    if (iteration === maxIter) capped = true;
-    continue;
-  }
-  lastCritic = critOut;
-  lastVerdict = mapCriticVerdict(critOut.verdict);
+  lastCritic = criticOut;
+  const criticApproval = Boolean(criticOut && criticOut.verdict === "APPROVE");
+  const criticFeedback = criticOut
+    ? {
+        round,
+        role: "critic",
+        verdict: criticOut.verdict,
+        summary: criticOut.summary || "",
+        findings: criticOut.findings || [],
+      }
+    : {
+        round,
+        role: "critic",
+        verdict: "MISSING",
+        summary: "Critic returned no schema-valid result",
+      };
 
-  if (lastVerdict === "APPROVE") {
-    log(
-      "consensus reached on round " +
-        iteration +
-        " (critic verdict=" +
-        critOut.verdict +
-        ")",
-    );
+  if (architectApproval && criticApproval && deliberateResult.valid) {
+    consensusReached = true;
+    log("explicit Architect and Critic approval reached on round " + round);
     break;
   }
-
-  feedback.push({
-    round: iteration,
-    role: "critic",
-    summary: critOut.summary || "",
-    findings: critOut.findings || [],
-  });
-  if (iteration === maxIter) {
-    capped = true;
-    log(
-      "hit max iterations (" +
-        maxIter +
-        "); surfacing best version (last round)",
-    );
-  }
+  feedback.push(architectFeedback, criticFeedback);
+  if (round < maxRounds)
+    log("non-approval; starting complete Planner → Architect → Critic round");
 }
 
-phase("Consolidate");
-const consensusReached = lastVerdict === "APPROVE" && lastDraft;
-let status;
-if (!lastDraft) {
-  status = "no_planner_output";
-} else if (consensusReached) {
-  status =
-    workflowArgs && workflowArgs.executeOnConsensus
-      ? "consensus_approved"
-      : "consensus";
-} else {
-  status = "no_consensus";
-}
-
-const chosenOptionName =
-  lastDraft && Array.isArray(lastDraft.options) && lastDraft.options[0]
-    ? lastDraft.options[0].name
-    : "pending";
-const altNames =
-  lastDraft && Array.isArray(lastDraft.options)
-    ? lastDraft.options.slice(1).map(function (o) {
-        return o.name;
-      })
-    : [];
-
-const adr = {
-  decision: chosenOptionName,
-  drivers: (lastDraft && lastDraft.decisionDrivers) || [],
-  alternativesConsidered: altNames,
-  whyChosen:
-    (lastArchitect && lastArchitect.synthesis) ||
-    (lastCritic && lastCritic.summary) ||
-    "awaiting consensus",
-  consequences: [],
-  followUps: (lastDraft && lastDraft.openQuestions) || [],
-};
-
-const recommendedSkill =
-  status === "consensus" || status === "consensus_approved"
-    ? "oh-my-claudecode:team"
-    : "oh-my-claudecode:ralph";
-const recommendedReason =
-  status === "consensus" || status === "consensus_approved"
-    ? "Consensus reached; team (parallel) recommended for time-sensitive tasks with isolated work streams. Workflow itself never executes."
-    : capped
-      ? "No consensus after cap; ralph (sequential) recommended for tighter iteration control. Workflow itself never executes."
-      : "Planner produced no output; ralph (sequential) recommended for re-interview. Workflow itself never executes.";
-
+const capped = !consensusReached && lastRoundReached >= maxRounds;
+const status = consensusReached
+  ? "consensus"
+  : lastDraft
+    ? "no_consensus"
+    : "no_planner_output";
 const result = {
-  status: status,
-  algorithm: "ralplan-consensus-v1",
-  gate: {
-    triggered: false,
-    reason: "gate passed",
-    promptWords: promptWords,
-    hadAnchor: hadAnchor,
-    hadEscapePrefix: hadEscapePrefix,
+  status,
+  consensus: consensusReached,
+  algorithm: "ralplan-occ-v1",
+  mode,
+  iterations: lastRoundReached,
+  capped,
+  gate: { enabled: gateEnabled, triggered: false, reason: gateResult.reason },
+  interactive: { enabled: interactive, markersEmitted: interactive },
+  draft: lastDraft || {},
+  architect: lastArchitect || { verdict: "MISSING", principleViolations: [] },
+  critic: lastCritic || { verdict: "MISSING", findings: [] },
+  deliberate: deliberateResult,
+  artifactPaths: {
+    plan:
+      (workflowArgs.artifactsDir || ".omc/plans") +
+      "/" +
+      (workflowArgs.planName || "ralplan") +
+      ".md",
+    drafts: [],
   },
-  mode: mode,
-  iterations: capped ? maxIter : lastRoundReached,
-  capped: capped,
-  draft: lastDraft || {
-    principles: [],
-    decisionDrivers: [],
-    options: [],
-    invalidatedOptions: [],
-    planBody: "",
-  },
-  architect: lastArchitect || {
-    steelman: "",
-    tradeoffTension: "",
-    synthesis: "",
-    principleViolations: [],
-  },
-  critic: lastCritic || {
-    verdict: "REJECT",
-    findings: [],
-    preMortemStatus: "missing",
-    testPlanStatus: "missing",
-  },
-  adr: adr,
-  openQuestions: (lastDraft && lastDraft.openQuestions) || [],
-  artifactPaths: { plan: planPath, drafts: [] },
-  pending_approval: true,
-  execution_halted: true,
-  awaitingApproval: {
-    draftReview: true,
-    finalApproval: true,
-    executionRouting: true,
-  },
-  recommendedExecution: { skill: recommendedSkill, reason: recommendedReason },
-  statusLine: "Status: pending approval -- workflow halted before execution",
+  ...pendingFields(),
+  ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
   fidelityGaps: {
     interactiveCheckpointsUnsupported: true,
-    perRoleModelRouting: true,
-    note: "Workflow runs to completion; emits [pending approval] markers; never invokes Skill(team|ralph); does not write .omc/plans/{name}.md directly.",
+    hostApprovalRequired: true,
+    note: "interactive markers are non-blocking; the workflow VM cannot suspend for user input or invoke execution skills",
   },
 };
-
-if (status === "no_consensus") {
-  result.lastVerdict = lastVerdict;
+if (plannerError) result.plannerError = plannerError;
+if (!consensusReached) {
+  result.lastVerdict = {
+    architect:
+      lastArchitect && lastArchitect.verdict
+        ? lastArchitect.verdict
+        : "MISSING",
+    critic: lastCritic && lastCritic.verdict ? lastCritic.verdict : "MISSING",
+  };
+  if (capped)
+    result.cappedReason =
+      "five-round safety cap reached; manual review required and execution unavailable";
 }
-if (capped) {
-  result.cappedReason =
-    "hit max iterations (" +
-    maxIter +
-    "); surfaced best version from round " +
-    lastRoundReached;
-}
-
 return result;

--- a/skills/ralplan/README.md
+++ b/skills/ralplan/README.md
@@ -1,66 +1,73 @@
 # pi-ralplan-local
 
-Consensus-driven implementation planning skill for Pi. The package bundles three role prompts (`planner`, `architect`, `critic`) plus a `SKILL.md` orchestration document that defines a strict Planner → Architect → Critic state machine.
+Consensus-driven planning for Pi. The skill defines isolated Planner, Architect,
+and Critic roles that independently review one immutable Planner snapshot.
 
-## What it does
+## Safety contract
 
-`/ralplan [idea]` runs an adversarial planning loop that produces `plans/plan.md` only after three separately-invoked agents reach unanimous approval. The loop prevents **Simulated Consensus** — the failure mode where one generation hallucinates all three approvals in a single output block.
+RALPLAN is planning-only. Every workflow result is `pending_approval: true` and
+`execution_halted: true`; no plan file, marker, `executeOnConsensus` argument,
+or consensus result authorizes source mutation or execution. A separate
+host-controlled approval and handoff is required for any later phase.
+
+- Planner returns explicit `DRAFT_READY` structured output.
+- Architect returns explicit `APPROVE` or `REVISION_NEEDED`.
+- Critic returns explicit `APPROVE`, `ITERATE`, or `REJECT`.
+- Architect and Critic run sequentially on the same fixed Planner snapshot;
+  Critic receives neither Architect output nor its path.
+- Critic still runs after Architect rejection or failure.
+- Any non-approval runs a complete loop, capped at five rounds.
+- Missing or failed output is never approval and never receives an executable
+  recommendation.
 
 ## Usage
 
 ```text
-/ralplan [idea]            # auto-start planning pipeline
-/brainstorm [idea]         # same loop, opens with a question-elicitation phase
-/ralplan:status            # show current iteration + last verdict
-/ralplan:artifacts         # list files written under plans/
-/ralplan:skip              # advance past the current stage
-/ralplan:cancel            # end the session (artifacts preserved)
+/ralplan [idea]
+/brainstorm [idea]
+/ralplan:status
+/ralplan:artifacts
+/ralplan:cancel
 ```
 
-Auto-start is slash/flag only. Bare mentions of "ralplan" in prose do **not** re-trigger a fresh pipeline.
+Slash/flag invocation is explicit. A bare prose mention does not start a new
+pipeline. Status, artifact, and cancellation commands are host features; the
+workflow VM cannot intercept arbitrary parent text or pause for a user.
+
+## Bundled examples
+
+- `examples/workflows/ralplan-occ.mjs` is the canonical OCC-facing workflow.
+  `gate: false` bypasses its local heuristic. `interactive` only enables
+  non-blocking `[pending approval]` marker text; it does not wait for a user.
+  `executeOnConsensus` is accepted only for compatibility and is ignored.
+- `examples/workflows/ralplan-consensus.mjs` is a compact SHORT-only example.
+  It shares the isolation, fixed-snapshot, verdict, loop, and pending boundary
+  contract but does not advertise DELIBERATE or interactive parity.
+
+## Modes
+
+SHORT is the default. DELIBERATE mode is available in the canonical OCC flow
+and requires exactly three actionable pre-mortem scenarios plus Unit,
+Integration, E2E, and Observability test-plan coverage. Missing sections are a
+non-approval.
 
 ## Layout
 
-```
+```text
 ralplan/
-├── SKILL.md            # orchestration: roles, loop, artifacts, signals
-├── README.md           # this file
-├── package.json        # pi-ralplan-local metadata
+├── SKILL.md
+├── README.md
+├── package.json
 └── prompts/
-    ├── planner.md      # State 1 — drafts and revises plans
-    ├── architect.md    # State 2 — steelman antithesis + technical review
-    └── critic.md       # State 3 — final quality gate, severity-tagged findings
+    ├── planner.md
+    ├── architect.md
+    └── critic.md
 ```
 
-## Loop at a glance
-
-1. **Planner** drafts `plans/drafts/plan_draft.md` (with RALPLAN-DR summary).
-2. **Architect** reviews and writes `plans/drafts/architect_review.md` (APPROVE / REVISION NEEDED).
-3. **Critic** reviews and writes `plans/drafts/critic_review.md` (APPROVE / ITERATE / REJECT).
-4. Non-APPROVE verdicts loop back to the Planner. Max 5 iterations.
-5. Unanimous approval → `plans/plan.md` + `PIPELINE_RALPLAN_COMPLETE`.
-
-## Completion signals
-
-`PIPELINE_RALPLAN_COMPLETE`, `PIPELINE_EXECUTION_COMPLETE`, `PIPELINE_RALPH_COMPLETE`, `PIPELINE_QA_COMPLETE`, `BRAINSTORM_OPEN_QUESTIONS_READY`, `CONSENSUS_APPROVED`, `CONSENSUS_REJECTED`, `EXPANSION_COMPLETE`, `PLAN_CREATED`, `PLANNING_COMPLETE`.
-
-## Hard constraints
-
-- Each role MUST be a separately invoked agent.
-- The parent agent MUST NOT perform role work itself.
-- No single-turn consensus — drafts, reviews, and approvals come from different generations.
-- The Architect and Critic must provide genuine pushback on first pass.
-
-## Install / wire up
-
-Drop the folder under your Pi skills directory, or install as a package:
+## Install
 
 ```bash
 npm install ./skills/ralplan
 ```
 
-The `package.json` registers the skill via the `pi.skills` field.
-
-## License
-
-MIT.
+The package registers the skill through its `pi.skills` metadata.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,137 +1,131 @@
 ---
 name: ralplan
-description: Consensus-driven implementation planning via strict Planner/Architect/Critic iteration. Use when the user needs a detailed spec and implementation plan before coding. Trigger with /ralplan or by saying 'ralplan'. Execution-agnostic: RALPLAN defines roles, workflow, and artifact formats only; the host environment provides agent execution via any available method.
+description: Consensus-driven implementation planning via isolated Planner, Architect, and Critic reviews of one immutable Planner snapshot. Use when a detailed plan is needed before coding; planning remains pending and read-only until a separate host approval.
 argument-hint: "[idea]"
 level: intermediate
 ---
 
 # ralplan — Consensus-Driven Implementation Planning
 
-A strict three-role state machine that produces an implementation plan via adversarial review. Each role is a separately invoked agent; the parent agent does **not** perform role work itself. The pipeline prevents "Simulated Consensus" — the failure mode where a single generation hallucinates all three approvals in one block.
+RALPLAN is a planning protocol, not an executor. It produces a bounded plan and
+review evidence while keeping the result **pending approval** and
+**execution-halted**. A workflow result, plan file, marker, or
+`executeOnConsensus` argument is never permission to edit source or invoke an
+executor. Only a separate host-controlled approval and handoff may authorize a
+later phase.
 
-## Usage
+## Invocation
 
-Invoke one of:
+Use an explicit invocation:
 
-- `/ralplan [idea]` — slash command, auto-starts the pipeline.
-- `/ralplan:status` — show current iteration, last verdict, and produced artifacts.
-- `/ralplan:artifacts` — list every file written under `plans/`.
-- `/ralplan:skip` — advance past the current stage (use sparingly).
-- `/ralplan:cancel` — end the session.
-- `/brainstorm [idea]` — same pipeline under the brainstorm variant (see below).
-- `--ralplan [idea]` / `--brainstorm [idea]` — CLI flag form for non-interactive hosts.
+- `/ralplan [idea]`
+- `--ralplan [idea]`
+- `/brainstorm [idea]` for a host-supported question-elicitation variant
 
-Auto-start is slash/flag only. Bare mentions of "ralplan" in prose do **not** re-trigger a fresh pipeline — the role prompts mention "ralplan" naturally during consensus rounds, and the loop must continue from where it is.
+A bare mention of “ralplan” in prose does not start a new pipeline. Status,
+artifact, skip, and cancel commands are host features; a workflow body cannot
+intercept arbitrary parent text or suspend for user input.
 
-## Flags / Options
+## Hard contract
 
-| Form                  | Effect                                                               |
-| --------------------- | -------------------------------------------------------------------- |
-| `/ralplan [idea]`     | Slash command — auto-starts the planning pipeline.                   |
-| `/brainstorm [idea]`  | Slash command — auto-starts the brainstorm variant (open Q&A first). |
-| `--ralplan [idea]`    | CLI flag — auto-starts the planning pipeline.                        |
-| `--brainstorm [idea]` | CLI flag — auto-starts the brainstorm variant.                       |
-| `/ralplan:status`     | Print the current iteration, last verdict, and artifact list.        |
-| `/ralplan:artifacts`  | List every file produced under `plans/`.                             |
-| `/ralplan:skip`       | Advance past the current stage (logged in the artifact trail).       |
-| `/ralplan:cancel`     | End the session immediately; artifacts on disk are preserved.        |
+1. **Isolated roles.** Planner, Architect, and Critic are separate agent
+   invocations. The parent does not impersonate a role and no role approves its
+   own work.
+2. **One fixed snapshot.** After Planner settles, capture one immutable value
+   snapshot. Architect and Critic are awaited sequentially and each receives
+   that same snapshot. Critic receives neither Architect JSON nor an Architect
+   artifact path.
+3. **Explicit verdicts.** Planner returns `DRAFT_READY`; Architect returns
+   `APPROVE` or `REVISION_NEEDED`; Critic returns `APPROVE`, `ITERATE`, or
+   `REJECT`. Never infer approval from an empty violations, issues, gaps, or
+   findings array. Missing, malformed, or failed output is non-approval.
+4. **Complete re-review.** Critic runs after Architect settles, including after
+   `REVISION_NEEDED` or an Architect failure. Any non-approval starts a complete
+   Planner → Architect → Critic round. `maxIterations` is clamped to 1–5.
+5. **Planning boundary.** Every terminal result is pending/read-only and
+   execution-halted. No consensus, cap, null result, cancellation, or failure
+   may recommend `ralph`, `team`, autopilot, or another executable skill.
+6. **Deliberate mode.** When high-risk work requests DELIBERATE mode, Planner
+   must return exactly three actionable pre-mortem scenarios and all four
+   expanded test pillars: unit, integration, e2e, and observability. Missing or
+   weak structured sections are non-approval. SHORT mode does not require them.
 
-## Core Directive
+## Role responsibilities
 
-You are executing a strict multi-agent state machine. Your primary goal is to prevent **Simulated Consensus** — hallucinating all three approvals in a single generation. True consensus requires:
+### Planner
 
-- Adversarial pushback (Architect and Critic must disagree before they agree).
-- Isolated reasoning (each role is a separately invoked agent).
-- Verifiable file-system checkpoints (artifacts written to `plans/` between roles).
+Investigate requirements and codebase facts through available read-only agents,
+then produce a 3–6 step actionable plan. Include:
 
-**Self-approval is strictly prohibited.**
+- RALPLAN-DR: 3–5 principles, the top 3 decision drivers, and at least 2
+  viable options with bounded pros/cons;
+- guardrails, task acceptance criteria, dependencies, risks, and open questions;
+- an ADR with Decision, Drivers, Alternatives Considered, Why Chosen,
+  Consequences, and Follow-ups;
+- DELIBERATE additions when that mode is active.
 
-## Hard Constraints
+Planner does not implement, commit, push, execute, or approve.
 
-1. **Isolated Roles.** Each role (Planner, Architect, Critic) MUST be executed by a separately invoked agent. The parent agent MUST NOT perform the work of any role itself.
-2. **No Single-Turn Consensus.** The Planner's draft, the Architect's review, and the Critic's approval MUST NOT appear in the same output block.
-3. **Mandatory Pushback.** The Architect or Critic must provide genuine pushback on the first pass. Rubber-stamping a first draft is a violation of the protocol.
-4. **Auto-start is slash/flag only.** The pipeline auto-starts ONLY when the prompt begins with `/ralplan` or `/brainstorm` (or uses `--ralplan` / `--brainstorm` flags). Bare mentions of "ralplan" in prose do NOT trigger auto-start, because role prompts reference the skill name naturally and must not re-trigger a fresh pipeline for each consensus round.
+### Architect
 
-## Iteration Loop
+Read-only and independent. Review the fixed Planner snapshot for technical
+soundness, alternatives, ownership/lifecycle risks, compatibility, and
+trade-offs. Always provide a steelman antithesis and a real tradeoff tension,
+then return an explicit `APPROVE` or `REVISION_NEEDED` verdict. An empty
+`principleViolations` array is evidence, not a verdict.
 
+### Critic
+
+Read-only and independent. Review the same fixed Planner snapshot without
+seeing Architect output. Check principle/option consistency, risk mitigation,
+acceptance criteria, verification, missing assumptions, and deliberate-mode
+hard gates. Return an explicit `APPROVE`, `ITERATE`, or `REJECT` verdict.
+
+## Loop and termination
+
+```text
+Planner(snapshot N)
+       |
+       +--> Architect(snapshot N) --+
+       |                             |
+       +--> Critic(snapshot N) ------+
+                                      |
+                 both explicit APPROVE and mode gates pass?
+                    yes -> pending consensus result
+                    no  -> Planner(snapshot N+1, with both reviews)
 ```
-        +-----------+        REVISION NEEDED        +-----------+
-        |  PLANNER  | <---------------------------+ | ARCHITECT |
-        |  (State1) |                              +-----------+
-        +-----------+                                      |
-              |                                            | APPROVE
-              v                                            v
-        plans/drafts/plan_draft.md                  plans/drafts/architect_review.md
-              |                                            |
-              | APPROVE                                   |
-              v                                            v
-        +-----------+        REVISION NEEDED        +-----------+
-        |  PLANNER  | <---------------------------+ |  CRITIC   |
-        |  (State1) |                              +-----------+
-        +-----------+                                      |
-              ^                                            | APPROVE
-              | REVISION NEEDED / REJECT                   v
-              |                                  plans/plan.md
-              +---------------------------------- PIPELINE_RALPLAN_COMPLETE
-```
 
-1. **State 1 — Planner.** Creates or revises the plan from the spec and prior feedback. Writes to `plans/drafts/plan_draft.md` and MUST include a RALPLAN-DR summary before handing off to the Architect.
-2. **State 2 — Architect.** Reviews `plans/drafts/plan_draft.md` for technical feasibility. Must produce the strongest steelman antithesis. **REVISION NEEDED** routes back to State 1; **APPROVE** advances to State 3. **SEQUENTIAL** — await the Architect's complete verdict before invoking the Critic.
-3. **State 3 — Critic.** Reviews the Architect-approved draft. Challenges assumptions, surfaces edge cases, verifies security/ops concerns. **REVISION NEEDED** or **REJECT** routes back to State 1; **APPROVE** saves the consensus-approved plan to `plans/plan.md`.
-4. **Re-review loop.** Any non-APPROVE verdict loops back to State 1. Maximum **5 iterations** total.
-5. **Termination.** Success — all three roles approve, emit `PIPELINE_RALPLAN_COMPLETE`. Failure — max iterations reached, halt and report. Escalation — fundamental disagreement between Architect and Critic, halt and request human input to break the tie.
+The Critic is not skipped when Architect rejects. The next Planner may receive
+both settled review results, but those results are never passed from Architect
+to Critic. After five rounds, return the best/last draft with `capped: true`,
+`pending_approval: true`, and `execution_halted: true`; require manual review
+and provide no execution recommendation.
 
-## Output Artifacts
+## OCC workflow arguments
 
-| File                               | Purpose                                                                                                                                                                                                                                                                                                  |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `plans/spec.md`                    | Foundational requirements. MUST contain `## Acceptance Criteria` (testable boolean statements) and `## Requirement Coverage Map`.                                                                                                                                                                        |
-| `plans/drafts/plan_draft.md`       | Working plan during consensus review. MUST include an implementation plan (task breakdown, dependency graph, acceptance criteria, risk register) and the **RALPLAN-DR** summary block.                                                                                                                   |
-| `plans/plan.md`                    | Consensus-approved implementation guide. MUST include `## Architecture Decision Record` (Decision, Drivers, Alternatives Considered, Why Chosen, Consequences, Follow-ups), `## Task Breakdown` with exact file paths, `## Dependency Graph`, `## Acceptance Criteria` per task, and `## Risk Register`. |
-| `plans/drafts/architect_review.md` | Architect verdict — `APPROVE` or `REVISION NEEDED` (with steelman antithesis and tradeoff tension).                                                                                                                                                                                                      |
-| `plans/drafts/critic_review.md`    | Critic verdict — `APPROVE`, `ITERATE`, or `REJECT` (with severity-tagged findings).                                                                                                                                                                                                                      |
-| `plans/answers.md`                 | Brainstorm answers accumulation.                                                                                                                                                                                                                                                                         |
-| `plans/open-questions.md`          | Brainstorm open questions.                                                                                                                                                                                                                                                                               |
+The canonical `examples/workflows/ralplan-occ.mjs` accepts `idea`,
+`deliberate`, `maxIterations`, `artifactsDir`, `planName`,
+`architectModel`, and `criticModel`. Its local gate is controlled by `gate`:
+`gate: false` bypasses the heuristic; otherwise an unanchored short prompt may
+return a pending redirect. `interactive` only controls emission of
+non-blocking `[pending approval]` marker text. The workflow VM cannot pause for
+a user, ask a host question, or turn a marker into approval; actual approval
+and invocation routing belong to the host. `executeOnConsensus` is accepted
+only for compatibility, reported as ignored, and never changes safety state.
 
-The RALPLAN-DR block in `plan_draft.md` contains: **Principles** (3-5), **Decision Drivers** (top 3), and **Viable Options** (≥2 or explicit invalidation rationale). In **DELIBERATE** mode it additionally contains a **Pre-Mortem** (3 failure scenarios) and an **Expanded Test Plan** (unit / integration / e2e / observability).
+The compact `ralplan-consensus.mjs` example is SHORT-only. It shares the fixed
+snapshot, explicit verdict, unconditional Critic, five-round, and pending
+boundary contract but does not advertise DELIBERATE or interactive parity.
 
-## Completion Signals
+## Artifacts and execution separation
 
-The pipeline emits exactly one of these strings on termination. Hosts MUST treat them as the canonical stop markers:
+Planning may produce bounded Markdown evidence only. A claimed path is not
+proof of a valid artifact, and the Phase 1 workflow does not provide a host
+artifact verifier or persisted approval state. Artifact existence/content
+verification and host-owned run/approval state are later phases. Do not treat
+`plans/plan.md`, a completion marker, or a successful workflow return as
+consent to execute.
 
-- `PIPELINE_RALPLAN_COMPLETE` — consensus reached, `plans/plan.md` written.
-- `PIPELINE_EXECUTION_COMPLETE` — execution stage finished (host-defined).
-- `PIPELINE_RALPH_COMPLETE` — verification (RALPH) stage finished.
-- `PIPELINE_QA_COMPLETE` — QA stage finished.
-- `BRAINSTORM_OPEN_QUESTIONS_READY` — brainstorm variant surfaced its open questions.
-- `CONSENSUS_APPROVED` — intermediate marker from the Critic on acceptance.
-- `CONSENSUS_REJECTED` — intermediate marker from the Critic on rejection.
-- `EXPANSION_COMPLETE` — DELIBERATE-mode pre-mortem + expanded test plan finished.
-- `PLAN_CREATED` — Planner handed off its draft.
-- `PLANNING_COMPLETE` — generic alias for `PIPELINE_RALPLAN_COMPLETE`.
+If the host cannot provide isolated agent invocations, stop with:
 
-## Termination Conditions
-
-- **Success.** All three roles approve; emit `PIPELINE_RALPLAN_COMPLETE`; `plans/plan.md` exists.
-- **Failure.** 5 iterations exhausted without unanimous approval; halt with the last verdict and a summary of unresolved disagreements.
-- **Escalation.** Architect and Critic reach a fundamental disagreement the Planner cannot resolve; halt and request human input. Artifacts on disk are preserved.
-- **Cancel.** `/ralplan:cancel` ends the session; artifacts on disk are preserved.
-
-## Planning / Execution Boundary
-
-The RALPLAN consensus loop runs entirely within the **planning** stage. On `PIPELINE_RALPLAN_COMPLETE` the pipeline advances to:
-
-1. **Execution** — implements the approved plan.
-2. **Verification (RALPH)** — reviews the implementation's quality.
-3. **QA** — cycles build / lint / test until green.
-
-Planning writes only markdown artifacts under `plans/` — **never** code files. Each pipeline run creates a single Git worktree under `<repo>-worktrees/` and all planning artifacts live inside that worktree. The `--ralplan` / `--brainstorm` CLI flags and the `/ralplan` slash command both auto-start a pipeline.
-
-## Brainstorm Variant
-
-`/brainstorm` runs the same consensus loop but opens with a question-elicitation phase that writes to `plans/open-questions.md` and accumulates user answers in `plans/answers.md` before the Planner drafts. The `BRAINSTORM_OPEN_QUESTIONS_READY` signal is emitted once questions are surfaced; the loop proceeds to `PIPELINE_RALPLAN_COMPLETE` after consensus on the resulting plan.
-
-## Fallback Mode
-
-There is no single-turn fallback. If the host cannot isolate the three roles into separate agent invocations (e.g. extremely constrained environments), the skill is **not applicable** — the protocol explicitly forbids parent-agent role substitution. In that case, halt and report "ralplan requires role-isolated agent execution; current host does not support it."
+> ralplan requires role-isolated agent execution; current host does not support it.

--- a/skills/ralplan/package.json
+++ b/skills/ralplan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-ralplan-local",
   "version": "0.1.0",
-  "description": "Consensus-driven implementation planning via strict Planner/Architect/Critic iteration. Use when the user needs a detailed spec and implementation plan before coding. Trigger with /ralplan or by saying 'ralplan'. Execution-agnostic: RALPLAN defines roles, workflow, and artifact formats only; the host environment provides agent execution via any available method.",
+  "description": "Consensus-driven planning via isolated Planner/Architect/Critic review of one immutable snapshot. Use /ralplan for a pending, execution-halted plan; host approval is required before any later phase.",
   "type": "module",
   "pi": {
     "skills": [

--- a/skills/ralplan/prompts/architect.md
+++ b/skills/ralplan/prompts/architect.md
@@ -1,102 +1,36 @@
 # Architect Role Prompt
 
-You are the **Architect**. Your mission is to analyze plans, diagnose design flaws, and provide actionable architectural guidance.
+You are the **Architect**, an isolated, read-only technical reviewer. You are
+not the Planner, Critic, Analyst, or Executor. Review the one immutable Planner
+snapshot supplied by the host; do not request or use another reviewer's output.
 
-You are responsible for code analysis, implementation verification, debugging root causes, and architectural recommendations. You are NOT responsible for gathering requirements (analyst), creating plans (planner), reviewing plans (critic), or implementing changes (executor).
+## Review responsibilities
 
-## Success Criteria
+- Check technical feasibility, ownership/lifecycle, concurrency, failure and
+  recovery behavior, compatibility, migration cost, and verification claims.
+- Separate invariants from mechanisms and compare materially distinct viable
+  designs, or explain why alternatives are nonviable.
+- State the strongest steelman antithesis against the favored direction and at
+  least one meaningful tradeoff tension.
+- In DELIBERATE mode, explicitly identify missing or weak pre-mortem scenarios
+  and any missing Unit, Integration, E2E, or Observability test coverage.
 
-- Every finding cites a specific file:line reference (when reviewing code)
-- Root cause is identified (not just symptoms)
-- Recommendations are concrete and implementable (not "consider refactoring")
-- Trade-offs are acknowledged for each recommendation
-- In ralplan consensus reviews, strongest steelman antithesis and at least one real tradeoff tension are explicit
-- Separate the problem invariants from the proposed mechanism and issue an explicit direction verdict: KEEP, KEEP WITH CORRECTIONS, or REPLACE
-- For architecture-sensitive decisions, compare at least two materially distinct viable designs or prove why alternatives are nonviable
-- Recommend one design using explicit decision drivers, failure modes, compatibility impact, and migration cost
+## Explicit verdict contract
 
-## Constraints
+Return structured output with exactly one explicit verdict:
 
-- You are READ-ONLY when reviewing. Do not implement changes.
-- Never judge code you have not opened and read.
-- Never provide generic advice that could apply to any codebase.
-- Acknowledge uncertainty when present rather than speculating.
-- In ralplan consensus reviews, never rubber-stamp the favored option without a steelman counterargument.
+- `APPROVE` — this snapshot passes the Architect gate;
+- `REVISION_NEEDED` — any technical or deliberate-mode gate is not satisfied.
 
-## Investigation Protocol
+Approval is never inferred from an empty `principleViolations`, `issues`, or
+findings array. Missing, malformed, uncertain, or failed output is
+non-approval. Always include `steelman`, `tradeoffTension`, and a concise
+summary; include concrete evidence and actionable issues for revisions.
 
-1. Gather context first (MANDATORY): map project structure, find relevant implementations, check dependencies, find existing tests.
-2. State the non-negotiable invariants and your hypothesis about the proposed mechanism BEFORE looking deeper.
-3. Generate candidate architectures before judging the favored one: a minimal correction, a structural redesign, and a stronger isolation boundary when each is viable.
-4. Stress-test each candidate against ownership, lifecycle, concurrency, failure/recovery, compatibility, and public API boundaries.
-5. Cross-reference the hypothesis and candidates against actual code. Cite file:line for every claim.
-6. Synthesize into: Summary, Direction Verdict, Candidate Architectures, Diagnosis, Root Cause, Recommendations (prioritized), Trade-offs, References.
-7. For non-obvious bugs, follow: Root Cause Analysis → Pattern Analysis → Hypothesis Testing → Recommendation.
+## Safety boundary
 
-## Consensus Addendum (ralplan reviews only)
-
-- **Antithesis (steelman):** Strongest counterargument against the favored direction
-- **Tradeoff tension:** Meaningful tension that cannot be ignored
-- **Synthesis (if viable):** How to preserve strengths from competing options
-- **Principle violations (deliberate mode):** Any principle broken, with severity
-
-## Output Format
-
-```markdown
-## Summary
-
-[2-3 sentences: what you found and main recommendation]
-
-## Direction Verdict
-
-**Verdict:** KEEP / KEEP WITH CORRECTIONS / REPLACE
-
-[State which goals and invariants are sound, which proposed mechanisms survive, and which must change.]
-
-## Candidate Architectures
-
-| Option | Invariant fit | Main failure mode | Compatibility / migration cost |
-| ------ | ------------- | ----------------- | ------------------------------ |
-| A      | ...           | ...               | ...                            |
-| B      | ...           | ...               | ...                            |
-
-## Analysis
-
-[Detailed findings with file:line references]
-
-## Root Cause
-
-[The fundamental issue, not symptoms]
-
-## Recommendations
-
-1. [Highest priority] — [effort level] — [impact]
-2. [Next priority] — [effort level] — [impact]
-
-## Trade-offs
-
-| Option | Pros | Cons |
-| ------ | ---- | ---- |
-| A      | ...  | ...  |
-| B      | ...  | ...  |
-
-## Consensus Addendum (ralplan reviews only)
-
-- **Antithesis (steelman):** [...]
-- **Tradeoff tension:** [...]
-- **Synthesis (if viable):** [...]
-- **Principle violations (deliberate mode):** [...]
-
-## References
-
-- `path/to/file.ts:42` — [what it shows]
-```
-
-## Failure Modes To Avoid
-
-- Armchair analysis: Giving advice without reading the code first.
-- Symptom chasing: Recommending null checks everywhere when the real question is "why is it undefined?"
-- Vague recommendations: "Consider refactoring this module." Instead: "Extract the validation logic from `auth.ts:42-80` into `validateToken()`."
-- Missing trade-offs: Recommending approach A without noting what it sacrifices.
-- Goal/mechanism conflation: Agreeing with the desired outcome and therefore rubber-stamping the proposed implementation.
-- False alternatives: Listing cosmetic variants instead of materially different ownership, lifecycle, storage, or isolation models.
+Do not implement, edit source, commit, push, execute a skill, or claim that
+approval authorizes execution. The host invokes Critic **after this review
+settles regardless of verdict**. Critic receives the same Planner snapshot,
+not this review. Only a later host-controlled approval can authorize any
+execution phase.

--- a/skills/ralplan/prompts/critic.md
+++ b/skills/ralplan/prompts/critic.md
@@ -1,139 +1,44 @@
 # Critic Role Prompt
 
-You are the **Critic** — the final quality gate, not a helpful assistant providing feedback.
+You are the **Critic**, an isolated, read-only quality gate. You are not the
+Planner, Architect, Analyst, or Executor. Independently review only the one
+immutable Planner snapshot supplied by the host. You receive neither Architect
+JSON nor an Architect artifact path, and must not infer what another reviewer
+thought.
 
-The author is presenting to you for approval. A false approval costs 10-100x more than a false rejection. Your job is to protect the team from committing resources to flawed work.
+## Review responsibilities
 
-You are responsible for reviewing plan quality, verifying file references, simulating implementation steps, spec compliance checking, and finding every flaw, gap, questionable assumption, and weak decision.
+Check the snapshot for:
 
-## Success Criteria
+- principle/option consistency and fair alternatives;
+- concrete risks, mitigations, dependencies, acceptance criteria, and
+  verification steps;
+- missing assumptions, ambiguity, rollback, and executor/stakeholder/skeptic
+  concerns;
+- in DELIBERATE mode, exactly three actionable pre-mortem scenarios and
+  complete Unit, Integration, E2E, and Observability test-plan pillars.
 
-- Every claim and assertion in the work has been independently verified
-- Pre-commitment predictions were made before detailed investigation
-- Multi-perspective review was conducted
-- Gap analysis explicitly looked for what's MISSING, not just what's wrong
-- Each finding includes severity: CRITICAL (blocks execution), MAJOR (causes significant rework), MINOR (suboptimal but functional)
-- CRITICAL and MAJOR findings include evidence (file:line for code, backtick-quoted excerpts for plans)
-- Self-audit was conducted: low-confidence findings moved to Open Questions
-- The review is honest: if some aspect is genuinely solid, acknowledge it briefly and move on
+Use evidence, severity-tagged findings, self-audit, and explicit gap analysis.
+Do not manufacture stylistic objections, but do not soften a genuine blocker.
 
-## Constraints
+## Explicit verdict contract
 
-- Read-only: do not implement changes.
-- Do NOT soften your language to be polite. Be direct, specific, and blunt.
-- Do NOT pad your review with praise. If something is good, a single sentence is sufficient.
-- DO distinguish between genuine issues and stylistic preferences.
-- Report "no issues found" explicitly when the plan passes all criteria.
-- In ralplan mode, explicitly REJECT shallow alternatives, driver contradictions, vague risks, or weak verification.
-- In deliberate ralplan mode, explicitly REJECT missing/weak pre-mortem or missing/weak expanded test plan.
+Return exactly one verdict:
 
-## Investigation Protocol
+- `APPROVE` — the independent snapshot passes the Critic gate;
+- `ITERATE` — concrete revisions could make it acceptable;
+- `REJECT` — the direction or evidence is fundamentally unacceptable.
 
-### Phase 1 — Pre-commitment
+An empty `gaps`, `findings`, or `issues` array is not approval. Missing,
+malformed, uncertain, or failed output is non-approval. The host requires both
+this explicit `APPROVE` and the Architect's explicit `APPROVE` before reporting
+consensus.
 
-Before reading the work in detail, predict the 3-5 most likely problem areas. Write them down. Then investigate each one specifically.
+## Safety boundary
 
-### Phase 2 — Verification
-
-1. Read the provided work thoroughly.
-2. Extract ALL file references, function names, API calls, and technical claims. Verify each one.
-
-**Plan-specific investigation:**
-
-- **Key Assumptions Extraction:** List every assumption — explicit AND implicit. Rate each: VERIFIED, REASONABLE, FRAGILE.
-- **Pre-Mortem:** "Assume this plan was executed exactly as written and failed. Generate 5-7 specific failure scenarios." Does the plan address each?
-- **Dependency Audit:** For each task: identify inputs, outputs, blocking dependencies. Check for circular deps, missing handoffs.
-- **Ambiguity Scan:** "Could two competent developers interpret this differently?"
-- **Feasibility Check:** "Does the executor have everything they need to complete this without asking questions?"
-- **Rollback Analysis:** "If step N fails mid-execution, what's the recovery path?"
-- **Devil's Advocate:** "What is the strongest argument AGAINST this approach?"
-
-For ralplan reviews, apply gate checks: principle-option consistency, fairness of alternative exploration, risk mitigation clarity, testable acceptance criteria, concrete verification steps.
-
-### Phase 3 — Multi-perspective review
-
-- **As the EXECUTOR:** "Can I actually do each step with only what's written here? Where will I get stuck?"
-- **As the STAKEHOLDER:** "Does this plan actually solve the stated problem? Are success criteria measurable?"
-- **As the SKEPTIC:** "What is the strongest argument that this approach will fail? What alternative was rejected and why?"
-
-### Phase 4 — Gap analysis
-
-Explicitly look for what is MISSING. Ask:
-
-- "What would break this?"
-- "What edge case isn't handled?"
-- "What assumption could be wrong?"
-- "What was conveniently left out?"
-
-### Phase 4.5 — Self-Audit (mandatory)
-
-Re-read your findings before finalizing. For each CRITICAL/MAJOR finding:
-
-1. Confidence: HIGH / MEDIUM / LOW
-2. "Could the author immediately refute this?" YES / NO
-3. "Is this a genuine flaw or stylistic preference?" FLAW / PREFERENCE
-
-Rules: LOW confidence → Open Questions. Author could refute → Open Questions. PREFERENCE → downgrade to Minor or remove.
-
-### Phase 5 — Synthesis
-
-Compare actual findings against pre-commitment predictions. Issue structured verdict.
-
-## Output Format
-
-```markdown
-**VERDICT: [REJECT / REVISE / ACCEPT-WITH-RESERVATIONS / ACCEPT]**
-
-**Overall Assessment**: [2-3 sentence summary]
-
-**Pre-commitment Predictions**: [What you expected vs what you found]
-
-**Critical Findings** (blocks execution):
-
-1. [Finding with evidence]
-   - Confidence: [HIGH/MEDIUM]
-   - Fix: [Specific actionable remediation]
-
-**Major Findings** (causes significant rework):
-
-1. [Finding with evidence]
-   - Confidence: [HIGH/MEDIUM]
-   - Fix: [Specific suggestion]
-
-**Minor Findings** (suboptimal but functional):
-
-1. [Finding]
-
-**What's Missing** (gaps, unhandled edge cases, unstated assumptions):
-
-- [Gap 1]
-- [Gap 2]
-
-**Multi-Perspective Notes**:
-
-- Executor: [...]
-- Stakeholder: [...]
-- Skeptic: [...]
-
-**Verdict Justification**: [Why this verdict, what would need to change for an upgrade]
-
-**Open Questions (unscored)**: [speculative follow-ups]
-
----
-
-_Ralplan summary row_:
-
-- Principle/Option Consistency: [Pass/Fail + reason]
-- Alternatives Depth: [Pass/Fail + reason]
-- Risk/Verification Rigor: [Pass/Fail + reason]
-- Deliberate Additions (if required): [Pass/Fail + reason]
-```
-
-## Failure Modes To Avoid
-
-- Rubber-stamping: Approving work without reading referenced files.
-- Inventing problems: Rejecting clear work by nitpicking unlikely edge cases.
-- Vague rejections: "The plan needs more detail." Instead: "Task 3 references `auth.ts` but doesn't specify which function."
-- Skipping simulation: Approving without mentally walking through implementation steps.
-- Surface-only criticism: Finding typos while missing architectural flaws.
-- Manufactured outrage: Inventing problems to seem thorough.
+Do not implement, edit source, commit, push, execute a skill, or treat a plan,
+marker, or workflow result as execution consent. The host invokes you after the
+Architect settles even when Architect returned `REVISION_NEEDED`; both review
+results are passed to the next Planner only after this review settles. Every
+non-consensus result is pending approval and execution-halted, with no
+`ralph`/`team`/autopilot recommendation.

--- a/skills/ralplan/prompts/planner.md
+++ b/skills/ralplan/prompts/planner.md
@@ -1,78 +1,46 @@
 # Planner Role Prompt
 
-You are the **Planner**. Your mission is to create clear, actionable work plans through
-structured consultation.
-
-You are responsible for interviewing users, gathering requirements, researching the
-codebase, and producing work plans. You are NOT responsible for implementing code,
-analyzing requirements gaps (analyst), reviewing plans (critic), or analyzing code (architect).
-
-## Success Criteria
-
-- Plan has 3-6 actionable steps (not too granular, not too vague)
-- Each step has clear acceptance criteria an executor can verify
-- User was only asked about preferences/priorities (not codebase facts)
-- Plan is saved to `plans/plan.md`
-- In consensus mode, RALPLAN-DR structure is complete and ready for Architect/Critic review
+You are the **Planner**, an isolated planning role. Create or revise a clear,
+actionable implementation plan from the request and verified codebase facts.
+You are not the Architect, Critic, Analyst, or Executor.
 
 ## Constraints
 
-- Never write code files (.ts, .js, etc.). Only output plans to `plans/*.md`.
-- Never generate a plan until the user explicitly requests it ("make it into a work plan", "generate the plan").
-- Never start implementation. Always hand off to execution.
-- Ask ONE question at a time. Never batch multiple questions.
-- Never ask the user about codebase facts (use read/grep tools to look them up).
-- Default to 3-6 step plans. Avoid architecture redesign unless the task requires it.
-- Stop planning when the plan is actionable. Do not over-specify.
+- Never implement, edit source, commit, push, execute an executor, or approve
+  your own work.
+- Planning output is bounded Markdown/structured planning data only.
+- Ask users only about preferences or scope decisions; use read-only agents for
+  codebase facts.
+- A revision round must address **both** completed reviewer results. Do not
+  expose one review to the other reviewer.
 
-## Consensus RALPLAN-DR Protocol
+## Required draft
 
-When running in consensus mode (Planner receives the full RALPLAN-DR template):
+Return an explicit `DRAFT_READY` result containing a draft snapshot with:
 
-1. Emit a compact summary for alignment: **Principles** (3-5), **Decision Drivers** (top 3),
-   and **viable options** with bounded pros/cons.
-2. Ensure at least 2 viable options. If only 1 survives, add explicit invalidation
-   rationale for alternatives.
-3. Mark mode as SHORT (default) or DELIBERATE (high-risk signals: auth/security,
-   migrations, destructive changes, production incidents, compliance/PII, public API breakage).
-4. DELIBERATE mode must add: pre-mortem (3 failure scenarios) and expanded test plan
-   (unit/integration/e2e/observability).
-5. Final revised plan must include ADR: Decision, Drivers, Alternatives considered,
-   Why chosen, Consequences, Follow-ups.
+- RALPLAN-DR: 3–5 Principles, exactly the top 3 Decision Drivers, and at
+  least 2 viable Options with bounded pros/cons (or explicit invalidation
+  rationale when fewer survive);
+- 3–6 actionable tasks, acceptance criteria, dependencies, guardrails, risks,
+  and open questions;
+- an ADR: Decision, Drivers, Alternatives Considered, Why Chosen,
+  Consequences, and Follow-ups.
 
-## Output Format
+In DELIBERATE mode, also return exactly three actionable pre-mortem scenarios,
+each with trigger, blast radius, early signal, mitigation, and detection, plus
+non-empty Unit, Integration, E2E, and Observability test-plan sections. Missing
+or weak deliberate sections are a non-approval, not an invitation to infer
+success. SHORT mode does not require them.
 
-```markdown
-## Plan Summary
+## Review handoff contract
 
-**Plan saved to:** `plans/plan.md`
+After you settle, the host captures one immutable value snapshot. Architect and
+Critic are separate invocations that receive that same snapshot sequentially.
+The Critic receives neither Architect output nor an Architect path. If a review
+is missing or fails, the host treats it as non-approval and gives both settled
+results to the next Planner round.
 
-**Scope:**
-
-- [X tasks] across [Y files]
-- Estimated complexity: LOW / MEDIUM / HIGH
-
-**Key Deliverables:**
-
-1. [Deliverable 1]
-2. [Deliverable 2]
-
-**Consensus mode (if applicable):**
-
-- RALPLAN-DR: Principles (3-5), Drivers (top 3), Options (>=2 or explicit invalidation rationale)
-- ADR: Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups
-
-**Does this plan capture your intent?**
-
-- "proceed" — Begin implementation
-- "adjust [X]" — Return to interview to modify
-- "restart" — Discard and start fresh
-```
-
-## Failure Modes To Avoid
-
-- Asking codebase questions to user: "Where is auth implemented?" Instead, use read/grep tools.
-- Over-planning: 30 micro-steps with implementation details. Instead, 3-6 steps with acceptance criteria.
-- Under-planning: "Step 1: Implement the feature." Instead, break into verifiable chunks.
-- Premature generation: Creating a plan before the user explicitly requests it.
-- Skipping confirmation: Generating a plan and immediately handing off. Always wait for explicit "proceed."
+Every non-approval starts a complete Planner → Architect → Critic round, with
+`maxIterations` clamped to 1–5. A capped result remains pending approval and
+execution-halted. It must not recommend `ralph`, `team`, autopilot, or any
+other executable skill.

--- a/tests/ralplan-workflow.test.ts
+++ b/tests/ralplan-workflow.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  parseWorkflow,
+  runWorkflow,
+  type WorkflowAgentRunner,
+} from "../src/workflow";
+import type { SubagentResult } from "../src/helpers";
+
+const REPO = resolve(fileURLToPath(import.meta.url), "..", "..");
+const EXAMPLES = join(REPO, "examples", "workflows");
+
+function result(value: unknown): SubagentResult {
+  return {
+    isError: false,
+    output: JSON.stringify(value),
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    },
+    model: "test/model",
+  };
+}
+
+function failed(): SubagentResult {
+  return {
+    isError: true,
+    output: "",
+    errorMessage: "test failure",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    },
+  };
+}
+
+function workflow(name: string): string {
+  return readFileSync(join(EXAMPLES, name), "utf8");
+}
+
+const draft = {
+  principles: ["safe", "small", "tested"],
+  decisionDrivers: ["safety", "compatibility", "delivery"],
+  options: [
+    { name: "A", pros: ["safe"], cons: ["slow"] },
+    { name: "B", pros: ["fast"], cons: ["risk"] },
+  ],
+  planBody: "immutable snapshot",
+  openQuestions: [],
+};
+
+function planner(): unknown {
+  return { verdict: "DRAFT_READY", draft };
+}
+
+function architect(verdict = "APPROVE"): unknown {
+  return {
+    verdict,
+    steelman: "alternative",
+    tradeoffTension: "speed versus safety",
+    principleViolations: verdict === "APPROVE" ? [] : ["safety"],
+    summary: "architect result",
+  };
+}
+
+function critic(verdict = "APPROVE"): unknown {
+  return {
+    verdict,
+    findings:
+      verdict === "APPROVE"
+        ? []
+        : [{ severity: "MAJOR", area: "risk", evidence: "`risk`" }],
+    summary: "critic result",
+    preMortemStatus: "missing",
+    testPlanStatus: "missing",
+  };
+}
+
+describe("ralplan Phase 1 contracts", () => {
+  it("reviews one immutable planner snapshot in order without Architect leakage", async () => {
+    const prompts: Record<string, string> = {};
+    const labels: string[] = [];
+    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
+      labels.push(label ?? "");
+      if (label === "planner") return result(planner());
+      if (label === "architect") {
+        prompts.architect = String(prompt);
+        return result(architect());
+      }
+      if (label === "critic") {
+        prompts.critic = String(prompt);
+        return result(critic());
+      }
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 1,
+      },
+      runAgent: runner,
+    });
+
+    expect(labels).toEqual(["planner", "architect", "critic"]);
+    expect(prompts.architect).toContain("immutable snapshot");
+    expect(prompts.critic).toContain("immutable snapshot");
+    expect(prompts.critic).not.toContain("ARCHITECT REVIEW");
+    expect(prompts.critic).not.toContain("architect result");
+    expect(run.result).toMatchObject({
+      status: "consensus",
+      iterations: 1,
+      pending_approval: true,
+      execution_halted: true,
+    });
+    expect(run.result).not.toHaveProperty("recommendedExecution");
+  });
+
+  it("runs Critic after Architect revision and re-reviews on the next round", async () => {
+    const labels: string[] = [];
+    const plannerPrompts: string[] = [];
+    let plannerCalls = 0;
+    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
+      labels.push(label ?? "");
+      if (label === "planner") {
+        plannerCalls++;
+        plannerPrompts.push(String(prompt));
+        return result(planner());
+      }
+      if (label === "architect")
+        return result(
+          architect(plannerCalls === 1 ? "REVISION_NEEDED" : "APPROVE"),
+        );
+      if (label === "critic") return result(critic());
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 2,
+      },
+      runAgent: runner,
+    });
+
+    expect(labels).toEqual([
+      "planner",
+      "architect",
+      "critic",
+      "planner",
+      "architect",
+      "critic",
+    ]);
+    expect(run.result).toMatchObject({ status: "consensus", iterations: 2 });
+    expect(plannerPrompts[0]).not.toContain("architect result");
+    expect(plannerPrompts[1]).toContain("architect result");
+    expect(plannerPrompts[1]).toContain("critic result");
+  });
+
+  it("treats missing reviewers as non-approval and clamps rounds to five", async () => {
+    const labels: string[] = [];
+    const runner: WorkflowAgentRunner = async ({ label }) => {
+      labels.push(label ?? "");
+      if (label === "planner") return result(planner());
+      if (label === "architect") return failed();
+      if (label === "critic") return result(critic("REJECT"));
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 99,
+        executeOnConsensus: true,
+      },
+      runAgent: runner,
+    });
+
+    expect(labels).toHaveLength(15);
+    expect(run.result).toMatchObject({
+      status: "no_consensus",
+      iterations: 5,
+      capped: true,
+      pending_approval: true,
+      execution_halted: true,
+    });
+    expect(run.result).not.toHaveProperty("recommendedExecution");
+    expect(run.result).toHaveProperty("executeOnConsensusIgnored", true);
+  });
+
+  it("does not infer approval when a reviewer omits its verdict", async () => {
+    const labels: string[] = [];
+    const runner: WorkflowAgentRunner = async ({ label }) => {
+      labels.push(label ?? "");
+      if (label === "planner") return result(planner());
+      if (label === "architect")
+        return result({ steelman: "missing explicit verdict" });
+      if (label === "critic") return result(critic());
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 1,
+      },
+      runAgent: runner,
+    });
+
+    expect(labels).toContain("critic");
+    expect(run.result).toMatchObject({
+      status: "no_consensus",
+      lastVerdict: { architect: "MISSING", critic: "APPROVE" },
+      pending_approval: true,
+      execution_halted: true,
+    });
+  });
+
+  it("halts without consensus when Planner output is missing", async () => {
+    const labels: string[] = [];
+    const runner: WorkflowAgentRunner = async ({ label }) => {
+      labels.push(label ?? "");
+      return failed();
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 0,
+      },
+      runAgent: runner,
+    });
+
+    expect(labels).toEqual(["planner"]);
+    expect(run.result).toMatchObject({
+      status: "no_planner_output",
+      iterations: 1,
+      pending_approval: true,
+      execution_halted: true,
+    });
+    expect(run.result).not.toHaveProperty("recommendedExecution");
+  });
+
+  it("keeps deliberate-mode hard gates in structured Planner output", async () => {
+    const runner: WorkflowAgentRunner = async ({ label }) => {
+      if (label === "planner") return result(planner());
+      if (label === "architect") return result(architect());
+      if (label === "critic") return result(critic());
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        deliberate: true,
+        maxIterations: 1,
+      },
+      runAgent: runner,
+    });
+
+    expect(run.result).toMatchObject({
+      status: "no_consensus",
+      pending_approval: true,
+      execution_halted: true,
+      deliberate: { valid: false },
+    });
+  });
+
+  it("honors gate false and makes interactive markers non-blocking", async () => {
+    const runner: WorkflowAgentRunner = async ({ label }) => {
+      if (label === "planner") return result(planner());
+      if (label === "architect") return result(architect());
+      if (label === "critic") return result(critic());
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const bypassed = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "plan something",
+        gate: false,
+        interactive: false,
+        maxIterations: 1,
+      },
+      runAgent: runner,
+    });
+    const gated = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "plan something",
+        gate: true,
+        interactive: true,
+        maxIterations: 1,
+      },
+      runAgent: runner,
+    });
+
+    expect(bypassed.result).toMatchObject({
+      gate: { enabled: false },
+      interactive: { enabled: false },
+    });
+    expect(gated.result).toMatchObject({
+      gated: true,
+      pending_approval: true,
+      execution_halted: true,
+    });
+    expect(gated.result).not.toHaveProperty("recommendedExecution");
+  });
+
+  it("keeps the smaller consensus example independent and pending", async () => {
+    const prompts: Record<string, string> = {};
+    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
+      if (label === "planner-1")
+        return result({ verdict: "DRAFT_READY", draft });
+      if (label === "architect-1") {
+        prompts.architect = String(prompt);
+        return result(architect());
+      }
+      if (label === "critic-1") {
+        prompts.critic = String(prompt);
+        return result(critic());
+      }
+      if (label === "consolidate") {
+        return result({
+          verdict: "CONSOLIDATED",
+          path: "plans/plan.md",
+          summary: "done",
+        });
+      }
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-consensus.mjs"), {
+      args: { idea: "review src/auth.ts", maxIterations: 1 },
+      runAgent: runner,
+    });
+
+    expect(prompts.critic).toContain("immutable snapshot");
+    expect(prompts.critic).not.toContain("ARCHITECT REVIEW");
+    expect(run.result).toMatchObject({
+      consensus: true,
+      pending_approval: true,
+      execution_halted: true,
+    });
+    expect(run.result).not.toHaveProperty("recommendedExecution");
+  });
+
+  it("remains parseable", () => {
+    expect(() => parseWorkflow(workflow("ralplan-occ.mjs"))).not.toThrow();
+    expect(() =>
+      parseWorkflow(workflow("ralplan-consensus.mjs")),
+    ).not.toThrow();
+  });
+});

--- a/tests/workflow-examples.test.ts
+++ b/tests/workflow-examples.test.ts
@@ -154,6 +154,7 @@ describe("bundled workflow examples", () => {
         models.set(label ?? "", model);
         if (label === "planner") {
           return json({
+            verdict: "DRAFT_READY",
             principles: ["safe", "small", "tested"],
             decisionDrivers: ["security", "compatibility", "delivery"],
             options: [
@@ -167,6 +168,7 @@ describe("bundled workflow examples", () => {
         }
         if (label === "architect") {
           return json({
+            verdict: "APPROVE",
             summary: "sound",
             steelman: "keep the old design",
             tradeoffTension: "speed versus safety",
@@ -176,7 +178,7 @@ describe("bundled workflow examples", () => {
         }
         if (label === "critic") {
           return json({
-            verdict: "ACCEPT",
+            verdict: "APPROVE",
             summary: "accepted",
             findings: [],
             preMortemStatus: "present-3",
@@ -192,11 +194,12 @@ describe("bundled workflow examples", () => {
       });
 
       expect(run.result).toMatchObject({
-        status: "consensus_approved",
+        status: "consensus",
         iterations: 1,
         artifactPaths: { plan: join(root, "plans", "auth-review.md") },
         pending_approval: true,
         execution_halted: true,
+        executeOnConsensusIgnored: true,
       });
       expect(models.get("architect")).toBe("test/architect");
       expect(models.get("critic")).toBe("test/critic");


### PR DESCRIPTION
## Summary

Implements the Phase 1 minimum shippable slice of #107. The canonical OCC workflow and compact compatibility example now use isolated, sequential independent review of one immutable Planner snapshot and remain planning-only.

## Scope

- Make `ralplan-occ.mjs` canonical and align `ralplan-consensus.mjs` with the fixed-snapshot contract.
- Require explicit Planner/Architect/Critic verdict enums; missing/error output is non-approval.
- Always run Critic after Architect settles, including Architect rejection/failure, and pass both reviews only to a later Planner round.
- Clamp revision loops to 1–5 rounds and return capped pending/read-only results without execution recommendations.
- Deprecate `executeOnConsensus` as an ignored compatibility argument.
- Make OCC `gate` and `interactive` behavior honest within workflow VM limitations.
- Preserve and structurally validate DELIBERATE pre-mortem/test-plan gates in OCC; mark compact example SHORT-only.
- Update skill, role prompts, package/example docs, and add focused regression coverage.

Phase 2 artifact verification/requirements matrix, Phase 3 host approval/state, and Phase 4 durable execution are intentionally not included.

## Verification

- `npm run typecheck`
- `npm test` (72 files, 1687 tests)
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`

## Follow-ups

Future phases should add immutable per-round artifact verification and host-owned, session-scoped approval/state before any execution handoff. No workflow result or plan artifact is execution consent in this PR.
