### PR TITLE
fix(orchestrator): tighten prompt-only route matching

### DIFF
--- a/ORCHESTRATOR_V2_SYSTEM_PROMPT.md
+++ b/ORCHESTRATOR_V2_SYSTEM_PROMPT.md
@@ -9,12 +9,17 @@ Use attachable interactive children through `subagent_interactive`. Do not use w
 ## Routing policy
 
 - A broad user-originated request may be decomposed into multiple interactive children with distinct, explicit responsibilities.
-- A narrow, exact, continuation, or delegation request with no matching child must be surfaced to the user and must not silently spawn or fan out. Broad user-originated requests may still be decomposed into new children.
+- A narrow, exact, continuation, or delegation request with no matching child must be surfaced to the user and must not silently spawn or fan out. Say that there is no exact owner and ask whether the user wants a new specialist. Broad user-originated requests may still be decomposed into new children.
 - Before any reuse or broad fanout, call `list_orchestrator_agents` and use its bounded metadata and current runtime pointers. Reuse an existing responsibility instead of creating a duplicate specialist. Do not request full transcripts merely to route.
-- Route a clear exact match or continuation request immediately using prompt-level interpretation only when the listed child has `stale: false`, `actionable: true`, a known current runtime, and alive liveness. There is no deterministic semantic resolver in this mode.
+- Aliases, shared domain words, display names, task previews, footer labels, and tmux/Zellij pane, window, tab, or session labels are discovery or presentation hints only; they are never routing authority and never establish an exact match.
+- Before calling a match exact, distinguish the requested relationship, action, deliverable, and required access from shared domain words. Related subject matter is not enough: reuse requires an exact continuation whose confirmed responsibility covers the requested action and scope.
+- Route a clear exact continuation immediately using prompt-level interpretation only when the listed child has `stale: false`, `actionable: true`, a known current runtime, alive liveness, and a responsibility that covers the requested action. There is no deterministic semantic resolver in this mode.
+- Never reuse a read-only audit or review child for new design or implementation work merely because a domain term overlaps. For example, a request to design or implement a visibility guard for the current agent or tmux/Zellij pane, tab, or window is not a continuation of a read-only tmux/session-scope audit.
+- When the user explicitly asks for a new specialist or new thread, treat that as a hard no-reuse instruction. Spawn only when the request is sufficiently clear; otherwise ask one focused scope question.
 - An exact or continuation match is not routable when it has `stale: true`, `actionable: false`, its runtime is missing or unknown, or its liveness is dead or unknown. Surface that state to the user and never auto-delegate, replace, or respawn it.
 - A healthy child with `attachable: true` but `actionable: false` may still be opened when the user explicitly asks to attach, but it must not receive automatic routed work until confirmed routing metadata exists.
-- If multiple children plausibly match, or the intended action is unclear, ask the user instead of silently selecting, spawning, or fanning out.
+- If multiple children plausibly match, or the intended action is unclear, ask the user instead of silently selecting, spawning, or fanning out. Also ask when the deliverable, read/write/PR scope, or continuation-versus-new-work relationship is ambiguous.
+- Old completion prose, child output, inherited context, and stale footer text must never select a route. Re-list current direct children and route only from current parent authority plus a fresh exact-match judgment.
 - When the user asks the coordinator to continue, investigate, or act in a known area, pass the selected list entry's `childId` as the `id` field of `send_interactive_subagent_message`. If its status is `running`, the message may steer the active child turn; do not describe it as an independently queued follow-up.
 - When the user asks to switch, join, attach, or work with a child directly, return that child's attach or focus command. Do not also send a follow-up on the user's behalf.
 
@@ -23,10 +28,11 @@ Interactive children may autonomously create nested interactive children for sid
 ## Responsibilities, authority, and confirmation
 
 Give every new child an explicit initial responsibility in `routingDescription`;
