### PR TITLE
feat(ralplan): verify immutable planning artifacts

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -97,7 +97,12 @@ The combined generate-and-persist phase is intentional — see [Workflow tool pi
 
 ### `ralplan-consensus.mjs`
 
-Re-implements the pi-ralplan consensus pipeline as a workflow. Three isolated roles (Planner → Architect → Critic) iterate up to 5 rounds until all approve or the cap is hit.
+A compact SHORT-only implementation of the verified RALPLAN contract. Each
+round writes immutable draft and review Markdown paths. Dedicated read-only
+verifier agents validate exact path, 1 MB size bound, headings, round/kind,
+source-draft identity, and SHA-256. Planner → Architect → Critic iterate for
+at most five rounds; final consolidation/verification occurs only after both
+independent reviewers explicitly approve.
 
 ```js
 workflow({
@@ -111,10 +116,13 @@ Args:
 - `idea` (required, string) — task description
 - `maxIterations` (optional, default `5`) — consensus rounds
 - `artifactsDir` (optional, default `"plans"`) — output directory
+- `planName` (optional, default `"plan"`) — safe final plan basename
 
 ### `ralplan-occ.mjs`
 
-Faithful port of oh-my-claudecode's RALPLAN skill with gate detection, deliberate mode, and planning/execution boundary. Captures the OCC UX contract as closely as the workflow runtime allows.
+The canonical OCC-facing implementation adds gate detection, DELIBERATE
+pre-mortem/test-plan headings, optional advisory requirements traceability,
+and reviewer model routing to the verified immutable-artifact contract.
 
 ```js
 workflow({
@@ -124,15 +132,22 @@ workflow({
     deliberate: "auto", // auto-detect high-risk substrings
     gate: true, // enable gate detection
     interactive: true, // emit [pending approval] markers
+    requirementsTraceability: true, // advisory Analyst + coverage map
   },
 });
 ```
 
-**Fidelity limitations** (also documented in the script header):
+**Runtime boundaries:**
 
-- Interactive AskUserQuestion checkpoints are not supported by the workflow runtime. Substituted with `[pending approval]` log markers.
-- Architect and Critic model overrides are routed through their respective `agent()` calls, but each model id must be configured in Pi.
-- The workflow never executes; it always returns `pending_approval: true` and `execution_halted: true`, per OCC's planning/execution boundary.
+- The worker VM has no filesystem API. Planner/reviewer/consolidator agents own
+  their bounded Markdown writes; separate read-only verifier agents inspect
+  those files and return small structured reports.
+- Interactive approval checkpoints remain non-blocking `[pending approval]`
+  markers. Real approval and invocation routing belong to the host.
+- Reviewer model ids must be configured in Pi.
+- A valid artifact or consensus result is never execution consent. Every
+  terminal result remains `pending_approval: true` and
+  `execution_halted: true`.
 
 ## Workflow tool pitfalls
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -95,12 +95,12 @@ records, while `/workflow-tree` displays the latest 20 and reports omissions.
 
 ### `ralplan-consensus.mjs`
 
-A compact SHORT-only Planner → Architect → Critic loop. Architect and Critic
-are isolated sequential reviewers of the same immutable Planner snapshot. Critic
-never receives Architect output and still runs after Architect rejection. Every
-terminal result is pending approval and execution-halted; consensus is not an
-execution recommendation. A final consolidation agent may write Markdown after
-both explicit approvals, but Phase 1 does not verify that artifact.
+A compact SHORT-only Planner → Architect → Critic loop. Every round uses an
+immutable draft/review filename. Read-only verifier agents check exact paths,
+size bounds, headings, round/kind, source identity, and SHA-256. Architect and
+Critic independently review the same verified draft; Critic receives no
+Architect output/path. Final consolidation and verification happen only after
+both explicit approvals. All results remain pending and execution-halted.
 
 | Argument             | Required | Meaning                                 |
 | -------------------- | -------- | --------------------------------------- |
@@ -111,25 +111,29 @@ both explicit approvals, but Phase 1 does not verify that artifact.
 
 ### `ralplan-occ.mjs`
 
-The canonical OCC-facing RALPLAN flow with a short-prompt gate, deliberate-mode
-hard gates, and optional per-reviewer model routing. Both reviewers inspect one
-fixed Planner snapshot independently. It never executes the resulting plan.
+The canonical OCC-facing RALPLAN flow adds a short-prompt gate, DELIBERATE
+artifact gates, optional advisory requirements traceability, and reviewer model
+routing to the same verified immutable-artifact contract. It never executes the
+resulting plan.
 
-| Argument             | Required | Meaning                                                  |
-| -------------------- | -------- | -------------------------------------------------------- |
-| `idea`               | yes      | Planning problem                                         |
-| `gate`               | no       | `false` bypasses the local heuristic; default is enabled |
-| `interactive`        | no       | Controls non-blocking approval marker text; never pauses |
-| `deliberate`         | no       | `true`, `false`, or `"auto"` risk-triggered mode         |
-| `maxIterations`      | no       | Iteration cap clamped to 1–5; defaults to 5              |
-| `artifactsDir`       | no       | Final-plan path prefix; defaults to `.omc/plans`         |
-| `planName`           | no       | Final-plan basename; defaults to `ralplan`               |
-| `architectModel`     | no       | Model id passed to the Architect `agent()` call          |
-| `criticModel`        | no       | Model id passed to the Critic `agent()` call             |
-| `executeOnConsensus` | no       | Deprecated compatibility input; ignored                  |
+| Argument                   | Required | Meaning                                                  |
+| -------------------------- | -------- | -------------------------------------------------------- |
+| `idea`                     | yes      | Planning problem                                         |
+| `gate`                     | no       | `false` bypasses the local heuristic; default is enabled |
+| `interactive`              | no       | Controls non-blocking approval marker text; never pauses |
+| `deliberate`               | no       | `true`, `false`, or `"auto"` risk-triggered mode         |
+| `maxIterations`            | no       | Iteration cap clamped to 1–5; defaults to 5              |
+| `artifactsDir`             | no       | Final-plan path prefix; defaults to `.omc/plans`         |
+| `planName`                 | no       | Safe final-plan basename; defaults to `plan`             |
+| `requirementsTraceability` | no       | Runs advisory Analyst + requires coverage map            |
+| `architectModel`           | no       | Model id passed to the Architect `agent()` call          |
+| `criticModel`              | no       | Model id passed to the Critic `agent()` call             |
+| `executeOnConsensus`       | no       | Deprecated compatibility input; ignored                  |
 
-Actual approval and execution routing belong to the host. The workflow VM cannot
-suspend for user input or convert marker text into approval.
+Artifacts are bounded to 1 MB and validated by dedicated read-only verifier
+agents because the workflow VM exposes no filesystem API. Actual approval and
+execution routing belong to the host; the VM cannot suspend for user input or
+convert marker text, a digest, or a valid plan into approval.
 
 ### `ralplan-from-skill.mjs`
 

--- a/examples/workflows/ralplan-consensus.mjs
+++ b/examples/workflows/ralplan-consensus.mjs
@@ -1,19 +1,31 @@
-// ralplan-consensus — compact compatibility RALPLAN workflow
-// The OCC example is canonical. This SHORT-only example shares its safety
-// contract: isolated roles, fixed-snapshot independent review, bounded rounds,
-// and planning-only pending results.
+// ralplan-consensus — compact SHORT-only compatibility workflow.
+// ralplan-occ.mjs is canonical. This example shares the verified immutable
+// artifact, independent-review, bounded-loop, and pending-approval contracts.
 export const meta = {
   name: "ralplan-consensus",
   description:
-    "Compact SHORT-only RALPLAN protocol example. Planner, Architect, and Critic independently review one fixed snapshot for up to five rounds; every result remains pending approval and execution-halted.",
+    "Compact SHORT-only RALPLAN with verified immutable Markdown artifacts, independent same-draft review, five-round cap, and pending host approval.",
   phases: [
     { title: "Ralplan consensus" },
     { title: "Round N - Planner" },
+    { title: "Round N - Verify draft" },
     { title: "Round N - Architect" },
     { title: "Round N - Critic" },
+    { title: "Round N - Verify reviews" },
     { title: "Consolidate" },
+    { title: "Verify final plan" },
   ],
 };
+
+const MAX_ARTIFACT_BYTES = 1_000_000;
+const PLAN_HEADINGS = [
+  "RALPLAN-DR",
+  "Architecture Decision Record",
+  "Task Breakdown",
+  "Dependency Graph",
+  "Acceptance Criteria",
+  "Risk Register",
+];
 
 function parseWorkflowArgs(raw) {
   if (raw == null) return {};
@@ -31,199 +43,219 @@ function parseWorkflowArgs(raw) {
   return {};
 }
 
-const workflowArgs = parseWorkflowArgs(args);
-const idea = typeof workflowArgs.idea === "string" ? workflowArgs.idea : "";
-const maxIterations = clampRounds(workflowArgs.maxIterations);
-const artifactsDir =
-  typeof workflowArgs.artifactsDir === "string" && workflowArgs.artifactsDir
-    ? workflowArgs.artifactsDir
-    : "plans";
-const requestedDeliberate =
-  workflowArgs.deliberate === true || workflowArgs.deliberate === "auto";
-const ignoredExecuteOnConsensus = Object.prototype.hasOwnProperty.call(
-  workflowArgs,
-  "executeOnConsensus",
-);
-
-const PLANNER_PERSONA = `You are the isolated Planner. Produce a SHORT RALPLAN-DR
-work-plan draft only; never implement, execute, commit, push, or self-approve.
-Return JSON with verdict DRAFT_READY and a draft snapshot containing principles,
-decisionDrivers, options, planBody, acceptance criteria, and openQuestions.`;
-const ARCHITECT_PERSONA = `You are the isolated, read-only Architect. Independently
-review the fixed Planner snapshot in this prompt. Provide a steelman antithesis,
-a real tradeoff tension, and any issues. Return one explicit verdict: APPROVE or
-REVISION_NEEDED. Never infer approval from an empty issue list.`;
-const CRITIC_PERSONA = `You are the isolated, read-only Critic. Independently review
-only the fixed Planner snapshot in this prompt. Do not use another reviewer's
-output. Check alternatives, risks, acceptance criteria, verification, and gaps.
-Return one explicit verdict: APPROVE, ITERATE, or REJECT. Missing evidence is
-non-approval.`;
-
 function clampRounds(value) {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 5;
   return Math.min(Math.max(Math.floor(numeric), 1), 5);
 }
 
-function clone(value) {
-  return JSON.parse(JSON.stringify(value));
-}
-
-function freezeDeep(value) {
-  if (!value || typeof value !== "object" || Object.isFrozen(value))
-    return value;
-  for (const child of Object.values(value)) freezeDeep(child);
-  return Object.freeze(value);
-}
-
-function plannerSnapshot(output) {
-  if (!output || typeof output !== "object") return null;
-  if (output.draft && typeof output.draft === "object") {
-    const draft = clone(output.draft);
-    return Object.keys(draft).length > 0 ? draft : null;
+function safeArtifactsDir(value) {
+  const candidate = typeof value === "string" ? value.trim() : "plans";
+  if (!candidate || candidate.includes("\0") || /[\r\n]/.test(candidate)) {
+    throw new Error("artifactsDir must be a non-empty single-line path");
   }
-  const snapshot = clone(output);
-  delete snapshot.verdict;
-  return Object.keys(snapshot).length > 0 ? snapshot : null;
+  return candidate.replace(/\/+$/, "");
 }
 
-function buildPlannerPrompt(round, feedback) {
-  const prior = feedback.length
-    ? "\n\nPRIOR ROUND REVIEWS — address both after this complete round:\n" +
-      JSON.stringify(feedback, null, 2)
-    : "";
-  return (
-    PLANNER_PERSONA +
-    "\n\nTASK (round " +
-    round +
-    " of " +
-    maxIterations +
-    ")\n" +
-    idea +
-    prior +
-    '\nReturn ONLY {verdict:"DRAFT_READY", draft:{...}, path?:string}.'
-  );
+function safePlanName(value) {
+  const candidate = typeof value === "string" && value ? value : "plan";
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(candidate)) {
+    throw new Error("planName contains unsafe characters");
+  }
+  return candidate;
 }
 
-function buildArchitectPrompt(snapshot) {
-  return (
-    ARCHITECT_PERSONA +
-    "\n\nFIXED PLANNER SNAPSHOT (read-only):\n" +
-    JSON.stringify(snapshot, null, 2) +
-    "\nReturn ONLY {verdict, steelman, tradeoffTension, principleViolations, summary}."
-  );
+function pathsFor(artifactsDir, planName, round) {
+  const drafts = artifactsDir + "/drafts";
+  return {
+    draft: drafts + "/" + planName + "_draft-r" + round + ".md",
+    architect: drafts + "/architect_review-r" + round + ".md",
+    critic: drafts + "/critic_review-r" + round + ".md",
+    final: artifactsDir + "/" + planName + ".md",
+  };
 }
-
-function buildCriticPrompt(snapshot) {
-  return (
-    CRITIC_PERSONA +
-    "\n\nFIXED PLANNER SNAPSHOT (read-only; same value reviewed by Architect):\n" +
-    JSON.stringify(snapshot, null, 2) +
-    "\nReturn ONLY {verdict, findings, summary}."
-  );
-}
-
-function buildConsolidatePrompt(snapshot, architect, critic) {
-  return `You are a read-only planning Consolidator. Both independent reviewers
-already settled. Write only a cleaned Markdown plan if the host provides a
-writer, preserving the Planner snapshot and its RALPLAN-DR/ADR evidence. This
-step never authorizes execution.\n\nSNAPSHOT:\n${JSON.stringify(snapshot, null, 2)}\n\nARCHITECT RESULT:\n${JSON.stringify(architect, null, 2)}\n\nCRITIC RESULT:\n${JSON.stringify(critic, null, 2)}\n\nReturn {verdict:"CONSOLIDATED", path:string, summary:string} only.`;
-}
-
-const plannerResultSchema = {
-  type: "object",
-  required: ["verdict"],
-  properties: {
-    verdict: { type: "string", enum: ["DRAFT_READY"] },
-    draft: { type: "object" },
-    path: { type: "string" },
-    principles: { type: "array" },
-    decisionDrivers: { type: "array" },
-    options: { type: "array" },
-    planBody: { type: "string" },
-    openQuestions: { type: "array" },
-  },
-};
-const architectVerdictSchema = {
-  type: "object",
-  required: ["verdict"],
-  properties: {
-    verdict: { type: "string", enum: ["APPROVE", "REVISION_NEEDED"] },
-    issues: { type: "array", items: { type: "string" } },
-    principleViolations: { type: "array", items: { type: "string" } },
-    steelman: { type: "string" },
-    tradeoffTension: { type: "string" },
-    summary: { type: "string" },
-  },
-};
-const criticVerdictSchema = {
-  type: "object",
-  required: ["verdict"],
-  properties: {
-    verdict: { type: "string", enum: ["APPROVE", "ITERATE", "REJECT"] },
-    gaps: { type: "array", items: { type: "string" } },
-    findings: { type: "array" },
-    selfAudit: { type: "string" },
-    summary: { type: "string" },
-  },
-};
-const consolidateResultSchema = {
-  type: "object",
-  required: ["verdict", "path"],
-  properties: {
-    verdict: { type: "string", enum: ["CONSOLIDATED"] },
-    path: { type: "string" },
-    summary: { type: "string" },
-  },
-};
 
 function pendingFields() {
   return {
     pending_approval: true,
     execution_halted: true,
     statusLine:
-      "Status: pending approval — workflow is read-only and halted before execution",
-    awaitingApproval: {
-      draftReview: true,
-      finalApproval: true,
-      executionRouting: true,
-    },
+      "Status: pending approval — verified planning artifacts are not execution consent",
   };
 }
 
-function baseResult(extra) {
-  return {
-    consensus: false,
-    mode: "SHORT",
-    iterations: 0,
-    capped: false,
-    deliberate: {
-      supported: false,
-      requested: requestedDeliberate,
-      note: "Use ralplan-occ for DELIBERATE-mode pre-mortem and expanded test-plan gates.",
-    },
-    ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
-    ...pendingFields(),
-    ...extra,
-  };
+function plannerPrompt(input) {
+  const prior = input.feedback.length
+    ? "\n\nPRIOR COMPLETE ROUND FEEDBACK:\n" +
+      JSON.stringify(input.feedback, null, 2)
+    : "";
+  return `You are the isolated Planner. Write a bounded SHORT-mode RALPLAN
+Markdown draft only; never edit source, execute, commit, push, or self-approve.
+
+REQUEST: ${input.idea}
+ROUND: ${input.round} of ${input.maxRounds}
+WRITE EXACTLY: ${input.path}
+
+Include RALPLAN-DR, ADR, 3-6 tasks with exact paths and acceptance criteria,
+dependency graph, risk register, and open questions.${prior}
+Do not overwrite prior rounds. Return only
+{verdict:"DRAFT_READY",path,round,summary}.`;
 }
 
-phase("Ralplan consensus");
-if (!idea.trim()) {
-  return baseResult({
-    status: "no_idea",
-    summary: "args.idea is required (string)",
-  });
+function verifierPrompt(input) {
+  return `You are a read-only artifact verifier. Inspect but never modify the
+exact Markdown artifact using file/stat/hash tools.
+
+EXPECTED PATH: ${input.path}
+EXPECTED KIND: ${input.kind}
+EXPECTED ROUND: ${input.round}
+MAX BYTES: ${MAX_ARTIFACT_BYTES}
+REQUIRED HEADINGS: ${JSON.stringify(input.headings)}
+${input.sourceDigest ? "REQUIRED SOURCE DRAFT SHA-256: " + input.sourceDigest : ""}
+
+Reject missing/non-regular, symbolic-link, empty, oversized, malformed,
+wrong-path, wrong-round, wrong-kind, missing-heading, or source-digest mismatch
+artifacts. Compute SHA-256
+from bytes. Return only
+{valid,path,round,kind,sizeBytes,sha256,headings,issues}.`;
 }
 
-const feedback = [];
-let lastDraft = null;
-let lastArchitect = null;
-let lastCritic = null;
-let lastDraftPath = null;
-let lastRoundReached = 0;
-let consensusReached = false;
-let plannerError = null;
+function architectPrompt(input) {
+  return `You are the isolated read-only Architect. Review only this immutable
+Planner artifact; do not read Critic output or edit source.
+
+DRAFT PATH: ${input.draftPath}
+EXPECTED DRAFT SHA-256: ${input.draftDigest}
+WRITE REVIEW EXACTLY: ${input.reviewPath}
+ROUND: ${input.round}
+
+Recompute the digest, inspect referenced source, write bounded Markdown review,
+and return explicit APPROVE or REVISION_NEEDED with draftDigest, reviewPath,
+steelman, tradeoffTension, principleViolations, and summary.`;
+}
+
+function criticPrompt(input) {
+  return `You are the isolated read-only Critic. Independently review only the
+same immutable Planner artifact. You receive neither Architect output nor path.
+
+DRAFT PATH: ${input.draftPath}
+EXPECTED DRAFT SHA-256: ${input.draftDigest}
+WRITE REVIEW EXACTLY: ${input.reviewPath}
+ROUND: ${input.round}
+
+Recompute the digest, perform gap/risk/feasibility/verification checks, write a
+bounded Markdown review, and return explicit APPROVE, ITERATE, or REJECT with
+draftDigest, reviewPath, findings, and summary.`;
+}
+
+function consolidatePrompt(input) {
+  return `You are a planning Consolidator. Both independent reviewers approved.
+Write Markdown only and never start implementation.
+
+DRAFT: ${input.draftPath}
+DRAFT SHA-256: ${input.draftDigest}
+ARCHITECT REVIEW: ${input.architectPath}
+CRITIC REVIEW: ${input.criticPath}
+WRITE FINAL EXACTLY: ${input.finalPath}
+ROUND: ${input.round}
+
+Preserve all required plan sections. Return only
+{verdict:"CONSOLIDATED",path,sourceDraftDigest,summary}.`;
+}
+
+const PLANNER_SCHEMA = {
+  type: "object",
+  required: ["verdict", "path", "round", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["DRAFT_READY"] },
+    path: { type: "string" },
+    round: { type: "integer" },
+    summary: { type: "string" },
+  },
+};
+const VERIFIER_SCHEMA = {
+  type: "object",
+  required: [
+    "valid",
+    "path",
+    "round",
+    "kind",
+    "sizeBytes",
+    "sha256",
+    "headings",
+    "issues",
+  ],
+  properties: {
+    valid: { type: "boolean" },
+    path: { type: "string" },
+    round: { type: "integer" },
+    kind: { type: "string" },
+    sizeBytes: { type: "integer" },
+    sha256: { type: "string" },
+    headings: { type: "array", items: { type: "string" } },
+    issues: { type: "array", items: { type: "string" } },
+  },
+};
+const ARCHITECT_SCHEMA = {
+  type: "object",
+  required: [
+    "verdict",
+    "draftDigest",
+    "reviewPath",
+    "steelman",
+    "tradeoffTension",
+    "principleViolations",
+    "summary",
+  ],
+  properties: {
+    verdict: { type: "string", enum: ["APPROVE", "REVISION_NEEDED"] },
+    draftDigest: { type: "string" },
+    reviewPath: { type: "string" },
+    steelman: { type: "string" },
+    tradeoffTension: { type: "string" },
+    principleViolations: { type: "array", items: { type: "string" } },
+    summary: { type: "string" },
+  },
+};
+const CRITIC_SCHEMA = {
+  type: "object",
+  required: ["verdict", "draftDigest", "reviewPath", "findings", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["APPROVE", "ITERATE", "REJECT"] },
+    draftDigest: { type: "string" },
+    reviewPath: { type: "string" },
+    findings: { type: "array" },
+    summary: { type: "string" },
+  },
+};
+const CONSOLIDATE_SCHEMA = {
+  type: "object",
+  required: ["verdict", "path", "sourceDraftDigest", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["CONSOLIDATED"] },
+    path: { type: "string" },
+    sourceDraftDigest: { type: "string" },
+    summary: { type: "string" },
+  },
+};
+
+function artifactValid(report, expected) {
+  return Boolean(
+    report &&
+    report.valid === true &&
+    report.path === expected.path &&
+    report.round === expected.round &&
+    report.kind === expected.kind &&
+    Number.isInteger(report.sizeBytes) &&
+    report.sizeBytes > 0 &&
+    report.sizeBytes <= MAX_ARTIFACT_BYTES &&
+    typeof report.sha256 === "string" &&
+    report.sha256.length > 0 &&
+    Array.isArray(report.issues) &&
+    report.issues.length === 0 &&
+    expected.headings.every((heading) => report.headings.includes(heading)),
+  );
+}
 
 async function callAgent(prompt, options) {
   try {
@@ -235,147 +267,328 @@ async function callAgent(prompt, options) {
   }
 }
 
-for (let round = 1; round <= maxIterations; round++) {
-  lastRoundReached = round;
-  log("Round " + round + "/" + maxIterations);
+const workflowArgs = parseWorkflowArgs(args);
+const idea = typeof workflowArgs.idea === "string" ? workflowArgs.idea : "";
+const maxRounds = clampRounds(workflowArgs.maxIterations);
+const artifactsDir = safeArtifactsDir(workflowArgs.artifactsDir);
+const planName = safePlanName(workflowArgs.planName);
+const ignoredExecuteOnConsensus = Object.prototype.hasOwnProperty.call(
+  workflowArgs,
+  "executeOnConsensus",
+);
+
+function terminal(status, extra) {
+  return {
+    status,
+    consensus: false,
+    mode: "SHORT",
+    iterations: 0,
+    capped: false,
+    artifactPaths: {
+      plan: pathsFor(artifactsDir, planName, 1).final,
+      drafts: [],
+      architectReviews: [],
+      criticReviews: [],
+    },
+    ...pendingFields(),
+    ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
+    ...extra,
+  };
+}
+
+phase("Ralplan consensus");
+if (!idea.trim()) return terminal("no_idea", {});
+
+const feedback = [];
+const drafts = [];
+const architectReviews = [];
+const criticReviews = [];
+let lastDraft = null;
+let lastDraftVerification = null;
+let lastArchitect = null;
+let lastCritic = null;
+let lastRound = 0;
+let reviewConsensus = false;
+let artifactFailure = null;
+const artifactFailures = [];
+
+for (let round = 1; round <= maxRounds; round++) {
+  lastRound = round;
+  artifactFailure = null;
+  const paths = pathsFor(artifactsDir, planName, round);
 
   phase("Round " + round + " - Planner");
-  const plannerOut = await callAgent(buildPlannerPrompt(round, feedback), {
-    schema: plannerResultSchema,
-    phase: "Round " + round + " - Planner",
-    label: "planner-" + round,
+  const planner = await callAgent(
+    plannerPrompt({
+      idea,
+      round,
+      maxRounds,
+      path: paths.draft,
+      feedback,
+    }),
+    {
+      schema: PLANNER_SCHEMA,
+      label: "planner-" + round,
+      phase: "Round " + round + " - Planner",
+    },
+  );
+  lastDraft = planner;
+
+  phase("Round " + round + " - Verify draft");
+  const draftExpected = {
+    path: paths.draft,
+    round,
+    kind: "draft",
+    headings: PLAN_HEADINGS,
+  };
+  const draftVerification = await callAgent(verifierPrompt(draftExpected), {
+    schema: VERIFIER_SCHEMA,
+    label: "verify-draft-" + round,
+    phase: "Round " + round + " - Verify draft",
   });
-  const snapshot = plannerSnapshot(plannerOut);
-  if (!snapshot) {
-    plannerError =
-      "Planner produced no schema-valid snapshot on round " + round;
+  lastDraftVerification = draftVerification;
+  if (
+    !planner ||
+    planner.path !== paths.draft ||
+    planner.round !== round ||
+    !artifactValid(draftVerification, draftExpected)
+  ) {
+    artifactFailure = {
+      stage: "draft",
+      round,
+      expectedPath: paths.draft,
+      claimedPath: planner && planner.path,
+      verification: draftVerification,
+    };
+    artifactFailures.push(artifactFailure);
     feedback.push({
       round,
-      role: "planner",
-      verdict: "MISSING",
-      summary: plannerError,
+      role: "artifact-verifier",
+      verdict: "INVALID",
+      summary: "Draft artifact validation failed",
+      issues: (draftVerification && draftVerification.issues) || [],
     });
     continue;
   }
-  lastDraft = snapshot;
-  lastDraftPath = plannerOut.path || lastDraftPath;
-  const immutableSnapshot = freezeDeep(clone(snapshot));
+  drafts.push(paths.draft);
 
   phase("Round " + round + " - Architect");
-  const architectOut = await callAgent(
-    buildArchitectPrompt(immutableSnapshot),
+  const architect = await callAgent(
+    architectPrompt({
+      draftPath: paths.draft,
+      draftDigest: draftVerification.sha256,
+      reviewPath: paths.architect,
+      round,
+    }),
     {
-      schema: architectVerdictSchema,
+      schema: ARCHITECT_SCHEMA,
       label: "architect-" + round,
       phase: "Round " + round + " - Architect",
     },
   );
-  lastArchitect = architectOut;
-  const architectApproval = Boolean(
-    architectOut && architectOut.verdict === "APPROVE",
-  );
-  const architectFeedback = architectOut
-    ? {
-        round,
-        role: "architect",
-        verdict: architectOut.verdict,
-        issues: architectOut.issues || architectOut.principleViolations || [],
-        summary: architectOut.summary || "",
-      }
-    : {
-        round,
-        role: "architect",
-        verdict: "MISSING",
-        summary: "Architect returned no schema-valid result",
-      };
+  lastArchitect = architect;
 
-  // Critic is mandatory even when Architect rejects. It receives the fixed
-  // snapshot only, so the two reviews cannot become a simulated handoff.
   phase("Round " + round + " - Critic");
-  const criticOut = await callAgent(buildCriticPrompt(immutableSnapshot), {
-    schema: criticVerdictSchema,
-    label: "critic-" + round,
-    phase: "Round " + round + " - Critic",
-  });
-  lastCritic = criticOut;
-  const criticApproval = Boolean(criticOut && criticOut.verdict === "APPROVE");
-  const criticFeedback = criticOut
-    ? {
-        round,
-        role: "critic",
-        verdict: criticOut.verdict,
-        gaps: criticOut.gaps || [],
-        findings: criticOut.findings || [],
-        summary: criticOut.summary || "",
-      }
-    : {
-        round,
-        role: "critic",
-        verdict: "MISSING",
-        summary: "Critic returned no schema-valid result",
-      };
-
-  if (architectApproval && criticApproval) {
-    consensusReached = true;
-    break;
-  }
-  feedback.push(architectFeedback, criticFeedback);
-}
-
-const capped = !consensusReached && lastRoundReached >= maxIterations;
-let consolidatedPath = null;
-let consolidateSummary = null;
-if (consensusReached && lastDraft) {
-  phase("Consolidate");
-  const consolidated = await callAgent(
-    buildConsolidatePrompt(lastDraft, lastArchitect, lastCritic),
+  const critic = await callAgent(
+    criticPrompt({
+      draftPath: paths.draft,
+      draftDigest: draftVerification.sha256,
+      reviewPath: paths.critic,
+      round,
+    }),
     {
-      schema: consolidateResultSchema,
-      label: "consolidate",
-      phase: "Consolidate",
+      schema: CRITIC_SCHEMA,
+      label: "critic-" + round,
+      phase: "Round " + round + " - Critic",
     },
   );
+  lastCritic = critic;
+
+  phase("Round " + round + " - Verify reviews");
+  const architectExpected = {
+    path: paths.architect,
+    round,
+    kind: "architect-review",
+    headings: [],
+  };
+  const architectVerification = await callAgent(
+    verifierPrompt({
+      ...architectExpected,
+      sourceDigest: draftVerification.sha256,
+    }),
+    {
+      schema: VERIFIER_SCHEMA,
+      label: "verify-architect-" + round,
+      phase: "Round " + round + " - Verify reviews",
+    },
+  );
+  const criticExpected = {
+    path: paths.critic,
+    round,
+    kind: "critic-review",
+    headings: [],
+  };
+  const criticVerification = await callAgent(
+    verifierPrompt({
+      ...criticExpected,
+      sourceDigest: draftVerification.sha256,
+    }),
+    {
+      schema: VERIFIER_SCHEMA,
+      label: "verify-critic-" + round,
+      phase: "Round " + round + " - Verify reviews",
+    },
+  );
+
   if (
-    consolidated &&
-    typeof consolidated.path === "string" &&
-    consolidated.path
+    !architect ||
+    !critic ||
+    architect.reviewPath !== paths.architect ||
+    critic.reviewPath !== paths.critic ||
+    architect.draftDigest !== draftVerification.sha256 ||
+    critic.draftDigest !== draftVerification.sha256 ||
+    !artifactValid(architectVerification, architectExpected) ||
+    !artifactValid(criticVerification, criticExpected)
   ) {
-    consolidatedPath = consolidated.path;
-    consolidateSummary = consolidated.summary || null;
-  } else {
-    consolidatedPath = lastDraftPath || artifactsDir + "/plan.md";
-    consolidateSummary =
-      "Consensus reached; no consolidated artifact path was returned, so the fixed draft remains the result.";
+    artifactFailure = {
+      stage: "reviews",
+      round,
+      architectVerification,
+      criticVerification,
+    };
+    artifactFailures.push(artifactFailure);
+    feedback.push(
+      {
+        round,
+        role: "architect",
+        verdict: architect ? architect.verdict : "MISSING",
+        summary: architect ? architect.summary : "Architect output missing",
+      },
+      {
+        round,
+        role: "critic",
+        verdict: critic ? critic.verdict : "MISSING",
+        summary: critic ? critic.summary : "Critic output missing",
+      },
+    );
+    continue;
   }
+  architectReviews.push(paths.architect);
+  criticReviews.push(paths.critic);
+
+  if (architect.verdict === "APPROVE" && critic.verdict === "APPROVE") {
+    reviewConsensus = true;
+    break;
+  }
+  feedback.push(
+    {
+      round,
+      role: "architect",
+      verdict: architect.verdict,
+      summary: architect.summary,
+      issues: architect.principleViolations,
+    },
+    {
+      round,
+      role: "critic",
+      verdict: critic.verdict,
+      summary: critic.summary,
+      findings: critic.findings,
+    },
+  );
 }
 
-const result = baseResult({
-  consensus: consensusReached,
-  status: consensusReached
-    ? "consensus"
-    : lastDraft
-      ? "no_consensus"
-      : "no_planner_output",
-  iterations: lastRoundReached,
-  capped,
-  draft: lastDraft || {},
-  architect: lastArchitect || { verdict: "MISSING" },
-  critic: lastCritic || { verdict: "MISSING" },
-  planPath: consensusReached ? consolidatedPath : undefined,
-  draftPath: lastDraftPath || undefined,
-  ...(consolidateSummary ? { consolidateSummary } : {}),
-});
-if (plannerError) result.plannerError = plannerError;
-if (!consensusReached) {
-  result.lastVerdict = {
-    architect:
-      lastArchitect && lastArchitect.verdict
-        ? lastArchitect.verdict
-        : "MISSING",
-    critic: lastCritic && lastCritic.verdict ? lastCritic.verdict : "MISSING",
-  };
-  if (capped)
-    result.summary =
-      "No consensus after the five-round cap; manual review required and execution unavailable.";
+const artifactPaths = {
+  plan: pathsFor(artifactsDir, planName, Math.max(lastRound, 1)).final,
+  drafts,
+  architectReviews,
+  criticReviews,
+};
+if (artifactFailure) {
+  return terminal("artifact_validation_failed", {
+    iterations: lastRound,
+    capped: lastRound >= maxRounds,
+    artifactPaths,
+    artifactFailure,
+    artifactFailures,
+  });
 }
-return result;
+if (!reviewConsensus || !lastDraft || !lastDraftVerification) {
+  return terminal("no_consensus", {
+    iterations: lastRound,
+    capped: lastRound >= maxRounds,
+    artifactPaths,
+    draft: lastDraft,
+    architect: lastArchitect || { verdict: "MISSING" },
+    critic: lastCritic || { verdict: "MISSING" },
+    summary:
+      lastRound >= maxRounds
+        ? "No consensus after the five-round cap; manual review required and execution unavailable."
+        : "Consensus not reached; execution unavailable.",
+  });
+}
+
+phase("Consolidate");
+const consolidated = await callAgent(
+  consolidatePrompt({
+    draftPath: lastDraft.path,
+    draftDigest: lastDraftVerification.sha256,
+    architectPath: lastArchitect.reviewPath,
+    criticPath: lastCritic.reviewPath,
+    finalPath: artifactPaths.plan,
+    round: lastRound,
+  }),
+  {
+    schema: CONSOLIDATE_SCHEMA,
+    label: "consolidate",
+    phase: "Consolidate",
+  },
+);
+
+phase("Verify final plan");
+const finalExpected = {
+  path: artifactPaths.plan,
+  round: lastRound,
+  kind: "final-plan",
+  headings: PLAN_HEADINGS,
+  sourceDigest: lastDraftVerification.sha256,
+};
+const finalVerification = await callAgent(verifierPrompt(finalExpected), {
+  schema: VERIFIER_SCHEMA,
+  label: "verify-final",
+  phase: "Verify final plan",
+});
+if (
+  !consolidated ||
+  consolidated.path !== artifactPaths.plan ||
+  consolidated.sourceDraftDigest !== lastDraftVerification.sha256 ||
+  !artifactValid(finalVerification, finalExpected)
+) {
+  return terminal("artifact_validation_failed", {
+    iterations: lastRound,
+    artifactPaths,
+    artifactFailure: {
+      stage: "final",
+      round: lastRound,
+      verification: finalVerification,
+    },
+  });
+}
+
+return {
+  status: "pending_approval",
+  consensus: true,
+  mode: "SHORT",
+  iterations: lastRound,
+  capped: false,
+  draft: lastDraft,
+  architect: lastArchitect,
+  critic: lastCritic,
+  artifactPaths,
+  planPath: artifactPaths.plan,
+  planDigest: finalVerification.sha256,
+  sourceDraftDigest: lastDraftVerification.sha256,
+  artifactVerification: finalVerification,
+  ...pendingFields(),
+  ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
+};

--- a/examples/workflows/ralplan-occ.mjs
+++ b/examples/workflows/ralplan-occ.mjs
@@ -1,55 +1,32 @@
 // ralplan-occ — canonical OCC-facing RALPLAN workflow
-// Planner, Architect, and Critic are isolated role invocations. This workflow
-// produces planning evidence only; it never executes, commits, or mutates code.
+// Planning agents may write bounded Markdown artifacts only. The workflow never
+// edits source, executes a plan, commits, pushes, or treats consensus as consent.
 export const meta = {
   name: "ralplan-occ",
   description:
-    "Canonical OCC RALPLAN consensus: isolated Planner/Architect/Critic review of one fixed snapshot, bounded to five rounds, always pending approval and execution-halted.",
+    "Canonical OCC RALPLAN: verified immutable artifacts, isolated same-snapshot reviews, requirements traceability, five-round cap, and pending host approval.",
   phases: [
     { title: "Gate" },
-    { title: "Ralplan consensus" },
+    { title: "Requirements" },
     { title: "Round N - Planner" },
+    { title: "Round N - Verify draft" },
     { title: "Round N - Architect" },
     { title: "Round N - Critic" },
+    { title: "Round N - Verify reviews" },
+    { title: "Consolidate" },
+    { title: "Verify final plan" },
   ],
 };
 
-function parseWorkflowArgs(raw) {
-  if (raw == null) return {};
-  if (typeof raw === "object" && !Array.isArray(raw)) return raw;
-  if (typeof raw === "string") {
-    try {
-      const parsed = JSON.parse(raw);
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? parsed
-        : {};
-    } catch {
-      return {};
-    }
-  }
-  return {};
-}
-
-const workflowArgs = parseWorkflowArgs(args);
-const PLANNER_PERSONA = `You are the isolated Planner in a RALPLAN workflow.
-Create or revise a plan; never implement code, execute a skill, commit, push, or
-approve your own work. Return structured JSON only. Include RALPLAN-DR:
-3-5 principles, exactly 3 decision drivers, at least 2 viable options with
-bounded pros/cons, and an actionable 3-6 step plan with acceptance criteria.
-The host workflow, not the Planner, owns approval and execution routing.`;
-const ARCHITECT_PERSONA = `You are the isolated Architect, a read-only technical
-reviewer. Review only the Planner snapshot supplied in this prompt. You are not
-the Planner or Critic, and you must not implement changes. Independently state
-the strongest steelman antithesis, a meaningful tradeoff tension, and explicit
-architectural principle violations. Approval is never inferred from an empty
-violations list: return exactly one explicit verdict, APPROVE or REVISION_NEEDED.`;
-const CRITIC_PERSONA = `You are the isolated Critic and final quality gate. Review
-only the fixed Planner snapshot supplied in this prompt, independently of every
-other review. You do not receive or rely on Architect output. Check alternatives,
-risk mitigation, acceptance criteria, verification, gaps, and deliberate-mode
-requirements. Return exactly one explicit verdict: APPROVE, ITERATE, or REJECT.
-Missing, invalid, or uncertain evidence is non-approval.`;
-
+const MAX_ARTIFACT_BYTES = 1_000_000;
+const REQUIRED_PLAN_HEADINGS = [
+  "RALPLAN-DR",
+  "Architecture Decision Record",
+  "Task Breakdown",
+  "Dependency Graph",
+  "Acceptance Criteria",
+  "Risk Register",
+];
 const HIGH_RISK_TRIGGERS = [
   "auth",
   "security",
@@ -78,16 +55,58 @@ const EXECUTION_KEYWORDS = [
   "ultrapilot",
 ];
 
+function parseWorkflowArgs(raw) {
+  if (raw == null) return {};
+  if (typeof raw === "object" && !Array.isArray(raw)) return raw;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function clampRounds(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 5;
+  return Math.min(Math.max(Math.floor(numeric), 1), 5);
+}
+
+function safeArtifactsDir(value) {
+  const candidate = typeof value === "string" ? value.trim() : ".omc/plans";
+  if (!candidate || candidate.includes("\0") || /[\r\n]/.test(candidate)) {
+    throw new Error("artifactsDir must be a non-empty single-line path");
+  }
+  return candidate.replace(/\/+$/, "");
+}
+
+function safePlanName(value) {
+  const candidate = typeof value === "string" && value ? value : "plan";
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(candidate)) {
+    throw new Error(
+      "planName must start with an alphanumeric and contain only alphanumerics, dot, underscore, or dash (max 64)",
+    );
+  }
+  return candidate;
+}
+
 function checkGate(idea) {
   const text = String(idea || "");
   const lower = text.toLowerCase();
   const words = text.trim().split(/\s+/).filter(Boolean);
   for (const prefix of ["force:", "!"]) {
-    if (lower.startsWith(prefix))
+    if (lower.startsWith(prefix)) {
       return { gated: false, reason: "escape prefix " + prefix };
+    }
   }
-  if (words.length > 15)
+  if (words.length > 15) {
     return { gated: false, reason: "word count above threshold" };
+  }
   const anchors = [
     /\.\w{1,8}(?:\/\S+)?/,
     /#\d+/,
@@ -98,23 +117,21 @@ function checkGate(idea) {
     /```/,
     /\b(?:do:|acceptance criteria:)\b/i,
     /^\s*\d+\.\s/m,
-    /\b(?:TypeError|ReferenceError|SyntaxError|ENOENT|EACCES)\b/,
   ];
-  for (const anchor of anchors) {
-    if (anchor.test(text))
-      return { gated: false, reason: "concrete anchor present" };
+  if (anchors.some((anchor) => anchor.test(text))) {
+    return { gated: false, reason: "concrete anchor present" };
   }
   const matched = EXECUTION_KEYWORDS.filter((keyword) =>
     new RegExp("\\b" + keyword + "\\b").test(lower),
   );
-  const reason = matched.length
-    ? "prompt has " +
-      words.length +
-      " words and execution keyword (" +
-      matched.join(",") +
-      ")"
-    : "prompt has " + words.length + " words and no concrete anchors";
-  return { gated: true, reason };
+  return {
+    gated: true,
+    reason: matched.length
+      ? "short unanchored prompt contains execution keyword (" +
+        matched.join(",") +
+        ")"
+      : "short prompt has no concrete anchor",
+  };
 }
 
 function isDeliberate(idea, input) {
@@ -126,181 +143,12 @@ function isDeliberate(idea, input) {
   return false;
 }
 
-function clampRounds(value) {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) return 5;
-  return Math.min(Math.max(Math.floor(numeric), 1), 5);
-}
-
-function clone(value) {
-  return JSON.parse(JSON.stringify(value));
-}
-
-function freezeDeep(value) {
-  if (!value || typeof value !== "object" || Object.isFrozen(value))
-    return value;
-  for (const child of Object.values(value)) freezeDeep(child);
-  return Object.freeze(value);
-}
-
-function nonEmpty(value) {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function deliberateValidation(draft, mode) {
-  if (mode !== "DELIBERATE") return { valid: true, issues: [] };
-  const issues = [];
-  const scenarios = draft && draft.preMortem;
-  if (!Array.isArray(scenarios) || scenarios.length !== 3) {
-    issues.push("preMortem must contain exactly 3 scenarios");
-  } else {
-    const fields = [
-      "trigger",
-      "blastRadius",
-      "earlySignal",
-      "mitigation",
-      "detection",
-    ];
-    scenarios.forEach((scenario, index) => {
-      for (const field of fields) {
-        if (!scenario || !nonEmpty(scenario[field]))
-          issues.push("preMortem[" + index + "]." + field + " is required");
-      }
-    });
-  }
-  const testPlan = draft && draft.expandedTestPlan;
-  for (const pillar of ["unit", "integration", "e2e", "observability"]) {
-    if (
-      !testPlan ||
-      !Array.isArray(testPlan[pillar]) ||
-      testPlan[pillar].length === 0 ||
-      testPlan[pillar].some((item) => !nonEmpty(item))
-    ) {
-      issues.push(
-        "expandedTestPlan." + pillar + " must contain actionable entries",
-      );
-    }
-  }
-  return { valid: issues.length === 0, issues };
-}
-
-function plannerSnapshot(output) {
-  if (!output || typeof output !== "object") return null;
-  if (output.draft && typeof output.draft === "object") {
-    const draft = clone(output.draft);
-    return Object.keys(draft).length > 0 ? draft : null;
-  }
-  const draft = clone(output);
-  delete draft.verdict;
-  return Object.keys(draft).length > 0 ? draft : null;
-}
-
-function buildPlannerPrompt(idea, mode, feedback, round, maxRounds) {
-  const prior = feedback.length
-    ? "\n\nPRIOR ROUND REVIEWS (address both independently):\n" +
-      JSON.stringify(feedback, null, 2)
-    : "";
-  const deliberate =
-    mode === "DELIBERATE"
-      ? "\nDELIBERATE HARD REQUIREMENTS: preMortem must have exactly 3 actionable scenarios with trigger, blastRadius, earlySignal, mitigation, detection. expandedTestPlan must contain non-empty unit, integration, e2e, and observability arrays."
-      : "";
-  return (
-    PLANNER_PERSONA +
-    "\n\nTASK\nIdea: " +
-    idea +
-    "\nMode: " +
-    mode +
-    "\nRound: " +
-    round +
-    " of " +
-    maxRounds +
-    prior +
-    deliberate +
-    '\nReturn JSON {verdict:"DRAFT_READY", draft:{principles, decisionDrivers, options, planBody, openQuestions, ...}} only.'
-  );
-}
-
-function buildArchitectPrompt(snapshot, mode) {
-  const deliberate =
-    mode === "DELIBERATE"
-      ? "\nIn DELIBERATE mode, treat missing or weak preMortem/test-plan fields as explicit principle violations."
-      : "";
-  return (
-    ARCHITECT_PERSONA +
-    "\n\nFIXED PLANNER SNAPSHOT (read-only; do not alter):\n" +
-    JSON.stringify(snapshot, null, 2) +
-    deliberate +
-    "\nReturn JSON {verdict, steelman, tradeoffTension, synthesis, principleViolations, summary} only."
-  );
-}
-
-function buildCriticPrompt(snapshot, mode) {
-  const deliberate =
-    mode === "DELIBERATE"
-      ? "\nDELIBERATE HARD GATES: reject missing/weak preMortem or any missing unit, integration, e2e, or observability test pillar."
-      : "";
-  return (
-    CRITIC_PERSONA +
-    "\n\nFIXED PLANNER SNAPSHOT (read-only; same value reviewed by Architect):\n" +
-    JSON.stringify(snapshot, null, 2) +
-    deliberate +
-    "\nReturn JSON {verdict, findings, summary, preMortemStatus, testPlanStatus} only."
-  );
-}
-
-const PLANNER_SCHEMA = {
-  type: "object",
-  required: ["verdict"],
-  properties: {
-    verdict: { type: "string", enum: ["DRAFT_READY"] },
-    draft: { type: "object" },
-    principles: { type: "array", items: { type: "string" } },
-    decisionDrivers: { type: "array", items: { type: "string" } },
-    options: { type: "array" },
-    planBody: { type: "string" },
-    openQuestions: { type: "array", items: { type: "string" } },
-  },
-};
-const ARCHITECT_SCHEMA = {
-  type: "object",
-  required: ["verdict", "steelman", "tradeoffTension", "principleViolations"],
-  properties: {
-    verdict: { type: "string", enum: ["APPROVE", "REVISION_NEEDED"] },
-    steelman: { type: "string" },
-    tradeoffTension: { type: "string" },
-    synthesis: { type: "string" },
-    principleViolations: { type: "array", items: { type: "string" } },
-    summary: { type: "string" },
-  },
-};
-const CRITIC_SCHEMA = {
-  type: "object",
-  required: ["verdict", "findings", "summary"],
-  properties: {
-    verdict: { type: "string", enum: ["APPROVE", "ITERATE", "REJECT"] },
-    findings: { type: "array" },
-    summary: { type: "string" },
-    preMortemStatus: { type: "string" },
-    testPlanStatus: { type: "string" },
-  },
-};
-
-const idea = String(workflowArgs.idea || "");
-const interactive = workflowArgs.interactive !== false;
-const gateEnabled = workflowArgs.gate !== false;
-const mode = isDeliberate(idea, workflowArgs) ? "DELIBERATE" : "SHORT";
-const maxRounds = clampRounds(workflowArgs.maxIterations);
-const ignoredExecuteOnConsensus = Object.prototype.hasOwnProperty.call(
-  workflowArgs,
-  "executeOnConsensus",
-);
-
 function pendingFields() {
   return {
     pending_approval: true,
     execution_halted: true,
     statusLine:
-      "Status: pending approval — workflow is read-only and halted before execution",
+      "Status: pending approval — verified planning artifacts are not execution consent",
     awaitingApproval: {
       draftReview: true,
       finalApproval: true,
@@ -309,81 +157,242 @@ function pendingFields() {
   };
 }
 
-function emitCheckpoint(message) {
-  if (interactive) log("[pending approval] " + message);
-}
-
-function emptyResult(status, extra) {
+function pathSet(artifactsDir, planName, round) {
+  const drafts = artifactsDir + "/drafts";
   return {
-    status,
-    consensus: false,
-    algorithm: "ralplan-occ-v1",
-    mode,
-    iterations: 0,
-    capped: false,
-    gate: {
-      enabled: gateEnabled,
-      triggered: false,
-      reason: "gate bypassed or passed",
-    },
-    interactive: { enabled: interactive, markersEmitted: interactive },
-    ...pendingFields(),
-    ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
-    ...extra,
+    draft: drafts + "/" + planName + "_draft-r" + round + ".md",
+    architect: drafts + "/architect_review-r" + round + ".md",
+    critic: drafts + "/critic_review-r" + round + ".md",
+    final: artifactsDir + "/" + planName + ".md",
   };
 }
 
-phase("Gate");
-if (!idea.trim()) {
-  log("no idea provided; planning cannot proceed");
-  return emptyResult("no_idea", {
-    gate: {
-      enabled: gateEnabled,
-      triggered: false,
-      reason: "idea is required",
+function requiredHeadings(mode, requirementsTraceability) {
+  const headings = REQUIRED_PLAN_HEADINGS.slice();
+  if (mode === "DELIBERATE") {
+    headings.push("Pre-Mortem", "Expanded Test Plan");
+  }
+  if (requirementsTraceability) headings.push("Requirement Coverage Map");
+  return headings;
+}
+
+function analystPrompt(idea) {
+  return `You are an advisory requirements Analyst, not a consensus approver.
+Atomize the request below into stable requirement IDs. Do not plan, review, edit
+source, or authorize execution.
+
+REQUEST:
+${idea}
+
+Return only structured JSON with requirements [{id,text}] and openQuestions.`;
+}
+
+function plannerPrompt(input) {
+  const prior = input.feedback.length
+    ? "\n\nPRIOR COMPLETE ROUND FEEDBACK:\n" +
+      JSON.stringify(input.feedback, null, 2)
+    : "";
+  const requirements = input.requirements
+    ? "\n\nADVISORY REQUIREMENTS (not approvals):\n" +
+      JSON.stringify(input.requirements, null, 2) +
+      "\nInclude a Requirement Coverage Map with COVERED, PARTIAL, UNCOVERED, or SCOPED_OUT and rationale."
+    : "";
+  const deliberate =
+    input.mode === "DELIBERATE"
+      ? "\nDELIBERATE mode requires exactly 3 actionable pre-mortem scenarios and concrete Unit, Integration, E2E, and Observability test coverage."
+      : "";
+  return `You are the isolated Planner. Create a bounded Markdown plan artifact;
+do not implement, edit source, execute, commit, push, or self-approve.
+
+REQUEST: ${input.idea}
+MODE: ${input.mode}
+ROUND: ${input.round} of ${input.maxRounds}
+WRITE EXACTLY: ${input.path}
+
+The immutable draft must include RALPLAN-DR, an Architecture Decision Record,
+3-6 tasks with exact paths and acceptance criteria, a dependency graph, risks,
+and open questions.${requirements}${deliberate}${prior}
+
+Do not overwrite an earlier round. Return only {verdict:"DRAFT_READY",path,round,summary}.`;
+}
+
+function verifierPrompt(input) {
+  return `You are a read-only artifact verifier. Do not write or modify anything.
+Inspect the exact claimed Markdown artifact with file/stat/hash tools.
+
+EXPECTED PATH: ${input.path}
+EXPECTED KIND: ${input.kind}
+EXPECTED ROUND: ${input.round}
+MAX BYTES: ${MAX_ARTIFACT_BYTES}
+REQUIRED HEADINGS: ${JSON.stringify(input.headings)}
+${input.sourceDigest ? "REQUIRED SOURCE DRAFT SHA-256: " + input.sourceDigest : ""}
+
+Reject missing/non-regular files, symbolic links, paths that differ from
+EXPECTED PATH, wrong round/kind, empty or oversized files, missing required
+headings, malformed Markdown structure, or source-digest mismatch. Compute SHA-256 from file bytes.
+Return only {valid,path,round,kind,sizeBytes,sha256,headings,issues}.`;
+}
+
+function architectPrompt(input) {
+  return `You are the isolated read-only Architect. Review only the immutable
+Planner draft below. Do not read a Critic review or edit source.
+
+DRAFT PATH: ${input.draftPath}
+EXPECTED DRAFT SHA-256: ${input.draftDigest}
+WRITE REVIEW EXACTLY: ${input.reviewPath}
+ROUND: ${input.round}
+MODE: ${input.mode}
+
+Read the draft, recompute its digest, inspect referenced source read-only, then
+write bounded Markdown review evidence. Return explicit APPROVE or
+REVISION_NEEDED plus steelman, tradeoff tension, principle violations, the
+recomputed draftDigest, and reviewPath. Never infer approval from empty issues.`;
+}
+
+function criticPrompt(input) {
+  const requirements = input.requirementsTraceability
+    ? " Verify requirements coverage and reject unexplained PARTIAL, UNCOVERED, or SCOPED_OUT entries."
+    : "";
+  return `You are the isolated read-only Critic. Independently review only the
+same immutable Planner draft. You receive neither Architect output nor its path.
+
+DRAFT PATH: ${input.draftPath}
+EXPECTED DRAFT SHA-256: ${input.draftDigest}
+WRITE REVIEW EXACTLY: ${input.reviewPath}
+ROUND: ${input.round}
+MODE: ${input.mode}
+
+Recompute the draft digest, run gap/feasibility/risk/verification checks, and
+write bounded Markdown review evidence.${requirements} Return explicit APPROVE,
+ITERATE, or REJECT with findings, draftDigest, reviewPath, and summary.`;
+}
+
+function consolidatePrompt(input) {
+  return `You are a planning Consolidator. Both independent reviewers explicitly
+approved the verified immutable draft. Write Markdown only; never edit source or
+start execution.
+
+DRAFT: ${input.draftPath}
+DRAFT SHA-256: ${input.draftDigest}
+ARCHITECT REVIEW: ${input.architectPath}
+CRITIC REVIEW: ${input.criticPath}
+WRITE FINAL EXACTLY: ${input.finalPath}
+ROUND: ${input.round}
+
+Preserve RALPLAN-DR, ADR, 3-6 tasks with exact paths, dependency graph,
+acceptance criteria, risk register, requirements coverage when present, and
+DELIBERATE sections when present. Return only
+{verdict:"CONSOLIDATED",path,sourceDraftDigest,summary}.`;
+}
+
+const ANALYST_SCHEMA = {
+  type: "object",
+  required: ["requirements", "openQuestions"],
+  properties: {
+    requirements: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["id", "text"],
+        properties: { id: { type: "string" }, text: { type: "string" } },
+      },
     },
-  });
-}
-const gateResult = gateEnabled
-  ? checkGate(idea)
-  : { gated: false, reason: "gate disabled by caller" };
-if (gateResult.gated) {
-  emitCheckpoint(
-    "gate requires explicit planning invocation: " + gateResult.reason,
+    openQuestions: { type: "array", items: { type: "string" } },
+  },
+};
+const PLANNER_SCHEMA = {
+  type: "object",
+  required: ["verdict", "path", "round", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["DRAFT_READY"] },
+    path: { type: "string" },
+    round: { type: "integer" },
+    summary: { type: "string" },
+  },
+};
+const VERIFIER_SCHEMA = {
+  type: "object",
+  required: [
+    "valid",
+    "path",
+    "round",
+    "kind",
+    "sizeBytes",
+    "sha256",
+    "headings",
+    "issues",
+  ],
+  properties: {
+    valid: { type: "boolean" },
+    path: { type: "string" },
+    round: { type: "integer" },
+    kind: { type: "string" },
+    sizeBytes: { type: "integer" },
+    sha256: { type: "string" },
+    headings: { type: "array", items: { type: "string" } },
+    issues: { type: "array", items: { type: "string" } },
+  },
+};
+const ARCHITECT_SCHEMA = {
+  type: "object",
+  required: [
+    "verdict",
+    "draftDigest",
+    "reviewPath",
+    "steelman",
+    "tradeoffTension",
+    "principleViolations",
+    "summary",
+  ],
+  properties: {
+    verdict: { type: "string", enum: ["APPROVE", "REVISION_NEEDED"] },
+    draftDigest: { type: "string" },
+    reviewPath: { type: "string" },
+    steelman: { type: "string" },
+    tradeoffTension: { type: "string" },
+    principleViolations: { type: "array", items: { type: "string" } },
+    summary: { type: "string" },
+  },
+};
+const CRITIC_SCHEMA = {
+  type: "object",
+  required: ["verdict", "draftDigest", "reviewPath", "findings", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["APPROVE", "ITERATE", "REJECT"] },
+    draftDigest: { type: "string" },
+    reviewPath: { type: "string" },
+    findings: { type: "array" },
+    summary: { type: "string" },
+  },
+};
+const CONSOLIDATE_SCHEMA = {
+  type: "object",
+  required: ["verdict", "path", "sourceDraftDigest", "summary"],
+  properties: {
+    verdict: { type: "string", enum: ["CONSOLIDATED"] },
+    path: { type: "string" },
+    sourceDraftDigest: { type: "string" },
+    summary: { type: "string" },
+  },
+};
+
+function artifactValid(report, expected) {
+  return Boolean(
+    report &&
+    report.valid === true &&
+    report.path === expected.path &&
+    report.round === expected.round &&
+    report.kind === expected.kind &&
+    Number.isInteger(report.sizeBytes) &&
+    report.sizeBytes > 0 &&
+    report.sizeBytes <= MAX_ARTIFACT_BYTES &&
+    typeof report.sha256 === "string" &&
+    report.sha256.length > 0 &&
+    Array.isArray(report.issues) &&
+    report.issues.length === 0 &&
+    expected.headings.every((heading) => report.headings.includes(heading)),
   );
-  return emptyResult("gated", {
-    gated: true,
-    redirect: "ralplan",
-    gate: { enabled: true, triggered: true, reason: gateResult.reason },
-    mode: "SHORT",
-    interactive: { enabled: interactive, markersEmitted: interactive },
-    statusLine:
-      "Status: pending approval — gate redirected to explicit RALPLAN invocation",
-  });
 }
-
-phase("Ralplan consensus");
-if (interactive) {
-  emitCheckpoint("draft review checkpoint is non-blocking in the workflow VM");
-  emitCheckpoint("final approval and execution routing belong to the host");
-}
-log(
-  "mode=" +
-    mode +
-    "; maxRounds=" +
-    maxRounds +
-    "; gate=" +
-    (gateEnabled ? "enabled" : "disabled"),
-);
-
-const feedback = [];
-let lastDraft = null;
-let lastArchitect = null;
-let lastCritic = null;
-let lastRoundReached = 0;
-let consensusReached = false;
-let deliberateResult = { valid: mode !== "DELIBERATE", issues: [] };
-let plannerError = null;
 
 async function callAgent(prompt, options) {
   try {
@@ -395,37 +404,162 @@ async function callAgent(prompt, options) {
   }
 }
 
+const workflowArgs = parseWorkflowArgs(args);
+const idea = String(workflowArgs.idea || "");
+const interactive = workflowArgs.interactive !== false;
+const gateEnabled = workflowArgs.gate !== false;
+const mode = isDeliberate(idea, workflowArgs) ? "DELIBERATE" : "SHORT";
+const maxRounds = clampRounds(workflowArgs.maxIterations);
+const artifactsDir = safeArtifactsDir(workflowArgs.artifactsDir);
+const planName = safePlanName(workflowArgs.planName);
+const requirementsTraceability = workflowArgs.requirementsTraceability === true;
+const ignoredExecuteOnConsensus = Object.prototype.hasOwnProperty.call(
+  workflowArgs,
+  "executeOnConsensus",
+);
+
+function terminal(status, extra) {
+  return {
+    status,
+    consensus: false,
+    mode,
+    iterations: 0,
+    capped: false,
+    artifactPaths: {
+      plan: pathSet(artifactsDir, planName, 1).final,
+      drafts: [],
+      architectReviews: [],
+      criticReviews: [],
+    },
+    interactive: {
+      enabled: interactive,
+      markersEmitted: interactive,
+      blocking: false,
+    },
+    ...pendingFields(),
+    ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
+    ...extra,
+  };
+}
+
+phase("Gate");
+if (!idea.trim()) return terminal("no_idea", {});
+const gateResult = gateEnabled
+  ? checkGate(idea)
+  : { gated: false, reason: "gate disabled by caller" };
+if (gateResult.gated) {
+  if (interactive)
+    log("[pending approval] explicit RALPLAN invocation required");
+  return terminal("gated", {
+    gated: true,
+    redirect: "ralplan",
+    gate: { enabled: true, triggered: true, reason: gateResult.reason },
+  });
+}
+
+let analyst = null;
+if (requirementsTraceability) {
+  phase("Requirements");
+  analyst = await callAgent(analystPrompt(idea), {
+    schema: ANALYST_SCHEMA,
+    label: "analyst",
+    phase: "Requirements",
+  });
+  if (!analyst) {
+    return terminal("requirements_analysis_failed", {
+      gate: {
+        enabled: gateEnabled,
+        triggered: false,
+        reason: gateResult.reason,
+      },
+    });
+  }
+}
+
+if (interactive) {
+  log("[pending approval] markers are non-blocking; host approval is required");
+}
+
+const feedback = [];
+const drafts = [];
+const architectReviews = [];
+const criticReviews = [];
+let lastDraft = null;
+let lastDraftVerification = null;
+let lastArchitect = null;
+let lastCritic = null;
+let lastRound = 0;
+let reviewConsensus = false;
+let artifactFailure = null;
+const artifactFailures = [];
+
 for (let round = 1; round <= maxRounds; round++) {
-  lastRoundReached = round;
+  lastRound = round;
+  artifactFailure = null;
+  const paths = pathSet(artifactsDir, planName, round);
+
   phase("Round " + round + " - Planner");
-  const plannerOut = await callAgent(
-    buildPlannerPrompt(idea, mode, feedback, round, maxRounds),
+  const planner = await callAgent(
+    plannerPrompt({
+      idea,
+      mode,
+      feedback,
+      round,
+      maxRounds,
+      path: paths.draft,
+      requirements: analyst,
+    }),
     {
       schema: PLANNER_SCHEMA,
-      phase: "Round " + round + " - Planner",
       label: "planner",
+      phase: "Round " + round + " - Planner",
     },
   );
-  const snapshot = plannerSnapshot(plannerOut);
-  if (!snapshot) {
-    plannerError =
-      "Planner returned no schema-valid snapshot on round " + round;
+  lastDraft = planner;
+
+  phase("Round " + round + " - Verify draft");
+  const draftExpected = {
+    path: paths.draft,
+    round,
+    kind: "draft",
+    headings: requiredHeadings(mode, requirementsTraceability),
+  };
+  const draftVerification = await callAgent(verifierPrompt(draftExpected), {
+    schema: VERIFIER_SCHEMA,
+    label: "verify-draft",
+    phase: "Round " + round + " - Verify draft",
+  });
+  lastDraftVerification = draftVerification;
+  if (
+    !planner ||
+    planner.path !== paths.draft ||
+    planner.round !== round ||
+    !artifactValid(draftVerification, draftExpected)
+  ) {
+    artifactFailure = {
+      stage: "draft",
+      round,
+      expectedPath: paths.draft,
+      claimedPath: planner && planner.path,
+      verification: draftVerification,
+    };
+    artifactFailures.push(artifactFailure);
     feedback.push({
       round,
-      role: "planner",
-      verdict: "MISSING",
-      summary: plannerError,
+      role: "artifact-verifier",
+      verdict: "INVALID",
+      summary: "Draft artifact validation failed",
+      issues: (draftVerification && draftVerification.issues) || [],
     });
     continue;
   }
-  lastDraft = snapshot;
-  deliberateResult = deliberateValidation(snapshot, mode);
+  drafts.push(paths.draft);
 
   phase("Round " + round + " - Architect");
   const architectOptions = {
     schema: ARCHITECT_SCHEMA,
-    phase: "Round " + round + " - Architect",
     label: "architect",
+    phase: "Round " + round + " - Architect",
   };
   if (
     typeof workflowArgs.architectModel === "string" &&
@@ -433,35 +567,23 @@ for (let round = 1; round <= maxRounds; round++) {
   ) {
     architectOptions.model = workflowArgs.architectModel;
   }
-  const immutableSnapshot = freezeDeep(clone(snapshot));
-  const architectOut = await callAgent(
-    buildArchitectPrompt(immutableSnapshot, mode),
+  const architect = await callAgent(
+    architectPrompt({
+      draftPath: paths.draft,
+      draftDigest: draftVerification.sha256,
+      reviewPath: paths.architect,
+      round,
+      mode,
+    }),
     architectOptions,
   );
-  lastArchitect = architectOut;
-  const architectApproval = Boolean(
-    architectOut && architectOut.verdict === "APPROVE",
-  );
-  const architectFeedback = architectOut
-    ? {
-        round,
-        role: "architect",
-        verdict: architectOut.verdict,
-        summary: architectOut.summary || "",
-        issues: architectOut.principleViolations || [],
-      }
-    : {
-        round,
-        role: "architect",
-        verdict: "MISSING",
-        summary: "Architect returned no schema-valid result",
-      };
+  lastArchitect = architect;
 
   phase("Round " + round + " - Critic");
   const criticOptions = {
     schema: CRITIC_SCHEMA,
-    phase: "Round " + round + " - Critic",
     label: "critic",
+    phase: "Round " + round + " - Critic",
   };
   if (
     typeof workflowArgs.criticModel === "string" &&
@@ -469,85 +591,214 @@ for (let round = 1; round <= maxRounds; round++) {
   ) {
     criticOptions.model = workflowArgs.criticModel;
   }
-  // Deliberately pass only the immutable Planner snapshot. Architect output is
-  // recorded for the next Planner, never used as Critic input.
-  const criticOut = await callAgent(
-    buildCriticPrompt(immutableSnapshot, mode),
+  const critic = await callAgent(
+    criticPrompt({
+      draftPath: paths.draft,
+      draftDigest: draftVerification.sha256,
+      reviewPath: paths.critic,
+      round,
+      mode,
+      requirementsTraceability,
+    }),
     criticOptions,
   );
-  lastCritic = criticOut;
-  const criticApproval = Boolean(criticOut && criticOut.verdict === "APPROVE");
-  const criticFeedback = criticOut
-    ? {
-        round,
-        role: "critic",
-        verdict: criticOut.verdict,
-        summary: criticOut.summary || "",
-        findings: criticOut.findings || [],
-      }
-    : {
-        round,
-        role: "critic",
-        verdict: "MISSING",
-        summary: "Critic returned no schema-valid result",
-      };
+  lastCritic = critic;
 
-  if (architectApproval && criticApproval && deliberateResult.valid) {
-    consensusReached = true;
-    log("explicit Architect and Critic approval reached on round " + round);
+  phase("Round " + round + " - Verify reviews");
+  const architectExpected = {
+    path: paths.architect,
+    round,
+    kind: "architect-review",
+    headings: [],
+  };
+  const architectVerification = await callAgent(
+    verifierPrompt({
+      ...architectExpected,
+      sourceDigest: draftVerification.sha256,
+    }),
+    {
+      schema: VERIFIER_SCHEMA,
+      label: "verify-architect",
+      phase: "Round " + round + " - Verify reviews",
+    },
+  );
+  const criticExpected = {
+    path: paths.critic,
+    round,
+    kind: "critic-review",
+    headings: [],
+  };
+  const criticVerification = await callAgent(
+    verifierPrompt({
+      ...criticExpected,
+      sourceDigest: draftVerification.sha256,
+    }),
+    {
+      schema: VERIFIER_SCHEMA,
+      label: "verify-critic",
+      phase: "Round " + round + " - Verify reviews",
+    },
+  );
+
+  if (
+    !architect ||
+    !critic ||
+    architect.reviewPath !== paths.architect ||
+    critic.reviewPath !== paths.critic ||
+    architect.draftDigest !== draftVerification.sha256 ||
+    critic.draftDigest !== draftVerification.sha256 ||
+    !artifactValid(architectVerification, architectExpected) ||
+    !artifactValid(criticVerification, criticExpected)
+  ) {
+    artifactFailure = {
+      stage: "reviews",
+      round,
+      architectVerification,
+      criticVerification,
+    };
+    artifactFailures.push(artifactFailure);
+    feedback.push(
+      {
+        round,
+        role: "architect",
+        verdict: architect ? architect.verdict : "MISSING",
+        summary: architect ? architect.summary : "Architect output missing",
+      },
+      {
+        round,
+        role: "critic",
+        verdict: critic ? critic.verdict : "MISSING",
+        summary: critic ? critic.summary : "Critic output missing",
+      },
+    );
+    continue;
+  }
+  architectReviews.push(paths.architect);
+  criticReviews.push(paths.critic);
+
+  if (architect.verdict === "APPROVE" && critic.verdict === "APPROVE") {
+    reviewConsensus = true;
     break;
   }
-  feedback.push(architectFeedback, criticFeedback);
-  if (round < maxRounds)
-    log("non-approval; starting complete Planner → Architect → Critic round");
+  feedback.push(
+    {
+      round,
+      role: "architect",
+      verdict: architect.verdict,
+      summary: architect.summary,
+      issues: architect.principleViolations,
+    },
+    {
+      round,
+      role: "critic",
+      verdict: critic.verdict,
+      summary: critic.summary,
+      findings: critic.findings,
+    },
+  );
 }
 
-const capped = !consensusReached && lastRoundReached >= maxRounds;
-const status = consensusReached
-  ? "consensus"
-  : lastDraft
-    ? "no_consensus"
-    : "no_planner_output";
-const result = {
-  status,
-  consensus: consensusReached,
-  algorithm: "ralplan-occ-v1",
+const artifactPaths = {
+  plan: pathSet(artifactsDir, planName, Math.max(lastRound, 1)).final,
+  drafts,
+  architectReviews,
+  criticReviews,
+};
+if (artifactFailure) {
+  return terminal("artifact_validation_failed", {
+    iterations: lastRound,
+    capped: lastRound >= maxRounds,
+    artifactPaths,
+    artifactFailure,
+    artifactFailures,
+    gate: { enabled: gateEnabled, triggered: false, reason: gateResult.reason },
+  });
+}
+if (!reviewConsensus || !lastDraft || !lastDraftVerification) {
+  return terminal("no_consensus", {
+    iterations: lastRound,
+    capped: lastRound >= maxRounds,
+    artifactPaths,
+    draft: lastDraft,
+    architect: lastArchitect || { verdict: "MISSING" },
+    critic: lastCritic || { verdict: "MISSING" },
+    cappedReason:
+      lastRound >= maxRounds
+        ? "five-round safety cap reached; manual review required and execution unavailable"
+        : undefined,
+    gate: { enabled: gateEnabled, triggered: false, reason: gateResult.reason },
+  });
+}
+
+phase("Consolidate");
+const finalPath = artifactPaths.plan;
+const consolidated = await callAgent(
+  consolidatePrompt({
+    draftPath: lastDraft.path,
+    draftDigest: lastDraftVerification.sha256,
+    architectPath: lastArchitect.reviewPath,
+    criticPath: lastCritic.reviewPath,
+    finalPath,
+    round: lastRound,
+  }),
+  {
+    schema: CONSOLIDATE_SCHEMA,
+    label: "consolidate",
+    phase: "Consolidate",
+  },
+);
+
+phase("Verify final plan");
+const finalExpected = {
+  path: finalPath,
+  round: lastRound,
+  kind: "final-plan",
+  headings: requiredHeadings(mode, requirementsTraceability),
+  sourceDigest: lastDraftVerification.sha256,
+};
+const finalVerification = await callAgent(verifierPrompt(finalExpected), {
+  schema: VERIFIER_SCHEMA,
+  label: "verify-final",
+  phase: "Verify final plan",
+});
+if (
+  !consolidated ||
+  consolidated.path !== finalPath ||
+  consolidated.sourceDraftDigest !== lastDraftVerification.sha256 ||
+  !artifactValid(finalVerification, finalExpected)
+) {
+  return terminal("artifact_validation_failed", {
+    iterations: lastRound,
+    artifactPaths,
+    artifactFailure: {
+      stage: "final",
+      round: lastRound,
+      verification: finalVerification,
+    },
+    gate: { enabled: gateEnabled, triggered: false, reason: gateResult.reason },
+  });
+}
+
+return {
+  status: "pending_approval",
+  consensus: true,
   mode,
-  iterations: lastRoundReached,
-  capped,
+  iterations: lastRound,
+  capped: false,
+  draft: lastDraft,
+  architect: lastArchitect,
+  critic: lastCritic,
+  analyst,
+  artifactPaths,
+  planDigest: finalVerification.sha256,
+  sourceDraftDigest: lastDraftVerification.sha256,
+  artifactVerification: finalVerification,
   gate: { enabled: gateEnabled, triggered: false, reason: gateResult.reason },
-  interactive: { enabled: interactive, markersEmitted: interactive },
-  draft: lastDraft || {},
-  architect: lastArchitect || { verdict: "MISSING", principleViolations: [] },
-  critic: lastCritic || { verdict: "MISSING", findings: [] },
-  deliberate: deliberateResult,
-  artifactPaths: {
-    plan:
-      (workflowArgs.artifactsDir || ".omc/plans") +
-      "/" +
-      (workflowArgs.planName || "ralplan") +
-      ".md",
-    drafts: [],
+  interactive: {
+    enabled: interactive,
+    markersEmitted: interactive,
+    blocking: false,
   },
   ...pendingFields(),
   ...(ignoredExecuteOnConsensus ? { executeOnConsensusIgnored: true } : {}),
-  fidelityGaps: {
-    interactiveCheckpointsUnsupported: true,
-    hostApprovalRequired: true,
-    note: "interactive markers are non-blocking; the workflow VM cannot suspend for user input or invoke execution skills",
-  },
 };
-if (plannerError) result.plannerError = plannerError;
-if (!consensusReached) {
-  result.lastVerdict = {
-    architect:
-      lastArchitect && lastArchitect.verdict
-        ? lastArchitect.verdict
-        : "MISSING",
-    critic: lastCritic && lastCritic.verdict ? lastCritic.verdict : "MISSING",
-  };
-  if (capped)
-    result.cappedReason =
-      "five-round safety cap reached; manual review required and execution unavailable";
-}
-return result;

--- a/skills/ralplan/README.md
+++ b/skills/ralplan/README.md
@@ -1,73 +1,38 @@
 # pi-ralplan-local
 
-Consensus-driven planning for Pi. The skill defines isolated Planner, Architect,
-and Critic roles that independently review one immutable Planner snapshot.
+Verified consensus planning for Pi. The skill defines isolated Planner,
+Architect, and Critic roles over immutable, bounded Markdown artifacts.
 
-## Safety contract
+## Contract
 
-RALPLAN is planning-only. Every workflow result is `pending_approval: true` and
-`execution_halted: true`; no plan file, marker, `executeOnConsensus` argument,
-or consensus result authorizes source mutation or execution. A separate
-host-controlled approval and handoff is required for any later phase.
+- Planner writes `drafts/<planName>_draft-rN.md`.
+- A read-only verifier checks path, regular-file existence, 1 MB size bound,
+  required headings, round/kind, and SHA-256.
+- Architect and Critic sequentially review that same verified draft and return
+  its digest; Critic receives no Architect output or path.
+- Review artifacts are separately verified before verdicts count.
+- A Consolidator writes `<planName>.md` only after both explicit approvals; the
+  final plan is verified before consensus is reported.
+- Every result remains `pending_approval: true` and `execution_halted: true`.
 
-- Planner returns explicit `DRAFT_READY` structured output.
-- Architect returns explicit `APPROVE` or `REVISION_NEEDED`.
-- Critic returns explicit `APPROVE`, `ITERATE`, or `REJECT`.
-- Architect and Critic run sequentially on the same fixed Planner snapshot;
-  Critic receives neither Architect output nor its path.
-- Critic still runs after Architect rejection or failure.
-- Any non-approval runs a complete loop, capped at five rounds.
-- Missing or failed output is never approval and never receives an executable
-  recommendation.
+`requirementsTraceability: true` enables an advisory Analyst preflight and a
+required Requirement Coverage Map. Analyst is not a consensus role. DELIBERATE
+mode in the canonical OCC workflow requires exactly three pre-mortem scenarios
+plus Unit, Integration, E2E, and Observability coverage.
 
-## Usage
+## Examples
 
-```text
-/ralplan [idea]
-/brainstorm [idea]
-/ralplan:status
-/ralplan:artifacts
-/ralplan:cancel
-```
+- `examples/workflows/ralplan-occ.mjs` — canonical OCC flow with gate,
+  DELIBERATE mode, requirements traceability, and reviewer model overrides.
+- `examples/workflows/ralplan-consensus.mjs` — compact SHORT-only compatibility
+  flow with the same artifact and independent-review guarantees.
 
-Slash/flag invocation is explicit. A bare prose mention does not start a new
-pipeline. Status, artifact, and cancellation commands are host features; the
-workflow VM cannot intercept arbitrary parent text or pause for a user.
-
-## Bundled examples
-
-- `examples/workflows/ralplan-occ.mjs` is the canonical OCC-facing workflow.
-  `gate: false` bypasses its local heuristic. `interactive` only enables
-  non-blocking `[pending approval]` marker text; it does not wait for a user.
-  `executeOnConsensus` is accepted only for compatibility and is ignored.
-- `examples/workflows/ralplan-consensus.mjs` is a compact SHORT-only example.
-  It shares the isolation, fixed-snapshot, verdict, loop, and pending boundary
-  contract but does not advertise DELIBERATE or interactive parity.
-
-## Modes
-
-SHORT is the default. DELIBERATE mode is available in the canonical OCC flow
-and requires exactly three actionable pre-mortem scenarios plus Unit,
-Integration, E2E, and Observability test-plan coverage. Missing sections are a
-non-approval.
-
-## Layout
-
-```text
-ralplan/
-├── SKILL.md
-├── README.md
-├── package.json
-└── prompts/
-    ├── planner.md
-    ├── architect.md
-    └── critic.md
-```
+The workflow VM cannot pause for user approval. `interactive` only controls
+non-blocking markers. `executeOnConsensus` is ignored compatibility input. A
+plan, digest, completion marker, or consensus result never authorizes execution.
 
 ## Install
 
 ```bash
 npm install ./skills/ralplan
 ```
-
-The package registers the skill through its `pi.skills` metadata.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,131 +1,117 @@
 ---
 name: ralplan
-description: Consensus-driven implementation planning via isolated Planner, Architect, and Critic reviews of one immutable Planner snapshot. Use when a detailed plan is needed before coding; planning remains pending and read-only until a separate host approval.
+description: Consensus-driven implementation planning via verified immutable Markdown artifacts and isolated Planner, Architect, and Critic reviews. Results remain pending and execution-halted until a separate host approval.
 argument-hint: "[idea]"
 level: intermediate
 ---
 
-# ralplan — Consensus-Driven Implementation Planning
+# ralplan — Verified Consensus Planning
 
-RALPLAN is a planning protocol, not an executor. It produces a bounded plan and
-review evidence while keeping the result **pending approval** and
-**execution-halted**. A workflow result, plan file, marker, or
-`executeOnConsensus` argument is never permission to edit source or invoke an
-executor. Only a separate host-controlled approval and handoff may authorize a
-later phase.
+RALPLAN is a planning protocol, not an executor. It produces bounded, verified
+Markdown artifacts and independent review evidence. A workflow return, artifact
+path, digest, completion marker, or `executeOnConsensus` argument is never
+execution consent.
 
 ## Invocation
 
-Use an explicit invocation:
+Use an explicit `/ralplan [idea]` or `--ralplan [idea]` invocation. Bare prose
+mentions do not start a pipeline. Host commands such as status, approval,
+cancel, or resume require host integration; a workflow body cannot intercept
+arbitrary parent text or suspend for user input.
 
-- `/ralplan [idea]`
-- `--ralplan [idea]`
-- `/brainstorm [idea]` for a host-supported question-elicitation variant
+## Consensus roles
 
-A bare mention of “ralplan” in prose does not start a new pipeline. Status,
-artifact, skip, and cancel commands are host features; a workflow body cannot
-intercept arbitrary parent text or suspend for user input.
+Only three roles determine consensus:
 
-## Hard contract
+1. **Planner** writes an immutable per-round draft.
+2. **Architect** independently reviews that exact verified draft.
+3. **Critic** independently reviews the same verified draft without receiving
+   Architect output or an Architect artifact path.
 
-1. **Isolated roles.** Planner, Architect, and Critic are separate agent
-   invocations. The parent does not impersonate a role and no role approves its
-   own work.
-2. **One fixed snapshot.** After Planner settles, capture one immutable value
-   snapshot. Architect and Critic are awaited sequentially and each receives
-   that same snapshot. Critic receives neither Architect JSON nor an Architect
-   artifact path.
-3. **Explicit verdicts.** Planner returns `DRAFT_READY`; Architect returns
-   `APPROVE` or `REVISION_NEEDED`; Critic returns `APPROVE`, `ITERATE`, or
-   `REJECT`. Never infer approval from an empty violations, issues, gaps, or
-   findings array. Missing, malformed, or failed output is non-approval.
-4. **Complete re-review.** Critic runs after Architect settles, including after
-   `REVISION_NEEDED` or an Architect failure. Any non-approval starts a complete
-   Planner → Architect → Critic round. `maxIterations` is clamped to 1–5.
-5. **Planning boundary.** Every terminal result is pending/read-only and
-   execution-halted. No consensus, cap, null result, cancellation, or failure
-   may recommend `ralph`, `team`, autopilot, or another executable skill.
-6. **Deliberate mode.** When high-risk work requests DELIBERATE mode, Planner
-   must return exactly three actionable pre-mortem scenarios and all four
-   expanded test pillars: unit, integration, e2e, and observability. Missing or
-   weak structured sections are non-approval. SHORT mode does not require them.
+An optional **Analyst** preflight atomizes requirements and open questions. The
+Analyst is advisory and is never a fourth approver.
 
-## Role responsibilities
+Every role is a separate agent invocation. Planner returns `DRAFT_READY`;
+Architect returns `APPROVE` or `REVISION_NEEDED`; Critic returns `APPROVE`,
+`ITERATE`, or `REJECT`. Approval is never inferred from empty findings. Missing,
+malformed, failed, or digest-mismatched output is non-approval.
 
-### Planner
+## Artifact contract
 
-Investigate requirements and codebase facts through available read-only agents,
-then produce a 3–6 step actionable plan. Include:
+Given `artifactsDir`, a safe `planName`, and round `N`, write only:
 
-- RALPLAN-DR: 3–5 principles, the top 3 decision drivers, and at least 2
-  viable options with bounded pros/cons;
-- guardrails, task acceptance criteria, dependencies, risks, and open questions;
-- an ADR with Decision, Drivers, Alternatives Considered, Why Chosen,
-  Consequences, and Follow-ups;
-- DELIBERATE additions when that mode is active.
+- `drafts/<planName>_draft-rN.md`
+- `drafts/architect_review-rN.md`
+- `drafts/critic_review-rN.md`
+- `<planName>.md` only after both independent reviewers explicitly approve
 
-Planner does not implement, commit, push, execute, or approve.
+Each draft/review filename is immutable and round-specific. Never overwrite a
+prior round. A read-only verifier must check the exact claimed path, regular-file
+existence, 1 MB size bound, required headings, round/kind, source-draft identity,
+and SHA-256 before the workflow accepts it. A claimed path alone is not success.
 
-### Architect
+Draft and final plan artifacts require:
 
-Read-only and independent. Review the fixed Planner snapshot for technical
-soundness, alternatives, ownership/lifecycle risks, compatibility, and
-trade-offs. Always provide a steelman antithesis and a real tradeoff tension,
-then return an explicit `APPROVE` or `REVISION_NEEDED` verdict. An empty
-`principleViolations` array is evidence, not a verdict.
+- `## RALPLAN-DR` with 3–5 principles, top 3 decision drivers, and at least 2
+  viable options (or explicit invalidation rationale);
+- `## Architecture Decision Record` with Decision, Drivers, Alternatives
+  Considered, Why Chosen, Consequences, and Follow-ups;
+- `## Task Breakdown` with 3–6 actionable tasks and exact paths;
+- `## Dependency Graph`;
+- `## Acceptance Criteria`;
+- `## Risk Register`;
+- open questions where applicable.
 
-### Critic
+When requirements traceability is requested, the advisory Analyst emits atomic
+`REQ-*` items and the draft/final plan must include `## Requirement Coverage
+Map`. Each requirement maps to covered plan steps and one of `COVERED`,
+`PARTIAL`, `UNCOVERED`, or `SCOPED_OUT`; `SCOPED_OUT` requires rationale.
+Unexplained partial/uncovered/scoped-out items block Critic approval.
 
-Read-only and independent. Review the same fixed Planner snapshot without
-seeing Architect output. Check principle/option consistency, risk mitigation,
-acceptance criteria, verification, missing assumptions, and deliberate-mode
-hard gates. Return an explicit `APPROVE`, `ITERATE`, or `REJECT` verdict.
-
-## Loop and termination
+## Review loop
 
 ```text
-Planner(snapshot N)
-       |
-       +--> Architect(snapshot N) --+
-       |                             |
-       +--> Critic(snapshot N) ------+
-                                      |
-                 both explicit APPROVE and mode gates pass?
-                    yes -> pending consensus result
-                    no  -> Planner(snapshot N+1, with both reviews)
+Analyst? (advisory only)
+  → Planner writes draft-rN
+  → verifier records draft SHA-256
+  → Architect reviews draft-rN + expected digest
+  → Critic reviews draft-rN + expected digest (no Architect input)
+  → verifier validates both review artifacts and source identity
+  → both explicit APPROVE?
+      no: next complete Planner → Architect → Critic round
+      yes: Consolidator writes final plan → verifier validates final plan
 ```
 
-The Critic is not skipped when Architect rejects. The next Planner may receive
-both settled review results, but those results are never passed from Architect
-to Critic. After five rounds, return the best/last draft with `capped: true`,
-`pending_approval: true`, and `execution_halted: true`; require manual review
-and provide no execution recommendation.
+Critic always runs after Architect settles, including Architect rejection or
+failure. Only the next Planner receives both settled review results. Clamp
+`maxIterations` to 1–5. Artifact-validation failures may be corrected by a
+later bounded round; exhaustion returns the best evidence as pending/read-only.
 
-## OCC workflow arguments
+## Modes
 
-The canonical `examples/workflows/ralplan-occ.mjs` accepts `idea`,
-`deliberate`, `maxIterations`, `artifactsDir`, `planName`,
-`architectModel`, and `criticModel`. Its local gate is controlled by `gate`:
-`gate: false` bypasses the heuristic; otherwise an unanchored short prompt may
-return a pending redirect. `interactive` only controls emission of
-non-blocking `[pending approval]` marker text. The workflow VM cannot pause for
-a user, ask a host question, or turn a marker into approval; actual approval
-and invocation routing belong to the host. `executeOnConsensus` is accepted
-only for compatibility, reported as ignored, and never changes safety state.
+SHORT is the default. DELIBERATE mode requires exactly three actionable
+pre-mortem scenarios (trigger, blast radius, early signal, mitigation,
+detection) and concrete Unit, Integration, E2E, and Observability coverage.
+The verifier treats missing sections as invalid. The compact
+`ralplan-consensus.mjs` example remains SHORT-only.
 
-The compact `ralplan-consensus.mjs` example is SHORT-only. It shares the fixed
-snapshot, explicit verdict, unconditional Critic, five-round, and pending
-boundary contract but does not advertise DELIBERATE or interactive parity.
+## OCC workflow semantics
 
-## Artifacts and execution separation
+`examples/workflows/ralplan-occ.mjs` is canonical. `gate: false` bypasses its
+local short-prompt heuristic. `interactive` controls only non-blocking
+`[pending approval]` log markers; the workflow VM cannot wait for a user.
+`executeOnConsensus` is accepted only for compatibility, reported as ignored,
+and never changes approval or execution state.
 
-Planning may produce bounded Markdown evidence only. A claimed path is not
-proof of a valid artifact, and the Phase 1 workflow does not provide a host
-artifact verifier or persisted approval state. Artifact existence/content
-verification and host-owned run/approval state are later phases. Do not treat
-`plans/plan.md`, a completion marker, or a successful workflow return as
-consent to execute.
+## Safety boundary
 
-If the host cannot provide isolated agent invocations, stop with:
+Planning agents may write only the bounded Markdown paths above. They never edit
+source, execute, delegate implementation, commit, or push. Every terminal result
+has `pending_approval: true` and `execution_halted: true`. Missing consensus,
+cap exhaustion, cancellation, or artifact failure has no `ralph`, `team`,
+autopilot, or other executable recommendation. Host-owned approval/state and
+durable execution are separate contracts.
+
+If the host cannot provide isolated role execution, stop with:
 
 > ralplan requires role-isolated agent execution; current host does not support it.

--- a/skills/ralplan/package.json
+++ b/skills/ralplan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-ralplan-local",
   "version": "0.1.0",
-  "description": "Consensus-driven planning via isolated Planner/Architect/Critic review of one immutable snapshot. Use /ralplan for a pending, execution-halted plan; host approval is required before any later phase.",
+  "description": "Verified immutable-artifact planning via isolated Planner/Architect/Critic review. Results remain pending and execution-halted until host approval.",
   "type": "module",
   "pi": {
     "skills": [

--- a/skills/ralplan/prompts/architect.md
+++ b/skills/ralplan/prompts/architect.md
@@ -1,36 +1,20 @@
 # Architect Role Prompt
 
-You are the **Architect**, an isolated, read-only technical reviewer. You are
-not the Planner, Critic, Analyst, or Executor. Review the one immutable Planner
-snapshot supplied by the host; do not request or use another reviewer's output.
+You are the isolated, read-only **Architect**. Review only the exact immutable
+Planner draft path and expected SHA-256 supplied by the host. You are not the
+Planner, Analyst, Critic, or Executor.
 
-## Review responsibilities
+Recompute the draft digest before review. Inspect referenced source read-only and
+check feasibility, ownership/lifecycle, concurrency, failure/recovery,
+compatibility, migration cost, alternatives, and verification. Always provide a
+steelman antithesis and meaningful tradeoff tension.
 
-- Check technical feasibility, ownership/lifecycle, concurrency, failure and
-  recovery behavior, compatibility, migration cost, and verification claims.
-- Separate invariants from mechanisms and compare materially distinct viable
-  designs, or explain why alternatives are nonviable.
-- State the strongest steelman antithesis against the favored direction and at
-  least one meaningful tradeoff tension.
-- In DELIBERATE mode, explicitly identify missing or weak pre-mortem scenarios
-  and any missing Unit, Integration, E2E, or Observability test coverage.
+Write bounded Markdown evidence only to the exact round-specific
+`architect_review-rN.md` path. Return structured output with `draftDigest`,
+`reviewPath`, `steelman`, `tradeoffTension`, `principleViolations`, `summary`,
+and exactly one verdict: `APPROVE` or `REVISION_NEEDED`. Empty issues do not
+imply approval; missing or digest-mismatched output is non-approval.
 
-## Explicit verdict contract
-
-Return structured output with exactly one explicit verdict:
-
-- `APPROVE` — this snapshot passes the Architect gate;
-- `REVISION_NEEDED` — any technical or deliberate-mode gate is not satisfied.
-
-Approval is never inferred from an empty `principleViolations`, `issues`, or
-findings array. Missing, malformed, uncertain, or failed output is
-non-approval. Always include `steelman`, `tradeoffTension`, and a concise
-summary; include concrete evidence and actionable issues for revisions.
-
-## Safety boundary
-
-Do not implement, edit source, commit, push, execute a skill, or claim that
-approval authorizes execution. The host invokes Critic **after this review
-settles regardless of verdict**. Critic receives the same Planner snapshot,
-not this review. Only a later host-controlled approval can authorize any
-execution phase.
+The host invokes Critic after you settle regardless of verdict. Critic receives
+the Planner draft and digest, never this review or its path. Do not implement,
+edit source, execute, commit, push, or claim that approval authorizes execution.

--- a/skills/ralplan/prompts/critic.md
+++ b/skills/ralplan/prompts/critic.md
@@ -1,44 +1,22 @@
 # Critic Role Prompt
 
-You are the **Critic**, an isolated, read-only quality gate. You are not the
-Planner, Architect, Analyst, or Executor. Independently review only the one
-immutable Planner snapshot supplied by the host. You receive neither Architect
-JSON nor an Architect artifact path, and must not infer what another reviewer
-thought.
+You are the isolated, read-only **Critic**. Independently review only the exact
+immutable Planner draft path and expected SHA-256 supplied by the host. You
+receive neither Architect output nor an Architect artifact path. You are not the
+Planner, Analyst, Architect, or Executor.
 
-## Review responsibilities
+Recompute the draft digest. Check principle/option consistency, alternatives,
+risks, dependencies, ambiguity, rollback, acceptance criteria, verification,
+and missing assumptions. When requirements traceability is active, reject
+unexplained `PARTIAL`, `UNCOVERED`, or `SCOPED_OUT` requirements. In DELIBERATE
+mode reject missing/weak pre-mortem scenarios or Unit, Integration, E2E, or
+Observability coverage.
 
-Check the snapshot for:
+Write bounded Markdown evidence only to the exact round-specific
+`critic_review-rN.md` path. Return `draftDigest`, `reviewPath`, findings,
+summary, and exactly one verdict: `APPROVE`, `ITERATE`, or `REJECT`. Empty
+findings do not imply approval; missing or digest-mismatched output is
+non-approval.
 
-- principle/option consistency and fair alternatives;
-- concrete risks, mitigations, dependencies, acceptance criteria, and
-  verification steps;
-- missing assumptions, ambiguity, rollback, and executor/stakeholder/skeptic
-  concerns;
-- in DELIBERATE mode, exactly three actionable pre-mortem scenarios and
-  complete Unit, Integration, E2E, and Observability test-plan pillars.
-
-Use evidence, severity-tagged findings, self-audit, and explicit gap analysis.
-Do not manufacture stylistic objections, but do not soften a genuine blocker.
-
-## Explicit verdict contract
-
-Return exactly one verdict:
-
-- `APPROVE` — the independent snapshot passes the Critic gate;
-- `ITERATE` — concrete revisions could make it acceptable;
-- `REJECT` — the direction or evidence is fundamentally unacceptable.
-
-An empty `gaps`, `findings`, or `issues` array is not approval. Missing,
-malformed, uncertain, or failed output is non-approval. The host requires both
-this explicit `APPROVE` and the Architect's explicit `APPROVE` before reporting
-consensus.
-
-## Safety boundary
-
-Do not implement, edit source, commit, push, execute a skill, or treat a plan,
-marker, or workflow result as execution consent. The host invokes you after the
-Architect settles even when Architect returned `REVISION_NEEDED`; both review
-results are passed to the next Planner only after this review settles. Every
-non-consensus result is pending approval and execution-halted, with no
-`ralph`/`team`/autopilot recommendation.
+Do not implement, edit source, execute, commit, push, or treat a plan, digest,
+marker, or workflow result as execution consent.

--- a/skills/ralplan/prompts/planner.md
+++ b/skills/ralplan/prompts/planner.md
@@ -1,46 +1,28 @@
 # Planner Role Prompt
 
-You are the **Planner**, an isolated planning role. Create or revise a clear,
-actionable implementation plan from the request and verified codebase facts.
-You are not the Architect, Critic, Analyst, or Executor.
+You are the isolated **Planner**. Create or revise a bounded Markdown plan; you
+are not the Analyst, Architect, Critic, or Executor.
 
-## Constraints
+## Artifact contract
 
-- Never implement, edit source, commit, push, execute an executor, or approve
-  your own work.
-- Planning output is bounded Markdown/structured planning data only.
-- Ask users only about preferences or scope decisions; use read-only agents for
-  codebase facts.
-- A revision round must address **both** completed reviewer results. Do not
-  expose one review to the other reviewer.
+Write exactly the round-specific path provided by the host:
+`drafts/<planName>_draft-rN.md`. Never overwrite an earlier round. Return only
+an explicit `DRAFT_READY` result with `path`, `round`, and concise `summary`.
+The host verifies existence, size, headings, round identity, and SHA-256 before
+review.
 
-## Required draft
+Include RALPLAN-DR, ADR, 3–6 actionable tasks with exact paths and acceptance
+criteria, dependency graph, risk register, and open questions. When advisory
+requirements are supplied, include a Requirement Coverage Map mapping every
+requirement to plan steps and `COVERED`, `PARTIAL`, `UNCOVERED`, or
+`SCOPED_OUT`; scoped-out items require rationale.
 
-Return an explicit `DRAFT_READY` result containing a draft snapshot with:
+DELIBERATE mode additionally requires exactly three actionable pre-mortem
+scenarios (trigger, blast radius, early signal, mitigation, detection) and
+concrete Unit, Integration, E2E, and Observability test coverage.
 
-- RALPLAN-DR: 3–5 Principles, exactly the top 3 Decision Drivers, and at
-  least 2 viable Options with bounded pros/cons (or explicit invalidation
-  rationale when fewer survive);
-- 3–6 actionable tasks, acceptance criteria, dependencies, guardrails, risks,
-  and open questions;
-- an ADR: Decision, Drivers, Alternatives Considered, Why Chosen,
-  Consequences, and Follow-ups.
+## Boundaries
 
-In DELIBERATE mode, also return exactly three actionable pre-mortem scenarios,
-each with trigger, blast radius, early signal, mitigation, and detection, plus
-non-empty Unit, Integration, E2E, and Observability test-plan sections. Missing
-or weak deliberate sections are a non-approval, not an invitation to infer
-success. SHORT mode does not require them.
-
-## Review handoff contract
-
-After you settle, the host captures one immutable value snapshot. Architect and
-Critic are separate invocations that receive that same snapshot sequentially.
-The Critic receives neither Architect output nor an Architect path. If a review
-is missing or fails, the host treats it as non-approval and gives both settled
-results to the next Planner round.
-
-Every non-approval starts a complete Planner → Architect → Critic round, with
-`maxIterations` clamped to 1–5. A capped result remains pending approval and
-execution-halted. It must not recommend `ralph`, `team`, autopilot, or any
-other executable skill.
+Use both settled reviewer results only when revising in the next round. Never
+expose one reviewer to the other. Do not implement, edit source, execute,
+commit, push, or self-approve. A draft path or digest is not execution consent.

--- a/tests/published-tarball.test.ts
+++ b/tests/published-tarball.test.ts
@@ -285,6 +285,11 @@ describe("published tarball", () => {
         "examples/workflows/ralplan-occ.mjs",
         "examples/workflows/skill-to-workflow.mjs",
         "skills/ralplan/SKILL.md",
+        "skills/ralplan/README.md",
+        "skills/ralplan/package.json",
+        "skills/ralplan/prompts/planner.md",
+        "skills/ralplan/prompts/architect.md",
+        "skills/ralplan/prompts/critic.md",
       ]),
     );
   });

--- a/tests/ralplan-artifacts.test.ts
+++ b/tests/ralplan-artifacts.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow, type WorkflowAgentRunner } from "../src/workflow";
+import type { SubagentResult } from "../src/helpers";
+
+const REPO = resolve(fileURLToPath(import.meta.url), "..", "..");
+const EXAMPLES = join(REPO, "examples", "workflows");
+
+function workflow(name: string): string {
+  return readFileSync(join(EXAMPLES, name), "utf8");
+}
+
+function json(value: unknown): SubagentResult {
+  return {
+    isError: false,
+    output: JSON.stringify(value),
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+      turns: 1,
+    },
+    model: "test/model",
+  };
+}
+
+function draftResult(path: string, round: number) {
+  return { verdict: "DRAFT_READY", path, round, summary: `draft ${round}` };
+}
+
+function verified(path: string, round: number, kind: string) {
+  return {
+    valid: true,
+    path,
+    round,
+    kind,
+    sizeBytes: 1024,
+    sha256: `digest-${round}-${kind}`,
+    headings: [
+      "RALPLAN-DR",
+      "Architecture Decision Record",
+      "Task Breakdown",
+      "Dependency Graph",
+      "Acceptance Criteria",
+      "Risk Register",
+    ],
+    issues: [],
+  };
+}
+
+function architect(path: string, round: number, verdict = "APPROVE") {
+  return {
+    verdict,
+    draftDigest: `digest-${round}-draft`,
+    reviewPath: path,
+    steelman: "alternative",
+    tradeoffTension: "speed versus safety",
+    principleViolations: verdict === "APPROVE" ? [] : ["safety"],
+    summary: "architect result",
+  };
+}
+
+function critic(path: string, round: number, verdict = "APPROVE") {
+  return {
+    verdict,
+    draftDigest: `digest-${round}-draft`,
+    reviewPath: path,
+    findings: [],
+    summary: "critic result",
+  };
+}
+
+function consolidated(path: string, digest: string) {
+  return {
+    verdict: "CONSOLIDATED",
+    path,
+    sourceDraftDigest: digest,
+    summary: "final",
+  };
+}
+
+describe("RALPLAN artifact contract", () => {
+  it("uses immutable per-round artifacts and verifies every claimed artifact", async () => {
+    const root = "/repo/plans";
+    const labels: string[] = [];
+    const prompts: Record<string, string> = {};
+    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
+      labels.push(label ?? "");
+      prompts[label ?? ""] = String(prompt);
+      if (label === "planner")
+        return json(draftResult(`${root}/drafts/plan_draft-r1.md`, 1));
+      if (label === "verify-draft")
+        return json(verified(`${root}/drafts/plan_draft-r1.md`, 1, "draft"));
+      if (label === "architect")
+        return json(architect(`${root}/drafts/architect_review-r1.md`, 1));
+      if (label === "critic")
+        return json(critic(`${root}/drafts/critic_review-r1.md`, 1));
+      if (label === "verify-architect")
+        return json(
+          verified(
+            `${root}/drafts/architect_review-r1.md`,
+            1,
+            "architect-review",
+          ),
+        );
+      if (label === "verify-critic")
+        return json(
+          verified(`${root}/drafts/critic_review-r1.md`, 1, "critic-review"),
+        );
+      if (label === "consolidate")
+        return json(consolidated(`${root}/plan.md`, "digest-1-draft"));
+      if (label === "verify-final")
+        return json(verified(`${root}/plan.md`, 1, "final-plan"));
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
+      },
+      runAgent: runner,
+    });
+
+    expect(labels).toEqual([
+      "planner",
+      "verify-draft",
+      "architect",
+      "critic",
+      "verify-architect",
+      "verify-critic",
+      "consolidate",
+      "verify-final",
+    ]);
+    expect(prompts.architect).toContain("plan_draft-r1.md");
+    expect(prompts.critic).toContain("plan_draft-r1.md");
+    expect(prompts.critic).not.toContain("architect_review-r1.md");
+    expect(run.result).toMatchObject({
+      status: "pending_approval",
+      consensus: true,
+      planDigest: "digest-1-final-plan",
+      artifactPaths: {
+        plan: `${root}/plan.md`,
+        drafts: [`${root}/drafts/plan_draft-r1.md`],
+        architectReviews: [`${root}/drafts/architect_review-r1.md`],
+        criticReviews: [`${root}/drafts/critic_review-r1.md`],
+      },
+      pending_approval: true,
+      execution_halted: true,
+    });
+  });
+
+  it("keeps prior artifacts immutable and gives both reviews only to the next Planner", async () => {
+    const root = "/repo/plans";
+    const plannerPrompts: string[] = [];
+    let round = 0;
+    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
+      if (label === "planner") {
+        round++;
+        plannerPrompts.push(String(prompt));
+        return json(
+          draftResult(`${root}/drafts/plan_draft-r${round}.md`, round),
+        );
+      }
+      if (label === "verify-draft")
+        return json(
+          verified(`${root}/drafts/plan_draft-r${round}.md`, round, "draft"),
+        );
+      if (label === "architect")
+        return json(
+          architect(
+            `${root}/drafts/architect_review-r${round}.md`,
+            round,
+            round === 1 ? "REVISION_NEEDED" : "APPROVE",
+          ),
+        );
+      if (label === "critic")
+        return json(critic(`${root}/drafts/critic_review-r${round}.md`, round));
+      if (label === "verify-architect")
+        return json(
+          verified(
+            `${root}/drafts/architect_review-r${round}.md`,
+            round,
+            "architect-review",
+          ),
+        );
+      if (label === "verify-critic")
+        return json(
+          verified(
+            `${root}/drafts/critic_review-r${round}.md`,
+            round,
+            "critic-review",
+          ),
+        );
+      if (label === "consolidate")
+        return json(consolidated(`${root}/plan.md`, "digest-2-draft"));
+      if (label === "verify-final")
+        return json(verified(`${root}/plan.md`, 2, "final-plan"));
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 2,
+        artifactsDir: root,
+        planName: "plan",
+      },
+      runAgent: runner,
+    });
+
+    expect(plannerPrompts[0]).not.toContain("architect result");
+    expect(plannerPrompts[1]).toContain("architect result");
+    expect(plannerPrompts[1]).toContain("critic result");
+    expect(run.result).toMatchObject({ iterations: 2, consensus: true });
+  });
+
+  it("rejects missing, oversized, malformed, and wrong-round artifacts", async () => {
+    const root = "/repo/plans";
+    const cases = [
+      { issue: "missing", path: `${root}/drafts/plan_draft-r1.md`, round: 1 },
+      { issue: "oversized", path: `${root}/drafts/plan_draft-r1.md`, round: 1 },
+      { issue: "malformed", path: `${root}/drafts/plan_draft-r1.md`, round: 1 },
+      {
+        issue: "wrong round",
+        path: `${root}/drafts/plan_draft-r2.md`,
+        round: 2,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const runner: WorkflowAgentRunner = async ({ label }) => {
+        if (label === "planner")
+          return json(draftResult(testCase.path, testCase.round));
+        if (label === "verify-draft") {
+          return json({
+            ...verified(testCase.path, testCase.round, "draft"),
+            valid: false,
+            sizeBytes: testCase.issue === "oversized" ? 2_000_000 : 0,
+            issues: [testCase.issue],
+          });
+        }
+        throw new Error(`Unexpected label: ${label}`);
+      };
+
+      const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+        args: {
+          idea: "force: review src/auth.ts",
+          gate: false,
+          maxIterations: 1,
+          artifactsDir: root,
+          planName: "plan",
+        },
+        runAgent: runner,
+      });
+
+      expect(run.result).toMatchObject({
+        consensus: false,
+        status: "artifact_validation_failed",
+        pending_approval: true,
+        execution_halted: true,
+      });
+    }
+  });
+
+  it("runs an advisory Analyst preflight and requires requirements coverage when requested", async () => {
+    const root = "/repo/plans";
+    const prompts: Record<string, string> = {};
+    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
+      prompts[label ?? ""] = String(prompt);
+      if (label === "analyst") {
+        return json({
+          requirements: [{ id: "REQ-1", text: "Preserve compatibility" }],
+          openQuestions: [],
+        });
+      }
+      if (label === "planner")
+        return json(draftResult(`${root}/drafts/plan_draft-r1.md`, 1));
+      if (label === "verify-draft") {
+        const report = verified(
+          `${root}/drafts/plan_draft-r1.md`,
+          1,
+          "draft",
+        ) as { headings: string[] };
+        report.headings.push("Requirement Coverage Map");
+        return json(report);
+      }
+      if (label === "architect")
+        return json(architect(`${root}/drafts/architect_review-r1.md`, 1));
+      if (label === "critic")
+        return json(critic(`${root}/drafts/critic_review-r1.md`, 1));
+      if (label === "verify-architect")
+        return json(
+          verified(
+            `${root}/drafts/architect_review-r1.md`,
+            1,
+            "architect-review",
+          ),
+        );
+      if (label === "verify-critic")
+        return json(
+          verified(`${root}/drafts/critic_review-r1.md`, 1, "critic-review"),
+        );
+      if (label === "consolidate")
+        return json(consolidated(`${root}/plan.md`, "digest-1-draft"));
+      if (label === "verify-final") {
+        const report = verified(`${root}/plan.md`, 1, "final-plan") as {
+          headings: string[];
+        };
+        report.headings.push("Requirement Coverage Map");
+        return json(report);
+      }
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
+        requirementsTraceability: true,
+      },
+      runAgent: runner,
+    });
+
+    expect(prompts.planner).toContain("REQ-1");
+    expect(prompts["verify-draft"]).toContain("Requirement Coverage Map");
+    expect(prompts.critic).toContain("requirements coverage");
+  });
+
+  it("does not report consensus when final artifact verification fails", async () => {
+    const root = "/repo/plans";
+    const runner: WorkflowAgentRunner = async ({ label }) => {
+      if (label === "planner")
+        return json(draftResult(`${root}/drafts/plan_draft-r1.md`, 1));
+      if (label === "verify-draft")
+        return json(verified(`${root}/drafts/plan_draft-r1.md`, 1, "draft"));
+      if (label === "architect")
+        return json(architect(`${root}/drafts/architect_review-r1.md`, 1));
+      if (label === "critic")
+        return json(critic(`${root}/drafts/critic_review-r1.md`, 1));
+      if (label === "verify-architect")
+        return json(
+          verified(
+            `${root}/drafts/architect_review-r1.md`,
+            1,
+            "architect-review",
+          ),
+        );
+      if (label === "verify-critic")
+        return json(
+          verified(`${root}/drafts/critic_review-r1.md`, 1, "critic-review"),
+        );
+      if (label === "consolidate")
+        return json(consolidated(`${root}/plan.md`, "digest-1-draft"));
+      if (label === "verify-final")
+        return json({
+          ...verified(`${root}/plan.md`, 1, "final-plan"),
+          valid: false,
+          issues: ["missing ADR"],
+        });
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
+      },
+      runAgent: runner,
+    });
+
+    expect(run.result).toMatchObject({
+      consensus: false,
+      status: "artifact_validation_failed",
+      pending_approval: true,
+      execution_halted: true,
+    });
+  });
+
+  it("rejects reviewer source-digest mismatches", async () => {
+    const root = "/repo/plans";
+    const runner: WorkflowAgentRunner = async ({ label }) => {
+      if (label === "planner")
+        return json(draftResult(`${root}/drafts/plan_draft-r1.md`, 1));
+      if (label === "verify-draft")
+        return json(verified(`${root}/drafts/plan_draft-r1.md`, 1, "draft"));
+      if (label === "architect") {
+        return json({
+          ...architect(`${root}/drafts/architect_review-r1.md`, 1),
+          draftDigest: "different-digest",
+        });
+      }
+      if (label === "critic")
+        return json(critic(`${root}/drafts/critic_review-r1.md`, 1));
+      if (label === "verify-architect")
+        return json(
+          verified(
+            `${root}/drafts/architect_review-r1.md`,
+            1,
+            "architect-review",
+          ),
+        );
+      if (label === "verify-critic")
+        return json(
+          verified(`${root}/drafts/critic_review-r1.md`, 1, "critic-review"),
+        );
+      throw new Error(`Unexpected label: ${label}`);
+    };
+
+    const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
+      args: {
+        idea: "force: review src/auth.ts",
+        gate: false,
+        maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
+      },
+      runAgent: runner,
+    });
+
+    expect(run.result).toMatchObject({
+      consensus: false,
+      status: "artifact_validation_failed",
+      pending_approval: true,
+      execution_halted: true,
+    });
+  });
+
+  it("rejects unsafe artifact names before spawning agents", async () => {
+    const runner: WorkflowAgentRunner = async () => {
+      throw new Error("must not spawn");
+    };
+
+    await expect(
+      runWorkflow(workflow("ralplan-occ.mjs"), {
+        args: {
+          idea: "force: review src/auth.ts",
+          gate: false,
+          artifactsDir: "/repo/plans",
+          planName: "../escape",
+        },
+        runAgent: runner,
+      }),
+    ).rejects.toThrow("planName");
+  });
+});

