### PR TITLE
fix: route orchestrated child attention through parent

### DIFF
--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -123,6 +123,8 @@ export function buildChildSubagentProtocol(artifactDir: string): string {
 
 BE BRIEF. The parent does not need a play-by-play of your reasoning — it needs a concise final answer in output.md and a one-sentence summary after the lifecycle command succeeds. Skip the recap, the apology, and the "let me know if..." closer. Long preambles waste tokens and delay the done signal.
 
+INPUT REQUESTS ARE ORCHESTRATOR-MEDIATED. As a child sub-agent, do not call the pane-local \`ask_user\` tool or ask the human directly. If you need input or a decision, surface one concise question or decision request to your owning orchestrator/parent in output.md and your final summary, complete the turn through the existing child result and lifecycle path, then wait in the REPL for orchestrator direction, usually via a follow-up. This is guidance only, not a technical guard: a parent or orchestrator session may still use \`ask_user\` to ask the human when appropriate.
+
 COMPLETION IS MANDATORY FOR EVERY TURN. A turn is not complete when output.md is written or when you have drafted a final response; it is complete only after cli.mjs returns successfully. This applies to the initial turn and every turn created by a follow-up message. Do not produce or send your final assistant response before invoking cli.mjs, because ending the response first can prevent the lifecycle command from running and leave the parent waiting forever.
 
 Your artifact directory is: ${artifactDir}

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -116,14 +116,18 @@ export { readPaneExitCode } from "./multiplexer-tmux";
  * script, but the `write` tool treats its `path` argument as a literal string,
  * so we must give it the absolute path up front.
  */
-export function buildChildSubagentProtocol(artifactDir: string): string {
+export function buildChildSubagentProtocol(
+  artifactDir: string,
+  orchestratorV2 = false,
+): string {
   const cliPath = `${artifactDir}/cli.mjs`;
   const outputPath = `${artifactDir}/output.md`;
+  const humanAttentionGuidance = orchestratorV2
+    ? `\n\nHUMAN ATTENTION IS ORCHESTRATOR-MEDIATED. As a child sub-agent, do not call the pane-local \`ask_user\` tool, ask the human directly, or otherwise solicit human attention from your pane. This covers any clarification, decision or tradeoff, approval or confirmation, missing requirement or data, permission or credential, external choice, blocker, or any other human action needed to proceed. Instead, surface one concise human-attention request to your owning orchestrator/parent in output.md and your final summary, explaining what is needed and why. Complete the turn through the existing child result and lifecycle path, then wait in the REPL for orchestrator direction, usually via a follow-up. This is guidance only, not a technical guard: a parent or orchestrator session may still use the host \`ask_user\` tool to ask the human when appropriate.`
+    : "";
   return `You are running inside a Pi sub-agent launched by a parent agent. The parent agent reads your work from two files in your artifact directory and from one CLI command. You MUST follow this protocol or your work will be lost.
 
-BE BRIEF. The parent does not need a play-by-play of your reasoning — it needs a concise final answer in output.md and a one-sentence summary after the lifecycle command succeeds. Skip the recap, the apology, and the "let me know if..." closer. Long preambles waste tokens and delay the done signal.
-
-INPUT REQUESTS ARE ORCHESTRATOR-MEDIATED. As a child sub-agent, do not call the pane-local \`ask_user\` tool or ask the human directly. If you need input or a decision, surface one concise question or decision request to your owning orchestrator/parent in output.md and your final summary, complete the turn through the existing child result and lifecycle path, then wait in the REPL for orchestrator direction, usually via a follow-up. This is guidance only, not a technical guard: a parent or orchestrator session may still use \`ask_user\` to ask the human when appropriate.
+BE BRIEF. The parent does not need a play-by-play of your reasoning — it needs a concise final answer in output.md and a one-sentence summary after the lifecycle command succeeds. Skip the recap, the apology, and the "let me know if..." closer. Long preambles waste tokens and delay the done signal.${humanAttentionGuidance}
 
 COMPLETION IS MANDATORY FOR EVERY TURN. A turn is not complete when output.md is written or when you have drafted a final response; it is complete only after cli.mjs returns successfully. This applies to the initial turn and every turn created by a follow-up message. Do not produce or send your final assistant response before invoking cli.mjs, because ending the response first can prevent the lifecycle command from running and leave the parent waiting forever.
 
@@ -517,6 +521,8 @@ export function launchInteractiveSubagent(params: {
   sessionScope?: SessionScope;
   /** Explicit lineage authority; ambient lineage environment is never consulted. */
   spawnTreeContext?: ParsedSpawnTreeContext;
+  /** Whether this child is launched directly by an Orchestratorv2 session. */
+  orchestratorV2?: boolean;
   /** Workflow owner for grouping and cancellation. */
   workflowId?: string;
   /** Workflow-managed completions are consumed by the workflow runner. */
@@ -613,7 +619,10 @@ export function launchInteractiveSubagent(params: {
   // parent-child notification loop working — is the most recent instruction
   // the LLM reads. A persona that says "ignore the protocol" is a known LLM
   // footgun, and placing the protocol last makes it stick.
-  const protocol = buildChildSubagentProtocol(paths.artifactDir);
+  const protocol = buildChildSubagentProtocol(
+    paths.artifactDir,
+    params.orchestratorV2 === true,
+  );
   const systemPromptContent = params.persona
     ? `# Persona\n\n${params.persona}\n\n${protocol}`
     : protocol;

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -621,6 +621,7 @@ export function registerInteractiveSubagentTools(
           thinkingLevel: params.thinkingLevel,
           sessionScope: registration.scope,
           spawnTreeContext: registration.scope?.spawnTreeContext,
+          orchestratorV2: topLevelOrchestratorV2,
         });
         if (registration.scope && completion.policy) {
           try {

--- a/tests/interactive-tmux.test.ts
+++ b/tests/interactive-tmux.test.ts
@@ -1026,20 +1026,49 @@ describe("interactive-tmux", () => {
       expect(protocol).toMatch(/BE BRIEF/);
     });
 
-    it("routes child input requests through the owning parent", async () => {
+    it("routes all child human-attention requests through the owning parent", async () => {
+      const { buildChildSubagentProtocol } = await importFresh<
+        typeof import("../src/interactive-tmux")
+      >("../src/interactive-tmux");
+      const protocol = buildChildSubagentProtocol(FIXTURE_DIR, true);
+
+      expect(protocol).toMatch(/child sub-agent.*do not call.*ask_user/is);
+      expect(protocol).toMatch(/do not.*ask the human directly/is);
+      for (const attentionKind of [
+        "clarification",
+        "decision or tradeoff",
+        "approval or confirmation",
+        "missing requirement or data",
+        "permission or credential",
+        "external choice",
+        "blocker",
+        "any other human action needed to proceed",
+      ]) {
+        expect(protocol).toContain(attentionKind);
+      }
+      expect(protocol).toMatch(
+        /concise human-attention request.*owning orchestrator\/parent/is,
+      );
+      expect(protocol).toMatch(
+        /output\.md.*final summary.*existing child result and lifecycle path/is,
+      );
+      expect(protocol).toMatch(/wait.*orchestrator direction.*follow-up/is);
+      expect(protocol).toMatch(/guidance only.*not a technical guard/is);
+      expect(protocol).toMatch(
+        /parent.*may still use.*host.*ask_user.*human/is,
+      );
+    });
+
+    it("omits human-attention guidance outside Orchestratorv2", async () => {
       const { buildChildSubagentProtocol } = await importFresh<
         typeof import("../src/interactive-tmux")
       >("../src/interactive-tmux");
       const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
 
-      expect(protocol).toMatch(/child sub-agent.*do not call.*ask_user/is);
-      expect(protocol).toMatch(/do not.*ask the human directly/is);
-      expect(protocol).toMatch(
-        /concise question.*owning orchestrator\/parent.*output\.md/is,
+      expect(protocol).not.toContain(
+        "HUMAN ATTENTION IS ORCHESTRATOR-MEDIATED",
       );
-      expect(protocol).toMatch(/wait.*orchestrator direction.*follow-up/is);
-      expect(protocol).toMatch(/guidance only.*not a technical guard/is);
-      expect(protocol).toMatch(/parent.*may still use.*ask_user.*human/is);
+      expect(protocol).not.toMatch(/pane-local.*ask_user/is);
     });
 
     it("requires done before the final assistant response on every turn", async () => {
@@ -1123,6 +1152,10 @@ describe("interactive-tmux", () => {
         name: "NoPersona",
         task: "x",
         cwd: tmp,
+        // Legacy orchestrator lineage alone must not enable V2 guidance.
+        spawnTreeContext: syntheticSpawnTreeContext(tmp, {
+          orchestratorMode: true,
+        }),
       });
       const sysFile = join(state.artifactDir, "nopersona-system.md");
 
@@ -1131,7 +1164,40 @@ describe("interactive-tmux", () => {
       // The system prompt must match the protocol function output for the
       // sub-agent's resolved artifactDir (the literal absolute path).
       expect(content).toBe(buildChildSubagentProtocol(state.artifactDir));
+      expect(content).not.toContain("HUMAN ATTENTION IS ORCHESTRATOR-MEDIATED");
       expect(statSync(sysFile).mode & 0o777).toBe(0o600);
+    });
+
+    it("writes human-attention guidance for Orchestratorv2 children", async () => {
+      const tmp = makeTmp();
+      process.env.PI_CODING_AGENT_SESSION_DIR = tmp;
+      process.env.TMUX = makeArgs().TMUX;
+      process.env.TMUX_PANE = "%9";
+
+      installMockExec((_f, args) => {
+        if (args[0] === "new-window") return MOCK_PANE_ID + "\n";
+        if (args[0] === "display-message") return MOCK_LOCATION;
+        if (args[0] === "show-options") return "0\n";
+        return "";
+      });
+
+      const mod = await importFresh<typeof import("../src/interactive-tmux")>(
+        "../src/interactive-tmux",
+      );
+      const { buildChildSubagentProtocol } = await importFresh<
+        typeof import("../src/interactive-tmux")
+      >("../src/interactive-tmux");
+      const state = mod.launchInteractiveSubagent({
+        name: "Orchestrated",
+        task: "x",
+        cwd: tmp,
+        orchestratorV2: true,
+      });
+      const sysFile = join(state.artifactDir, "orchestrated-system.md");
+
+      expect(readFileSync(sysFile, "utf8")).toBe(
+        buildChildSubagentProtocol(state.artifactDir, true),
+      );
     });
 
     it("places the persona ABOVE the protocol (recency favors the protocol)", async () => {

--- a/tests/interactive-tmux.test.ts
+++ b/tests/interactive-tmux.test.ts
@@ -1026,6 +1026,22 @@ describe("interactive-tmux", () => {
       expect(protocol).toMatch(/BE BRIEF/);
     });
 
+    it("routes child input requests through the owning parent", async () => {
+      const { buildChildSubagentProtocol } = await importFresh<
+        typeof import("../src/interactive-tmux")
+      >("../src/interactive-tmux");
+      const protocol = buildChildSubagentProtocol(FIXTURE_DIR);
+
+      expect(protocol).toMatch(/child sub-agent.*do not call.*ask_user/is);
+      expect(protocol).toMatch(/do not.*ask the human directly/is);
+      expect(protocol).toMatch(
+        /concise question.*owning orchestrator\/parent.*output\.md/is,
+      );
+      expect(protocol).toMatch(/wait.*orchestrator direction.*follow-up/is);
+      expect(protocol).toMatch(/guidance only.*not a technical guard/is);
+      expect(protocol).toMatch(/parent.*may still use.*ask_user.*human/is);
+    });
+
     it("requires done before the final assistant response on every turn", async () => {
       const { buildChildSubagentProtocol } = await importFresh<
         typeof import("../src/interactive-tmux")

--- a/tests/subagent-interactive-default.test.ts
+++ b/tests/subagent-interactive-default.test.ts
@@ -438,6 +438,9 @@ describe("subagent_interactive tool lifecycle", () => {
     );
 
     expect(mockLaunchInteractiveSubagent).toHaveBeenCalledOnce();
+    expect(mockLaunchInteractiveSubagent).toHaveBeenCalledWith(
+      expect.objectContaining({ orchestratorV2: true }),
+    );
     expect(mockUpsertOrchestratorRoutingEntry).toHaveBeenCalledWith(
       "/tmp",
       entry,


### PR DESCRIPTION
## Summary
- add prompt-only guidance exclusively to children launched directly by Orchestratorv2
- tell those children not to solicit human attention pane-locally for clarifications, decisions/tradeoffs, approvals/confirmations, missing requirements/data, permissions/credentials, external choices, blockers, or any other human action needed to proceed
- route concise attention requests through the truthful existing `output.md` / completion / final-summary path, then wait for orchestrator follow-up
- preserve ordinary interactive-child prompts and parent/orchestrator host `ask_user` behavior

## Tests
- `npm test -- tests/interactive-tmux.test.ts tests/subagent-interactive-default.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run format:check`
- `npm run pack:check`

## Limitations
This is prompt-only, best-effort guidance. It adds no enforcement, durable attention state or protocol, tool, guard, RPC broker, response API, footer, popup, or generic UI interception. Delivery remains the existing child result/completion path and orchestrator-sent follow-up.