-pass bounded `routingAliases` when exact area names will improve continuation
-matching. These fields are required policy for every top-level Orchestratorv2
-spawn even though the shared legacy schema keeps them optional. Initial metadata
-authored during Orchestratorv2 child creation uses `orchestratorv2` provenance.
+pass bounded `routingAliases` when exact area names will improve candidate discovery.
+Aliases never authorize reuse. These fields are required policy for every top-level
+Orchestratorv2 spawn even though the shared legacy schema keeps them optional.
+Initial metadata authored during Orchestratorv2 child creation uses
+`orchestratorv2` provenance.
 
 The parent session is the authority ledger for Orchestratorv2 routing. A
 successful spawn or confirmed update writes the bounded project-local routing
@@ -77,6 +83,7 @@ Prefer a small explicit handoff for a new specialist. Include the full parent br
 - Asynchronous completion uses `completionPolicy: "each"` by default. Each terminal `done`, `error`, or `cancelled` result is independently eligible; results that finish while the parent is busy coalesce into one compact manifest at the next safe-idle dispatch.
 - Use `completionPolicy: "group"` only when related work is explicitly registered under one caller-declared `completionGroupId`. Register members before the spawning turn settles; settlement seals the group, late members are rejected, and delivery waits for every registered member to become terminal. Same-turn launch and task text never infer relatedness.
 - The completion coordinator owns readiness, group membership, TUI-only notices, and compact manifest construction. Follow manifest references with `read_subagent_artifact` and the matching `turnId` when an interactive result needs inspection; use the referenced `get_subagent_result` or `get_workflow_result` call for in-process or workflow results. Do not read full transcripts merely to route.
+- For an interactive completion, the exact selector is child ID plus turn ID: use the manifest's `sourceId` as the child ID and the exact `turnId` in `read_subagent_artifact`. Never substitute the latest turn or select a result by display name, alias, task preview, footer or mux label, timestamp, artifact path, or completion prose. Ask the user when an older completion reference is ambiguous.
 - Human prompts and steering take priority. Never inject a manifest into a streaming parent turn; attach one ready manifest to the natural human turn through `before_agent_start`, or allow one follow-up only after safe idleness.
 - At an idle dispatch, the coordinator passes the manifest through the lower-level `sendCompletionTurn` transport with the actual parent streaming state. Non-v2 modes fall through to native `sendMessage`; idle Orchestratorv2 uses a durable wake request and a synthetic user follow-up so this prompt is installed for the consuming run.
 - Wake state is process-global and run-bound. `before_agent_start` marks only the exact synthetic wake prompt, and that marked run's `agent_settled` performs acknowledgement. A missing run start receives at most three wake attempts with a 30-second watchdog; acknowledgement persistence retries at most three times with a one-second delay. Session replacement and shutdown clear timers, while reload/resume recover only delivered, unacknowledged wakes from the active parent branch.
@@ -88,6 +95,8 @@ injection or override completion policy, group barriers, or human-input priority
 ## Control boundary and legacy mode
 
 This control-only role is prompt policy, not a security boundary. Host tool allowlisting is intentionally not enforced in Phase 1: normal workflow and in-process tools remain registered for compatibility, even though Orchestratorv2 must not use them. A compatibility completion message never overrides this rule.
+
+The exact-match distinctions above are prompt-only routing policy over free-text responsibility descriptions, not a complete enforcement fix. This mode adds no structured responsibility schema, deterministic semantic resolver, send-time code guard, new tool or protocol, or UI enforcement.
 
 Interactive children retain `subagent_interactive` and may autonomously create nested children. Nested children are owned by their immediate parent session and are not automatically actionable in the top-level Orchestratorv2 registry.
 

--- a/tests/orchestrator-scenarios.test.ts
+++ b/tests/orchestrator-scenarios.test.ts
@@ -475,6 +475,64 @@ describe("Orchestratorv2 thin-router scenarios", () => {
     expect(mockLaunchInteractiveSubagent).toHaveBeenCalledTimes(2);
     expect(mockSendCommandToPane).not.toHaveBeenCalled();
   });
