### PR TITLE
fix(supervisor): navigate grid columns top-to-bottom

### DIFF
--- a/src/interactive-supervisor-ui.ts
+++ b/src/interactive-supervisor-ui.ts
@@ -134,6 +134,9 @@ export interface InteractiveSupervisorOptions {
 
 export class InteractiveSupervisorComponent {
   private selectedIndex = 0;
+  // Match vertical movement to the layout the user last saw. Before the first
+  // render, and whenever the list falls back to one column, movement is linear.
+  private renderedColumns = 1;
   private selectedKey?: string;
   private expanded = new Set<string>();
   private cachedWidth?: number;
@@ -186,6 +189,7 @@ export class InteractiveSupervisorComponent {
     ];
 
     if (items.length === 0) {
+      this.renderedColumns = 1;
       lines.push(trunc("│ No async subagents.", width));
     } else {
       const fixedHeight = lines.length + status.length + 1;
@@ -212,8 +216,12 @@ export class InteractiveSupervisorComponent {
     const columns = interactiveSupervisorColumnCount(width, items.length);
     if (columns > 1 && availableHeight !== undefined) {
       const grid = this.renderGridItems(items, width, columns, now);
-      if (fixedHeight + grid.length <= availableHeight) return grid;
+      if (fixedHeight + grid.length <= availableHeight) {
+        this.renderedColumns = columns;
+        return grid;
+      }
     }
+    this.renderedColumns = 1;
     return this.renderLinearItems(items, width, now);
   }
 
@@ -293,12 +301,12 @@ export class InteractiveSupervisorComponent {
 
     const items = this.items();
     if (matchesKey(data, Key.up) || matchesKey(data, "k")) {
-      this.selectIndex(items, this.selectedIndex - 1);
+      this.selectIndex(items, this.moveSelectionIndex(items.length, -1));
       this.changed();
       return;
     }
     if (matchesKey(data, Key.down) || matchesKey(data, "j")) {
-      this.selectIndex(items, this.selectedIndex + 1);
+      this.selectIndex(items, this.moveSelectionIndex(items.length, 1));
       this.changed();
       return;
     }
@@ -392,6 +400,16 @@ export class InteractiveSupervisorComponent {
     this.selectedKey = items[this.selectedIndex]
       ? supervisorItemKey(items[this.selectedIndex])
       : undefined;
+  }
+
+  private moveSelectionIndex(length: number, delta: -1 | 1): number {
+    if (this.renderedColumns <= 1) return this.selectedIndex + delta;
+    return moveGridIndex(
+      this.selectedIndex,
+      length,
+      this.renderedColumns,
+      delta,
+    );
   }
 
   private toggle(id: string): void {
@@ -1035,6 +1053,45 @@ function formatElapsed(milliseconds: number): string {
 
 function clampIndex(index: number, length: number): number {
   return Math.min(Math.max(0, index), Math.max(0, length - 1));
+}
+
+function moveGridIndex(
+  index: number,
+  length: number,
+  columns: number,
+  delta: -1 | 1,
+): number {
+  const count = Math.max(0, Math.floor(length));
+  const columnCount = Math.max(1, Math.min(Math.floor(columns), count));
+  if (count <= 1 || columnCount <= 1) {
+    return clampIndex(index + delta, count);
+  }
+  const rowCount = Math.ceil(count / columnCount);
+  const remainder = count % columnCount;
+  const currentIndex = clampIndex(index, count);
+  const column = currentIndex % columnCount;
+  const row = Math.floor(currentIndex / columnCount);
+  const fullColumns = remainder === 0 ? column : Math.min(column, remainder);
+  const shortColumns = remainder === 0 ? 0 : Math.max(0, column - remainder);
+  const currentRank =
+    fullColumns * rowCount + shortColumns * (rowCount - 1) + row;
+  const targetRank = clampIndex(currentRank + delta, count);
+  if (remainder === 0) {
+    const targetColumn = Math.floor(targetRank / rowCount);
+    const targetRow = targetRank % rowCount;
+    return targetRow * columnCount + targetColumn;
+  }
+  const fullRank = remainder * rowCount;
+  if (targetRank < fullRank) {
+    const targetColumn = Math.floor(targetRank / rowCount);
+    const targetRow = targetRank % rowCount;
+    return targetRow * columnCount + targetColumn;
+  }
+  const shortRowCount = rowCount - 1;
+  const remainingRank = targetRank - fullRank;
+  const targetColumn = remainder + Math.floor(remainingRank / shortRowCount);
+  const targetRow = remainingRank % shortRowCount;
+  return targetRow * columnCount + targetColumn;
 }
 
 function supervisorGridColumnWidths(width: number, columns: number): number[] {

--- a/tests/interactive-supervisor.test.ts
+++ b/tests/interactive-supervisor.test.ts
@@ -343,7 +343,66 @@ describe("interactive supervisor", () => {
     expect(interactiveSupervisorColumnCount(fourColumnWidth, 2)).toBe(2);
   });
 
-  it("uses row-major order for odd counts, navigation, and resize", () => {
+  it("navigates grid items by visual column in both directions", () => {
+    const items = ["zero", "one", "two", "three", "four", "five"].map((id) => ({
+      kind: "interactive" as const,
+      state: state(id),
+      depth: 0,
+      actionable: true,
+    }));
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => items,
+      availableHeight: () => 40,
+    });
+    const width = interactiveSupervisorMinimumGridWidth(2);
+    const selected = () =>
+      component.render(width).find((line) => line.includes("▶"));
+    const expected = [
+      "agent-zero",
+      "agent-two",
+      "agent-four",
+      "agent-one",
+      "agent-three",
+      "agent-five",
+    ];
+
+    for (const name of expected) {
+      expect(selected()).toMatch(new RegExp(`▶.*${name}`));
+      component.handleInput("\x1b[B");
+    }
+    for (const name of [...expected].reverse()) {
+      expect(selected()).toMatch(new RegExp(`▶.*${name}`));
+      component.handleInput("\x1b[A");
+    }
+  });
+
+  it("opens and collapses details with right and left arrows", () => {
+    const item = state("right-arrow");
+    const component = new InteractiveSupervisorComponent({
+      done: vi.fn(),
+      items: () => [
+        { kind: "interactive", state: item, depth: 0, actionable: true },
+      ],
+    });
+    const width = 120;
+    component.render(width);
+    component.handleInput("\x1b[C");
+
+    const rendered = component.render(width);
+    expect(rendered.find((line) => line.includes("▶"))).toContain(
+      "agent-right-arrow",
+    );
+    expect(rendered.join("\n")).toContain("Task: inspect right-arrow");
+    component.handleInput("\x1b[D");
+    const collapsed = component.render(width);
+    expect(collapsed.find((line) => line.includes("▶"))).toContain(
+      "agent-right-arrow",
+    );
+    expect(collapsed.join("\n")).not.toContain("Task: inspect right-arrow");
+  });
+
+  it("uses row-major rendering and column-major navigation across resize", () => {
     const items = ["zero", "one", "two", "three", "four"].map((id) => ({
       kind: "interactive" as const,
       state: state(id),
@@ -373,18 +432,18 @@ describe("interactive supervisor", () => {
     component.handleInput("j");
     expect(
       component.render(threeColumnWidth).find((line) => line.includes("▶")),
-    ).toMatch(/▶.*agent-three/);
-    expect(
-      component.render(twoColumnWidth).find((line) => line.includes("▶")),
-    ).toMatch(/▶.*agent-three/);
-    component.handleInput("j");
+    ).toMatch(/▶.*agent-four/);
     expect(
       component.render(twoColumnWidth).find((line) => line.includes("▶")),
     ).toMatch(/▶.*agent-four/);
+    component.handleInput("j");
+    expect(
+      component.render(twoColumnWidth).find((line) => line.includes("▶")),
+    ).toMatch(/▶.*agent-one/);
     component.handleInput("k");
     expect(
       component.render(threeColumnWidth).find((line) => line.includes("▶")),
-    ).toMatch(/▶.*agent-three/);
+    ).toMatch(/▶.*agent-four/);
   });
 
   it("uses multiple columns only when the complete grid fits the height", () => {
@@ -481,6 +540,8 @@ describe("interactive supervisor", () => {
       availableHeight: () => 40,
       refreshIntervalMs: 0,
     });
+
+    component.render(interactiveSupervisorMinimumGridWidth(2));
 
     for (let index = 0; index < 1_000; index++) {
       component.handleInput(index % 2 === 0 ? "j" : "k");


### PR DESCRIPTION
## Summary
- Align supervisor Up/Down navigation with the rendered grid so each column is traversed top-to-bottom before moving right.
- Preserve Right as the details action and Left as the collapse action.
- Add regression and repeated-navigation coverage.

## Verification
- `npm test -- --run tests/interactive-supervisor.test.ts tests/performance-regression.test.ts`
- `npm run typecheck`
- Changed-file Prettier check
- `git diff --check`
