### PR TITLE
feat: show working sub-agent count in footer

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -88,6 +88,7 @@ interface WidgetSurfaceState {
 interface SubagentFooterContribution {
   kind: "subagent";
   count: number;
+  workingCount: number;
   footerLabel?: string;
 }
 interface WorkflowFooterContribution {
@@ -157,6 +158,23 @@ function getRunningSubagentCount(
   return inProcessCount + interactiveCount;
 }
 
+/**
+ * Count active execution rows, not containers. Workflow-owned children already
+ * live in exactly one child registry, so counting workflow jobs/snapshots here
+ * would count the same work twice.
+ */
+function getWorkingSubagentCount(
+  owners: (SessionOwnerToken | undefined)[],
+): number {
+  const inProcessCount = inProcessJobsForOwners(owners).filter(
+    (job) => job.status === "running",
+  ).length;
+  const interactiveCount = interactiveStatesForOwners(owners).filter(
+    (state) => state.status === "running",
+  ).length;
+  return inProcessCount + interactiveCount;
+}
+
 function addAggregateWorkflowUsage(
   total: WorkflowUsage,
   usage: WorkflowUsage | undefined,
@@ -179,15 +197,18 @@ function mergeFooterContributions(
 ): string | undefined {
   if (key === FOOTER_KEY) {
     let total = 0;
+    let totalWorking = 0;
     let footerLabel: string | undefined;
     for (const contribution of contributions) {
       if (contribution.kind !== "subagent") continue;
       total += contribution.count;
+      totalWorking += contribution.workingCount;
       footerLabel ??= contribution.footerLabel;
     }
     if (total === 0) return footerLabel;
+    const working = totalWorking > 0 ? ` · ${totalWorking} working` : "";
     const label = footerLabel ? ` · ${footerLabel}` : "";
-    return `⚡ ${total} sub-agent${total > 1 ? "s" : ""} alive${label}`;
+    return `⚡ ${total} sub-agent${total > 1 ? "s" : ""} alive${working}${label}`;
   }
   if (key === WORKFLOW_FOOTER_KEY) {
     let total = 0;
@@ -302,26 +323,29 @@ function footerLabelsForOwner(
   return labels.length > 0 ? labels.join(" · ") : undefined;
 }
 /**
- * Repaint the "N sub-agents alive" footer, scoped to `owner` when supplied.
+ * Repaint the "N sub-agents alive · N working" footer, scoped to `owner`.
  *
- * Liveness is decided here rather than at the call sites: callers pass the raw
- * active token, so a token whose lifecycle already ended reads as "this session
- * owns nothing" (count 0) instead of silently falling back to a cross-session
- * global count.
+ * `alive` keeps the established liveness contract: running in-process jobs
+ * plus running, idle, or unknown interactive panes. `working` is the strict
+ * subset currently executing: running in-process jobs and running interactive
+ * turns only. Idle/unknown/terminal rows and workflow containers are excluded.
+ * A stale owner reads as zero instead of falling back to cross-session state.
  */
 export function updateRunningSubagentFooter(
   ui: StatusUi,
   owner?: SessionOwnerToken,
 ): void {
   const ownerContext = resolveLiveSessionScope(owner);
-  const runningCount =
-    owner !== undefined && !ownerContext ? 0 : getRunningSubagentCount([owner]);
+  const staleOwner = owner !== undefined && !ownerContext;
+  const runningCount = staleOwner ? 0 : getRunningSubagentCount([owner]);
+  const workingCount = staleOwner ? 0 : getWorkingSubagentCount([owner]);
   const footerLabel = footerLabelsForOwner(owner);
   const contribution: SubagentFooterContribution | undefined =
     runningCount > 0 || footerLabel !== undefined
       ? {
           kind: "subagent",
           count: runningCount,
+          workingCount,
           footerLabel,
         }
       : undefined;

--- a/tests/footer-working-count.test.ts
+++ b/tests/footer-working-count.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { updateRunningSubagentFooter } from "../src/artifact-poller";
+import { jobRegistry, type JobState, type JobStatus } from "../src/helpers";
+import {
+  interactiveSubagentRegistry,
+  type InteractiveSubagentState,
+  type InteractiveSubagentStatus,
+} from "../src/interactive-tmux";
+import {
+  advanceSessionScopeGeneration,
+  clearSessionScopes,
+  registerSessionScope,
+  sessionOwner,
+  type SessionScope,
+} from "../src/session-scope";
+import {
+  workflowJobRegistry,
+  type WorkflowJobState,
+} from "../src/workflow-jobs";
+
+function makeJob(id: string, status: JobStatus): JobState {
+  return {
+    id,
+    status,
+    liveStatus: {
+      turn: 0,
+      output: "",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: 0,
+        turns: 0,
+      },
+    },
+    session: { abort: vi.fn() } as never,
+    startedAt: 0,
+    promise: new Promise(() => {}),
+  };
+}
+
+function makeInteractive(
+  id: string,
+  status: InteractiveSubagentStatus,
+): InteractiveSubagentState {
+  return {
+    id,
+    name: id,
+    task: "test",
+    paneId: `%${id}`,
+    mux: "tmux",
+    sessionFile: `/tmp/${id}.jsonl`,
+    cwd: "/tmp",
+    startedAt: 0,
+    status,
+    attachCommand: "attach",
+    selectPaneCommand: "select",
+    launchScriptFile: `/tmp/${id}.sh`,
+    artifactDir: `/tmp/${id}`,
+  };
+}
+
+function makeScope(orchestratorv2 = false): SessionScope {
+  return registerSessionScope({
+    id: 1,
+    generation: 1,
+    lifecycle: "started",
+    pi: {
+      getFlag: vi.fn((name: string) =>
+        name === "orchestratorv2" ? orchestratorv2 : false,
+      ),
+    } as never,
+  });
+}
+
+function makeWorkflow(id: string, name: string): WorkflowJobState {
+  return {
+    id,
+    name,
+    status: "running",
+    startedAt: 0,
+    promise: new Promise(() => {}),
+    abort: new AbortController(),
+    snapshot: {
+      agentsSpawned: 1,
+      errorCount: 0,
+      tokensSpent: 0,
+      phases: [],
+      runningCount: 1,
+    },
+  };
+}
+
+beforeEach(() => {
+  clearSessionScopes();
+  jobRegistry.clear();
+  interactiveSubagentRegistry.clear();
+  workflowJobRegistry.clear();
+});
+
+afterEach(() => {
+  clearSessionScopes();
+  jobRegistry.clear();
+  interactiveSubagentRegistry.clear();
+  workflowJobRegistry.clear();
+});
+
+describe("footer working count", () => {
+  it("keeps alive semantics while counting only running interactive turns and in-process jobs", () => {
+    const scope = makeScope();
+    for (const status of [
+      "running",
+      "idle",
+      "unknown",
+      "exited",
+      "cancelled",
+    ] as const) {
+      scope.interactiveStates.set(
+        `interactive-${status}`,
+        makeInteractive(`interactive-${status}`, status),
+      );
+    }
+    for (const status of ["running", "done", "error", "cancelled"] as const) {
+      scope.inProcessJobs.set(
+        `job-${status}`,
+        makeJob(`job-${status}`, status),
+      );
+    }
+    const ui = { setStatus: vi.fn() };
+
+    updateRunningSubagentFooter(ui, sessionOwner(scope));
+
+    expect(ui.setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 4 sub-agents alive · 2 working",
+    );
+  });
+
+  it("counts workflow-owned children once and not their workflow aggregate", () => {
+    const scope = makeScope();
+    const owner = sessionOwner(scope);
+    const processChild = makeJob("process-child", "running");
+    processChild.workflowId = "workflow-1";
+    processChild.completionOwner = "workflow";
+    const interactiveChild = makeInteractive("interactive-child", "running");
+    interactiveChild.workflowId = "workflow-1";
+    interactiveChild.completionOwner = "workflow";
+    scope.inProcessJobs.set(processChild.id, processChild);
+    scope.interactiveStates.set(interactiveChild.id, interactiveChild);
+    const workflow = makeWorkflow("workflow-1", "review-auth");
+    workflow.parentSessionOwner = owner;
+    workflow.snapshot.agentsSpawned = 2;
+    workflow.snapshot.runningCount = 2;
+    workflowJobRegistry.set(workflow.id, workflow);
+    const ui = { setStatus: vi.fn() };
+
+    updateRunningSubagentFooter(ui, owner);
+
+    expect(ui.setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 2 sub-agents alive · 2 working · workflow review-auth",
+    );
+  });
+
+  it("omits the working segment at zero and omits the whole plain footer at zero alive", () => {
+    const scope = makeScope();
+    scope.interactiveStates.set("idle", makeInteractive("idle", "idle"));
+    scope.interactiveStates.set(
+      "unknown",
+      makeInteractive("unknown", "unknown"),
+    );
+    const ui = { setStatus: vi.fn() };
+
+    updateRunningSubagentFooter(ui, sessionOwner(scope));
+    expect(ui.setStatus).toHaveBeenLastCalledWith(
+      "subagentura-running",
+      "⚡ 2 sub-agents alive",
+    );
+
+    scope.interactiveStates.clear();
+    updateRunningSubagentFooter(ui, sessionOwner(scope));
+    expect(ui.setStatus).toHaveBeenLastCalledWith(
+      "subagentura-running",
+      undefined,
+    );
+  });
+
+  it("preserves Orchestratorv2 and legacy identity behavior", () => {
+    const scope = makeScope(true);
+    scope.inProcessJobs.set("owned", makeJob("owned", "running"));
+    const orchestratorUi = { setStatus: vi.fn() };
+
+    updateRunningSubagentFooter(orchestratorUi, sessionOwner(scope));
+    expect(orchestratorUi.setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent alive · 1 working · orchestrator",
+    );
+
+    clearSessionScopes();
+    const legacyJob = makeJob("legacy", "running");
+    jobRegistry.set(legacyJob.id, legacyJob);
+    const legacyUi = { setStatus: vi.fn() };
+    updateRunningSubagentFooter(legacyUi);
+    expect(legacyUi.setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent alive · 1 working",
+    );
+  });
+
+  it("fails closed for a stale owner generation", () => {
+    const scope = makeScope();
+    const staleOwner = sessionOwner(scope);
+    scope.inProcessJobs.set("stale", makeJob("stale", "running"));
+    advanceSessionScopeGeneration(scope.id);
+    const ui = { setStatus: vi.fn() };
+
+    updateRunningSubagentFooter(ui, staleOwner);
+
+    expect(ui.setStatus).toHaveBeenCalledWith("subagentura-running", undefined);
+  });
+
+  it("memoizes identical counts and repaints when working changes", () => {
+    const scope = makeScope();
+    const state = makeInteractive("agent", "running");
+    scope.interactiveStates.set(state.id, state);
+    const ui = { setStatus: vi.fn() };
+    const owner = sessionOwner(scope);
+
+    updateRunningSubagentFooter(ui, owner);
+    updateRunningSubagentFooter(ui, owner);
+    expect(ui.setStatus).toHaveBeenCalledTimes(1);
+
+    state.status = "idle";
+    updateRunningSubagentFooter(ui, owner);
+    updateRunningSubagentFooter(ui, owner);
+    expect(ui.setStatus).toHaveBeenCalledTimes(2);
+    expect(ui.setStatus).toHaveBeenLastCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent alive",
+    );
+  });
+});

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -528,7 +528,7 @@ describe("session handler lifecycle callbacks", () => {
     updateRunningSubagentFooter(sharedUi, sessionOwner(a.sessionScope));
     expect(sharedUi.setStatus).toHaveBeenLastCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent alive · orchestrator",
+      "⚡ 1 sub-agent alive · 1 working · orchestrator",
     );
 
     a.handlers.get("session_shutdown")![0]({ reason: "quit" }, aCtx);
@@ -556,7 +556,7 @@ describe("session handler lifecycle callbacks", () => {
 
     expect(ui.setStatus).toHaveBeenLastCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent alive · orchestrator",
+      "⚡ 1 sub-agent alive · 1 working · orchestrator",
     );
   });
 
@@ -603,7 +603,7 @@ describe("session handler lifecycle callbacks", () => {
 
       expect(ui.setStatus).toHaveBeenLastCalledWith(
         "subagentura-running",
-        "⚡ 1 sub-agent alive · subagent of orchestrator orchestrator-agent · workflow review-auth",
+        "⚡ 1 sub-agent alive · 1 working · subagent of orchestrator orchestrator-agent · workflow review-auth",
       );
     },
   );
@@ -630,7 +630,7 @@ describe("session handler lifecycle callbacks", () => {
 
     expect(ui.setStatus).toHaveBeenLastCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent alive · orchestrator · workflow workflow-id",
+      "⚡ 1 sub-agent alive · 1 working · orchestrator · workflow workflow-id",
     );
   });
 

--- a/tests/subagent-interactive-default.test.ts
+++ b/tests/subagent-interactive-default.test.ts
@@ -745,7 +745,7 @@ describe("subagent_interactive tool lifecycle", () => {
 
     expect(ctx.ui.setStatus).toHaveBeenCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent alive",
+      "⚡ 1 sub-agent alive · 1 working",
     );
   });
 
@@ -782,7 +782,7 @@ describe("subagent_interactive tool lifecycle", () => {
 
       expect(ctx.ui.setStatus).toHaveBeenCalledWith(
         "subagentura-running",
-        "⚡ 1 sub-agent alive · orchestrator",
+        "⚡ 1 sub-agent alive · 1 working · orchestrator",
       );
     },
   );
@@ -819,7 +819,7 @@ describe("subagent_interactive tool lifecycle", () => {
 
     expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent alive",
+      "⚡ 1 sub-agent alive · 1 working",
     );
   });
 

--- a/tests/subagent-notify.test.ts
+++ b/tests/subagent-notify.test.ts
@@ -408,7 +408,7 @@ describe("notifyOnComplete", () => {
 
           expect(ctx.ui.setStatus).toHaveBeenCalledWith(
             "subagentura-running",
-            "⚡ 1 sub-agent alive",
+            "⚡ 1 sub-agent alive · 1 working",
           );
 
           control.resolve(SUCCESS_RESULT);

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -395,7 +395,7 @@ describe("pollArtifactChanges", () => {
     const footerCalls = sharedUi.setStatus.mock.calls.filter(
       ([key]) => key === "subagentura-running",
     );
-    expect(footerCalls.at(-1)?.[1]).toBe("⚡ 1 sub-agent alive");
+    expect(footerCalls.at(-1)?.[1]).toBe("⚡ 1 sub-agent alive · 1 working");
   });
 
   it("aggregates workflow footer contributions across owners sharing one UI", async () => {
@@ -985,7 +985,7 @@ describe("pollArtifactChanges", () => {
 
     expect(setStatus).toHaveBeenCalledWith(
       "subagentura-running",
-      "⚡ 1 sub-agent alive",
+      "⚡ 1 sub-agent alive · 1 working",
     );
   });
 
@@ -2047,7 +2047,7 @@ describe("pollArtifactChanges", () => {
 
       expect(setStatus).toHaveBeenCalledWith(
         "subagentura-running",
-        "⚡ 2 sub-agents alive",
+        "⚡ 2 sub-agents alive · 1 working",
       );
       expect(setWidget).toHaveBeenCalledWith(
         "subagentura-activity",
@@ -2221,7 +2221,7 @@ describe("pollArtifactChanges", () => {
 
       expect(setStatus).toHaveBeenCalledWith(
         "subagentura-running",
-        "⚡ 3 sub-agents alive",
+        "⚡ 3 sub-agents alive · 3 working",
       );
       const widgetArgs = setWidget.mock.calls[0];
       expect(widgetArgs[1].length).toBe(2);

--- a/tests/workflow-supervisor.integration.test.ts
+++ b/tests/workflow-supervisor.integration.test.ts
@@ -368,7 +368,7 @@ describe("workflow supervisor integration", () => {
     expect((rows as string[]).join("\n")).toContain("reviewer");
     expect((rows as string[]).join("\n")).not.toContain("sibling-agent");
     expect(lastFooter(a.ui)).toBe(
-      "⚡ 1 sub-agent alive · workflow widget-visible",
+      "⚡ 1 sub-agent alive · 1 working · workflow widget-visible",
     );
     // B's surfaces are untouched by A's tick.
     expect(lastWidgetRows(b.ui)).toBe("never-painted");


### PR DESCRIPTION
## Summary
- add a separate `· N working` segment to the existing sub-agent footer
- preserve `alive` semantics while counting only running in-process jobs and running interactive turns as working
- omit the working segment at zero and avoid counting workflow containers in addition to their child agents

## Semantics
- `alive`: unchanged — running in-process jobs plus running, idle, or unknown interactive children
- `working`: running in-process jobs plus interactive children whose status is `running`
- idle, unknown, exited, cancelled, stale-owner, done, and error states do not contribute to `working`
- workflow-owned children contribute through their interactive or in-process child row; workflow job/snapshot aggregates are intentionally excluded

## Verification
- `npm run format:check`
- `npm run typecheck`
- `npm test` (72 files, 1695 tests)
- `npm run pack:check`
- `git diff --check`