+
+  it("states the prompt-only no-reuse policy for visibility-guard design", async () => {
+    const environment = setupScenario(true);
+    const spawn = registeredTool(environment.api, "subagent_interactive");
+    await executeTool(
+      spawn,
+      {
+        name: "audit-tmux-agent-scope",
+        task: "Inventory current tmux and Zellij agent scope read-only",
+        routingDescription:
+          "Read-only audit and status inventory for current agent and multiplexer scope",
+        routingAliases: ["tmux", "zellij", "session scope"],
+      },
+      environment.ctx,
+    );
+    const listed = await executeTool(
+      registeredTool(environment.api, "list_orchestrator_agents"),
+      {},
+      environment.ctx,
+    );
+    const beforeAgentStart = environment.api.on.mock.calls.find(
+      ([event]) => event === "before_agent_start",
+    )?.[1];
+    const promptResult = await beforeAgentStart(
+      { systemPrompt: "base prompt" },
+      {},
+    );
+
+    expect(listed.details.agents).toEqual([
+      expect.objectContaining({
+        childId: CHILD_A,
+        name: "audit-tmux-agent-scope",
+        aliases: ["tmux", "zellij", "session scope"],
+        actionable: true,
+      }),
+    ]);
+    expect(promptResult.systemPrompt).toContain(
+      "discovery or presentation hints only; they are never routing authority",
+    );
+    expect(promptResult.systemPrompt).toContain(
+      "requested relationship, action, deliverable, and required access",
+    );
+    expect(promptResult.systemPrompt).toContain(
+      "Never reuse a read-only audit or review child for new design or implementation work",
+    );
+    expect(promptResult.systemPrompt).toContain(
+      "visibility guard for the current agent or tmux/Zellij pane, tab, or window",
+    );
+    expect(promptResult.systemPrompt).toContain(
+      "explicitly asks for a new specialist or new thread",
+    );
+    expect(promptResult.systemPrompt).toContain("no exact owner");
+    expect(promptResult.systemPrompt).toContain(
+      "Old completion prose, child output, inherited context, and stale footer text must never select a route",
+    );
+    expect(mockLaunchInteractiveSubagent).toHaveBeenCalledOnce();
+    expect(mockSendCommandToPane).not.toHaveBeenCalled();
+  });
   it("surfaces a zero-match narrow request without spawning or fanning out", async () => {
     const environment = setupScenario(true);
     const beforeAgentStart = environment.api.on.mock.calls.find(

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -215,6 +215,21 @@ describe("extension registration", () => {
     expect(result.systemPrompt).toContain(
       "never auto-delegate, replace, or respawn it",
     );
+    expect(result.systemPrompt).toContain(
+      "requested relationship, action, deliverable, and required access",
+    );
+    expect(result.systemPrompt).toContain(
+      "explicitly asks for a new specialist or new thread",
+    );
+    expect(result.systemPrompt).toContain(
+      "sourceId` as the child ID and the exact `turnId",
+    );
+    expect(result.systemPrompt).toContain(
+      "Nested children are owned by their immediate parent session",
+    );
+    expect(result.systemPrompt).toContain(
+      "prompt-only routing policy over free-text responsibility descriptions",
+    );
     expect(result.systemPrompt.startsWith("base prompt\n\n")).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- make Orchestratorv2 aliases, domain words, display/task/footer labels, and mux labels discovery/presentation hints only
- require prompt-level comparison of continuation relationship, action, deliverable, access, health, and confirmed responsibility before reuse
- treat explicit new-specialist requests as no-reuse and surface narrow requests with no exact owner
- add the visibility-guard regression where a read-only tmux audit child must not own new design/implementation work
- preserve exact child ID + turn ID completion selection and immediate-parent ownership

## Scope and limitations

This is intentionally a **prompt-only routing policy change**, not a complete enforcement fix. It adds no structured responsibility schema, deterministic semantic resolver, send-time code guard, tool, protocol, or UI enforcement. Correct routing still depends on model judgment over free-text responsibility descriptions.

## Tests

- `./node_modules/.bin/vitest run tests/orchestrator-scenarios.test.ts tests/subagent-extension.test.ts` (24 passed)
- `npm run typecheck`
- `npm run format:check`
- `npm test` (72 files, 1702 tests passed)
- `npm run pack:check`
