### PR TITLE
feat(ralplan): add host approval state

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ The extension registers these public tools for parent agents.
 | `get_workflow_status`                   | Inspect a background workflow                                     |
 | `get_workflow_result`                   | Wait for and return a workflow result                             |
 | `cancel_workflow`                       | Cancel a background workflow                                      |
+| `get_ralplan_status`                    | Inspect owner/session-scoped RALPLAN state                        |
+| `approve_ralplan`                       | Approve an exact run and plan digest without executing            |
+| `reject_ralplan`                        | Reject a pending RALPLAN run terminally                           |
+| `cancel_ralplan`                        | Cancel the exact active RALPLAN planning workflow                 |
+| `prepare_ralplan_recovery`              | Return same-session interrupted evidence read-only                |
 | `subagent_with_context`                 | Delegate with the parent conversation                             |
 | `subagent_isolated`                     | Delegate with a fresh context                                     |
 | `get_subagent_status`                   | Inspect an async in-process job                                   |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -149,6 +149,29 @@ workflow({
   terminal result remains `pending_approval: true` and
   `execution_halted: true`.
 
+## Host-owned RALPLAN state and approval
+
+Canonical RALPLAN workflows launched through the extension's `workflow` tool
+create a bounded mode-0600 `.pi/ralplan-state.json` record before planning
+settles. The record is bound to canonical cwd, exact session owner generation,
+parent session id, workflow id, and a random run id. Verified consensus advances
+to `pending_approval` and stores the exact final-plan digest.
+
+Host tools are explicit:
+
+- `get_ralplan_status` lists exact-owner records and same-parent-session
+  interrupted evidence;
+- `approve_ralplan` requires matching `{runId, planDigest}`, deactivates the
+  record, and returns `approved_handoff` without executing;
+- `reject_ralplan` and `cancel_ralplan` are owner/session-scoped terminal actions;
+- `prepare_ralplan_recovery` returns interrupted evidence read-only and never
+  replays agents or resumes automatically.
+
+Workflow session shutdown cancels live jobs first, then records `interrupted`
+for reload/resume/quit and `cancelled` for new/fork. Capped, failed, and rejected
+planning exits are inactive. Stale owner generations or parent sessions cannot
+approve, reject, cancel, or recover another run.
+
 ## Workflow tool pitfalls
 
 These are the failure modes we hit while building the converters above. Document them before designing new workflows.

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -135,6 +135,13 @@ agents because the workflow VM exposes no filesystem API. Actual approval and
 execution routing belong to the host; the VM cannot suspend for user input or
 convert marker text, a digest, or a valid plan into approval.
 
+When launched through the extension's `workflow` tool, canonical RALPLAN runs
+receive a host-owned run id and mode-0600 `.pi/ralplan-state.json` record.
+Use `get_ralplan_status`, `approve_ralplan`, `reject_ralplan`,
+`cancel_ralplan`, and `prepare_ralplan_recovery`. Approval is bound to the
+exact run/digest and records an inactive handoff; no tool in this phase executes
+the plan. Reload/resume/quit preserve interrupted evidence without replay.
+
 ### `ralplan-from-skill.mjs`
 
 A generated, self-contained RALPLAN example derived from the bundled skill.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "src/session-scope.ts",
     "src/subagent.ts",
     "src/subagent-artifact-cli.ts",
+    "src/ralplan-state.ts",
+    "src/ralplan-tool.ts",
     "src/workflow.ts",
     "src/workflow-core.ts",
     "src/workflow-script.ts",

--- a/skills/ralplan/README.md
+++ b/skills/ralplan/README.md
@@ -31,6 +31,15 @@ The workflow VM cannot pause for user approval. `interactive` only controls
 non-blocking markers. `executeOnConsensus` is ignored compatibility input. A
 plan, digest, completion marker, or consensus result never authorizes execution.
 
+## Host approval
+
+The extension persists owner/session-scoped state in mode-0600
+`.pi/ralplan-state.json`. Inspect with `get_ralplan_status`; explicitly approve
+an exact `{runId, planDigest}` with `approve_ralplan`, or use
+`reject_ralplan`/`cancel_ralplan`. `prepare_ralplan_recovery` exposes
+same-session interrupted evidence read-only and never auto-resumes work.
+Approval records an inactive `approved_handoff`; it does not execute the plan.
+
 ## Install
 
 ```bash

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -103,14 +103,35 @@ local short-prompt heuristic. `interactive` controls only non-blocking
 `executeOnConsensus` is accepted only for compatibility, reported as ignored,
 and never changes approval or execution state.
 
+## Host-owned approval and recovery
+
+The extension persists bounded mode-0600 state at `.pi/ralplan-state.json`,
+keyed to canonical project cwd, exact parent owner generation, and parent
+session id. Workflow start records `planning`; verified consensus records
+`pending_approval` with the exact final-plan digest. Other terminal paths record
+`rejected`, `capped`, `cancelled`, `failed`, or `interrupted` evidence.
+
+Use explicit host tools:
+
+- `get_ralplan_status` — inspect current or same-session interrupted evidence;
+- `approve_ralplan` — approve exactly `{runId, planDigest}`; it deactivates state
+  before returning `approved_handoff` and starts no execution;
+- `reject_ralplan` — reject a pending run terminally;
+- `cancel_ralplan` — cancel the exact owner-scoped planning workflow;
+- `prepare_ralplan_recovery` — return read-only interrupted evidence only.
+
+Reload/resume/quit interrupt active runs; new/fork cancel them. Recovery never
+replays model work or resumes automatically. Stale owners, generations, sessions,
+run IDs, and digest mismatches cannot approve, reject, or cancel a run.
+
 ## Safety boundary
 
 Planning agents may write only the bounded Markdown paths above. They never edit
 source, execute, delegate implementation, commit, or push. Every terminal result
 has `pending_approval: true` and `execution_halted: true`. Missing consensus,
 cap exhaustion, cancellation, or artifact failure has no `ralph`, `team`,
-autopilot, or other executable recommendation. Host-owned approval/state and
-durable execution are separate contracts.
+autopilot, or other executable recommendation. Host approval records only an
+approved handoff; durable declarative execution remains a separate contract.
 
 If the host cannot provide isolated role execution, stop with:
 

--- a/src/ralplan-state.ts
+++ b/src/ralplan-state.ts
@@ -1,0 +1,600 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { dirname, join, resolve } from "node:path";
+import type { SessionOwnerToken } from "./session-scope";
+
+export const RALPLAN_STATE_SCHEMA_VERSION = 1;
+export const MAX_RALPLAN_STATE_BYTES = 1_000_000;
+export const MAX_RALPLAN_RECORDS = 128;
+const MAX_PATH_CHARS = 4096;
+
+export type RalplanPhase =
+  | "planning"
+  | "reviewing"
+  | "pending_approval"
+  | "approved_handoff"
+  | "rejected"
+  | "capped"
+  | "cancelled"
+  | "failed"
+  | "interrupted";
+
+export type RalplanApprovalStatus =
+  "pending" | "approved" | "rejected" | "unavailable";
+
+export interface RalplanArtifactPaths {
+  plan?: string;
+  drafts: string[];
+  architectReviews: string[];
+  criticReviews: string[];
+}
+
+export interface RalplanRunRecord {
+  runId: string;
+  workflowId: string;
+  workflowName: string;
+  cwd: string;
+  owner: SessionOwnerToken;
+  parentSessionId?: string;
+  phase: RalplanPhase;
+  approvalStatus: RalplanApprovalStatus;
+  active: boolean;
+  artifactPaths: RalplanArtifactPaths;
+  planDigest?: string;
+  sourceDraftDigest?: string;
+  createdAt: number;
+  updatedAt: number;
+  deactivationReason?: string;
+}
+
+interface RalplanStateFile {
+  schemaVersion: 1;
+  records: RalplanRunRecord[];
+}
+
+interface RalplanBinding {
+  cwd: string;
+  runId: string;
+}
+
+const workflowBindings = new Map<string, RalplanBinding>();
+
+function canonicalCwd(cwd: string): string {
+  const absolute = resolve(cwd);
+  try {
+    return realpathSync(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+export function ralplanStatePath(cwd: string): string {
+  return join(canonicalCwd(cwd), ".pi", "ralplan-state.json");
+}
+
+function emptyState(): RalplanStateFile {
+  return { schemaVersion: RALPLAN_STATE_SCHEMA_VERSION, records: [] };
+}
+
+function isOwner(value: unknown): value is SessionOwnerToken {
+  if (!value || typeof value !== "object") return false;
+  const owner = value as Record<string, unknown>;
+  return Number.isInteger(owner.id) && Number.isInteger(owner.generation);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= 64 &&
+    value.every(
+      (item) =>
+        typeof item === "string" &&
+        item.length > 0 &&
+        item.length <= MAX_PATH_CHARS,
+    )
+  );
+}
+
+function isArtifactPaths(value: unknown): value is RalplanArtifactPaths {
+  if (!value || typeof value !== "object") return false;
+  const paths = value as Record<string, unknown>;
+  return (
+    (paths.plan === undefined ||
+      (typeof paths.plan === "string" &&
+        paths.plan.length > 0 &&
+        paths.plan.length <= MAX_PATH_CHARS)) &&
+    isStringArray(paths.drafts) &&
+    isStringArray(paths.architectReviews) &&
+    isStringArray(paths.criticReviews)
+  );
+}
+
+const PHASES = new Set<RalplanPhase>([
+  "planning",
+  "reviewing",
+  "pending_approval",
+  "approved_handoff",
+  "rejected",
+  "capped",
+  "cancelled",
+  "failed",
+  "interrupted",
+]);
+const APPROVALS = new Set<RalplanApprovalStatus>([
+  "pending",
+  "approved",
+  "rejected",
+  "unavailable",
+]);
+
+function isRecord(value: unknown): value is RalplanRunRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.runId === "string" &&
+    /^rp_[a-f0-9]{20}$/.test(record.runId) &&
+    typeof record.workflowId === "string" &&
+    record.workflowId.length > 0 &&
+    typeof record.workflowName === "string" &&
+    record.workflowName.length > 0 &&
+    typeof record.cwd === "string" &&
+    record.cwd.length > 0 &&
+    isOwner(record.owner) &&
+    (record.parentSessionId === undefined ||
+      typeof record.parentSessionId === "string") &&
+    typeof record.phase === "string" &&
+    PHASES.has(record.phase as RalplanPhase) &&
+    typeof record.approvalStatus === "string" &&
+    APPROVALS.has(record.approvalStatus as RalplanApprovalStatus) &&
+    typeof record.active === "boolean" &&
+    isArtifactPaths(record.artifactPaths) &&
+    (record.planDigest === undefined ||
+      typeof record.planDigest === "string") &&
+    (record.sourceDraftDigest === undefined ||
+      typeof record.sourceDraftDigest === "string") &&
+    typeof record.createdAt === "number" &&
+    Number.isFinite(record.createdAt) &&
+    typeof record.updatedAt === "number" &&
+    Number.isFinite(record.updatedAt) &&
+    (record.deactivationReason === undefined ||
+      typeof record.deactivationReason === "string")
+  );
+}
+
+function validateState(value: unknown): RalplanStateFile {
+  if (!value || typeof value !== "object") {
+    throw new Error("RALPLAN state schema is invalid");
+  }
+  const state = value as Record<string, unknown>;
+  if (
+    state.schemaVersion !== RALPLAN_STATE_SCHEMA_VERSION ||
+    !Array.isArray(state.records) ||
+    state.records.length > MAX_RALPLAN_RECORDS ||
+    !state.records.every(isRecord)
+  ) {
+    throw new Error("RALPLAN state schema is invalid");
+  }
+  return state as unknown as RalplanStateFile;
+}
+
+function readState(cwd: string): RalplanStateFile {
+  const path = ralplanStatePath(cwd);
+  if (!existsSync(path)) return emptyState();
+  if (lstatSync(path).isSymbolicLink()) {
+    throw new Error("RALPLAN state path must not be a symbolic link");
+  }
+  const stats = statSync(path);
+  if (!stats.isFile())
+    throw new Error("RALPLAN state path is not a regular file");
+  if (stats.size > MAX_RALPLAN_STATE_BYTES) {
+    throw new Error("RALPLAN state file is too large");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `RALPLAN state JSON is invalid: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return validateState(parsed);
+}
+
+function writeState(cwd: string, state: RalplanStateFile): void {
+  const boundedRecords = state.records.slice(-MAX_RALPLAN_RECORDS);
+  const content = `${JSON.stringify({
+    schemaVersion: RALPLAN_STATE_SCHEMA_VERSION,
+    records: boundedRecords,
+  })}\n`;
+  if (Buffer.byteLength(content) > MAX_RALPLAN_STATE_BYTES) {
+    throw new Error("RALPLAN state exceeds the bounded file size");
+  }
+  const path = ralplanStatePath(cwd);
+  const directory = dirname(path);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  if (lstatSync(directory).isSymbolicLink()) {
+    throw new Error("RALPLAN state directory must not be a symbolic link");
+  }
+  const temp = `${path}.tmp-${process.pid}-${randomBytes(6).toString("hex")}`;
+  try {
+    writeFileSync(temp, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    chmodSync(temp, 0o600);
+    renameSync(temp, path);
+    chmodSync(path, 0o600);
+  } finally {
+    try {
+      if (existsSync(temp)) unlinkSync(temp);
+    } catch {
+      /* a failed cleanup must not hide the original persistence result */
+    }
+  }
+}
+
+function emptyArtifacts(): RalplanArtifactPaths {
+  return { drafts: [], architectReviews: [], criticReviews: [] };
+}
+
+function cleanPath(value: unknown): string | undefined {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_PATH_CHARS
+    ? value
+    : undefined;
+}
+
+function cleanPaths(value: unknown): RalplanArtifactPaths {
+  if (!value || typeof value !== "object") return emptyArtifacts();
+  const paths = value as Record<string, unknown>;
+  const list = (entry: unknown): string[] =>
+    Array.isArray(entry)
+      ? entry
+          .map(cleanPath)
+          .filter((item): item is string => item !== undefined)
+          .slice(0, 64)
+      : [];
+  return {
+    ...(cleanPath(paths.plan) ? { plan: cleanPath(paths.plan) } : {}),
+    drafts: list(paths.drafts),
+    architectReviews: list(paths.architectReviews),
+    criticReviews: list(paths.criticReviews),
+  };
+}
+
+function upsertRecord(cwd: string, record: RalplanRunRecord): RalplanRunRecord {
+  const state = readState(cwd);
+  const index = state.records.findIndex((item) => item.runId === record.runId);
+  if (index >= 0) state.records[index] = record;
+  else state.records.push(record);
+  writeState(cwd, state);
+  return record;
+}
+
+function bindingFor(workflowId: string): RalplanBinding | undefined {
+  return workflowBindings.get(workflowId);
+}
+
+export function isRalplanWorkflowName(name: string): boolean {
+  return name === "ralplan-occ" || name === "ralplan-consensus";
+}
+
+export function createRalplanRun(input: {
+  cwd: string;
+  workflowId: string;
+  workflowName: string;
+  owner: SessionOwnerToken;
+  parentSessionId?: string;
+  now?: number;
+}): RalplanRunRecord {
+  if (!isRalplanWorkflowName(input.workflowName)) {
+    throw new Error(
+      "Only canonical RALPLAN workflows may create RALPLAN state",
+    );
+  }
+  const cwd = canonicalCwd(input.cwd);
+  const existing = getRalplanRunForWorkflow(cwd, input.workflowId);
+  if (existing) return existing;
+  const now = input.now ?? Date.now();
+  const record: RalplanRunRecord = {
+    runId: `rp_${randomBytes(10).toString("hex")}`,
+    workflowId: input.workflowId,
+    workflowName: input.workflowName,
+    cwd,
+    owner: { ...input.owner },
+    parentSessionId: input.parentSessionId,
+    phase: "planning",
+    approvalStatus: "pending",
+    active: true,
+    artifactPaths: emptyArtifacts(),
+    createdAt: now,
+    updatedAt: now,
+  };
+  workflowBindings.set(input.workflowId, { cwd, runId: record.runId });
+  return upsertRecord(cwd, record);
+}
+
+export function getRalplanRunById(
+  cwd: string,
+  runId: string,
+): RalplanRunRecord | undefined {
+  return readState(cwd).records.find((record) => record.runId === runId);
+}
+
+export function getRalplanRunForWorkflow(
+  cwd: string,
+  workflowId: string,
+): RalplanRunRecord | undefined {
+  const binding = bindingFor(workflowId);
+  const canonical = canonicalCwd(cwd);
+  if (binding?.cwd === canonical) {
+    return getRalplanRunById(canonical, binding.runId);
+  }
+  const record = readState(canonical).records.find(
+    (item) => item.workflowId === workflowId,
+  );
+  if (record)
+    workflowBindings.set(workflowId, { cwd: canonical, runId: record.runId });
+  return record;
+}
+
+export function markRalplanReviewing(input: {
+  cwd: string;
+  workflowId: string;
+  now?: number;
+}): RalplanRunRecord {
+  const record = getRalplanRunForWorkflow(input.cwd, input.workflowId);
+  if (!record)
+    throw new Error(`RALPLAN workflow ${input.workflowId} is not registered`);
+  if (!record.active || record.phase !== "planning") return record;
+  return upsertRecord(record.cwd, {
+    ...record,
+    phase: "reviewing",
+    updatedAt: input.now ?? Date.now(),
+  });
+}
+
+export function completeRalplanRun(input: {
+  cwd: string;
+  workflowId: string;
+  result: unknown;
+  now?: number;
+}): RalplanRunRecord {
+  const record = getRalplanRunForWorkflow(input.cwd, input.workflowId);
+  if (!record)
+    throw new Error(`RALPLAN workflow ${input.workflowId} is not registered`);
+  const result =
+    input.result && typeof input.result === "object"
+      ? (input.result as Record<string, unknown>)
+      : {};
+  const now = input.now ?? Date.now();
+  const artifactPaths = cleanPaths(result.artifactPaths);
+  const consensus = result.consensus === true;
+  const pending = result.pending_approval === true;
+  const planDigest = cleanPath(result.planDigest);
+  let phase: RalplanPhase;
+  let approvalStatus: RalplanApprovalStatus;
+  let active: boolean;
+  let deactivationReason: string | undefined;
+  if (consensus && pending && planDigest && artifactPaths.plan) {
+    phase = "pending_approval";
+    approvalStatus = "pending";
+    active = true;
+  } else if (result.capped === true) {
+    phase = "capped";
+    approvalStatus = "unavailable";
+    active = false;
+    deactivationReason = "planning round cap reached";
+  } else if (result.status === "no_consensus") {
+    phase = "rejected";
+    approvalStatus = "unavailable";
+    active = false;
+    deactivationReason = "planning consensus not reached";
+  } else {
+    phase = "failed";
+    approvalStatus = "unavailable";
+    active = false;
+    deactivationReason = `planning ended with status ${String(result.status ?? "unknown")}`;
+  }
+  return upsertRecord(record.cwd, {
+    ...record,
+    phase,
+    approvalStatus,
+    active,
+    artifactPaths,
+    planDigest,
+    sourceDraftDigest: cleanPath(result.sourceDraftDigest),
+    updatedAt: now,
+    ...(deactivationReason ? { deactivationReason } : {}),
+  });
+}
+
+export function failRalplanRun(input: {
+  cwd?: string;
+  workflowId: string;
+  reason: string;
+  phase?: "failed" | "cancelled";
+  now?: number;
+}): RalplanRunRecord {
+  const binding = input.cwd
+    ? {
+        cwd: canonicalCwd(input.cwd),
+        runId: getRalplanRunForWorkflow(input.cwd, input.workflowId)?.runId,
+      }
+    : bindingFor(input.workflowId);
+  if (!binding?.runId)
+    throw new Error(`RALPLAN workflow ${input.workflowId} is not registered`);
+  const record = getRalplanRunById(binding.cwd, binding.runId);
+  if (!record)
+    throw new Error(`RALPLAN run for workflow ${input.workflowId} is missing`);
+  return upsertRecord(record.cwd, {
+    ...record,
+    phase: input.phase ?? "failed",
+    approvalStatus: "unavailable",
+    active: false,
+    updatedAt: input.now ?? Date.now(),
+    deactivationReason: input.reason,
+  });
+}
+
+function exactOwner(
+  record: RalplanRunRecord,
+  owner: SessionOwnerToken,
+): boolean {
+  return (
+    record.owner.id === owner.id && record.owner.generation === owner.generation
+  );
+}
+
+function requirePendingOwned(input: {
+  cwd: string;
+  runId: string;
+  owner: SessionOwnerToken;
+  parentSessionId?: string;
+}): RalplanRunRecord {
+  const record = getRalplanRunById(input.cwd, input.runId);
+  if (!record) throw new Error("RALPLAN run not found");
+  if (!exactOwner(record, input.owner))
+    throw new Error("RALPLAN owner mismatch");
+  if (record.parentSessionId !== input.parentSessionId) {
+    throw new Error("RALPLAN parent session mismatch");
+  }
+  if (
+    !record.active ||
+    record.phase !== "pending_approval" ||
+    record.approvalStatus !== "pending"
+  ) {
+    throw new Error("RALPLAN run is not pending approval");
+  }
+  return record;
+}
+
+export function approveRalplanRun(input: {
+  cwd: string;
+  runId: string;
+  planDigest: string;
+  owner: SessionOwnerToken;
+  parentSessionId?: string;
+  now?: number;
+}): RalplanRunRecord {
+  const record = requirePendingOwned(input);
+  if (record.planDigest !== input.planDigest) {
+    throw new Error("RALPLAN plan digest mismatch");
+  }
+  return upsertRecord(record.cwd, {
+    ...record,
+    phase: "approved_handoff",
+    approvalStatus: "approved",
+    active: false,
+    updatedAt: input.now ?? Date.now(),
+    deactivationReason: "explicit host approval recorded",
+  });
+}
+
+export function rejectRalplanRun(input: {
+  cwd: string;
+  runId: string;
+  owner: SessionOwnerToken;
+  parentSessionId?: string;
+  reason: string;
+  now?: number;
+}): RalplanRunRecord {
+  const record = requirePendingOwned(input);
+  return upsertRecord(record.cwd, {
+    ...record,
+    phase: "rejected",
+    approvalStatus: "rejected",
+    active: false,
+    updatedAt: input.now ?? Date.now(),
+    deactivationReason: input.reason,
+  });
+}
+
+export function interruptRalplanRuns(input: {
+  cwd: string;
+  owner: SessionOwnerToken;
+  lifecycleReason: string;
+  now?: number;
+}): RalplanRunRecord[] {
+  const state = readState(input.cwd);
+  const now = input.now ?? Date.now();
+  const fresh =
+    input.lifecycleReason === "new" || input.lifecycleReason === "fork";
+  const changed: RalplanRunRecord[] = [];
+  state.records = state.records.map((record) => {
+    if (!record.active || !exactOwner(record, input.owner)) return record;
+    const updated: RalplanRunRecord = {
+      ...record,
+      phase: fresh ? "cancelled" : "interrupted",
+      approvalStatus: "unavailable",
+      active: false,
+      updatedAt: now,
+      deactivationReason: `session ${input.lifecycleReason}`,
+    };
+    changed.push(updated);
+    return updated;
+  });
+  if (changed.length > 0) writeState(input.cwd, state);
+  return changed;
+}
+
+export function listRalplanRuns(
+  cwd: string,
+  access: { owner?: SessionOwnerToken; parentSessionId?: string },
+): RalplanRunRecord[] {
+  const records = readState(cwd).records;
+  if (!access.owner && !access.parentSessionId) return records;
+  return records.filter(
+    (record) =>
+      (access.owner !== undefined && exactOwner(record, access.owner)) ||
+      (record.phase === "interrupted" &&
+        access.parentSessionId !== undefined &&
+        record.parentSessionId === access.parentSessionId),
+  );
+}
+
+export function prepareRalplanRecovery(input: {
+  cwd: string;
+  runId: string;
+  parentSessionId?: string;
+}): {
+  runId: string;
+  readOnly: true;
+  automaticResume: false;
+  phase: RalplanPhase;
+  planPath?: string;
+  planDigest?: string;
+  sourceDraftDigest?: string;
+} {
+  const record = getRalplanRunById(input.cwd, input.runId);
+  if (!record || record.parentSessionId !== input.parentSessionId) {
+    throw new Error(
+      "RALPLAN recovery evidence not found for this parent session",
+    );
+  }
+  if (record.phase !== "interrupted") {
+    throw new Error("RALPLAN recovery is available only for interrupted runs");
+  }
+  return {
+    runId: record.runId,
+    readOnly: true,
+    automaticResume: false,
+    phase: record.phase,
+    planPath: record.artifactPaths.plan,
+    planDigest: record.planDigest,
+    sourceDraftDigest: record.sourceDraftDigest,
+  };
+}
+
+export function clearRalplanBindingsForTests(): void {
+  workflowBindings.clear();
+}

--- a/src/ralplan-tool.ts
+++ b/src/ralplan-tool.ts
@@ -1,0 +1,268 @@
+import { Type } from "typebox";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  approveRalplanRun,
+  failRalplanRun,
+  getRalplanRunById,
+  listRalplanRuns,
+  prepareRalplanRecovery,
+  rejectRalplanRun,
+  type RalplanRunRecord,
+} from "./ralplan-state";
+import {
+  getWorkflowJobForOwner,
+  invokeWorkflowCompletionHook,
+  normalizeCancelledWorkflowState,
+} from "./workflow-jobs";
+import { registerToolWithDefaultGuidance } from "./tool-guidance";
+import { sessionOwner, type SessionScope } from "./session-scope";
+
+function sessionId(scope: SessionScope): string | undefined {
+  try {
+    return scope.sessionManager?.getSessionId?.();
+  } catch {
+    return undefined;
+  }
+}
+
+function errorResult(message: string, runId?: string) {
+  return {
+    content: [
+      { type: "text" as const, text: `RALPLAN action failed: ${message}` },
+    ],
+    details: { status: "error", error: message, ...(runId ? { runId } : {}) },
+    isError: true,
+  };
+}
+
+function requireScope(scope: SessionScope): {
+  cwd: string;
+  owner: ReturnType<typeof sessionOwner>;
+  parentSessionId?: string;
+} {
+  if (scope.lifecycle !== "started" || !scope.cwd) {
+    throw new Error("RALPLAN host tools require a live parent session");
+  }
+  return {
+    cwd: scope.cwd,
+    owner: sessionOwner(scope),
+    parentSessionId: sessionId(scope),
+  };
+}
+
+function summarize(record: RalplanRunRecord): string {
+  return `${record.runId} [${record.phase}] digest=${record.planDigest ?? "unavailable"} workflow=${record.workflowId}`;
+}
+
+export function registerRalplanTools(
+  pi: ExtensionAPI,
+  scope: SessionScope,
+): void {
+  registerToolWithDefaultGuidance(pi, {
+    name: "get_ralplan_status",
+    label: "RALPLAN Status",
+    description:
+      "List host-owned RALPLAN planning state for this parent session. Interrupted evidence from the same parent session is read-only; status never resumes or executes work.",
+    parameters: Type.Object({
+      runId: Type.Optional(
+        Type.String({ description: "Optional exact RALPLAN run id." }),
+      ),
+    }),
+    async execute(_id: string, params: { runId?: string }): Promise<any> {
+      try {
+        const context = requireScope(scope);
+        const records = listRalplanRuns(context.cwd, context).filter(
+          (record) => !params.runId || record.runId === params.runId,
+        );
+        if (params.runId && records.length === 0) {
+          return errorResult(
+            "run not found in this parent session",
+            params.runId,
+          );
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: records.length
+                ? records.map(summarize).join("\n")
+                : "No RALPLAN runs are visible in this parent session.",
+            },
+          ],
+          details: { status: "ok", records },
+        };
+      } catch (error) {
+        return errorResult(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    },
+  });
+
+  registerToolWithDefaultGuidance(pi, {
+    name: "approve_ralplan",
+    label: "Approve RALPLAN",
+    description:
+      "Record explicit host approval for exactly {runId, planDigest}. Deactivates pending planning state before returning an approved handoff; does not execute the plan.",
+    parameters: Type.Object({
+      runId: Type.String({ description: "Pending RALPLAN run id." }),
+      planDigest: Type.String({
+        description: "Exact verified final-plan digest from RALPLAN status.",
+      }),
+    }),
+    async execute(
+      _id: string,
+      params: { runId: string; planDigest: string },
+    ): Promise<any> {
+      try {
+        const context = requireScope(scope);
+        const record = approveRalplanRun({ ...context, ...params });
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `RALPLAN ${record.runId} approved for a separate handoff. ` +
+                "No execution was started.",
+            },
+          ],
+          details: {
+            status: record.phase,
+            runId: record.runId,
+            planDigest: record.planDigest,
+            executionStarted: false,
+          },
+        };
+      } catch (error) {
+        return errorResult(
+          error instanceof Error ? error.message : String(error),
+          params.runId,
+        );
+      }
+    },
+  });
+
+  registerToolWithDefaultGuidance(pi, {
+    name: "reject_ralplan",
+    label: "Reject RALPLAN",
+    description:
+      "Reject an exact pending RALPLAN run in this parent session. Rejection is terminal and starts no execution.",
+    parameters: Type.Object({
+      runId: Type.String({ description: "Pending RALPLAN run id." }),
+      reason: Type.String({ description: "Why the plan is rejected." }),
+    }),
+    async execute(
+      _id: string,
+      params: { runId: string; reason: string },
+    ): Promise<any> {
+      try {
+        const context = requireScope(scope);
+        const record = rejectRalplanRun({ ...context, ...params });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `RALPLAN ${record.runId} rejected. No execution was started.`,
+            },
+          ],
+          details: {
+            status: record.phase,
+            runId: record.runId,
+            executionStarted: false,
+          },
+        };
+      } catch (error) {
+        return errorResult(
+          error instanceof Error ? error.message : String(error),
+          params.runId,
+        );
+      }
+    },
+  });
+
+  registerToolWithDefaultGuidance(pi, {
+    name: "cancel_ralplan",
+    label: "Cancel RALPLAN",
+    description:
+      "Cancel an active RALPLAN planning workflow owned by this exact parent session and persist terminal cancellation evidence.",
+    parameters: Type.Object({
+      runId: Type.String({ description: "Active RALPLAN run id." }),
+    }),
+    async execute(_id: string, params: { runId: string }): Promise<any> {
+      try {
+        const context = requireScope(scope);
+        const record = getRalplanRunById(context.cwd, params.runId);
+        if (!record) throw new Error("RALPLAN run not found");
+        if (
+          record.owner.id !== context.owner.id ||
+          record.owner.generation !== context.owner.generation ||
+          record.parentSessionId !== context.parentSessionId
+        ) {
+          throw new Error("RALPLAN owner or parent session mismatch");
+        }
+        if (!record.active) throw new Error("RALPLAN run is already terminal");
+        const job = getWorkflowJobForOwner(record.workflowId, context.owner);
+        if (!job || job.status !== "running") {
+          throw new Error("active RALPLAN workflow is not running");
+        }
+        job.abort.abort();
+        job.status = "cancelled";
+        normalizeCancelledWorkflowState(job);
+        failRalplanRun({
+          cwd: context.cwd,
+          workflowId: record.workflowId,
+          reason: "cancelled by explicit host action",
+          phase: "cancelled",
+        });
+        invokeWorkflowCompletionHook(job);
+        return {
+          content: [
+            { type: "text", text: `RALPLAN ${record.runId} cancelled.` },
+          ],
+          details: { status: "cancelled", runId: record.runId },
+        };
+      } catch (error) {
+        return errorResult(
+          error instanceof Error ? error.message : String(error),
+          params.runId,
+        );
+      }
+    },
+  });
+
+  registerToolWithDefaultGuidance(pi, {
+    name: "prepare_ralplan_recovery",
+    label: "Prepare RALPLAN Recovery",
+    description:
+      "Return read-only evidence for an interrupted run from the same parent session. Never auto-resumes agents or execution; a new explicit workflow run is required.",
+    parameters: Type.Object({
+      runId: Type.String({ description: "Interrupted RALPLAN run id." }),
+    }),
+    async execute(_id: string, params: { runId: string }): Promise<any> {
+      try {
+        const context = requireScope(scope);
+        const recovery = prepareRalplanRecovery({
+          cwd: context.cwd,
+          runId: params.runId,
+          parentSessionId: context.parentSessionId,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Recovery evidence for ${recovery.runId} is read-only. ` +
+                "Start a new RALPLAN workflow explicitly if planning should continue.",
+            },
+          ],
+          details: { status: "recovery_ready", ...recovery },
+        };
+      } catch (error) {
+        return errorResult(
+          error instanceof Error ? error.message : String(error),
+          params.runId,
+        );
+      }
+    },
+  });
+}

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -48,6 +48,7 @@ import {
   type InteractiveSubagentState,
 } from "./interactive-tmux";
 import { cleanupWorkflowJobsForOwner } from "./workflow-jobs";
+import { interruptRalplanRuns } from "./ralplan-state";
 import {
   advanceSessionScopeGeneration,
   createSessionScope,
@@ -180,6 +181,18 @@ function cleanupScopeGeneration(
   const reason = `${lifecycleOrigin} (${event?.reason ?? "unknown"})`;
   snapshotOwnedJobs(scope, sessionId, ctx?.cwd, reason);
   cleanupWorkflowJobsForOwner(owner);
+  const ralplanCwd = scope.cwd ?? ctx?.cwd;
+  if (ralplanCwd) {
+    try {
+      interruptRalplanRuns({
+        cwd: ralplanCwd,
+        owner,
+        lifecycleReason: event?.reason ?? "unknown",
+      });
+    } catch (error) {
+      logSessionError("ralplan_state_interruption_failed", error);
+    }
+  }
   clearInProcessDeliveries(owner);
 
   const destroysStandalonePanes =

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -43,6 +43,7 @@ import { registerChildProtocol } from "./child-protocol";
 import { registerCancelAllFlows } from "./cancel-all-flows-registration";
 import { renderSubagentNotify } from "./rendering";
 import { registerInteractiveSupervisor } from "./interactive-supervisor-registration";
+import { registerRalplanTools } from "./ralplan-tool";
 import {
   acquireRuntimeSpawnTreeContext,
   LINEAGE_BOOTSTRAP_ENV,
@@ -152,6 +153,7 @@ export default function (pi: ExtensionAPI) {
   registerOrchestratorTools(pi, sessionScope);
   registerInteractiveSupervisor(pi, sessionScope);
   registerWorkflowTool(pi, sessionScope);
+  registerRalplanTools(pi, sessionScope);
   registerInProcessSubagentTools(pi, sessionScope);
   registerInProcessMaintenanceTools(pi, sessionScope);
   // ── Cancel-all-flows shortcut and command ──────────────────────

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -84,6 +84,14 @@ import {
   type ResolvedCompletionPolicy,
   type CompletionGroupReservation,
 } from "./completion-coordinator";
+import {
+  completeRalplanRun,
+  createRalplanRun,
+  failRalplanRun,
+  getRalplanRunForWorkflow,
+  isRalplanWorkflowName,
+  markRalplanReviewing,
+} from "./ralplan-state";
 
 const WORKFLOW_SESSION_SCOPE_MESSAGE =
   "Workflow jobs are scoped to the current parent session and do not survive reload/resume/new/quit.";
@@ -484,6 +492,107 @@ export function registerWorkflowTool(
     }
   }
 
+  function ralplanParentSessionId(): string | undefined {
+    try {
+      return sessionScope?.sessionManager?.getSessionId?.();
+    } catch {
+      return undefined;
+    }
+  }
+
+  function ensureRalplanStart(
+    job: WorkflowJobState,
+    cwd: string,
+    workflowOwner: SessionOwnerToken | undefined,
+  ) {
+    if (!isRalplanWorkflowName(job.name)) return undefined;
+    if (!workflowOwner) {
+      throw new Error("RALPLAN workflows require a live host session owner");
+    }
+    return (
+      getRalplanRunForWorkflow(cwd, job.id) ??
+      createRalplanRun({
+        cwd,
+        workflowId: job.id,
+        workflowName: job.name,
+        owner: workflowOwner,
+        parentSessionId: ralplanParentSessionId(),
+      })
+    );
+  }
+
+  function captureRalplanCompletion(
+    job: WorkflowJobState,
+    cwd: string,
+    workflowOwner: SessionOwnerToken | undefined,
+  ): boolean {
+    if (!isRalplanWorkflowName(job.name)) return true;
+    try {
+      ensureRalplanStart(job, cwd, workflowOwner);
+      if (job.status === "done" && job.result) {
+        completeRalplanRun({
+          cwd,
+          workflowId: job.id,
+          result: job.result.result,
+        });
+      } else {
+        failRalplanRun({
+          cwd,
+          workflowId: job.id,
+          reason: job.error ?? `workflow ${job.status}`,
+          phase: job.status === "cancelled" ? "cancelled" : "failed",
+        });
+      }
+      return true;
+    } catch (error) {
+      debugLog("error", "ralplan_state_capture_failed", {
+        workflowId: job.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
+  function captureRalplanProgress(
+    workflowId: string,
+    workflowName: string,
+    cwd: string,
+    progress: WorkflowProgress,
+  ): void {
+    if (
+      !isRalplanWorkflowName(workflowName) ||
+      progress.kind !== "phase" ||
+      !progress.phase ||
+      !/(Architect|Critic|Verify reviews)/i.test(progress.phase)
+    ) {
+      return;
+    }
+    try {
+      markRalplanReviewing({ cwd, workflowId });
+    } catch {
+      /* the start record may not be committed until immediately after spawn */
+    }
+  }
+
+  function notifyCapturedWorkflow(
+    job: WorkflowJobState,
+    cwd: string,
+    workflowOwner: SessionOwnerToken | undefined,
+  ): boolean {
+    if (!captureRalplanCompletion(job, cwd, workflowOwner)) return false;
+    return notifyWorkflowCompletion(job);
+  }
+
+  function ralplanDetails(workflowId: string) {
+    if (!sessionScope?.cwd) return {};
+    try {
+      const record = getRalplanRunForWorkflow(sessionScope.cwd, workflowId);
+      return record ? { ralplanRunId: record.runId } : {};
+    } catch {
+      return {};
+    }
+  }
+
   registerToolWithDefaultGuidance(pi, {
     name: "workflow",
     label: "Workflow",
@@ -673,12 +782,17 @@ export function registerWorkflowTool(
         };
       }
 
-      const baseOpts = (workflowId: string) => ({
+      const baseOpts = (workflowId: string, workflowName?: string) => ({
         args: params.args,
         cwd: ctx.cwd,
         budgetTotal: params.budget ?? DEFAULT_WORKFLOW_OUTPUT_BUDGET,
         runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
         loadWorkflow: (n: string) => loadWorkflowScript(n),
+        onProgress: (progress: WorkflowProgress) => {
+          if (workflowName) {
+            captureRalplanProgress(workflowId, workflowName, ctx.cwd, progress);
+          }
+        },
       });
 
       // ── Async (background) path — default ──
@@ -715,9 +829,10 @@ export function registerWorkflowTool(
           job = startWorkflowJob(
             meta.name,
             script,
-            baseOpts,
+            (workflowId) => baseOpts(workflowId, meta.name),
             jobStartedAt,
-            notifyWorkflowCompletion,
+            (completedJob) =>
+              notifyCapturedWorkflow(completedJob, ctx.cwd, workflowOwner),
             workflowOwner,
             "async",
           );
@@ -730,7 +845,9 @@ export function registerWorkflowTool(
             isError: true,
           };
         }
+        let ralplanRunId: string | undefined;
         try {
+          ralplanRunId = ensureRalplanStart(job, ctx.cwd, workflowOwner)?.runId;
           configureWorkflowCompletion(
             job,
             completion,
@@ -740,6 +857,24 @@ export function registerWorkflowTool(
         } catch (error) {
           discardWorkflowJob(job);
           releaseCompletionGroup(completionReservation);
+          if (ralplanRunId) {
+            try {
+              failRalplanRun({
+                cwd: ctx.cwd,
+                workflowId: job.id,
+                reason: "workflow startup registration failed",
+                phase: "failed",
+              });
+            } catch (stateError) {
+              debugLog("error", "ralplan_start_rollback_failed", {
+                workflowId: job.id,
+                error:
+                  stateError instanceof Error
+                    ? stateError.message
+                    : String(stateError),
+              });
+            }
+          }
           const msg = error instanceof Error ? error.message : String(error);
           return {
             content: [{ type: "text", text: `Workflow not started: ${msg}` }],
@@ -756,7 +891,12 @@ export function registerWorkflowTool(
                 `Completion coordination will notify the user and resume the parent with a compact result reference; use get_workflow_status / get_workflow_result only for explicit inspection. ${WORKFLOW_SESSION_SCOPE_MESSAGE}`,
             },
           ],
-          details: { status: "started", workflowId: job.id, name: meta.name },
+          details: {
+            status: "started",
+            workflowId: job.id,
+            name: meta.name,
+            ...(ralplanRunId ? { ralplanRunId } : {}),
+          },
         };
       }
 
@@ -785,16 +925,30 @@ export function registerWorkflowTool(
           meta.name,
           script,
           (workflowId) => ({
-            ...baseOpts(workflowId),
+            ...baseOpts(workflowId, meta.name),
             signal,
-            onProgress: syncProgress,
+            onProgress: (progress: WorkflowProgress) => {
+              captureRalplanProgress(workflowId, meta.name, ctx.cwd, progress);
+              syncProgress(progress);
+            },
           }),
           Date.now(),
-          undefined,
+          (completedJob) =>
+            captureRalplanCompletion(completedJob, ctx.cwd, workflowOwner),
           workflowOwner,
           "sync",
         );
+        let ralplanRunId: string | undefined;
+        try {
+          ralplanRunId = ensureRalplanStart(job, ctx.cwd, workflowOwner)?.runId;
+        } catch (error) {
+          discardWorkflowJob(job);
+          throw error;
+        }
         const run = await job.promise;
+        if (!captureRalplanCompletion(job, ctx.cwd, workflowOwner)) {
+          throw new Error("RALPLAN state could not be persisted");
+        }
         const resultText =
           typeof run.result === "string" ? run.result : stringify(run.result);
         const presentation = getWorkflowCompletionPresentation(
@@ -829,6 +983,7 @@ export function registerWorkflowTool(
             usage: run.usage,
             budgetTotal: job.snapshot.budgetTotal,
             phases: run.phases,
+            ...(ralplanRunId ? { ralplanRunId } : {}),
           },
         };
       } catch (err) {
@@ -918,6 +1073,7 @@ export function registerWorkflowTool(
           name: st.name,
           elapsedMs: Date.now() - st.startedAt,
           ...st.snapshot,
+          ...ralplanDetails(st.id),
         },
       };
     },
@@ -1062,6 +1218,7 @@ export function registerWorkflowTool(
           usage: run.usage,
           budgetTotal: st.snapshot.budgetTotal,
           phases: run.phases,
+          ...ralplanDetails(st.id),
         },
       };
     },
@@ -1294,17 +1451,26 @@ export function registerWorkflowTool(
           budgetTotal: DEFAULT_WORKFLOW_OUTPUT_BUDGET,
           runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
           loadWorkflow: (n: string) => loadWorkflowScript(n),
+          onProgress: (progress: WorkflowProgress) =>
+            captureRalplanProgress(workflowId, meta.name, ctx.cwd, progress),
         }),
         Date.now(),
-        notifyWorkflowCompletion,
+        (completedJob) =>
+          notifyCapturedWorkflow(completedJob, ctx.cwd, workflowOwner),
         workflowOwner,
       );
-      configureWorkflowCompletion(
-        job,
-        sessionScope ? { policy: "each", legacy: false } : { legacy: true },
-        workflowOwner,
-      );
-      return { job, meta };
+      try {
+        const ralplanRun = ensureRalplanStart(job, ctx.cwd, workflowOwner);
+        configureWorkflowCompletion(
+          job,
+          sessionScope ? { policy: "each", legacy: false } : { legacy: true },
+          workflowOwner,
+        );
+        return { job, meta, ralplanRun };
+      } catch (error) {
+        discardWorkflowJob(job);
+        throw error;
+      }
     };
 
     const selectSavedWorkflow = async (

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -4,3 +4,5 @@ export * from "./workflow-jobs";
 export * from "./workflow-ui";
 export * from "./workflow-tree-ui";
 export { registerWorkflowTool } from "./workflow-tool";
+export * from "./ralplan-state";
+export { registerRalplanTools } from "./ralplan-tool";

--- a/tests/published-tarball.test.ts
+++ b/tests/published-tarball.test.ts
@@ -290,6 +290,8 @@ describe("published tarball", () => {
         "skills/ralplan/prompts/planner.md",
         "skills/ralplan/prompts/architect.md",
         "skills/ralplan/prompts/critic.md",
+        "src/ralplan-state.ts",
+        "src/ralplan-tool.ts",
       ]),
     );
   });

--- a/tests/ralplan-lifecycle.test.ts
+++ b/tests/ralplan-lifecycle.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerSessionHandlers } from "../src/session-handlers";
+import { sessionOwner, clearSessionScopes } from "../src/session-scope";
+import { workflowJobRegistry } from "../src/workflow-jobs";
+import {
+  clearRalplanBindingsForTests,
+  createRalplanRun,
+  getRalplanRunById,
+} from "../src/ralplan-state";
+
+const roots: string[] = [];
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "ralplan-lifecycle-"));
+  roots.push(value);
+  return value;
+}
+
+function registration() {
+  const handlers = new Map<string, Function[]>();
+  const pi = {
+    on: vi.fn((name: string, handler: Function) => {
+      const values = handlers.get(name) ?? [];
+      values.push(handler);
+      handlers.set(name, values);
+    }),
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+    sendUserMessage: vi.fn(),
+    getFlag: vi.fn(() => false),
+  } as any;
+  const scope = registerSessionHandlers(pi);
+  return { handlers, scope };
+}
+
+afterEach(() => {
+  const handle = (globalThis as any).__piSubagenturaInteractivePollerHandle;
+  if (handle) clearInterval(handle);
+  (globalThis as any).__piSubagenturaInteractivePollerHandle = undefined;
+  workflowJobRegistry.clear();
+  clearRalplanBindingsForTests();
+  clearSessionScopes();
+  for (const dir of roots.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("RALPLAN session lifecycle", () => {
+  it.each([
+    ["reload", "interrupted"],
+    ["resume", "interrupted"],
+    ["quit", "interrupted"],
+    ["new", "cancelled"],
+    ["fork", "cancelled"],
+  ])("cancels jobs before persisting %s evidence", (reason, phase) => {
+    const cwd = root();
+    const { handlers, scope } = registration();
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+      sessionManager: {
+        getSessionId: () => "session-a",
+        getEntries: () => [],
+        getBranch: () => [],
+      },
+    };
+    handlers.get("session_start")![0]({ reason: "startup" }, ctx);
+    const owner = sessionOwner(scope);
+    const record = createRalplanRun({
+      cwd,
+      workflowId: "wf_lifecycle",
+      workflowName: "ralplan-occ",
+      owner,
+      parentSessionId: "session-a",
+    });
+    const abort = new AbortController();
+    workflowJobRegistry.set("wf_lifecycle", {
+      id: "wf_lifecycle",
+      name: "ralplan-occ",
+      status: "running",
+      executionMode: "async",
+      startedAt: Date.now(),
+      promise: new Promise(() => {}),
+      abort,
+      snapshot: { agentsSpawned: 0, errorCount: 0, tokensSpent: 0, phases: [] },
+      parentSessionOwner: owner,
+    });
+
+    if (
+      reason === "reload" ||
+      reason === "resume" ||
+      reason === "new" ||
+      reason === "fork"
+    ) {
+      handlers.get("session_start")![0]({ reason }, ctx);
+    } else {
+      handlers.get("session_shutdown")![0]({ reason }, ctx);
+    }
+
+    expect(abort.signal.aborted).toBe(true);
+    expect(workflowJobRegistry.has("wf_lifecycle")).toBe(false);
+    expect(getRalplanRunById(cwd, record.runId)).toMatchObject({
+      phase,
+      active: false,
+      deactivationReason: `session ${reason}`,
+    });
+  });
+});

--- a/tests/ralplan-state.test.ts
+++ b/tests/ralplan-state.test.ts
@@ -1,0 +1,341 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  approveRalplanRun,
+  clearRalplanBindingsForTests,
+  completeRalplanRun,
+  createRalplanRun,
+  failRalplanRun,
+  getRalplanRunById,
+  getRalplanRunForWorkflow,
+  interruptRalplanRuns,
+  listRalplanRuns,
+  markRalplanReviewing,
+  prepareRalplanRecovery,
+  ralplanStatePath,
+  rejectRalplanRun,
+} from "../src/ralplan-state";
+import type { SessionOwnerToken } from "../src/session-scope";
+
+const roots: string[] = [];
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "ralplan-state-"));
+  roots.push(value);
+  return value;
+}
+
+function owner(id = 7, generation = 2): SessionOwnerToken {
+  return { id, generation };
+}
+
+function successfulResult(planPath: string) {
+  return {
+    status: "pending_approval",
+    consensus: true,
+    pending_approval: true,
+    execution_halted: true,
+    planDigest: "abc123",
+    sourceDraftDigest: "draft123",
+    artifactPaths: {
+      plan: planPath,
+      drafts: [planPath.replace("plan.md", "drafts/plan_draft-r1.md")],
+      architectReviews: [
+        planPath.replace("plan.md", "drafts/architect_review-r1.md"),
+      ],
+      criticReviews: [
+        planPath.replace("plan.md", "drafts/critic_review-r1.md"),
+      ],
+    },
+  };
+}
+
+afterEach(() => {
+  clearRalplanBindingsForTests();
+  for (const dir of roots.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("RALPLAN persisted state", () => {
+  it("writes bounded mode-0600 state atomically and updates to pending approval", () => {
+    const cwd = root();
+    const created = createRalplanRun({
+      cwd,
+      workflowId: "wf_one",
+      workflowName: "ralplan-occ",
+      owner: owner(),
+      parentSessionId: "session-a",
+      now: 100,
+    });
+    const reviewing = markRalplanReviewing({
+      cwd,
+      workflowId: "wf_one",
+      now: 150,
+    });
+    const completed = completeRalplanRun({
+      cwd,
+      workflowId: "wf_one",
+      result: successfulResult(join(cwd, "plans", "plan.md")),
+      now: 200,
+    });
+
+    expect(created.phase).toBe("planning");
+    expect(reviewing).toMatchObject({ phase: "reviewing", updatedAt: 150 });
+    expect(completed).toMatchObject({
+      runId: created.runId,
+      phase: "pending_approval",
+      approvalStatus: "pending",
+      active: true,
+      planDigest: "abc123",
+      updatedAt: 200,
+    });
+    const path = ralplanStatePath(cwd);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+      schemaVersion: 1,
+      records: [{ runId: created.runId }],
+    });
+    expect(getRalplanRunForWorkflow(cwd, "wf_one")?.runId).toBe(created.runId);
+  });
+
+  it("binds approval to exact owner, session, run, and plan digest", () => {
+    const cwd = root();
+    const created = createRalplanRun({
+      cwd,
+      workflowId: "wf_two",
+      workflowName: "ralplan-occ",
+      owner: owner(),
+      parentSessionId: "session-a",
+      now: 1,
+    });
+    completeRalplanRun({
+      cwd,
+      workflowId: "wf_two",
+      result: successfulResult(join(cwd, "plans", "plan.md")),
+      now: 2,
+    });
+
+    expect(() =>
+      approveRalplanRun({
+        cwd,
+        runId: created.runId,
+        planDigest: "wrong",
+        owner: owner(),
+        parentSessionId: "session-a",
+        now: 3,
+      }),
+    ).toThrow(/digest/i);
+    expect(() =>
+      approveRalplanRun({
+        cwd,
+        runId: created.runId,
+        planDigest: "abc123",
+        owner: owner(7, 3),
+        parentSessionId: "session-a",
+        now: 3,
+      }),
+    ).toThrow(/owner/i);
+    expect(() =>
+      approveRalplanRun({
+        cwd,
+        runId: created.runId,
+        planDigest: "abc123",
+        owner: owner(),
+        parentSessionId: "session-b",
+        now: 3,
+      }),
+    ).toThrow(/session/i);
+
+    const approved = approveRalplanRun({
+      cwd,
+      runId: created.runId,
+      planDigest: "abc123",
+      owner: owner(),
+      parentSessionId: "session-a",
+      now: 4,
+    });
+    expect(approved).toMatchObject({
+      phase: "approved_handoff",
+      approvalStatus: "approved",
+      active: false,
+      updatedAt: 4,
+    });
+    expect(() =>
+      approveRalplanRun({
+        cwd,
+        runId: created.runId,
+        planDigest: "abc123",
+        owner: owner(),
+        parentSessionId: "session-a",
+      }),
+    ).toThrow(/pending/i);
+  });
+
+  it("rejects a pending plan without executing it", () => {
+    const cwd = root();
+    const created = createRalplanRun({
+      cwd,
+      workflowId: "wf_reject",
+      workflowName: "ralplan-consensus",
+      owner: owner(),
+      parentSessionId: "session-a",
+    });
+    completeRalplanRun({
+      cwd,
+      workflowId: "wf_reject",
+      result: successfulResult(join(cwd, "plans", "plan.md")),
+    });
+
+    const rejected = rejectRalplanRun({
+      cwd,
+      runId: created.runId,
+      owner: owner(),
+      parentSessionId: "session-a",
+      reason: "scope changed",
+    });
+    expect(rejected).toMatchObject({
+      phase: "rejected",
+      approvalStatus: "rejected",
+      active: false,
+      deactivationReason: "scope changed",
+    });
+  });
+
+  it("persists capped, failed, and interrupted terminal evidence", () => {
+    const cwd = root();
+    const capped = createRalplanRun({
+      cwd,
+      workflowId: "wf_capped",
+      workflowName: "ralplan-occ",
+      owner: owner(),
+      parentSessionId: "session-a",
+    });
+    completeRalplanRun({
+      cwd,
+      workflowId: "wf_capped",
+      result: {
+        status: "no_consensus",
+        consensus: false,
+        capped: true,
+        artifactPaths: { plan: join(cwd, "plans", "plan.md") },
+      },
+    });
+    expect(getRalplanRunById(cwd, capped.runId)?.phase).toBe("capped");
+
+    const failed = createRalplanRun({
+      cwd,
+      workflowId: "wf_failed",
+      workflowName: "ralplan-occ",
+      owner: owner(),
+      parentSessionId: "session-a",
+    });
+    failRalplanRun({ cwd, workflowId: "wf_failed", reason: "agent failed" });
+    expect(getRalplanRunById(cwd, failed.runId)).toMatchObject({
+      phase: "failed",
+      active: false,
+      deactivationReason: "agent failed",
+    });
+
+    const interrupted = createRalplanRun({
+      cwd,
+      workflowId: "wf_running",
+      workflowName: "ralplan-occ",
+      owner: owner(),
+      parentSessionId: "session-a",
+    });
+    interruptRalplanRuns({
+      cwd,
+      owner: owner(),
+      lifecycleReason: "reload",
+      now: 20,
+    });
+    expect(getRalplanRunById(cwd, interrupted.runId)).toMatchObject({
+      phase: "interrupted",
+      active: false,
+      deactivationReason: "session reload",
+    });
+  });
+
+  it("allows read-only recovery evidence only for the same parent session", () => {
+    const cwd = root();
+    const created = createRalplanRun({
+      cwd,
+      workflowId: "wf_recover",
+      workflowName: "ralplan-occ",
+      owner: owner(),
+      parentSessionId: "session-a",
+    });
+    completeRalplanRun({
+      cwd,
+      workflowId: "wf_recover",
+      result: successfulResult(join(cwd, "plans", "plan.md")),
+    });
+    interruptRalplanRuns({
+      cwd,
+      owner: owner(),
+      lifecycleReason: "quit",
+    });
+
+    expect(
+      listRalplanRuns(cwd, {
+        owner: owner(7, 3),
+        parentSessionId: "session-a",
+      }).map((record) => record.runId),
+    ).toContain(created.runId);
+    expect(
+      listRalplanRuns(cwd, {
+        owner: owner(8, 1),
+        parentSessionId: "session-b",
+      }),
+    ).toEqual([]);
+    const recovery = prepareRalplanRecovery({
+      cwd,
+      runId: created.runId,
+      parentSessionId: "session-a",
+    });
+    expect(recovery).toMatchObject({
+      runId: created.runId,
+      readOnly: true,
+      automaticResume: false,
+      planDigest: "abc123",
+    });
+    expect(recovery).not.toHaveProperty("execute");
+  });
+
+  it("rejects oversized or malformed persisted state", () => {
+    const cwd = root();
+    const path = ralplanStatePath(cwd);
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(path, "x".repeat(1_100_000), { mode: 0o600 });
+    expect(() => listRalplanRuns(cwd, {})).toThrow(/too large/i);
+
+    writeFileSync(path, "{}", { mode: 0o600 });
+    chmodSync(path, 0o600);
+    expect(() => listRalplanRuns(cwd, {})).toThrow(/schema/i);
+  });
+
+  it("rejects symbolic-link state files", () => {
+    const cwd = root();
+    const path = ralplanStatePath(cwd);
+    const target = join(cwd, "target.json");
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(target, JSON.stringify({ schemaVersion: 1, records: [] }), {
+      mode: 0o600,
+    });
+    symlinkSync(target, path);
+
+    expect(() => listRalplanRuns(cwd, {})).toThrow(/symbolic link/i);
+  });
+});

--- a/tests/ralplan-tools.test.ts
+++ b/tests/ralplan-tools.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerRalplanTools } from "../src/ralplan-tool";
+import {
+  clearRalplanBindingsForTests,
+  completeRalplanRun,
+  createRalplanRun,
+  getRalplanRunById,
+  interruptRalplanRuns,
+} from "../src/ralplan-state";
+import { workflowJobRegistry } from "../src/workflow-jobs";
+import type { SessionScope } from "../src/session-scope";
+
+const roots: string[] = [];
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "ralplan-tools-"));
+  roots.push(value);
+  return value;
+}
+
+function setup(cwd: string, generation = 1) {
+  const tools: Record<string, any> = {};
+  const pi = {
+    registerTool: vi.fn((tool: any) => {
+      tools[tool.name] = tool;
+    }),
+  } as any;
+  const scope: SessionScope = {
+    id: 9,
+    generation,
+    pi,
+    cwd,
+    lifecycle: "started",
+    sessionManager: { getSessionId: () => "session-a" },
+    parentStreaming: false,
+    inProcessJobs: new Map(),
+    pendingInProcessDeliveries: [],
+    interactiveStates: new Map(),
+  };
+  registerRalplanTools(pi, scope);
+  return { tools, scope };
+}
+
+function pending(cwd: string, workflowId: string) {
+  const record = createRalplanRun({
+    cwd,
+    workflowId,
+    workflowName: "ralplan-occ",
+    owner: { id: 9, generation: 1 },
+    parentSessionId: "session-a",
+  });
+  completeRalplanRun({
+    cwd,
+    workflowId,
+    result: {
+      status: "pending_approval",
+      consensus: true,
+      pending_approval: true,
+      execution_halted: true,
+      planDigest: "digest-a",
+      sourceDraftDigest: "draft-a",
+      artifactPaths: {
+        plan: join(cwd, "plans", "plan.md"),
+        drafts: [],
+        architectReviews: [],
+        criticReviews: [],
+      },
+    },
+  });
+  return record;
+}
+
+afterEach(() => {
+  clearRalplanBindingsForTests();
+  workflowJobRegistry.clear();
+  for (const dir of roots.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("RALPLAN host tools", () => {
+  it("registers explicit status, approval, rejection, cancellation, and recovery tools", () => {
+    const { tools } = setup(root());
+    expect(Object.keys(tools).sort()).toEqual([
+      "approve_ralplan",
+      "cancel_ralplan",
+      "get_ralplan_status",
+      "prepare_ralplan_recovery",
+      "reject_ralplan",
+    ]);
+  });
+
+  it("requires exact digest and deactivates before approved handoff", async () => {
+    const cwd = root();
+    const { tools } = setup(cwd);
+    const record = pending(cwd, "wf_approve");
+
+    const mismatch = await tools.approve_ralplan.execute("approve", {
+      runId: record.runId,
+      planDigest: "wrong",
+    });
+    expect(mismatch).toMatchObject({
+      isError: true,
+      details: { status: "error" },
+    });
+
+    const approved = await tools.approve_ralplan.execute("approve", {
+      runId: record.runId,
+      planDigest: "digest-a",
+    });
+    expect(approved).toMatchObject({
+      details: {
+        status: "approved_handoff",
+        runId: record.runId,
+        executionStarted: false,
+      },
+    });
+    expect(getRalplanRunById(cwd, record.runId)).toMatchObject({
+      active: false,
+      phase: "approved_handoff",
+    });
+  });
+
+  it("keeps stale generations from approving or rejecting current runs", async () => {
+    const cwd = root();
+    const record = pending(cwd, "wf_stale");
+    const { tools } = setup(cwd, 2);
+
+    const approved = await tools.approve_ralplan.execute("approve", {
+      runId: record.runId,
+      planDigest: "digest-a",
+    });
+    const rejected = await tools.reject_ralplan.execute("reject", {
+      runId: record.runId,
+      reason: "stale",
+    });
+    expect(approved.isError).toBe(true);
+    expect(rejected.isError).toBe(true);
+    expect(getRalplanRunById(cwd, record.runId)?.active).toBe(true);
+  });
+
+  it("cancels only its owned active workflow and persists cancellation", async () => {
+    const cwd = root();
+    const { tools } = setup(cwd);
+    const record = createRalplanRun({
+      cwd,
+      workflowId: "wf_cancel",
+      workflowName: "ralplan-occ",
+      owner: { id: 9, generation: 1 },
+      parentSessionId: "session-a",
+    });
+    const abort = new AbortController();
+    workflowJobRegistry.set("wf_cancel", {
+      id: "wf_cancel",
+      name: "ralplan-occ",
+      status: "running",
+      executionMode: "async",
+      startedAt: Date.now(),
+      promise: new Promise(() => {}),
+      abort,
+      snapshot: { agentsSpawned: 0, errorCount: 0, tokensSpent: 0, phases: [] },
+      parentSessionOwner: { id: 9, generation: 1 },
+    });
+
+    const cancelled = await tools.cancel_ralplan.execute("cancel", {
+      runId: record.runId,
+    });
+    expect(cancelled).toMatchObject({
+      details: { status: "cancelled", runId: record.runId },
+    });
+    expect(abort.signal.aborted).toBe(true);
+    expect(getRalplanRunById(cwd, record.runId)).toMatchObject({
+      phase: "cancelled",
+      active: false,
+    });
+  });
+
+  it("surfaces same-session interrupted evidence as read-only recovery", async () => {
+    const cwd = root();
+    const { tools } = setup(cwd, 2);
+    const record = pending(cwd, "wf_recovery");
+    interruptRalplanRuns({
+      cwd,
+      owner: { id: 9, generation: 1 },
+      lifecycleReason: "reload",
+    });
+
+    const status = await tools.get_ralplan_status.execute("status", {
+      runId: record.runId,
+    });
+    const recovery = await tools.prepare_ralplan_recovery.execute("recover", {
+      runId: record.runId,
+    });
+    expect(status).toMatchObject({
+      details: { status: "ok", records: [{ phase: "interrupted" }] },
+    });
+    expect(recovery).toMatchObject({
+      details: {
+        status: "recovery_ready",
+        readOnly: true,
+        automaticResume: false,
+      },
+    });
+  });
+});

--- a/tests/ralplan-workflow-state.test.ts
+++ b/tests/ralplan-workflow-state.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerWorkflowTool } from "../src/workflow-tool";
+import { workflowJobRegistry } from "../src/workflow-jobs";
+import {
+  clearRalplanBindingsForTests,
+  getRalplanRunById,
+  listRalplanRuns,
+} from "../src/ralplan-state";
+import {
+  clearSessionScopes,
+  registerSessionScope,
+  type SessionScope,
+} from "../src/session-scope";
+import {
+  clearCompletionCoordinator,
+  registerCompletionCoordinator,
+} from "../src/completion-coordinator";
+
+const roots: string[] = [];
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "ralplan-workflow-state-"));
+  roots.push(value);
+  return value;
+}
+
+function setup(cwd: string) {
+  const tools: Record<string, any> = {};
+  const entries: unknown[] = [];
+  const pi = {
+    registerTool: vi.fn((tool: any) => {
+      tools[tool.name] = tool;
+    }),
+    registerCommand: vi.fn(),
+    appendEntry: vi.fn((_type: string, value: unknown) => entries.push(value)),
+    sendMessage: vi.fn(),
+    sendUserMessage: vi.fn(),
+  } as any;
+  const scope = registerSessionScope({
+    id: 77,
+    generation: 1,
+    pi,
+    cwd,
+    lifecycle: "started",
+    sessionManager: {
+      getSessionId: () => "parent-session",
+      getEntries: () => entries,
+    },
+    parentStreaming: false,
+    inProcessJobs: new Map(),
+    pendingInProcessDeliveries: [],
+    interactiveStates: new Map(),
+  }) as SessionScope;
+  registerCompletionCoordinator(pi, scope);
+  registerWorkflowTool(pi, scope);
+  return { tools, scope };
+}
+
+function script(cwd: string): string {
+  return `export const meta = { name: "ralplan-occ", description: "test" };
+return {
+  status: "pending_approval",
+  consensus: true,
+  pending_approval: true,
+  execution_halted: true,
+  planDigest: "plan-digest",
+  sourceDraftDigest: "draft-digest",
+  artifactPaths: {
+    plan: ${JSON.stringify(join(cwd, "plans", "plan.md"))},
+    drafts: [],
+    architectReviews: [],
+    criticReviews: []
+  }
+};`;
+}
+
+afterEach(() => {
+  workflowJobRegistry.clear();
+  clearRalplanBindingsForTests();
+  for (const scope of [] as SessionScope[]) clearCompletionCoordinator(scope);
+  clearSessionScopes();
+  for (const dir of roots.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("workflow RALPLAN state integration", () => {
+  it("persists sync RALPLAN completion and returns its run id", async () => {
+    const cwd = root();
+    const { tools } = setup(cwd);
+    const result = await tools.workflow.execute(
+      "call",
+      { script: script(cwd), async: false },
+      undefined,
+      vi.fn(),
+      { cwd, model: undefined, modelRegistry: undefined },
+    );
+
+    expect(result).toMatchObject({
+      details: { status: "done", ralplanRunId: expect.stringMatching(/^rp_/) },
+    });
+    const record = getRalplanRunById(cwd, result.details.ralplanRunId);
+    expect(record).toMatchObject({
+      phase: "pending_approval",
+      approvalStatus: "pending",
+      active: true,
+      planDigest: "plan-digest",
+      parentSessionId: "parent-session",
+    });
+  });
+
+  it("persists background completion before result collection", async () => {
+    const cwd = root();
+    const { tools } = setup(cwd);
+    const started = await tools.workflow.execute(
+      "call",
+      { script: script(cwd), async: true },
+      undefined,
+      vi.fn(),
+      { cwd, model: undefined, modelRegistry: undefined },
+    );
+    expect(started.details.ralplanRunId).toMatch(/^rp_/);
+    const job = workflowJobRegistry.get(started.details.workflowId)!;
+    await job.promise;
+
+    expect(getRalplanRunById(cwd, started.details.ralplanRunId)).toMatchObject({
+      phase: "pending_approval",
+      planDigest: "plan-digest",
+    });
+    const collected = await tools.get_workflow_result.execute("result", {
+      workflowId: started.details.workflowId,
+    });
+    expect(collected.details.ralplanRunId).toBe(started.details.ralplanRunId);
+  });
+
+  it("marks a failed RALPLAN workflow terminal without approval", async () => {
+    const cwd = root();
+    const { tools } = setup(cwd);
+    const failedScript = `export const meta = { name: "ralplan-consensus", description: "test" }; throw new Error("boom");`;
+    const result = await tools.workflow.execute(
+      "call",
+      { script: failedScript, async: false },
+      undefined,
+      vi.fn(),
+      { cwd, model: undefined, modelRegistry: undefined },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(listRalplanRuns(cwd, {})).toEqual([
+      expect.objectContaining({
+        phase: "failed",
+        approvalStatus: "unavailable",
+        active: false,
+      }),
+    ]);
+  });
+});

--- a/tests/readme-surface.test.ts
+++ b/tests/readme-surface.test.ts
@@ -58,7 +58,7 @@ describe("README public surface", () => {
       "#### Coordinated completion delivery",
       "#### Consumption-receipt fallback",
     );
-    expect(tools).toHaveLength(23);
+    expect(tools).toHaveLength(28);
     expect(
       tools.filter((name) => name.includes("orchestrator")).sort(),
     ).toEqual(

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -55,6 +55,14 @@ const WORKFLOW_TOOL_NAMES = [
   "workflow",
 ].sort();
 
+const RALPLAN_TOOL_NAMES = [
+  "approve_ralplan",
+  "cancel_ralplan",
+  "get_ralplan_status",
+  "prepare_ralplan_recovery",
+  "reject_ralplan",
+];
+
 function getRegisteredToolNames(api: {
   registerTool: ReturnType<typeof vi.fn>;
 }) {
@@ -103,6 +111,7 @@ describe("extension registration", () => {
         ...IN_PROCESS_TOOL_NAMES,
         ...ORCHESTRATOR_TOOL_NAMES,
         ...WORKFLOW_TOOL_NAMES,
+        ...RALPLAN_TOOL_NAMES,
       ].sort(),
     );
     expect(api.registerCommand).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Phase 3 of #107, stacked on #121 (which is stacked on #120).

- Adds bounded atomic mode-0600 `.pi/ralplan-state.json` records keyed to canonical cwd, exact owner generation, parent session, workflow, run id, and plan digest.
- Captures canonical RALPLAN workflow start/review/completion into deterministic planning, reviewing, pending approval, approved handoff, rejected, capped, cancelled, failed, and interrupted states.
- Adds explicit `get_ralplan_status`, `approve_ralplan`, `reject_ralplan`, `cancel_ralplan`, and read-only `prepare_ralplan_recovery` tools.
- Approval requires exact `{runId, planDigest}`, deactivates state before handoff, and starts no execution.
- Cancels live workflow jobs first on session replacement/shutdown, then records interrupted evidence for reload/resume/quit or cancelled evidence for new/fork.
- Rejects stale owner generation/session actions, malformed/oversized/symlink state, digest mismatches, and automatic recovery.
- Updates package/docs/public tool inventory and adds state, tool, workflow integration, lifecycle, ownership, and recovery tests.

Durable declarative execution remains Phase 4 and is not included here.

## Verification

- `npm test` — 77 files, 1714 tests
- `npm run typecheck`
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`