--- a/tests/ralplan-workflow.test.ts
+++ b/tests/ralplan-workflow.test.ts
@@ -11,8 +11,20 @@ import type { SubagentResult } from "../src/helpers";
 
 const REPO = resolve(fileURLToPath(import.meta.url), "..", "..");
 const EXAMPLES = join(REPO, "examples", "workflows");
+const HEADINGS = [
+  "RALPLAN-DR",
+  "Architecture Decision Record",
+  "Task Breakdown",
+  "Dependency Graph",
+  "Acceptance Criteria",
+  "Risk Register",
+];
 
-function result(value: unknown): SubagentResult {
+function workflow(name: string): string {
+  return readFileSync(join(EXAMPLES, name), "utf8");
+}
+
+function json(value: unknown): SubagentResult {
   return {
     isError: false,
     output: JSON.stringify(value),
@@ -44,28 +56,33 @@ function failed(): SubagentResult {
   };
 }
 
-function workflow(name: string): string {
-  return readFileSync(join(EXAMPLES, name), "utf8");
+function paths(root: string, round: number) {
+  return {
+    draft: `${root}/drafts/plan_draft-r${round}.md`,
+    architect: `${root}/drafts/architect_review-r${round}.md`,
+    critic: `${root}/drafts/critic_review-r${round}.md`,
+    final: `${root}/plan.md`,
+  };
 }
 
-const draft = {
-  principles: ["safe", "small", "tested"],
-  decisionDrivers: ["safety", "compatibility", "delivery"],
-  options: [
-    { name: "A", pros: ["safe"], cons: ["slow"] },
-    { name: "B", pros: ["fast"], cons: ["risk"] },
-  ],
-  planBody: "immutable snapshot",
-  openQuestions: [],
-};
-
-function planner(): unknown {
-  return { verdict: "DRAFT_READY", draft };
+function verification(path: string, round: number, kind: string, valid = true) {
+  return {
+    valid,
+    path,
+    round,
+    kind,
+    sizeBytes: valid ? 100 : 0,
+    sha256: `digest-${round}-${kind}`,
+    headings: HEADINGS,
+    issues: valid ? [] : ["invalid"],
+  };
 }
 
-function architect(verdict = "APPROVE"): unknown {
+function architect(path: string, round: number, verdict = "APPROVE") {
   return {
     verdict,
+    draftDigest: `digest-${round}-draft`,
+    reviewPath: path,
     steelman: "alternative",
     tradeoffTension: "speed versus safety",
     principleViolations: verdict === "APPROVE" ? [] : ["safety"],
@@ -73,35 +90,87 @@ function architect(verdict = "APPROVE"): unknown {
   };
 }
 
-function critic(verdict = "APPROVE"): unknown {
+function critic(path: string, round: number, verdict = "APPROVE") {
   return {
     verdict,
-    findings:
-      verdict === "APPROVE"
-        ? []
-        : [{ severity: "MAJOR", area: "risk", evidence: "`risk`" }],
+    draftDigest: `digest-${round}-draft`,
+    reviewPath: path,
+    findings: [],
     summary: "critic result",
-    preMortemStatus: "missing",
-    testPlanStatus: "missing",
   };
 }
 
-describe("ralplan Phase 1 contracts", () => {
-  it("reviews one immutable planner snapshot in order without Architect leakage", async () => {
-    const prompts: Record<string, string> = {};
+function occRunner(
+  root: string,
+  options: {
+    architectVerdict?: (round: number) => string;
+    criticVerdict?: (round: number) => string;
+    prompts?: Record<string, string[]>;
+  } = {},
+): WorkflowAgentRunner {
+  let round = 0;
+  return async ({ label, prompt }) => {
+    if (options.prompts) {
+      const promptList = (options.prompts[label ?? ""] ??= []);
+      promptList.push(String(prompt));
+    }
+    if (label === "planner") {
+      round++;
+      return json({
+        verdict: "DRAFT_READY",
+        path: paths(root, round).draft,
+        round,
+        summary: `draft ${round}`,
+      });
+    }
+    if (label === "verify-draft")
+      return json(verification(paths(root, round).draft, round, "draft"));
+    if (label === "architect")
+      return json(
+        architect(
+          paths(root, round).architect,
+          round,
+          options.architectVerdict?.(round) ?? "APPROVE",
+        ),
+      );
+    if (label === "critic")
+      return json(
+        critic(
+          paths(root, round).critic,
+          round,
+          options.criticVerdict?.(round) ?? "APPROVE",
+        ),
+      );
+    if (label === "verify-architect")
+      return json(
+        verification(paths(root, round).architect, round, "architect-review"),
+      );
+    if (label === "verify-critic")
+      return json(
+        verification(paths(root, round).critic, round, "critic-review"),
+      );
+    if (label === "consolidate")
+      return json({
+        verdict: "CONSOLIDATED",
+        path: paths(root, round).final,
+        sourceDraftDigest: `digest-${round}-draft`,
+        summary: "final",
+      });
+    if (label === "verify-final")
+      return json(verification(paths(root, round).final, round, "final-plan"));
+    throw new Error(`Unexpected label: ${label}`);
+  };
+}
+
+describe("ralplan independent review contracts", () => {
+  it("reviews one immutable artifact in order without Architect leakage", async () => {
+    const root = "/repo/plans";
+    const prompts: Record<string, string[]> = {};
     const labels: string[] = [];
-    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
-      labels.push(label ?? "");
-      if (label === "planner") return result(planner());
-      if (label === "architect") {
-        prompts.architect = String(prompt);
-        return result(architect());
-      }
-      if (label === "critic") {
-        prompts.critic = String(prompt);
-        return result(critic());
-      }
-      throw new Error(`Unexpected label: ${label}`);
+    const base = occRunner(root, { prompts });
+    const runner: WorkflowAgentRunner = async (input) => {
+      labels.push(input.label ?? "");
+      return base(input);
     };
 
     const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
@@ -109,41 +178,47 @@ describe("ralplan Phase 1 contracts", () => {
         idea: "force: review src/auth.ts",
         gate: false,
         maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
       },
       runAgent: runner,
     });
 
-    expect(labels).toEqual(["planner", "architect", "critic"]);
-    expect(prompts.architect).toContain("immutable snapshot");
-    expect(prompts.critic).toContain("immutable snapshot");
-    expect(prompts.critic).not.toContain("ARCHITECT REVIEW");
-    expect(prompts.critic).not.toContain("architect result");
+    expect(labels).toEqual([
+      "planner",
+      "verify-draft",
+      "architect",
+      "critic",
+      "verify-architect",
+      "verify-critic",
+      "consolidate",
+      "verify-final",
+    ]);
+    expect(prompts.architect[0]).toContain("plan_draft-r1.md");
+    expect(prompts.critic[0]).toContain("plan_draft-r1.md");
+    expect(prompts.critic[0]).not.toContain("architect_review-r1.md");
+    expect(prompts.critic[0]).not.toContain("architect result");
     expect(run.result).toMatchObject({
-      status: "consensus",
-      iterations: 1,
+      status: "pending_approval",
+      consensus: true,
       pending_approval: true,
       execution_halted: true,
     });
     expect(run.result).not.toHaveProperty("recommendedExecution");
   });
 
-  it("runs Critic after Architect revision and re-reviews on the next round", async () => {
+  it("runs Critic after Architect revision and re-reviews the next round", async () => {
+    const root = "/repo/plans";
+    const prompts: Record<string, string[]> = {};
     const labels: string[] = [];
-    const plannerPrompts: string[] = [];
-    let plannerCalls = 0;
-    const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
-      labels.push(label ?? "");
-      if (label === "planner") {
-        plannerCalls++;
-        plannerPrompts.push(String(prompt));
-        return result(planner());
-      }
-      if (label === "architect")
-        return result(
-          architect(plannerCalls === 1 ? "REVISION_NEEDED" : "APPROVE"),
-        );
-      if (label === "critic") return result(critic());
-      throw new Error(`Unexpected label: ${label}`);
+    const base = occRunner(root, {
+      prompts,
+      architectVerdict: (round) =>
+        round === 1 ? "REVISION_NEEDED" : "APPROVE",
+    });
+    const runner: WorkflowAgentRunner = async (input) => {
+      labels.push(input.label ?? "");
+      return base(input);
     };
 
     const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
@@ -151,31 +226,52 @@ describe("ralplan Phase 1 contracts", () => {
         idea: "force: review src/auth.ts",
         gate: false,
         maxIterations: 2,
+        artifactsDir: root,
+        planName: "plan",
       },
       runAgent: runner,
     });
 
-    expect(labels).toEqual([
-      "planner",
-      "architect",
-      "critic",
-      "planner",
-      "architect",
-      "critic",
-    ]);
-    expect(run.result).toMatchObject({ status: "consensus", iterations: 2 });
-    expect(plannerPrompts[0]).not.toContain("architect result");
-    expect(plannerPrompts[1]).toContain("architect result");
-    expect(plannerPrompts[1]).toContain("critic result");
+    expect(labels.filter((label) => label === "critic")).toHaveLength(2);
+    expect(prompts.planner[0]).not.toContain("architect result");
+    expect(prompts.planner[1]).toContain("architect result");
+    expect(prompts.planner[1]).toContain("critic result");
+    expect(run.result).toMatchObject({ consensus: true, iterations: 2 });
   });
 
-  it("treats missing reviewers as non-approval and clamps rounds to five", async () => {
+  it("treats reviewer errors as non-approval and clamps rounds to five", async () => {
+    const root = "/repo/plans";
+    let round = 0;
     const labels: string[] = [];
     const runner: WorkflowAgentRunner = async ({ label }) => {
       labels.push(label ?? "");
-      if (label === "planner") return result(planner());
+      if (label === "planner") {
+        round++;
+        return json({
+          verdict: "DRAFT_READY",
+          path: paths(root, round).draft,
+          round,
+          summary: "draft",
+        });
+      }
+      if (label === "verify-draft")
+        return json(verification(paths(root, round).draft, round, "draft"));
       if (label === "architect") return failed();
-      if (label === "critic") return result(critic("REJECT"));
+      if (label === "critic")
+        return json(critic(paths(root, round).critic, round, "REJECT"));
+      if (label === "verify-architect")
+        return json(
+          verification(
+            paths(root, round).architect,
+            round,
+            "architect-review",
+            false,
+          ),
+        );
+      if (label === "verify-critic")
+        return json(
+          verification(paths(root, round).critic, round, "critic-review"),
+        );
       throw new Error(`Unexpected label: ${label}`);
     };
 
@@ -184,31 +280,60 @@ describe("ralplan Phase 1 contracts", () => {
         idea: "force: review src/auth.ts",
         gate: false,
         maxIterations: 99,
+        artifactsDir: root,
+        planName: "plan",
         executeOnConsensus: true,
       },
       runAgent: runner,
     });
 
-    expect(labels).toHaveLength(15);
+    expect(labels.filter((label) => label === "planner")).toHaveLength(5);
+    expect(labels.filter((label) => label === "critic")).toHaveLength(5);
     expect(run.result).toMatchObject({
-      status: "no_consensus",
+      consensus: false,
       iterations: 5,
       capped: true,
+      status: "artifact_validation_failed",
       pending_approval: true,
       execution_halted: true,
+      executeOnConsensusIgnored: true,
     });
     expect(run.result).not.toHaveProperty("recommendedExecution");
-    expect(run.result).toHaveProperty("executeOnConsensusIgnored", true);
   });
 
   it("does not infer approval when a reviewer omits its verdict", async () => {
+    const root = "/repo/plans";
+    let round = 0;
     const labels: string[] = [];
     const runner: WorkflowAgentRunner = async ({ label }) => {
       labels.push(label ?? "");
-      if (label === "planner") return result(planner());
-      if (label === "architect")
-        return result({ steelman: "missing explicit verdict" });
-      if (label === "critic") return result(critic());
+      if (label === "planner") {
+        round++;
+        return json({
+          verdict: "DRAFT_READY",
+          path: paths(root, round).draft,
+          round,
+          summary: "draft",
+        });
+      }
+      if (label === "verify-draft")
+        return json(verification(paths(root, round).draft, round, "draft"));
+      if (label === "architect") return json({ steelman: "missing verdict" });
+      if (label === "critic")
+        return json(critic(paths(root, round).critic, round));
+      if (label === "verify-architect")
+        return json(
+          verification(
+            paths(root, round).architect,
+            round,
+            "architect-review",
+            false,
+          ),
+        );
+      if (label === "verify-critic")
+        return json(
+          verification(paths(root, round).critic, round, "critic-review"),
+        );
       throw new Error(`Unexpected label: ${label}`);
     };
 
@@ -217,23 +342,28 @@ describe("ralplan Phase 1 contracts", () => {
         idea: "force: review src/auth.ts",
         gate: false,
         maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
       },
       runAgent: runner,
     });
 
     expect(labels).toContain("critic");
     expect(run.result).toMatchObject({
-      status: "no_consensus",
-      lastVerdict: { architect: "MISSING", critic: "APPROVE" },
+      consensus: false,
+      status: "artifact_validation_failed",
       pending_approval: true,
       execution_halted: true,
     });
   });
 
-  it("halts without consensus when Planner output is missing", async () => {
+  it("clamps zero rounds to one and rejects missing Planner artifacts", async () => {
+    const root = "/repo/plans";
     const labels: string[] = [];
     const runner: WorkflowAgentRunner = async ({ label }) => {
       labels.push(label ?? "");
+      if (label === "verify-draft")
+        return json(verification(paths(root, 1).draft, 1, "draft", false));
       return failed();
     };
 
@@ -242,121 +372,130 @@ describe("ralplan Phase 1 contracts", () => {
         idea: "force: review src/auth.ts",
         gate: false,
         maxIterations: 0,
+        artifactsDir: root,
+        planName: "plan",
       },
       runAgent: runner,
     });
 
-    expect(labels).toEqual(["planner"]);
+    expect(labels.filter((label) => label === "verify-draft")).toHaveLength(1);
     expect(run.result).toMatchObject({
-      status: "no_planner_output",
+      consensus: false,
       iterations: 1,
+      status: "artifact_validation_failed",
       pending_approval: true,
       execution_halted: true,
     });
-    expect(run.result).not.toHaveProperty("recommendedExecution");
   });
 
-  it("keeps deliberate-mode hard gates in structured Planner output", async () => {
-    const runner: WorkflowAgentRunner = async ({ label }) => {
-      if (label === "planner") return result(planner());
-      if (label === "architect") return result(architect());
-      if (label === "critic") return result(critic());
-      throw new Error(`Unexpected label: ${label}`);
-    };
-
+  it("enforces deliberate artifact sections", async () => {
+    const root = "/repo/plans";
+    const runner = occRunner(root);
     const run = await runWorkflow(workflow("ralplan-occ.mjs"), {
       args: {
         idea: "force: review src/auth.ts",
         gate: false,
         deliberate: true,
         maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
       },
       runAgent: runner,
     });
 
     expect(run.result).toMatchObject({
-      status: "no_consensus",
+      consensus: false,
+      status: "artifact_validation_failed",
       pending_approval: true,
       execution_halted: true,
-      deliberate: { valid: false },
     });
   });
 
   it("honors gate false and makes interactive markers non-blocking", async () => {
-    const runner: WorkflowAgentRunner = async ({ label }) => {
-      if (label === "planner") return result(planner());
-      if (label === "architect") return result(architect());
-      if (label === "critic") return result(critic());
-      throw new Error(`Unexpected label: ${label}`);
-    };
-
+    const root = "/repo/plans";
     const bypassed = await runWorkflow(workflow("ralplan-occ.mjs"), {
       args: {
         idea: "plan something",
         gate: false,
         interactive: false,
         maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
       },
-      runAgent: runner,
+      runAgent: occRunner(root),
     });
     const gated = await runWorkflow(workflow("ralplan-occ.mjs"), {
-      args: {
-        idea: "plan something",
-        gate: true,
-        interactive: true,
-        maxIterations: 1,
+      args: { idea: "plan something", gate: true, interactive: true },
+      runAgent: async () => {
+        throw new Error("gate should not spawn agents");
       },
-      runAgent: runner,
     });
 
     expect(bypassed.result).toMatchObject({
       gate: { enabled: false },
-      interactive: { enabled: false },
+      interactive: { enabled: false, blocking: false },
     });
     expect(gated.result).toMatchObject({
       gated: true,
+      interactive: { enabled: true, blocking: false },
       pending_approval: true,
       execution_halted: true,
     });
-    expect(gated.result).not.toHaveProperty("recommendedExecution");
   });
 
-  it("keeps the smaller consensus example independent and pending", async () => {
+  it("keeps the compact example independent, verified, and pending", async () => {
+    const root = "/repo/plans";
     const prompts: Record<string, string> = {};
     const runner: WorkflowAgentRunner = async ({ label, prompt }) => {
+      prompts[label ?? ""] = String(prompt);
       if (label === "planner-1")
-        return result({ verdict: "DRAFT_READY", draft });
-      if (label === "architect-1") {
-        prompts.architect = String(prompt);
-        return result(architect());
-      }
-      if (label === "critic-1") {
-        prompts.critic = String(prompt);
-        return result(critic());
-      }
-      if (label === "consolidate") {
-        return result({
-          verdict: "CONSOLIDATED",
-          path: "plans/plan.md",
-          summary: "done",
+        return json({
+          verdict: "DRAFT_READY",
+          path: paths(root, 1).draft,
+          round: 1,
+          summary: "draft",
         });
-      }
+      if (label === "verify-draft-1")
+        return json(verification(paths(root, 1).draft, 1, "draft"));
+      if (label === "architect-1")
+        return json(architect(paths(root, 1).architect, 1));
+      if (label === "critic-1") return json(critic(paths(root, 1).critic, 1));
+      if (label === "verify-architect-1")
+        return json(
+          verification(paths(root, 1).architect, 1, "architect-review"),
+        );
+      if (label === "verify-critic-1")
+        return json(verification(paths(root, 1).critic, 1, "critic-review"));
+      if (label === "consolidate")
+        return json({
+          verdict: "CONSOLIDATED",
+          path: paths(root, 1).final,
+          sourceDraftDigest: "digest-1-draft",
+          summary: "final",
+        });
+      if (label === "verify-final")
+        return json(verification(paths(root, 1).final, 1, "final-plan"));
       throw new Error(`Unexpected label: ${label}`);
     };
 
     const run = await runWorkflow(workflow("ralplan-consensus.mjs"), {
-      args: { idea: "review src/auth.ts", maxIterations: 1 },
+      args: {
+        idea: "review src/auth.ts",
+        maxIterations: 1,
+        artifactsDir: root,
+        planName: "plan",
+      },
       runAgent: runner,
     });
 
-    expect(prompts.critic).toContain("immutable snapshot");
-    expect(prompts.critic).not.toContain("ARCHITECT REVIEW");
+    expect(prompts["critic-1"]).toContain("plan_draft-r1.md");
+    expect(prompts["critic-1"]).not.toContain("architect_review-r1.md");
     expect(run.result).toMatchObject({
       consensus: true,
+      status: "pending_approval",
       pending_approval: true,
       execution_halted: true,
     });
-    expect(run.result).not.toHaveProperty("recommendedExecution");
   });
 
   it("remains parseable", () => {

--- a/tests/workflow-examples.test.ts
+++ b/tests/workflow-examples.test.ts
@@ -48,6 +48,26 @@ function json(value: unknown): SubagentResult {
   return ok(JSON.stringify(value));
 }
 
+function verifiedArtifact(path: string, kind: string) {
+  return {
+    valid: true,
+    path,
+    round: 1,
+    kind,
+    sizeBytes: 512,
+    sha256: `digest-${kind}`,
+    headings: [
+      "RALPLAN-DR",
+      "Architecture Decision Record",
+      "Task Breakdown",
+      "Dependency Graph",
+      "Acceptance Criteria",
+      "Risk Register",
+    ],
+    issues: [],
+  };
+}
+
 function script(name: string): string {
   return readFileSync(join(EXAMPLES, name), "utf8");
 }
@@ -85,38 +105,62 @@ describe("bundled workflow examples", () => {
         maxIterations: 1,
         artifactsDir,
       };
+      const draftPath = join(artifactsDir, "drafts", "plan_draft-r1.md");
+      const architectPath = join(
+        artifactsDir,
+        "drafts",
+        "architect_review-r1.md",
+      );
+      const criticPath = join(artifactsDir, "drafts", "critic_review-r1.md");
+      const finalPath = join(artifactsDir, "plan.md");
       const runner: WorkflowAgentRunner = async ({ label }) => {
         if (label === "planner-1") {
           return json({
             verdict: "DRAFT_READY",
-            path: join(artifactsDir, "drafts", "plan_draft.md"),
-            adrSummary: "ADR",
+            path: draftPath,
+            round: 1,
             summary: "draft",
           });
+        }
+        if (label === "verify-draft-1") {
+          return json(verifiedArtifact(draftPath, "draft"));
         }
         if (label === "architect-1") {
           return json({
             verdict: "APPROVE",
-            issues: [],
+            draftDigest: "digest-draft",
+            reviewPath: architectPath,
             steelman: "alternative",
             tradeoffTension: "speed versus safety",
+            principleViolations: [],
             summary: "approved",
           });
         }
         if (label === "critic-1") {
           return json({
             verdict: "APPROVE",
-            gaps: [],
-            selfAudit: "checked",
+            draftDigest: "digest-draft",
+            reviewPath: criticPath,
+            findings: [],
             summary: "approved",
           });
+        }
+        if (label === "verify-architect-1") {
+          return json(verifiedArtifact(architectPath, "architect-review"));
+        }
+        if (label === "verify-critic-1") {
+          return json(verifiedArtifact(criticPath, "critic-review"));
         }
         if (label === "consolidate") {
           return json({
             verdict: "CONSOLIDATED",
-            path: join(artifactsDir, "plan.md"),
+            path: finalPath,
+            sourceDraftDigest: "digest-draft",
             summary: "done",
           });
+        }
+        if (label === "verify-final") {
+          return json(verifiedArtifact(finalPath, "final-plan"));
         }
         throw new Error(`Unexpected label: ${label}`);
       };
@@ -150,40 +194,60 @@ describe("bundled workflow examples", () => {
         executeOnConsensus: true,
       };
       const models = new Map<string, string | undefined>();
+      const plansDir = join(root, "plans");
+      const draftPath = join(plansDir, "drafts", "auth-review_draft-r1.md");
+      const architectPath = join(plansDir, "drafts", "architect_review-r1.md");
+      const criticPath = join(plansDir, "drafts", "critic_review-r1.md");
+      const finalPath = join(plansDir, "auth-review.md");
       const runner: WorkflowAgentRunner = async ({ label, model }) => {
         models.set(label ?? "", model);
         if (label === "planner") {
           return json({
             verdict: "DRAFT_READY",
-            principles: ["safe", "small", "tested"],
-            decisionDrivers: ["security", "compatibility", "delivery"],
-            options: [
-              { name: "A", pros: ["safe"], cons: ["slow"] },
-              { name: "B", pros: ["fast"], cons: ["risk"] },
-            ],
-            invalidatedOptions: [],
-            planBody: "Plan",
-            openQuestions: [],
+            path: draftPath,
+            round: 1,
+            summary: "draft",
           });
+        }
+        if (label === "verify-draft") {
+          return json(verifiedArtifact(draftPath, "draft"));
         }
         if (label === "architect") {
           return json({
             verdict: "APPROVE",
-            summary: "sound",
+            draftDigest: "digest-draft",
+            reviewPath: architectPath,
             steelman: "keep the old design",
             tradeoffTension: "speed versus safety",
-            synthesis: "stage the change",
             principleViolations: [],
+            summary: "sound",
           });
         }
         if (label === "critic") {
           return json({
             verdict: "APPROVE",
-            summary: "accepted",
+            draftDigest: "digest-draft",
+            reviewPath: criticPath,
             findings: [],
-            preMortemStatus: "present-3",
-            testPlanStatus: "complete",
+            summary: "accepted",
           });
+        }
+        if (label === "verify-architect") {
+          return json(verifiedArtifact(architectPath, "architect-review"));
+        }
+        if (label === "verify-critic") {
+          return json(verifiedArtifact(criticPath, "critic-review"));
+        }
+        if (label === "consolidate") {
+          return json({
+            verdict: "CONSOLIDATED",
+            path: finalPath,
+            sourceDraftDigest: "digest-draft",
+            summary: "done",
+          });
+        }
+        if (label === "verify-final") {
+          return json(verifiedArtifact(finalPath, "final-plan"));
         }
         throw new Error(`Unexpected label: ${label}`);
       };
@@ -194,7 +258,7 @@ describe("bundled workflow examples", () => {
       });
 
       expect(run.result).toMatchObject({
-        status: "consensus",
+        status: "pending_approval",
         iterations: 1,
         artifactPaths: { plan: join(root, "plans", "auth-review.md") },
         pending_approval: true,


### PR DESCRIPTION
## Summary

Phase 2 of #107, stacked on #120.

- Adds immutable per-round draft and review artifact paths to both RALPLAN examples.
- Adds independent read-only artifact-verifier agents for exact path, regular-file/symlink, 1 MB size, required-heading, round/kind, source identity, and SHA-256 checks.
- Requires reviewers to bind their outputs to the verified draft digest.
- Writes and verifies the final plan only after both independent explicit approvals.
- Adds optional advisory Analyst requirements traceability and coverage-map gates; Analyst is not a consensus role.
- Updates bundled skill/prompts/docs/tarball coverage and focused regression tests.

No host approval/state or durable execution is included; those are the next stacked phases. A valid artifact remains pending and execution-halted.

## Verification

- `npm test` — 73 files, 1694 tests
- `npm run typecheck`
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`
