### PR TITLE
feat(supervisor): add adaptive popup grid

### DIFF
--- a/src/interactive-supervisor-ui.ts
+++ b/src/interactive-supervisor-ui.ts
@@ -3,7 +3,12 @@ import type {
   Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { Component, OverlayHandle, TUI } from "@earendil-works/pi-tui";
-import { Key, matchesKey } from "@earendil-works/pi-tui";
+import {
+  Key,
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
 import { promises as fs, type promises as fsTypes } from "node:fs";
 import { join } from "node:path";
 import type { JobState } from "./helpers";
@@ -28,6 +33,40 @@ const DETAIL_EVENTS_MAX_BYTES = 8 * 1024;
 const DETAIL_PREVIEW_MAX_CHARS = 512;
 const DETAIL_EVENT_COUNT = 3;
 const DETAIL_WORKFLOW_AGENT_COUNT = 20;
+// Pi's SelectList starts a secondary column above 40 cells. Forty-four keeps
+// source, status, and the beginning of a label visible before truncation.
+export const INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH = 44;
+const SUPERVISOR_GRID_PREFIX = "│ ";
+const SUPERVISOR_GRID_GAP = " │ ";
+const SUPERVISOR_GRID_PREFIX_WIDTH = visibleWidth(SUPERVISOR_GRID_PREFIX);
+const SUPERVISOR_GRID_GAP_WIDTH = visibleWidth(SUPERVISOR_GRID_GAP);
+
+export function interactiveSupervisorMinimumGridWidth(columns: number): number {
+  const count = Math.max(1, Math.floor(Number.isFinite(columns) ? columns : 1));
+  return (
+    SUPERVISOR_GRID_PREFIX_WIDTH +
+    count * INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH +
+    (count - 1) * SUPERVISOR_GRID_GAP_WIDTH
+  );
+}
+
+export function interactiveSupervisorColumnCount(
+  width: number,
+  itemCount: number,
+): number {
+  const count = Math.max(
+    0,
+    Math.floor(Number.isFinite(itemCount) ? itemCount : 0),
+  );
+  if (count <= 1) return 1;
+  const safeWidth = Math.max(0, Math.floor(Number.isFinite(width) ? width : 0));
+  const contentWidth = Math.max(0, safeWidth - SUPERVISOR_GRID_PREFIX_WIDTH);
+  const fitting = Math.floor(
+    (contentWidth + SUPERVISOR_GRID_GAP_WIDTH) /
+      (INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH + SUPERVISOR_GRID_GAP_WIDTH),
+  );
+  return Math.max(1, Math.min(count, fitting));
+}
 
 export type InteractiveSupervisorAction = { kind: "close" };
 type SupervisorDone = (action: InteractiveSupervisorAction) => void;
@@ -97,6 +136,8 @@ export interface InteractiveSupervisorOptions {
   ) => Promise<boolean | undefined> | boolean | undefined;
   /** Warning/status lines rendered under the list (hidden nodes, refresh failures). */
   status?: () => string[];
+  /** Effective overlay height; absent means the safe height is unknown. */
+  availableHeight?: () => number | undefined;
   refreshIntervalMs?: number;
   now?: () => number;
   items?: () => AsyncSupervisorItem[];
@@ -108,6 +149,7 @@ export class InteractiveSupervisorComponent {
   private selectedKey?: string;
   private expanded = new Set<string>();
   private cachedWidth?: number;
+  private cachedHeight?: number;
   private cachedLines?: string[];
   private readonly timer?: ReturnType<typeof setInterval>;
   private disposed = false;
@@ -130,8 +172,21 @@ export class InteractiveSupervisorComponent {
   }
 
   render(width: number): string[] {
-    if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
+    const availableHeight = normalizeAvailableHeight(
+      this.opts.availableHeight?.(),
+    );
+    if (
+      this.cachedLines &&
+      this.cachedWidth === width &&
+      this.cachedHeight === availableHeight
+    ) {
+      return this.cachedLines;
+    }
     const items = this.items();
+    const now = this.now();
+    const status = (this.opts.status?.() ?? []).map((line) =>
+      trunc(`│ ${compactText(line)}`, width),
+    );
     const lines = [
       trunc("┌ Async Subagents", width),
       trunc("│ All: ↑↓/jk select · enter/→ details · ← collapse", width),
@@ -145,40 +200,97 @@ export class InteractiveSupervisorComponent {
     if (items.length === 0) {
       lines.push(trunc("│ No async subagents.", width));
     } else {
-      items.forEach((item, index) => {
-        const selected = index === this.selectedIndex;
-        const itemKey = supervisorItemKey(item);
-        const expanded = this.expanded.has(itemKey);
-        const marker = selected ? "▶" : "○";
-        lines.push(
-          trunc(
-            `│ ${"  ".repeat(item.depth)}${marker} ${expanded ? "▾" : "▸"} ${formatAsyncSupervisorSummary(
-              item,
-              this.now(),
-            )}`,
-            width,
-          ),
-        );
-        if (expanded) {
-          lines.push(
-            ...formatAsyncDetails(
-              item,
-              width,
-              this.artifactDetails.get(itemKey),
-            ),
-          );
-        }
-      });
+      const fixedHeight = lines.length + status.length + 1;
+      lines.push(
+        ...this.renderItems(items, width, availableHeight, fixedHeight, now),
+      );
     }
 
-    for (const line of this.opts.status?.() ?? []) {
-      lines.push(trunc(`│ ${compactText(line)}`, width));
-    }
-
+    lines.push(...status);
     lines.push(trunc(`└${"─".repeat(Math.max(0, width - 2))}┘`, width));
     this.cachedWidth = width;
+    this.cachedHeight = availableHeight;
     this.cachedLines = lines;
     return lines;
+  }
+
+  private renderItems(
+    items: AsyncSupervisorItem[],
+    width: number,
+    availableHeight: number | undefined,
+    fixedHeight: number,
+    now: number,
+  ): string[] {
+    const columns = interactiveSupervisorColumnCount(width, items.length);
+    if (columns > 1 && availableHeight !== undefined) {
+      const grid = this.renderGridItems(items, width, columns, now);
+      if (fixedHeight + grid.length <= availableHeight) return grid;
+    }
+    return this.renderLinearItems(items, width, now);
+  }
+
+  private renderLinearItems(
+    items: AsyncSupervisorItem[],
+    width: number,
+    now: number,
+  ): string[] {
+    const lines: string[] = [];
+    items.forEach((item, index) => {
+      const itemKey = supervisorItemKey(item);
+      lines.push(trunc(`│ ${this.summary(item, index, now)}`, width));
+      if (this.expanded.has(itemKey)) {
+        lines.push(
+          ...formatAsyncDetails(item, width, this.artifactDetails.get(itemKey)),
+        );
+      }
+    });
+    return lines;
+  }
+
+  private renderGridItems(
+    items: AsyncSupervisorItem[],
+    width: number,
+    columns: number,
+    now: number,
+  ): string[] {
+    const columnWidths = supervisorGridColumnWidths(width, columns);
+    const lines: string[] = [];
+    for (let start = 0; start < items.length; start += columns) {
+      const cells = columnWidths.map((cellWidth, offset) => {
+        const item = items[start + offset];
+        const summary = item ? this.summary(item, start + offset, now) : "";
+        return truncateToWidth(summary, cellWidth, "…", true);
+      });
+      lines.push(
+        trunc(
+          `${SUPERVISOR_GRID_PREFIX}${cells.join(SUPERVISOR_GRID_GAP)}`,
+          width,
+        ),
+      );
+      // Details retain the original full width instead of becoming unreadable
+      // inside a summary cell. Multiple expansions follow row-major item order.
+      for (let offset = 0; offset < columns; offset++) {
+        const item = items[start + offset];
+        if (!item) continue;
+        const itemKey = supervisorItemKey(item);
+        if (!this.expanded.has(itemKey)) continue;
+        lines.push(
+          ...formatAsyncDetails(item, width, this.artifactDetails.get(itemKey)),
+        );
+      }
+    }
+    return lines;
+  }
+
+  private summary(
+    item: AsyncSupervisorItem,
+    index: number,
+    now: number,
+  ): string {
+    const itemKey = supervisorItemKey(item);
+    const marker = index === this.selectedIndex ? "▶" : "○";
+    const disclosure = this.expanded.has(itemKey) ? "▾" : "▸";
+    return `${"  ".repeat(item.depth)}${marker} ${disclosure} ${formatAsyncSupervisorSummary(item, now)}`;
   }
 
   handleInput(data: string): void {
@@ -256,6 +368,7 @@ export class InteractiveSupervisorComponent {
 
   invalidate(): void {
     this.cachedWidth = undefined;
+    this.cachedHeight = undefined;
     this.cachedLines = undefined;
   }
 
@@ -538,6 +651,7 @@ export async function showInteractiveSupervisor(
           done,
           requestRender: () => tui.requestRender?.(),
           notify: (message, level) => ui.notify(message, level),
+          availableHeight: () => supervisorOverlayHeight(tui.terminal?.rows),
         });
         return component;
       },
@@ -935,9 +1049,34 @@ function clampIndex(index: number, length: number): number {
   return Math.min(Math.max(0, index), Math.max(0, length - 1));
 }
 
+function supervisorGridColumnWidths(width: number, columns: number): number[] {
+  const gapWidth = (columns - 1) * SUPERVISOR_GRID_GAP_WIDTH;
+  const contentWidth = Math.max(
+    0,
+    Math.floor(width) - SUPERVISOR_GRID_PREFIX_WIDTH - gapWidth,
+  );
+  const baseWidth = Math.floor(contentWidth / columns);
+  const remainder = contentWidth % columns;
+  return Array.from(
+    { length: columns },
+    (_, index) => baseWidth + (index < remainder ? 1 : 0),
+  );
+}
+
+function normalizeAvailableHeight(
+  availableHeight: number | undefined,
+): number | undefined {
+  if (availableHeight === undefined || !Number.isFinite(availableHeight)) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(availableHeight));
+}
+
+function supervisorOverlayHeight(rows: number | undefined): number | undefined {
+  if (rows === undefined || !Number.isFinite(rows)) return undefined;
+  return Math.max(1, Math.floor(rows * 0.85));
+}
+
 function trunc(text: string, width: number): string {
-  if (width <= 0) return "";
-  if (text.length <= width) return text;
-  if (width === 1) return text.slice(0, 1);
-  return `${text.slice(0, width - 1)}…`;
+  return truncateToWidth(text, width, "…");
 }

--- a/tests/interactive-supervisor.test.ts
+++ b/tests/interactive-supervisor.test.ts
@@ -17,10 +17,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import {
   InteractiveSupervisorComponent,
   closeActiveInteractiveSupervisor,
   formatSupervisorSummary,
+  interactiveSupervisorColumnCount,
+  interactiveSupervisorMinimumGridWidth,
   showInteractiveSupervisor,
 } from "../src/interactive-supervisor-ui";
 import {
@@ -297,8 +300,194 @@ describe("interactive supervisor", () => {
 
     expect(lines.some((line) => line.includes("abcdef12"))).toBe(true);
     expect(lines.some((line) => line.includes("reading"))).toBe(true);
-    expect(lines.every((line) => line.length <= 72)).toBe(true);
+    expect(lines.every((line) => visibleWidth(line) <= 72)).toBe(true);
     expect(formatSupervisorSummary(item, Date.now())).toContain("tmux");
+  });
+
+  it("derives one, two, three, and four columns from readable width", () => {
+    const ids = ["zero", "one", "two", "three", "four", "five", "six"];
+    const items = ids.map((id) => ({
+      kind: "interactive" as const,
+      state: state(id),
+      depth: 0,
+      actionable: true,
+    }));
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => items,
+      availableHeight: () => 40,
+    });
+    const itemRows = (width: number) =>
+      component.render(width).filter((line) => line.includes("[registry]"));
+    const oneColumnWidth = interactiveSupervisorMinimumGridWidth(2) - 1;
+    const twoColumnWidth = interactiveSupervisorMinimumGridWidth(2);
+    const threeColumnWidth = interactiveSupervisorMinimumGridWidth(3);
+    const fourColumnWidth = interactiveSupervisorMinimumGridWidth(4);
+
+    expect(interactiveSupervisorColumnCount(oneColumnWidth, items.length)).toBe(
+      1,
+    );
+    expect(interactiveSupervisorColumnCount(twoColumnWidth, items.length)).toBe(
+      2,
+    );
+    expect(
+      interactiveSupervisorColumnCount(threeColumnWidth, items.length),
+    ).toBe(3);
+    expect(
+      interactiveSupervisorColumnCount(fourColumnWidth, items.length),
+    ).toBe(4);
+    expect(itemRows(oneColumnWidth)).toHaveLength(7);
+    expect(itemRows(twoColumnWidth)).toHaveLength(4);
+    expect(itemRows(threeColumnWidth)).toHaveLength(3);
+    expect(itemRows(fourColumnWidth)).toHaveLength(2);
+    expect(interactiveSupervisorColumnCount(fourColumnWidth, 2)).toBe(2);
+  });
+
+  it("uses row-major order for odd counts, navigation, and resize", () => {
+    const items = ["zero", "one", "two", "three", "four"].map((id) => ({
+      kind: "interactive" as const,
+      state: state(id),
+      depth: 0,
+      actionable: true,
+    }));
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => items,
+      availableHeight: () => 40,
+    });
+    const threeColumnWidth = interactiveSupervisorMinimumGridWidth(3);
+    const twoColumnWidth = interactiveSupervisorMinimumGridWidth(2);
+
+    const itemRows = component
+      .render(threeColumnWidth)
+      .filter((line) => line.includes("[registry]"));
+    expect(itemRows).toHaveLength(2);
+    expect(itemRows[0]).toContain("agent-zero");
+    expect(itemRows[0]).toContain("agent-one");
+    expect(itemRows[0]).toContain("agent-two");
+    expect(itemRows[1]).toContain("agent-three");
+    expect(itemRows[1]).toContain("agent-four");
+
+    component.handleInput("j");
+    component.handleInput("j");
+    component.handleInput("j");
+    expect(
+      component.render(threeColumnWidth).find((line) => line.includes("▶")),
+    ).toMatch(/▶.*agent-three/);
+    expect(
+      component.render(twoColumnWidth).find((line) => line.includes("▶")),
+    ).toMatch(/▶.*agent-three/);
+    component.handleInput("j");
+    expect(
+      component.render(twoColumnWidth).find((line) => line.includes("▶")),
+    ).toMatch(/▶.*agent-four/);
+    component.handleInput("k");
+    expect(
+      component.render(threeColumnWidth).find((line) => line.includes("▶")),
+    ).toMatch(/▶.*agent-three/);
+  });
+
+  it("uses multiple columns only when the complete grid fits the height", () => {
+    const items = ["one", "two"].map((id) => ({
+      kind: "interactive" as const,
+      state: state(id),
+      depth: 0,
+      actionable: true,
+    }));
+    let availableHeight = 8;
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => items,
+      availableHeight: () => availableHeight,
+    });
+    const width = interactiveSupervisorMinimumGridWidth(2);
+    const itemRows = () =>
+      component.render(width).filter((line) => line.includes("[registry]"));
+
+    expect(itemRows()).toHaveLength(2);
+    availableHeight = 9;
+    expect(itemRows()).toHaveLength(1);
+  });
+
+  it("renders expanded loading details full-span with Unicode-safe bounds", () => {
+    const longText = `${"界🙂 long label ".repeat(80)}\nsecond line`;
+    const items = [
+      state("expanded", {
+        name: longText,
+        task: longText,
+        artifactDir: "unknown",
+      }),
+      state("peer"),
+      state("third"),
+    ].map((interactive) => ({
+      kind: "interactive" as const,
+      state: interactive,
+      depth: 0,
+      actionable: true,
+    }));
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => items,
+      availableHeight: () => 40,
+      status: () => [`⚠ ${longText}`],
+    });
+    const width = interactiveSupervisorMinimumGridWidth(3);
+
+    component.handleInput("\r");
+    const lines = component.render(width);
+    const summaryRow = lines.find((line) => line.includes("[registry]"));
+
+    expect(summaryRow).toContain("agent-peer");
+    expect(summaryRow).toContain("agent-third");
+    expect(lines.some((line) => line.includes("Task: 界🙂 long label"))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes("Lifecycle: loading…"))).toBe(
+      true,
+    );
+    expect(lines.every((line) => !line.includes("\n"))).toBe(true);
+    expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+  });
+
+  it("keeps the empty state single-span at multi-column widths", () => {
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => [],
+      availableHeight: () => 40,
+    });
+
+    const lines = component.render(interactiveSupervisorMinimumGridWidth(4));
+
+    expect(lines).toContain("│ No async subagents.");
+    expect(lines.filter((line) => line.includes("No async subagents"))).toEqual(
+      ["│ No async subagents."],
+    );
+  });
+
+  it("does not refresh async state during repeated navigation", () => {
+    const refresh = vi.fn();
+    const requestRender = vi.fn();
+    const items = ["one", "two"].map((id) => ({
+      kind: "interactive" as const,
+      state: state(id),
+      depth: 0,
+      actionable: true,
+    }));
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => items,
+      refresh,
+      requestRender,
+      availableHeight: () => 40,
+      refreshIntervalMs: 0,
+    });
+
+    for (let index = 0; index < 1_000; index++) {
+      component.handleInput(index % 2 === 0 ? "j" : "k");
+    }
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(requestRender).toHaveBeenCalledTimes(1_000);
   });
 
   it("renders in-process, workflow, and interactive async work", () => {
@@ -381,7 +570,7 @@ describe("interactive supervisor", () => {
       true,
     );
     expect(lines.some((line) => line.includes("turns: 2"))).toBe(true);
-    expect(lines.every((line) => line.length <= 60)).toBe(true);
+    expect(lines.every((line) => visibleWidth(line) <= 60)).toBe(true);
   });
 
   it("omits empty provenance-free workflow totals", () => {


### PR DESCRIPTION
## Summary
- flow async-supervisor summaries into as many readable columns as the overlay width and item count allow
- preserve narrow one-column rendering, stable row-major selection, full-width expanded details, and height-safe fallback
- use Pi TUI display-width helpers for Unicode-aware truncation and column padding

## Layout semantics
- each summary column is at least 44 display cells with a 3-cell divider gap
- column count is `min(itemCount, floor((contentWidth + gap) / (minColumnWidth + gap)))`
- multi-column rendering is used only when the complete grid, expanded details, status rows, and popup chrome fit the effective 85% overlay height
- expanded details remain full width and follow their summary row in stable row-major order

## Tests
- 1/2/3/4-column thresholds and item-count cap
- odd counts, linear navigation, and width resize
- height fallback, expanded/loading details, Unicode/long text, empty state
- repeated navigation does not invoke async refresh
- full typecheck, 1,695-test suite, Prettier check, pack dry-run, and diff check

Popup layout only; no footer-count, attention, prompt, or recipient-name changes.
