### PR TITLE
feat: add current pane activity guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The extension registers these public tools for parent agents.
 | `cancel_subagent`                       | Cancel an async job                                               |
 | `prune_subagent_jobs`                   | Remove completed and failed jobs                                  |
 | `list_available_models`                 | List configured model identifiers                                 |
+| `get_current_pane_activity`             | Check whether this Pi pane is active for user attention           |
 | `list_orchestrator_agents`              | List bounded Orchestratorv2 routing metadata and runtime pointers |
 | `update_orchestrator_agent_description` | Update a child's confirmed routing description and aliases        |
 | `subagent_interactive`                  | Launch an attachable Pi session in tmux/Zellij                    |
@@ -490,6 +491,12 @@ The sub-agent's artifact contains `events.ndjson` lifecycle records, mutable
 snapshots. Terminal retrieval uses the immutable snapshot by `turnId`; mutable
 output is legacy/staging fallback only. The pane is for live monitoring, and the
 artifact survives parent restarts.
+
+Interactive children also have `get_current_pane_activity`, which reports
+whether their tmux/Zellij pane is active for the user's current client. The child
+protocol instructs them to check it immediately before tools or extensions that
+may wait for user input; inactive or unknown panes should report the decision to
+the orchestrator instead of opening a hidden prompt.
 
 The interactive sub-agent **registry state** survives parent reloads and restarts. When spawned,
 a per-(cwd) state file is written to `<cwd>/.pi/subagentura-state.json`.

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -65,6 +65,7 @@ import {
   NoMultiplexerAvailableError,
   type MuxName,
   type Multiplexer,
+  type PaneActivity,
   type PaneLiveness,
   type PaneRef,
   safeSegment,
@@ -124,6 +125,8 @@ export function buildChildSubagentProtocol(artifactDir: string): string {
 BE BRIEF. The parent does not need a play-by-play of your reasoning — it needs a concise final answer in output.md and a one-sentence summary after the lifecycle command succeeds. Skip the recap, the apology, and the "let me know if..." closer. Long preambles waste tokens and delay the done signal.
 
 COMPLETION IS MANDATORY FOR EVERY TURN. A turn is not complete when output.md is written or when you have drafted a final response; it is complete only after cli.mjs returns successfully. This applies to the initial turn and every turn created by a follow-up message. Do not produce or send your final assistant response before invoking cli.mjs, because ending the response first can prevent the lifecycle command from running and leave the parent waiting forever.
+
+USER ATTENTION AND PANE ACTIVITY. Before calling any tool or extension that may wait for user input, call get_current_pane_activity immediately first. If it reports active, continue with the user-attention call in this pane. If it reports inactive or unknown, do not open a prompt here; include the exact decision needed in your result so the orchestrator can ask the user.
 
 Your artifact directory is: ${artifactDir}
 
@@ -836,6 +839,58 @@ export function launchInteractiveSubagent(params: {
  */
 function getMuxForState(state: InteractiveSubagentState): Multiplexer {
   return getMux({ preference: state.mux });
+}
+
+export interface CurrentPaneActivity {
+  readonly status: PaneActivity;
+  readonly mux?: MuxName;
+  readonly paneId?: string;
+  readonly session?: string;
+}
+
+interface CurrentPaneTarget {
+  readonly mux: MuxName;
+  readonly paneId?: string;
+  readonly session?: string;
+}
+
+function currentPaneTarget(): CurrentPaneTarget | undefined {
+  if (process.env.ZELLIJ) {
+    return {
+      mux: "zellij",
+      paneId: process.env.ZELLIJ_PANE_ID,
+      session: process.env.ZELLIJ_SESSION_NAME,
+    };
+  }
+  if (process.env.TMUX) {
+    return { mux: "tmux", paneId: process.env.TMUX_PANE };
+  }
+  return undefined;
+}
+
+/** Probe whether the current Pi process's mux pane is active for the user. */
+export async function getCurrentPaneActivity(): Promise<CurrentPaneActivity> {
+  const target = currentPaneTarget();
+  const location = target
+    ? {
+        mux: target.mux,
+        ...(target.paneId ? { paneId: target.paneId } : {}),
+        ...(target.session ? { session: target.session } : {}),
+      }
+    : {};
+  let status: PaneActivity;
+  if (!target?.paneId) return { status: "unknown", ...location };
+
+  try {
+    status = await getMux({ preference: target.mux }).getPaneActivityAsync(
+      target.paneId,
+      target.session,
+    );
+  } catch {
+    // Activity is advisory; an unavailable mux must not break the child.
+    status = "unknown";
+  }
+  return { status, ...location };
 }
 
 export function paneRefForState(state: InteractiveSubagentState): PaneRef {

--- a/src/multiplexer-tmux.ts
+++ b/src/multiplexer-tmux.ts
@@ -27,6 +27,7 @@ import type {
   CapturePaneOptions,
   CapturePaneResult,
   Multiplexer,
+  PaneActivity,
   PaneLiveness,
   PaneRef,
 } from "./multiplexer";
@@ -405,6 +406,57 @@ export class TmuxMultiplexer implements Multiplexer {
     if (!/^%\d+$/.test(paneId)) return "unknown";
     const panes = await this.listPanesAsync();
     return panes ? (panes.has(paneId) ? "alive" : "dead") : "unknown";
+  }
+
+  /**
+   * Probe whether a pane is focused in an attached tmux client's active
+   * window. Tmux's pane ids are server-global, so the session is unused.
+   */
+  getPaneActivityAsync(
+    paneId: string,
+    _session?: string,
+  ): Promise<PaneActivity> {
+    if (!/^%\d+$/.test(paneId)) return Promise.resolve("unknown");
+    return new Promise((resolve) => {
+      try {
+        execFile(
+          "tmux",
+          withTmuxSocket([
+            "display-message",
+            "-p",
+            "-t",
+            paneId,
+            "#{window_active_clients}\t#{pane_active}\t#{pane_dead}",
+          ]),
+          { encoding: "utf8", timeout: 5000 },
+          (error, stdout) => {
+            if (error) {
+              resolve("unknown");
+              return;
+            }
+            const fields = stdout.trim().split("\t");
+            const clients = Number(fields[0]);
+            if (
+              fields.length !== 3 ||
+              !Number.isSafeInteger(clients) ||
+              clients < 0 ||
+              !/^[01]$/.test(fields[1] ?? "") ||
+              !/^[01]$/.test(fields[2] ?? "")
+            ) {
+              resolve("unknown");
+              return;
+            }
+            resolve(
+              clients > 0 && fields[1] === "1" && fields[2] === "0"
+                ? "active"
+                : "inactive",
+            );
+          },
+        );
+      } catch {
+        resolve("unknown");
+      }
+    });
   }
 
   sendKeys(paneId: string, text: string): void {

--- a/src/multiplexer-zellij.ts
+++ b/src/multiplexer-zellij.ts
@@ -33,6 +33,7 @@ import type {
   CapturePaneOptions,
   CapturePaneResult,
   Multiplexer,
+  PaneActivity,
   PaneLiveness,
   PaneRef,
 } from "./multiplexer";
@@ -61,6 +62,18 @@ interface ZellijPaneRow {
   readonly id: number | string;
   readonly is_plugin?: boolean;
   readonly exited?: boolean;
+  readonly is_focused?: boolean;
+  readonly is_floating?: boolean;
+  readonly is_suppressed?: boolean;
+  readonly tab_id?: number | string;
+  readonly tab_position?: number;
+}
+
+function isNonNegativeInteger(value: unknown): boolean {
+  return (
+    (typeof value === "number" && Number.isInteger(value) && value >= 0) ||
+    (typeof value === "string" && /^\d+$/.test(value))
+  );
 }
 
 function parsePaneListing(output: string): ZellijPaneRow[] {
@@ -73,20 +86,103 @@ function parsePaneListing(output: string): ZellijPaneRow[] {
       throw new Error("Malformed zellij pane listing row");
     }
     const pane = row as Record<string, unknown>;
-    const validId =
-      (typeof pane.id === "number" &&
-        Number.isInteger(pane.id) &&
-        pane.id >= 0) ||
-      (typeof pane.id === "string" && /^\d+$/.test(pane.id));
+    const validId = isNonNegativeInteger(pane.id);
+    const validTabId =
+      pane.tab_id === undefined || isNonNegativeInteger(pane.tab_id);
+    const validTabPosition =
+      pane.tab_position === undefined ||
+      (typeof pane.tab_position === "number" &&
+        Number.isInteger(pane.tab_position) &&
+        pane.tab_position >= 0);
     if (
       !validId ||
+      !validTabId ||
+      !validTabPosition ||
       (pane.is_plugin !== undefined && typeof pane.is_plugin !== "boolean") ||
-      (pane.exited !== undefined && typeof pane.exited !== "boolean")
+      (pane.exited !== undefined && typeof pane.exited !== "boolean") ||
+      (pane.is_focused !== undefined && typeof pane.is_focused !== "boolean") ||
+      (pane.is_floating !== undefined &&
+        typeof pane.is_floating !== "boolean") ||
+      (pane.is_suppressed !== undefined &&
+        typeof pane.is_suppressed !== "boolean")
     ) {
       throw new Error("Malformed zellij pane listing row");
     }
   }
   return parsed as ZellijPaneRow[];
+}
+
+interface ZellijTabRow {
+  readonly position?: number;
+  readonly tab_id?: number | string;
+  readonly active?: boolean;
+  readonly are_floating_panes_visible?: boolean;
+}
+
+function parseTabListing(output: string): ZellijTabRow[] {
+  const parsed: unknown = JSON.parse(output);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Malformed zellij tab listing");
+  }
+  for (const row of parsed) {
+    if (row === null || typeof row !== "object") {
+      throw new Error("Malformed zellij tab listing row");
+    }
+    const tab = row as Record<string, unknown>;
+    const validPosition =
+      typeof tab.position === "number" &&
+      Number.isInteger(tab.position) &&
+      tab.position >= 0;
+    const validId =
+      tab.tab_id === undefined || isNonNegativeInteger(tab.tab_id);
+    if (
+      !validPosition ||
+      !validId ||
+      (tab.active !== undefined && typeof tab.active !== "boolean") ||
+      (tab.are_floating_panes_visible !== undefined &&
+        typeof tab.are_floating_panes_visible !== "boolean")
+    ) {
+      throw new Error("Malformed zellij tab listing row");
+    }
+  }
+  return parsed as ZellijTabRow[];
+}
+
+function paneBelongsToTab(pane: ZellijPaneRow, tab: ZellijTabRow): boolean {
+  if (pane.tab_id !== undefined && tab.tab_id !== undefined) {
+    return String(pane.tab_id) === String(tab.tab_id);
+  }
+  return (
+    pane.tab_position !== undefined &&
+    tab.position !== undefined &&
+    pane.tab_position === tab.position
+  );
+}
+
+function isFocusedVisibleFloatingPane(
+  pane: ZellijPaneRow,
+  tab: ZellijTabRow,
+): boolean {
+  return (
+    paneBelongsToTab(pane, tab) &&
+    pane.is_floating === true &&
+    pane.is_focused === true &&
+    pane.is_suppressed !== true &&
+    tab.are_floating_panes_visible !== false
+  );
+}
+
+const ZELLIJ_CLIENT_HEADER = "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND";
+
+function parseClientListing(output: string): boolean {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0 || lines[0] !== ZELLIJ_CLIENT_HEADER) {
+    throw new Error("Malformed zellij client listing");
+  }
+  return lines.length > 1;
 }
 
 class BoundedByteTail {
@@ -470,6 +566,94 @@ export class ZellijMultiplexer implements Multiplexer {
     return panes.some((pane) => this.paneRowMatches(pane, target))
       ? "alive"
       : "dead";
+  }
+
+  private runActionAsync(
+    session: string | undefined,
+    args: readonly string[],
+  ): Promise<string | undefined> {
+    return new Promise((resolve) => {
+      try {
+        execFile(
+          "zellij",
+          [...this.sessionFlag(session), "action", ...args],
+          { encoding: "utf8", timeout: 5000 },
+          (error, stdout) => {
+            resolve(error ? undefined : stdout);
+          },
+        );
+      } catch {
+        resolve(undefined);
+      }
+    });
+  }
+
+  /**
+   * Probe whether a pane is focused in the user's attached zellij client.
+   * A detached session has no listed clients and is therefore inactive.
+   */
+  async getPaneActivityAsync(
+    paneId: string,
+    session?: string,
+  ): Promise<PaneActivity> {
+    const target = normalizePaneId(paneId);
+    if (!/^\d+$/.test(target)) return "unknown";
+
+    const [clientsOutput, tabsOutput, panesOutput] = await Promise.all([
+      this.runActionAsync(session, ["list-clients"]),
+      this.runActionAsync(session, ["list-tabs", "--json"]),
+      this.runActionAsync(session, [
+        "list-panes",
+        "--all",
+        "--state",
+        "--tab",
+        "--json",
+      ]),
+    ]);
+    if (
+      clientsOutput === undefined ||
+      tabsOutput === undefined ||
+      panesOutput === undefined
+    ) {
+      return "unknown";
+    }
+
+    let attached: boolean;
+    let tabs: ZellijTabRow[];
+    let panes: ZellijPaneRow[];
+    try {
+      attached = parseClientListing(clientsOutput);
+      tabs = parseTabListing(tabsOutput);
+      panes = parsePaneListing(panesOutput);
+    } catch {
+      return "unknown";
+    }
+    if (!attached) return "inactive";
+
+    const pane = panes.find(
+      (candidate) => !candidate.is_plugin && String(candidate.id) === target,
+    );
+    if (!pane || pane.exited === true) return "inactive";
+    if (
+      pane.is_focused === undefined ||
+      pane.is_floating === undefined ||
+      pane.is_suppressed === undefined ||
+      (pane.tab_id === undefined && pane.tab_position === undefined)
+    ) {
+      return "unknown";
+    }
+
+    const tab = tabs.find((candidate) => paneBelongsToTab(pane, candidate));
+    if (!tab || tab.active === undefined) return "unknown";
+    if (tab.active !== true || pane.is_suppressed) return "inactive";
+    if (!pane.is_focused) return "inactive";
+    if (
+      pane.is_floating !== true &&
+      panes.some((candidate) => isFocusedVisibleFloatingPane(candidate, tab))
+    ) {
+      return "inactive";
+    }
+    return "active";
   }
 
   /**

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -8,7 +8,7 @@
  * implementation behind the same interface.
  *
  * Backends that participate MUST:
- *   - implement the 8 methods below with the documented semantics;
+ *   - implement the methods below with the documented semantics;
  *   - stringify any internal numeric pane id to match `paneId: string` on
  *     `InteractiveSubagentState`;
  *   - be safe to instantiate cheaply (the resolver holds a long-lived instance
@@ -32,6 +32,8 @@ import { assertNever } from "./artifact";
 export type MuxName = "tmux" | "zellij";
 /** Result of a backend pane-listing liveness probe. */
 export type PaneLiveness = "alive" | "dead" | "unknown";
+/** Result of a pane-focus activity probe for the user's mux client. */
+export type PaneActivity = "active" | "inactive" | "unknown";
 
 /** Backend-neutral structured reference to a durable mux pane. */
 export interface PaneRef {
@@ -187,6 +189,13 @@ export interface Multiplexer {
 
   /** Asynchronously perform the same tri-state pane-listing probe. */
   getPaneLivenessAsync(paneId: string, session?: string): Promise<PaneLiveness>;
+
+  /**
+   * Probe whether the pane is focused in the user's currently attached mux
+   * client. `inactive` includes a detached session or an unfocused pane;
+   * command, setup, timeout, and parse failures return `unknown`.
+   */
+  getPaneActivityAsync(paneId: string, session?: string): Promise<PaneActivity>;
 
   /**
    * Send literal text to the pane's shell input buffer, character-by-character.

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -41,6 +41,7 @@ import {
 } from "../completion-coordinator";
 import {
   cancelInteractiveSubagent,
+  getCurrentPaneActivity,
   removeInteractiveSubagentState,
   formatInteractiveState,
   interactiveSubagentRegistry,
@@ -48,6 +49,7 @@ import {
   pruneDeadInteractiveSubagents,
   sendCommandToPane,
   tmuxSetupHint,
+  type CurrentPaneActivity,
   type InteractiveSubagentState,
 } from "../interactive-tmux";
 import { debugLog } from "../helpers";
@@ -410,6 +412,21 @@ function findOwnedDiskArtifact(
   }
 }
 
+function formatCurrentPaneActivity(activity: CurrentPaneActivity): string {
+  const location = [
+    activity.mux ? `Mux: ${activity.mux}.` : "No mux pane was detected.",
+    activity.paneId ? `Pane: ${activity.paneId}.` : "",
+    activity.session ? `Session: ${activity.session}.` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const guidance =
+    activity.status === "active"
+      ? "User attention can be requested in this pane."
+      : "Do not request user attention here; report the decision to the orchestrator.";
+  return `Current pane activity: ${activity.status}. ${guidance} ${location}`;
+}
+
 export function registerInteractiveSubagentTools(
   pi: ExtensionAPI,
   registrationScope?: SessionScope,
@@ -417,7 +434,28 @@ export function registerInteractiveSubagentTools(
   const toolToken: SessionToolToken | undefined = registrationScope
     ? { id: registrationScope.id }
     : undefined;
-  // ── Tool 6: spawn an attachable mux-backed Pi session ──────────────
+
+  registerToolWithDefaultGuidance(pi, {
+    name: "get_current_pane_activity",
+    label: "Current Pane Activity",
+    description:
+      "Check whether this Pi process's tmux or Zellij pane is active in the user's current client before requesting user attention.",
+    promptSnippet:
+      "Check whether the current mux pane is active before requesting user attention",
+    promptGuidelines: [
+      "Use get_current_pane_activity immediately before calling any tool or extension that may wait for user input.",
+      "If get_current_pane_activity reports inactive or unknown, do not open a user-attention prompt in this pane; include the exact decision needed in your result so the orchestrator can ask the user.",
+    ],
+    parameters: Type.Object({}),
+    async execute() {
+      const activity = await getCurrentPaneActivity();
+      return {
+        content: [{ type: "text", text: formatCurrentPaneActivity(activity) }],
+        details: activity,
+      };
+    },
+  });
+  // ── Tool 7: spawn an attachable mux-backed Pi session ──────────────
   registerToolWithDefaultGuidance(pi, {
     name: "subagent_interactive",
     label: "Interactive Subagent",
@@ -755,7 +793,7 @@ export function registerInteractiveSubagentTools(
     },
   });
 
-  // ── Tool 7: inspect attachable tmux-backed sessions ────────────────
+  // ── Tool 8: inspect attachable tmux-backed sessions ────────────────
   registerToolWithDefaultGuidance(pi, {
     name: "get_interactive_subagent_status",
     label: "Get Interactive Subagent Status",
@@ -817,7 +855,7 @@ export function registerInteractiveSubagentTools(
     },
   });
 
-  // ── Tool 8: cancel an attachable tmux-backed session ───────────────
+  // ── Tool 9: cancel an attachable tmux-backed session ───────────────
   registerToolWithDefaultGuidance(pi, {
     name: "cancel_interactive_subagent",
     label: "Cancel Interactive Subagent",

--- a/tests/current-pane-activity.test.ts
+++ b/tests/current-pane-activity.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { importFresh } from "./test-utils";
+
+function installMockChildProcess(scenario: (args: string[]) => string): void {
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({
+    execFileSync: (_file: string, args: string[]) => scenario(args),
+    execFile: (
+      _file: string,
+      args: string[],
+      _options: object,
+      callback: (error: Error | null, stdout: string) => void,
+    ) => {
+      try {
+        callback(null, scenario(args));
+      } catch (error) {
+        callback(error as Error, "");
+      }
+    },
+    spawn: vi.fn(),
+  }));
+}
+
+describe("current pane activity", () => {
+  afterEach(() => {
+    vi.doUnmock("node:child_process");
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+    delete process.env.ZELLIJ;
+    delete process.env.ZELLIJ_SESSION_NAME;
+    delete process.env.ZELLIJ_PANE_ID;
+  });
+
+  it("reports an active tmux pane when the user's window has focus", async () => {
+    process.env.TMUX = "/tmp/tmux.sock,123,0";
+    process.env.TMUX_PANE = "%42";
+    const calls: string[][] = [];
+    installMockChildProcess((args) => {
+      calls.push(args);
+      return args[0] === "display-message" ? "1\t1\t0\n" : "";
+    });
+
+    const { getCurrentPaneActivity } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    await expect(getCurrentPaneActivity()).resolves.toMatchObject({
+      status: "active",
+      mux: "tmux",
+      paneId: "%42",
+    });
+    expect(calls).toContainEqual([
+      "display-message",
+      "-p",
+      "-t",
+      "%42",
+      "#{window_active_clients}\t#{pane_active}\t#{pane_dead}",
+    ]);
+  });
+
+  it("reports an inactive tmux pane when its window is not viewed", async () => {
+    process.env.TMUX = "/tmp/tmux.sock,123,0";
+    process.env.TMUX_PANE = "%42";
+    installMockChildProcess((args) =>
+      args[0] === "display-message" ? "0\t1\t0\n" : "",
+    );
+
+    const { getCurrentPaneActivity } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    await expect(getCurrentPaneActivity()).resolves.toMatchObject({
+      status: "inactive",
+      mux: "tmux",
+      paneId: "%42",
+    });
+  });
+
+  it("reports zellij activity for the current session and pane", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    process.env.ZELLIJ_PANE_ID = "42";
+    installMockChildProcess((args) => {
+      if (args.includes("list-clients")) {
+        return "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND\nclient-1 42 pi\n";
+      }
+      if (args.includes("list-tabs")) {
+        return JSON.stringify([{ position: 0, tab_id: 7, active: true }]);
+      }
+      if (args.includes("list-panes")) {
+        return JSON.stringify([
+          {
+            id: 42,
+            is_plugin: false,
+            is_focused: true,
+            is_floating: false,
+            is_suppressed: false,
+            tab_id: 7,
+            tab_position: 0,
+          },
+        ]);
+      }
+      return "";
+    });
+
+    const { getCurrentPaneActivity } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    await expect(getCurrentPaneActivity()).resolves.toMatchObject({
+      status: "active",
+      mux: "zellij",
+      paneId: "42",
+      session: "main",
+    });
+  });
+
+  it("reports zellij inactive when no client is attached", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    process.env.ZELLIJ_PANE_ID = "42";
+    installMockChildProcess((args) => {
+      if (args.includes("list-clients")) {
+        return "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND\n";
+      }
+      if (args.includes("list-tabs")) {
+        return JSON.stringify([{ position: 0, tab_id: 7, active: true }]);
+      }
+      if (args.includes("list-panes")) {
+        return JSON.stringify([
+          {
+            id: 42,
+            is_plugin: false,
+            is_focused: true,
+            is_floating: false,
+            is_suppressed: false,
+            tab_id: 7,
+            tab_position: 0,
+          },
+        ]);
+      }
+      return "";
+    });
+
+    const { getCurrentPaneActivity } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    await expect(getCurrentPaneActivity()).resolves.toMatchObject({
+      status: "inactive",
+      mux: "zellij",
+      paneId: "42",
+      session: "main",
+    });
+  });
+
+  it("returns unknown when the current process has no mux pane identity", async () => {
+    const calls: string[][] = [];
+    installMockChildProcess((args) => {
+      calls.push(args);
+      return "";
+    });
+
+    const { getCurrentPaneActivity } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    await expect(getCurrentPaneActivity()).resolves.toEqual({
+      status: "unknown",
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("registers activity guidance for child agents", async () => {
+    const api = { registerTool: vi.fn() };
+    const { registerInteractiveSubagentTools } = await importFresh<
+      typeof import("../src/tools/interactive")
+    >("../src/tools/interactive");
+
+    registerInteractiveSubagentTools(api as any);
+    const tool = api.registerTool.mock.calls
+      .map(([definition]) => definition)
+      .find((definition) => definition.name === "get_current_pane_activity");
+
+    expect(tool).toBeDefined();
+    expect(tool.description).toMatch(/user attention/i);
+    expect(tool.promptGuidelines).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/get_current_pane_activity/),
+      ]),
+    );
+  });
+
+  it("includes pane activity guidance in the child protocol", async () => {
+    const { buildChildSubagentProtocol } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+    const protocol = buildChildSubagentProtocol("/tmp/artifacts");
+
+    expect(protocol).toContain("get_current_pane_activity");
+    expect(protocol).toMatch(/If it reports active, continue/);
+    expect(protocol).toMatch(/inactive or unknown, do not open a prompt here/);
+  });
+});

--- a/tests/current-pane-activity.test.ts
+++ b/tests/current-pane-activity.test.ts
@@ -76,6 +76,25 @@ describe("current pane activity", () => {
     });
   });
 
+  it("returns unknown when the tmux activity probe fails", async () => {
+    process.env.TMUX = "/tmp/tmux.sock,123,0";
+    process.env.TMUX_PANE = "%42";
+    installMockChildProcess((args) => {
+      if (args[0] === "display-message") throw new Error("tmux unavailable");
+      return "";
+    });
+
+    const { getCurrentPaneActivity } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    await expect(getCurrentPaneActivity()).resolves.toMatchObject({
+      status: "unknown",
+      mux: "tmux",
+      paneId: "%42",
+    });
+  });
+
   it("reports zellij activity for the current session and pane", async () => {
     process.env.ZELLIJ = "0";
     process.env.ZELLIJ_SESSION_NAME = "main";
@@ -148,6 +167,31 @@ describe("current pane activity", () => {
 
     await expect(getCurrentPaneActivity()).resolves.toMatchObject({
       status: "inactive",
+      mux: "zellij",
+      paneId: "42",
+      session: "main",
+    });
+  });
+
+  it("returns unknown when the zellij activity payload is malformed", async () => {
+    process.env.ZELLIJ = "0";
+    process.env.ZELLIJ_SESSION_NAME = "main";
+    process.env.ZELLIJ_PANE_ID = "42";
+    installMockChildProcess((args) => {
+      if (args.includes("list-clients")) {
+        return "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND\nclient-1 42 pi\n";
+      }
+      if (args.includes("list-tabs")) return "not-json";
+      if (args.includes("list-panes")) return "[]";
+      return "";
+    });
+
+    const { getCurrentPaneActivity } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    await expect(getCurrentPaneActivity()).resolves.toMatchObject({
+      status: "unknown",
       mux: "zellij",
       paneId: "42",
       session: "main",

--- a/tests/readme-surface.test.ts
+++ b/tests/readme-surface.test.ts
@@ -58,7 +58,7 @@ describe("README public surface", () => {
       "#### Coordinated completion delivery",
       "#### Consumption-receipt fallback",
     );
-    expect(tools).toHaveLength(23);
+    expect(tools).toHaveLength(24);
     expect(
       tools.filter((name) => name.includes("orchestrator")).sort(),
     ).toEqual(

--- a/tests/subagent-extension.test.ts
+++ b/tests/subagent-extension.test.ts
@@ -19,6 +19,7 @@ import {
 const BASE_INTERACTIVE_TOOL_NAMES = [
   "cancel_interactive_subagent",
   "get_interactive_subagent_status",
+  "get_current_pane_activity",
   "read_subagent_artifact",
   "send_interactive_subagent_message",
   "subagent_interactive",
@@ -310,6 +311,7 @@ describe("extension registration", () => {
         "cancel_interactive_subagent",
         "cleanup_subagent_artifacts",
         "get_interactive_subagent_status",
+        "get_current_pane_activity",
         "list_available_models",
         "list_subagent_artifacts",
         "read_subagent_artifact",

--- a/tests/tmux.integration.test.ts
+++ b/tests/tmux.integration.test.ts
@@ -195,6 +195,20 @@ test("launches an interactive subagent in an isolated tmux session", async () =>
   expect(events).toContain('"outcome":"done"');
 });
 
+test("reports inactive for a pane in a detached session", async () => {
+  const cwd = mkdtempSync(join(tempRoot, "workspace-"));
+  const pane = new TmuxMultiplexer().createPane({
+    name: "Activity child",
+    cwd,
+    background: true,
+    id: "activity-child",
+  });
+
+  await expect(
+    new TmuxMultiplexer().getPaneActivityAsync(pane.paneId, pane.session),
+  ).resolves.toBe("inactive");
+});
+
 test("sends a follow-up message into the same tmux pane", async () => {
   const cwd = mkdtempSync(join(tempRoot, "workspace-"));
 

--- a/tests/zellij.integration.test.ts
+++ b/tests/zellij.integration.test.ts
@@ -165,6 +165,13 @@ describe.skipIf(!hasZellij)("zellij backend against the real binary", () => {
     ).resolves.toBe("alive");
   });
 
+  it("reports inactive for a pane in a detached session", async () => {
+    const pane = await spawnPane(mux, "Activity child");
+    await expect(
+      mux.getPaneActivityAsync(pane.paneId, pane.session),
+    ).resolves.toBe("inactive");
+  });
+
   it("reports dead for an id the session never had", async () => {
     const pane = await spawnPane(mux, "Liveness child");
     expect(mux.getPaneLiveness("99999", pane.session)).toBe("dead");


### PR DESCRIPTION
## Summary
- add `get_current_pane_activity` for tmux and Zellij
- report active/inactive/unknown using the current pane identity
- instruct interactive children to check activity before user-attention tools
- document and test the new tool, including real detached mux probes

## Validation
- `npm run typecheck`
- `npm test -- --maxWorkers=1`
- `npm run format:check`
- `npm run pack:check`
- `npm run test:tmux -- --maxWorkers=1`
- `npm run test:zellij -- --maxWorkers=1`