### PR TITLE
feat(activity): add adaptive widget grid

### DIFF
--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -45,7 +45,11 @@ import {
 } from "./delivery";
 import { completionDisplayLabel } from "./completion-presentation";
 import { debugLog, jobRegistry, type JobState } from "./helpers";
-import { coarseElapsedMs, formatActivityRow } from "./rendering";
+import {
+  coarseElapsedMs,
+  formatActivityRow,
+  ResponsiveFlowComponent,
+} from "./rendering";
 import {
   addWorkflowUsage,
   formatWorkflowUsage,
@@ -398,7 +402,13 @@ function updateWidgetRows(
   const rendered = renderedRows.length > 0 ? renderedRows : undefined;
   if (surface.painted && widgetRowsEqual(surface.rendered, rendered)) return;
   try {
-    ui.setWidget(key, rendered, { placement: "belowEditor" });
+    if (key === WIDGET_KEY && rendered) {
+      ui.setWidget(key, () => new ResponsiveFlowComponent(rendered), {
+        placement: "belowEditor",
+      });
+    } else {
+      ui.setWidget(key, rendered, { placement: "belowEditor" });
+    }
     surface.rendered = rendered ? [...rendered] : undefined;
     surface.painted = true;
   } catch {

--- a/src/interactive-supervisor-ui.ts
+++ b/src/interactive-supervisor-ui.ts
@@ -3,12 +3,7 @@ import type {
   Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { Component, OverlayHandle, TUI } from "@earendil-works/pi-tui";
-import {
-  Key,
-  matchesKey,
-  truncateToWidth,
-  visibleWidth,
-} from "@earendil-works/pi-tui";
+import { Key, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
 import { promises as fs, type promises as fsTypes } from "node:fs";
 import { join } from "node:path";
 import type { JobState } from "./helpers";
@@ -25,6 +20,13 @@ import {
   formatWorkflowUsageLegend,
   presentWorkflowUsage,
 } from "./workflow-core";
+import {
+  RESPONSIVE_FLOW_GAP,
+  RESPONSIVE_FLOW_MIN_COLUMN_WIDTH,
+  responsiveFlowColumnCount,
+  responsiveFlowColumnWidths,
+  responsiveFlowMinimumWidth,
+} from "./rendering";
 
 export const INTERACTIVE_SUPERVISOR_SHORTCUT = "ctrl+alt+a";
 const DEFAULT_REFRESH_INTERVAL_MS = 1_000;
@@ -33,39 +35,25 @@ const DETAIL_EVENTS_MAX_BYTES = 8 * 1024;
 const DETAIL_PREVIEW_MAX_CHARS = 512;
 const DETAIL_EVENT_COUNT = 3;
 const DETAIL_WORKFLOW_AGENT_COUNT = 20;
-// Pi's SelectList starts a secondary column above 40 cells. Forty-four keeps
-// source, status, and the beginning of a label visible before truncation.
-export const INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH = 44;
+export const INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH =
+  RESPONSIVE_FLOW_MIN_COLUMN_WIDTH;
 const SUPERVISOR_GRID_PREFIX = "│ ";
-const SUPERVISOR_GRID_GAP = " │ ";
-const SUPERVISOR_GRID_PREFIX_WIDTH = visibleWidth(SUPERVISOR_GRID_PREFIX);
-const SUPERVISOR_GRID_GAP_WIDTH = visibleWidth(SUPERVISOR_GRID_GAP);
+const SUPERVISOR_GRID_GAP = RESPONSIVE_FLOW_GAP;
+const SUPERVISOR_GRID_OPTIONS = {
+  prefix: SUPERVISOR_GRID_PREFIX,
+  gap: SUPERVISOR_GRID_GAP,
+  minColumnWidth: INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH,
+};
 
 export function interactiveSupervisorMinimumGridWidth(columns: number): number {
-  const count = Math.max(1, Math.floor(Number.isFinite(columns) ? columns : 1));
-  return (
-    SUPERVISOR_GRID_PREFIX_WIDTH +
-    count * INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH +
-    (count - 1) * SUPERVISOR_GRID_GAP_WIDTH
-  );
+  return responsiveFlowMinimumWidth(columns, SUPERVISOR_GRID_OPTIONS);
 }
 
 export function interactiveSupervisorColumnCount(
   width: number,
   itemCount: number,
 ): number {
-  const count = Math.max(
-    0,
-    Math.floor(Number.isFinite(itemCount) ? itemCount : 0),
-  );
-  if (count <= 1) return 1;
-  const safeWidth = Math.max(0, Math.floor(Number.isFinite(width) ? width : 0));
-  const contentWidth = Math.max(0, safeWidth - SUPERVISOR_GRID_PREFIX_WIDTH);
-  const fitting = Math.floor(
-    (contentWidth + SUPERVISOR_GRID_GAP_WIDTH) /
-      (INTERACTIVE_SUPERVISOR_MIN_COLUMN_WIDTH + SUPERVISOR_GRID_GAP_WIDTH),
-  );
-  return Math.max(1, Math.min(count, fitting));
+  return responsiveFlowColumnCount(width, itemCount, SUPERVISOR_GRID_OPTIONS);
 }
 
 export type InteractiveSupervisorAction = { kind: "close" };
@@ -1050,17 +1038,7 @@ function clampIndex(index: number, length: number): number {
 }
 
 function supervisorGridColumnWidths(width: number, columns: number): number[] {
-  const gapWidth = (columns - 1) * SUPERVISOR_GRID_GAP_WIDTH;
-  const contentWidth = Math.max(
-    0,
-    Math.floor(width) - SUPERVISOR_GRID_PREFIX_WIDTH - gapWidth,
-  );
-  const baseWidth = Math.floor(contentWidth / columns);
-  const remainder = contentWidth % columns;
-  return Array.from(
-    { length: columns },
-    (_, index) => baseWidth + (index < remainder ? 1 : 0),
-  );
+  return responsiveFlowColumnWidths(width, columns, SUPERVISOR_GRID_OPTIONS);
 }
 
 function normalizeAvailableHeight(

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -1,7 +1,12 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { Text, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+  Text,
+  truncateToWidth,
+  visibleWidth,
+  type Component,
+} from "@earendil-works/pi-tui";
 import { formatUsage } from "./helpers";
 import type { SubagentDetails } from "./subagent";
 import type { SubagentResult } from "./helpers";
@@ -226,6 +231,130 @@ export function renderSubagentNotify(
   return new Text(line, 0, 0);
 }
 
+// Pi's SelectList starts a secondary column above 40 cells. Forty-four keeps
+// the activity marker, agent name, and beginning of its status readable.
+export const RESPONSIVE_FLOW_MIN_COLUMN_WIDTH = 44;
+export const RESPONSIVE_FLOW_GAP = " │ ";
+
+export interface ResponsiveFlowOptions {
+  prefix?: string;
+  gap?: string;
+  minColumnWidth?: number;
+}
+
+export function responsiveFlowMinimumWidth(
+  columns: number,
+  options: ResponsiveFlowOptions = {},
+): number {
+  const count = positiveInteger(columns);
+  const prefixWidth = visibleWidth(options.prefix ?? "");
+  const gapWidth = visibleWidth(options.gap ?? RESPONSIVE_FLOW_GAP);
+  const minColumnWidth = Math.max(
+    1,
+    options.minColumnWidth ?? RESPONSIVE_FLOW_MIN_COLUMN_WIDTH,
+  );
+  return prefixWidth + count * minColumnWidth + (count - 1) * gapWidth;
+}
+
+export function responsiveFlowColumnCount(
+  width: number,
+  itemCount: number,
+  options: ResponsiveFlowOptions = {},
+): number {
+  const count = Math.max(0, Math.floor(finiteOr(itemCount, 0)));
+  if (count <= 1) return 1;
+  const gapWidth = visibleWidth(options.gap ?? RESPONSIVE_FLOW_GAP);
+  const prefixWidth = visibleWidth(options.prefix ?? "");
+  const minColumnWidth = Math.max(
+    1,
+    options.minColumnWidth ?? RESPONSIVE_FLOW_MIN_COLUMN_WIDTH,
+  );
+  const contentWidth = Math.max(
+    0,
+    Math.floor(finiteOr(width, 0)) - prefixWidth,
+  );
+  const fitting = Math.floor(
+    (contentWidth + gapWidth) / (minColumnWidth + gapWidth),
+  );
+  return Math.max(1, Math.min(count, fitting));
+}
+
+export function responsiveFlowColumnWidths(
+  width: number,
+  columns: number,
+  options: ResponsiveFlowOptions = {},
+): number[] {
+  const count = positiveInteger(columns);
+  const gapWidth = visibleWidth(options.gap ?? RESPONSIVE_FLOW_GAP);
+  const prefixWidth = visibleWidth(options.prefix ?? "");
+  const contentWidth = Math.max(
+    0,
+    Math.floor(finiteOr(width, 0)) - prefixWidth - (count - 1) * gapWidth,
+  );
+  const baseWidth = Math.floor(contentWidth / count);
+  const remainder = contentWidth % count;
+  return Array.from(
+    { length: count },
+    (_, index) => baseWidth + (index < remainder ? 1 : 0),
+  );
+}
+
+export function renderResponsiveFlowRows(
+  rows: readonly string[],
+  width: number,
+  options: ResponsiveFlowOptions = {},
+): string[] {
+  if (rows.length === 0) return [];
+  const prefix = options.prefix ?? "";
+  const gap = options.gap ?? RESPONSIVE_FLOW_GAP;
+  const columns = responsiveFlowColumnCount(width, rows.length, options);
+  const columnWidths = responsiveFlowColumnWidths(width, columns, options);
+  if (columns === 1) {
+    return rows.map((row) => truncateToWidth(row, columnWidths[0]!, "…"));
+  }
+  const rendered: string[] = [];
+  for (let start = 0; start < rows.length; start += columns) {
+    const cells = columnWidths.map((columnWidth, offset) =>
+      truncateToWidth(rows[start + offset] ?? "", columnWidth, "…", true),
+    );
+    rendered.push(`${prefix}${cells.join(gap)}`);
+  }
+  return rendered;
+}
+
+export class ResponsiveFlowComponent implements Component {
+  private cachedWidth?: number;
+  private cachedLines?: string[];
+  private readonly rows: string[];
+
+  constructor(
+    rows: readonly string[],
+    private readonly options: ResponsiveFlowOptions = {},
+  ) {
+    this.rows = [...rows];
+  }
+
+  render(width: number): string[] {
+    if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
+    this.cachedLines = renderResponsiveFlowRows(this.rows, width, this.options);
+    this.cachedWidth = width;
+    return this.cachedLines;
+  }
+
+  invalidate(): void {
+    this.cachedWidth = undefined;
+    this.cachedLines = undefined;
+  }
+}
+
+function positiveInteger(value: number): number {
+  return Math.max(1, Math.floor(finiteOr(value, 1)));
+}
+
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
 /**
  * Coarse bucket for widget elapsed clocks.
  *
@@ -235,6 +364,7 @@ export function renderSubagentNotify(
  * without reintroducing a repaint on every 5s tick.
  */
 export const ACTIVITY_ELAPSED_BUCKET_MS = 10_000;
+const ACTIVITY_PREVIEW_MAX_CHARS = 512;
 
 /** Quantize an elapsed duration down to the coarse widget bucket. */
 export function coarseElapsedMs(milliseconds: number): number {
@@ -250,14 +380,23 @@ export function formatActivityRow(
   state: InteractiveSubagentState,
   now: number = Date.now(),
 ): string {
+  const name = compactActivityText(state.name, "subagent");
   if (state.status === "idle") {
-    return `○ ${state.name}: idle — ready for follow-up`;
+    return `○ ${name}: idle — ready for follow-up`;
   }
-  const summary = state.lastToolSummary ?? "starting…";
+  const summary = compactActivityText(state.lastToolSummary ?? "starting…");
   const ago = state.lastActivityAt
     ? ` (${agoStr(coarseElapsedMs(now - state.lastActivityAt))})`
     : "";
-  return `▶ ${state.name}: ${summary}${ago}`;
+  return `▶ ${name}: ${summary}${ago}`;
+}
+
+function compactActivityText(value: unknown, fallback = ""): string {
+  return String(value ?? fallback)
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, ACTIVITY_PREVIEW_MAX_CHARS);
 }
 
 function agoStr(milliseconds: number): string {

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -40,6 +40,7 @@ const { formatUsageMock, sanitizeOutputMock } = vi.hoisted(() => ({
 vi.mock("@earendil-works/pi-tui", () => ({
   Text: MockText,
   truncateToWidth: truncateToWidthMock,
+  visibleWidth: (text: string) => text.length,
 }));
 
 vi.mock("../src/helpers", () => ({

--- a/tests/responsive-flow.test.ts
+++ b/tests/responsive-flow.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+  ResponsiveFlowComponent,
+  responsiveFlowColumnCount,
+  responsiveFlowMinimumWidth,
+} from "../src/rendering";
+
+describe("responsive flow", () => {
+  it("derives one, two, three, and four columns from readable width", () => {
+    const rows = ["zero", "one", "two", "three", "four", "five", "six"];
+    const component = new ResponsiveFlowComponent(rows);
+    const oneColumnWidth = responsiveFlowMinimumWidth(2) - 1;
+    const twoColumnWidth = responsiveFlowMinimumWidth(2);
+    const threeColumnWidth = responsiveFlowMinimumWidth(3);
+    const fourColumnWidth = responsiveFlowMinimumWidth(4);
+
+    expect(responsiveFlowColumnCount(oneColumnWidth, rows.length)).toBe(1);
+    expect(responsiveFlowColumnCount(twoColumnWidth, rows.length)).toBe(2);
+    expect(responsiveFlowColumnCount(threeColumnWidth, rows.length)).toBe(3);
+    expect(responsiveFlowColumnCount(fourColumnWidth, rows.length)).toBe(4);
+    expect(component.render(oneColumnWidth)).toHaveLength(7);
+    expect(component.render(twoColumnWidth)).toHaveLength(4);
+    expect(component.render(threeColumnWidth)).toHaveLength(3);
+    expect(component.render(fourColumnWidth)).toHaveLength(2);
+    expect(responsiveFlowColumnCount(fourColumnWidth, 2)).toBe(2);
+    expect("handleInput" in component).toBe(false);
+  });
+
+  it("keeps odd rows in stable row-major order across resize", () => {
+    const component = new ResponsiveFlowComponent([
+      "zero",
+      "one",
+      "two",
+      "three",
+      "four",
+    ]);
+    const threeColumns = component.render(responsiveFlowMinimumWidth(3));
+
+    expect(threeColumns).toHaveLength(2);
+    expect(threeColumns[0]).toMatch(/zero.*one.*two/);
+    expect(threeColumns[1]).toMatch(/three.*four/);
+
+    const twoColumns = component.render(responsiveFlowMinimumWidth(2));
+    expect(twoColumns).toHaveLength(3);
+    expect(twoColumns[0]).toMatch(/zero.*one/);
+    expect(twoColumns[1]).toMatch(/two.*three/);
+    expect(twoColumns[2]).toContain("four");
+  });
+
+  it("truncates long Unicode rows to display-cell bounds", () => {
+    const width = responsiveFlowMinimumWidth(3);
+    const component = new ResponsiveFlowComponent([
+      "界🙂 alpha ".repeat(80),
+      "界🙂 beta ".repeat(80),
+      "界🙂 gamma ".repeat(80),
+    ]);
+    const rendered = component.render(width);
+
+    expect(rendered).toHaveLength(1);
+    expect(rendered[0]).toContain("界🙂 alpha");
+    expect(rendered[0]).toContain("界🙂 beta");
+    expect(rendered[0]).toContain("界🙂 gamma");
+    expect(rendered.every((line) => visibleWidth(line) <= width)).toBe(true);
+  });
+});

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import {
   appendEvent,
   appendCompletionEvent,
@@ -33,6 +34,7 @@ import {
   registerSessionScope,
   removeSessionScope,
 } from "../src/session-scope";
+import { responsiveFlowMinimumWidth } from "../src/rendering";
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
 }
@@ -70,6 +72,26 @@ function installDeliverySpies() {
     setWidget: vi.fn(),
   };
   return sendMessage;
+}
+
+function renderWidgetContent(content: unknown, width: number): string[] {
+  if (typeof content !== "function") return (content as string[]) ?? [];
+  const component = content(
+    { terminal: { rows: 24 }, requestRender: vi.fn() },
+    {},
+  );
+  return component.render(width);
+}
+
+function renderedWidgetRows(
+  setWidget: ReturnType<typeof vi.fn>,
+  key: string,
+  width: number,
+): string[] {
+  const content = setWidget.mock.calls
+    .filter(([candidate]) => candidate === key)
+    .at(-1)?.[1];
+  return renderWidgetContent(content, width);
 }
 
 describe("pollArtifactChanges", () => {
@@ -164,6 +186,55 @@ describe("pollArtifactChanges", () => {
     const sendMessage = installDeliverySpies();
     await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("registers the activity widget as an adaptive grid component", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const setStatus = vi.fn();
+    const setWidget = vi.fn();
+    const ui = { notify: vi.fn(), setStatus, setWidget };
+    for (let index = 0; index < 5; index++) {
+      const item = makeState();
+      item.state.name = index === 0 ? "agent-0\nprimary" : `agent-${index}`;
+      item.state.lastToolSummary =
+        index === 0 ? `${"界🙂 reading ".repeat(80)}\nsecond` : `task-${index}`;
+      mod.interactiveSubagentRegistry.set(item.id, item.state);
+    }
+    (globalThis as any).__piSubagenturaUi = ui;
+    multiplexer.__setTmuxMultiplexer({
+      getPaneLivenessAsync: async () => "alive",
+    } as any);
+
+    await mod.pollArtifactChanges({} as any);
+
+    const activityCall = setWidget.mock.calls.find(
+      ([key]) => key === "subagentura-activity",
+    );
+    expect(activityCall?.[1]).toEqual(expect.any(Function));
+    expect(setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 5 sub-agents alive · 5 working",
+    );
+
+    const narrowWidth = responsiveFlowMinimumWidth(2) - 1;
+    expect(
+      renderedWidgetRows(setWidget, "subagentura-activity", narrowWidth),
+    ).toHaveLength(5);
+    const wideWidth = responsiveFlowMinimumWidth(3);
+    const wideRows = renderedWidgetRows(
+      setWidget,
+      "subagentura-activity",
+      wideWidth,
+    );
+    expect(wideRows).toHaveLength(2);
+    expect(wideRows[0]).toMatch(/agent-0.*agent-1.*agent-2/);
+    expect(wideRows[1]).toMatch(/agent-3.*agent-4/);
+    expect(wideRows.every((line) => visibleWidth(line) <= wideWidth)).toBe(
+      true,
+    );
+    expect(wideRows.every((line) => !line.includes("\n"))).toBe(true);
   });
 
   it("skips aborted child settlement but delivers the next turn", async () => {
@@ -388,7 +459,11 @@ describe("pollArtifactChanges", () => {
     const widgetCalls = sharedUi.setWidget.mock.calls.filter(
       ([key]) => key === "subagentura-activity",
     );
-    const finalRows = widgetCalls.at(-1)?.[1] as string[] | undefined;
+    const finalRows = renderedWidgetRows(
+      sharedUi.setWidget,
+      "subagentura-activity",
+      80,
+    );
     expect(finalRows).toEqual(
       expect.arrayContaining([expect.stringContaining("agent-a")]),
     );
@@ -605,9 +680,7 @@ describe("pollArtifactChanges", () => {
 
     await mod.pollArtifactChanges({} as any, ownerA);
 
-    const rows = uiA.setWidget.mock.calls
-      .filter(([key]) => key === "subagentura-activity")
-      .at(-1)?.[1] as string[] | undefined;
+    const rows = renderedWidgetRows(uiA.setWidget, "subagentura-activity", 80);
     expect(rows).toEqual(
       expect.arrayContaining([expect.stringContaining("wf-child")]),
     );
@@ -663,12 +736,8 @@ describe("pollArtifactChanges", () => {
     await mod.pollArtifactChanges({} as any, ownerA);
     await mod.pollArtifactChanges({} as any, ownerB);
 
-    const rowsFor = (ui: typeof uiA): string[] => {
-      const calls = ui.setWidget.mock.calls.filter(
-        ([key]) => key === "subagentura-activity",
-      );
-      return calls.at(-1)?.[1] as string[];
-    };
+    const rowsFor = (ui: typeof uiA): string[] =>
+      renderedWidgetRows(ui.setWidget, "subagentura-activity", 80);
     expect(rowsFor(uiA).join("\n")).toContain("agent-a");
     expect(rowsFor(uiA).join("\n")).not.toContain("agent-b");
     expect(rowsFor(uiB).join("\n")).toContain("agent-b");
@@ -767,7 +836,7 @@ describe("pollArtifactChanges", () => {
       ([key]) => key === "subagentura-workflows",
     );
     expect(workflowFooterCalls).toHaveLength(1);
-    expect((activityCalls[0][1] as string[])[0]).toBe(
+    expect(renderWidgetContent(activityCalls[0][1], 80)[0]).toBe(
       "▶ steady-agent: reading src/main.ts (10s ago)",
     );
     expect((workflowWidgetCalls[0][1] as string[])[0]).toContain("0s");
@@ -806,10 +875,10 @@ describe("pollArtifactChanges", () => {
       ([key]) => key === "subagentura-activity",
     );
     expect(activityCalls).toHaveLength(2);
-    expect((activityCalls[0][1] as string[])[0]).toBe(
+    expect(renderWidgetContent(activityCalls[0][1], 80)[0]).toBe(
       "▶ ticking-agent: reading src/main.ts (10s ago)",
     );
-    expect((activityCalls[1][1] as string[])[0]).toBe(
+    expect(renderWidgetContent(activityCalls[1][1], 80)[0]).toBe(
       "▶ ticking-agent: reading src/main.ts (20s ago)",
     );
   });
@@ -928,12 +997,14 @@ describe("pollArtifactChanges", () => {
 
     await mod.pollArtifactChanges({} as any);
 
-    const rowsFor = (key: string): string[] =>
-      ui.setWidget.mock.calls.filter(([name]) => name === key).at(-1)?.[1] ??
-      [];
+    const rowsFor = (key: string, width = 80): string[] =>
+      renderedWidgetRows(ui.setWidget, key, width);
     const activityRows = rowsFor("subagentura-activity");
     expect(activityRows).toHaveLength(11);
     expect(activityRows.at(-1)).toBe("… and 2 more");
+    expect(
+      rowsFor("subagentura-activity", responsiveFlowMinimumWidth(3)),
+    ).toHaveLength(4);
     const workflowRows = rowsFor("subagentura-workflow-activity");
     expect(workflowRows).toHaveLength(6);
     expect(workflowRows.at(-1)).toBe("… and 2 more workflows");
@@ -2051,11 +2122,12 @@ describe("pollArtifactChanges", () => {
       );
       expect(setWidget).toHaveBeenCalledWith(
         "subagentura-activity",
-        expect.any(Array),
+        expect.any(Function),
         { placement: "belowEditor" },
       );
-      const widgetArgs = setWidget.mock.calls[0];
-      expect(widgetArgs[1].length).toBe(2);
+      expect(
+        renderedWidgetRows(setWidget, "subagentura-activity", 80),
+      ).toHaveLength(2);
 
       expect(exited.status).toBe("exited");
       expect(idle.status).toBe("idle");
@@ -2126,7 +2198,11 @@ describe("pollArtifactChanges", () => {
         "subagentura-running",
         "⚡ 1 sub-agent alive",
       );
-      const widgetRows = setWidget.mock.calls[0][1] as string[];
+      const widgetRows = renderedWidgetRows(
+        setWidget,
+        "subagentura-activity",
+        80,
+      );
       expect(widgetRows).toContain(
         "○ rehydrated-idle: idle — ready for follow-up",
       );
@@ -2223,8 +2299,9 @@ describe("pollArtifactChanges", () => {
         "subagentura-running",
         "⚡ 3 sub-agents alive · 3 working",
       );
-      const widgetArgs = setWidget.mock.calls[0];
-      expect(widgetArgs[1].length).toBe(2);
+      expect(
+        renderedWidgetRows(setWidget, "subagentura-activity", 80),
+      ).toHaveLength(2);
 
       delete (globalThis as any).__piSubagenturaUi;
     });

--- a/tests/subagent-session-log.test.ts
+++ b/tests/subagent-session-log.test.ts
@@ -537,8 +537,13 @@ describe("session-log tail-read", () => {
       ([key]) => key === "subagentura-activity",
     );
     expect(activityWidgetCall).toBeDefined();
-    const [, lines, opts] = activityWidgetCall!;
+    const [, factory, opts] = activityWidgetCall!;
     expect(opts).toEqual({ placement: "belowEditor" });
+    expect(factory).toEqual(expect.any(Function));
+    const lines = factory(
+      { terminal: { rows: 24 }, requestRender: vi.fn() },
+      {},
+    ).render(80);
     expect(lines[0]).toContain("Test:");
     expect(lines[0]).toContain("rg TODO src/");
   });

--- a/tests/workflow-supervisor.integration.test.ts
+++ b/tests/workflow-supervisor.integration.test.ts
@@ -152,7 +152,11 @@ function lastWidgetRows(
     ([key]) => key === ACTIVITY_WIDGET_KEY,
   );
   if (calls.length === 0) return "never-painted";
-  return calls.at(-1)?.[1] as string[] | undefined;
+  const content = calls.at(-1)?.[1];
+  if (typeof content !== "function") return content as string[] | undefined;
+  return content({ terminal: { rows: 24 }, requestRender: vi.fn() }, {}).render(
+    80,
+  );
 }
 
 function lastFooter(


### PR DESCRIPTION
## Summary
- render the `subagentura-activity` below-editor widget as a resize-aware adaptive flow grid
- extract the popup's display-width grid math into shared rendering helpers so popup and activity use identical readable-column semantics
- preserve the one-line `setStatus` footer/count behavior and the separate workflow activity widget

## Layout
- uncapped column count derived from render width, item count, 44-cell readable minimum, and 3-cell gap
- stable row-major ordering with deterministic remainder distribution
- Unicode-aware truncation/padding through Pi TUI helpers
- existing 10-agent + overflow-row bound retained; wide layouts reduce rendered height
- no input handler or per-key work on the widget; resize rerenders from cached in-memory rows

## Tests
- shared 1/2/3/4-column thresholds, item cap, odd counts, resize, long Unicode rows, and display-width bounds
- actual poller registration of the activity component, narrow/wide rendering, status-footer separation, truncation bound, multiline sanitization, ownership, idle, and workflow-child integration
- existing popup width/height, expansion/loading, resize, and navigation tests remain green

## Verification
- `npm run typecheck`
- `npm test` (73 files, 1,705 tests)
- `npm run format:check`
- `npm run pack:check`
- `git diff --check`

PR #127 is already merged, so this follow-up is intentionally separate. No prompt, attention, routing, recipient-name, or footer-count changes are included.
