### PR TITLE
feat(settings): configure Orchestrator V2 depth and agent-list visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ directs the parent to delegate only through attachable interactive children and
 use the parent session's authoritative routing ledger together with the
 project-local routing cache.
 
+### Extension settings
+
+The extension exposes these validated flags for advanced configurations:
+
+- `--subagentura-max-depth <n>` — Orchestratorv2 lineage depth, default `2`; legacy orchestration keeps its existing depth of `8`.
+- `--subagentura-hide-agents-list` — hide agent-list tools and the visual agent-list/status supervisor. It defaults to `false` and does not disable spawning, cancellation, or result tools.
+
 #### See the thin-router flow
 
 > **A small real-session story:** [open the parent replay](https://htmlpreview.github.io/?https://gist.githubusercontent.com/lmn451/7da0271b7e863c1a215e2b7aec822c18/raw/index.html) to see one user talking with a lightweight Orchestratorv2 parent while it fans work out to many attachable child sessions. The highlighted spawn point shows the thin router creating a second Pi session for the reusable workflow-child work.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "src/rehydrate.ts",
     "src/session-handlers.ts",
     "src/session-scope.ts",
+    "src/settings.ts",
     "src/subagent.ts",
     "src/subagent-artifact-cli.ts",
     "src/workflow.ts",

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -72,6 +72,7 @@ import {
   type SessionOwnerToken,
   resolveLiveSessionScope,
 } from "./session-scope";
+import { isAgentsListHidden } from "./settings";
 // ── Footer / Widget Status Keys ────────────────────────────────────────
 
 export const FOOTER_KEY = "subagentura-running";
@@ -340,6 +341,10 @@ export function updateRunningSubagentFooter(
   owner?: SessionOwnerToken,
 ): void {
   const ownerContext = resolveLiveSessionScope(owner);
+  if (ownerContext && isAgentsListHidden(ownerContext.pi)) {
+    updateFooterStatus(ui, FOOTER_KEY, undefined, owner);
+    return;
+  }
   const staleOwner = owner !== undefined && !ownerContext;
   const runningCount = staleOwner ? 0 : getRunningSubagentCount([owner]);
   const workingCount = staleOwner ? 0 : getWorkingSubagentCount([owner]);
@@ -764,8 +769,11 @@ async function runPollArtifactChanges(
 
     // Paint footer + widget. Both are TUI surfaces that never reach the LLM.
     if (ui) {
+      const ownerContext = resolveLiveSessionScope(owner);
+      const hideAgentsList =
+        ownerContext !== undefined && isAgentsListHidden(ownerContext.pi);
       updateRunningSubagentFooter(ui, owner);
-      updateWidgetRows(ui, WIDGET_KEY, widgetRows, owner);
+      updateWidgetRows(ui, WIDGET_KEY, hideAgentsList ? [] : widgetRows, owner);
       // Workflow TUI footer + widget: show running async workflows.
       try {
         const wfCount = getRunningWorkflowCount(owner);

--- a/src/interactive-supervisor-registration.ts
+++ b/src/interactive-supervisor-registration.ts
@@ -459,6 +459,7 @@ export function registerInteractiveSupervisor(
   pi: ExtensionAPI,
   sessionScope?: SessionScope,
   explicitSpawnTreeContext?: ParsedSpawnTreeContext,
+  explicitHideAgentsList = false,
 ): void {
   const owner = (): SessionOwnerToken | undefined =>
     sessionScope
@@ -641,6 +642,7 @@ export function registerInteractiveSupervisor(
     );
   };
 
+  if (explicitHideAgentsList) return;
   if (typeof pi.registerShortcut === "function") {
     pi.registerShortcut(INTERACTIVE_SUPERVISOR_SHORTCUT, {
       description: "Open the async subagent supervisor",

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -69,6 +69,7 @@ import {
   recoverCompletionTurnWakes,
   settleCompletionTurnWake,
 } from "./completion-turn";
+import type { ExtensionSettings } from "./settings";
 
 function getGlobalState() {
   return typeof global !== "undefined" ? global : globalThis;
@@ -236,6 +237,7 @@ export function registerSessionHandlers(
   pi: ExtensionAPI,
   initialSpawnTreeContext?: ParsedSpawnTreeContext,
   allowRootLineage = true,
+  settings?: ExtensionSettings,
 ): SessionScope {
   const scope = createSessionScope(
     pi,
@@ -313,6 +315,7 @@ export function registerSessionHandlers(
         undefined,
         orchestratorMode,
         orchestratorV2Mode,
+        settings?.maxDepth,
       );
     }
     scope.isParentIdle =

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -64,6 +64,7 @@ import { closeActiveInteractiveSupervisor } from "./interactive-supervisor-ui";
 import {
   clearCompletionTurnWake,
   isOrchestratorMode,
+  isOrchestratorV2Enabled,
   markCompletionTurnWakeStarted,
   recoverCompletionTurnWakes,
   settleCompletionTurnWake,
@@ -301,6 +302,7 @@ export function registerSessionHandlers(
     clearFreshChildLineage(scope, event.reason);
     const sessionId = ctx.sessionManager?.getSessionId?.();
     const orchestratorMode = isOrchestratorMode(pi);
+    const orchestratorV2Mode = isOrchestratorV2Enabled(pi);
     if (
       allowRootLineage &&
       sessionId &&
@@ -310,6 +312,7 @@ export function registerSessionHandlers(
         sessionId,
         undefined,
         orchestratorMode,
+        orchestratorV2Mode,
       );
     }
     scope.isParentIdle =

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,70 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const MAX_DEPTH_FLAG = "subagentura-max-depth";
+export const HIDE_AGENTS_LIST_FLAG = "subagentura-hide-agents-list";
+export const DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH = 2;
+const MAX_CONFIGURED_DEPTH = 64;
+
+export interface ExtensionSettings {
+  maxDepth: number;
+  hideAgentsList: boolean;
+}
+
+export function registerExtensionSettings(pi: ExtensionAPI): void {
+  pi.registerFlag(MAX_DEPTH_FLAG, {
+    description:
+      "Maximum Orchestratorv2 lineage depth (default: 2; legacy stays at 8)",
+    type: "string",
+    default: String(DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH),
+  });
+  pi.registerFlag(HIDE_AGENTS_LIST_FLAG, {
+    description:
+      "Hide agent-list tools and the visual agent list/status supervisor",
+    type: "boolean",
+    default: false,
+  });
+}
+
+export function readExtensionSettings(pi: ExtensionAPI): ExtensionSettings {
+  const maxDepthValue = readFlag(pi, MAX_DEPTH_FLAG);
+  const hideAgentsListValue = readFlag(pi, HIDE_AGENTS_LIST_FLAG);
+  return {
+    maxDepth: parseMaxDepth(maxDepthValue),
+    hideAgentsList: parseHideAgentsList(hideAgentsListValue),
+  };
+}
+
+function readFlag(pi: ExtensionAPI, name: string): unknown {
+  const getFlag = (pi as Partial<ExtensionAPI>).getFlag;
+  if (typeof getFlag !== "function") return undefined;
+  return getFlag.call(pi, name);
+}
+
+function parseMaxDepth(value: unknown): number {
+  if (value === undefined || value === false) {
+    return DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH;
+  }
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/.test(value)) {
+    throw new Error(
+      `${MAX_DEPTH_FLAG} (max depth) must be a non-negative integer no greater than ${MAX_CONFIGURED_DEPTH}`,
+    );
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed > MAX_CONFIGURED_DEPTH) {
+    throw new Error(
+      `${MAX_DEPTH_FLAG} (max depth) must be a non-negative integer no greater than ${MAX_CONFIGURED_DEPTH}`,
+    );
+  }
+  return parsed;
+}
+
+function parseHideAgentsList(value: unknown): boolean {
+  if (value === undefined || typeof value === "boolean") return value ?? false;
+  throw new Error(
+    `${HIDE_AGENTS_LIST_FLAG} (hide agents list) must be a boolean`,
+  );
+}
+
+export function isAgentsListHidden(pi: ExtensionAPI): boolean {
+  return readExtensionSettings(pi).hideAgentsList;
+}

--- a/src/spawn-tree-context.ts
+++ b/src/spawn-tree-context.ts
@@ -189,6 +189,7 @@ export function createRootSpawnTreeContext(
   rootId: string,
   sessionRoot = defaultSpawnTreeSessionRoot(),
   orchestratorMode = false,
+  orchestratorV2Mode = false,
 ): ParsedSpawnTreeContext {
   return parseSpawnTreeContext({
     schemaVersion: LINEAGE_BOOTSTRAP_SCHEMA_VERSION,
@@ -197,7 +198,7 @@ export function createRootSpawnTreeContext(
     sessionRoot,
     ...(orchestratorMode ? { orchestratorMode: true } : {}),
     depth: 0,
-    maxDepth: DEFAULT_MAX_DEPTH,
+    maxDepth: orchestratorV2Mode ? 2 : DEFAULT_MAX_DEPTH,
     maxNodes: DEFAULT_MAX_NODES,
   });
 }

--- a/src/spawn-tree-context.ts
+++ b/src/spawn-tree-context.ts
@@ -190,6 +190,7 @@ export function createRootSpawnTreeContext(
   sessionRoot = defaultSpawnTreeSessionRoot(),
   orchestratorMode = false,
   orchestratorV2Mode = false,
+  configuredMaxDepth?: number,
 ): ParsedSpawnTreeContext {
   return parseSpawnTreeContext({
     schemaVersion: LINEAGE_BOOTSTRAP_SCHEMA_VERSION,
@@ -198,7 +199,9 @@ export function createRootSpawnTreeContext(
     sessionRoot,
     ...(orchestratorMode ? { orchestratorMode: true } : {}),
     depth: 0,
-    maxDepth: orchestratorV2Mode ? 2 : DEFAULT_MAX_DEPTH,
+    maxDepth: orchestratorV2Mode
+      ? (configuredMaxDepth ?? 2)
+      : DEFAULT_MAX_DEPTH,
     maxNodes: DEFAULT_MAX_NODES,
   });
 }

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -43,6 +43,7 @@ import { registerChildProtocol } from "./child-protocol";
 import { registerCancelAllFlows } from "./cancel-all-flows-registration";
 import { renderSubagentNotify } from "./rendering";
 import { registerInteractiveSupervisor } from "./interactive-supervisor-registration";
+import { registerExtensionSettings, readExtensionSettings } from "./settings";
 import {
   acquireRuntimeSpawnTreeContext,
   LINEAGE_BOOTSTRAP_ENV,
@@ -123,6 +124,8 @@ export default function (pi: ExtensionAPI) {
       "pi-subagentura requires Pi >= 0.80.6 with agent_settled and custom message renderer support",
     );
   }
+  registerExtensionSettings(pi);
+  const settings = readExtensionSettings(pi);
   pi.registerFlag("orchestrator", {
     description: "Append the bundled orchestration system prompt",
     type: "boolean",
@@ -147,10 +150,15 @@ export default function (pi: ExtensionAPI) {
     };
   });
   pi.registerMessageRenderer("subagent-notify", renderSubagentNotify);
-  const sessionScope = registerSessionHandlers(pi);
-  registerInteractiveSubagentTools(pi, sessionScope);
-  registerOrchestratorTools(pi, sessionScope);
-  registerInteractiveSupervisor(pi, sessionScope);
+  const sessionScope = registerSessionHandlers(pi, undefined, true, settings);
+  registerInteractiveSubagentTools(pi, sessionScope, settings.hideAgentsList);
+  registerOrchestratorTools(pi, sessionScope, settings.hideAgentsList);
+  registerInteractiveSupervisor(
+    pi,
+    sessionScope,
+    undefined,
+    settings.hideAgentsList,
+  );
   registerWorkflowTool(pi, sessionScope);
   registerInProcessSubagentTools(pi, sessionScope);
   registerInProcessMaintenanceTools(pi, sessionScope);

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -413,6 +413,7 @@ function findOwnedDiskArtifact(
 export function registerInteractiveSubagentTools(
   pi: ExtensionAPI,
   registrationScope?: SessionScope,
+  hideAgentsList = false,
 ): void {
   const toolToken: SessionToolToken | undefined = registrationScope
     ? { id: registrationScope.id }
@@ -1292,61 +1293,69 @@ export function registerInteractiveSubagentTools(
     },
   });
 
-  // ── Tool: list known interactive sub-agent artifacts ─────────────
-  registerToolWithDefaultGuidance(pi, {
-    name: "list_subagent_artifacts",
-    label: "List Subagent Artifacts",
-    description: [
-      "List interactive sub-agent artifacts visible to this parent session.",
-      "Returns id, name, status, and last-update time. Use read_subagent_artifact",
-      "to fetch a specific one.",
-    ].join("\n"),
-    parameters: Type.Object({}),
+  if (!hideAgentsList) {
+    // ── Tool: list known interactive sub-agent artifacts ─────────────
+    registerToolWithDefaultGuidance(pi, {
+      name: "list_subagent_artifacts",
+      label: "List Subagent Artifacts",
+      description: [
+        "List interactive sub-agent artifacts visible to this parent session.",
+        "Returns id, name, status, and last-update time. Use read_subagent_artifact",
+        "to fetch a specific one.",
+      ].join("\n"),
+      parameters: Type.Object({}),
 
-    async execute(_toolCallId, _params, _signal, _onUpdate, ctx): Promise<any> {
-      const registration = resolveInteractiveToolStates(toolToken);
-      const visibleStates = registration?.states;
-      if (visibleStates) {
-        pruneDeadInteractiveSubagents(visibleStates.values());
-        updateRunningSubagentFooter(
-          ctx.ui,
-          registration.scope ? sessionOwner(registration.scope) : undefined,
-        );
-      }
-      const states = visibleStates ? [...visibleStates.values()] : [];
-      const summary = states.map((s) => {
-        const art = getArtifactForState(s);
-        const last = lastEvent(art);
+      async execute(
+        _toolCallId,
+        _params,
+        _signal,
+        _onUpdate,
+        ctx,
+      ): Promise<any> {
+        const registration = resolveInteractiveToolStates(toolToken);
+        const visibleStates = registration?.states;
+        if (visibleStates) {
+          pruneDeadInteractiveSubagents(visibleStates.values());
+          updateRunningSubagentFooter(
+            ctx.ui,
+            registration.scope ? sessionOwner(registration.scope) : undefined,
+          );
+        }
+        const states = visibleStates ? [...visibleStates.values()] : [];
+        const summary = states.map((s) => {
+          const art = getArtifactForState(s);
+          const last = lastEvent(art);
+          return {
+            id: s.id,
+            name: s.name,
+            task: s.task,
+            status: s.status,
+            lastEvent: last,
+            lastUpdate: last?.ts,
+            artifactDir: s.artifactDir,
+          };
+        });
+        if (summary.length === 0) {
+          return {
+            content: [
+              { type: "text", text: "No interactive sub-agents are tracked." },
+            ],
+            details: { count: 0, subagents: [] },
+          };
+        }
+        const lines = summary.map((s) => {
+          const ev = s.lastEvent;
+          const taskPreview = (s.task ?? "").replace(/\s+/g, " ").slice(0, 60);
+          const evStr = ev
+            ? `last: ${ev.type}${ev.message ? ` (${ev.message.slice(0, 60)})` : ""}`
+            : "no events yet";
+          return `${s.id}  ${s.name}  [${s.status}]  ${taskPreview} — ${evStr}`;
+        });
         return {
-          id: s.id,
-          name: s.name,
-          task: s.task,
-          status: s.status,
-          lastEvent: last,
-          lastUpdate: last?.ts,
-          artifactDir: s.artifactDir,
+          content: [{ type: "text", text: lines.join("\n") }],
+          details: { count: summary.length, subagents: summary },
         };
-      });
-      if (summary.length === 0) {
-        return {
-          content: [
-            { type: "text", text: "No interactive sub-agents are tracked." },
-          ],
-          details: { count: 0, subagents: [] },
-        };
-      }
-      const lines = summary.map((s) => {
-        const ev = s.lastEvent;
-        const taskPreview = (s.task ?? "").replace(/\s+/g, " ").slice(0, 60);
-        const evStr = ev
-          ? `last: ${ev.type}${ev.message ? ` (${ev.message.slice(0, 60)})` : ""}`
-          : "no events yet";
-        return `${s.id}  ${s.name}  [${s.status}]  ${taskPreview} — ${evStr}`;
-      });
-      return {
-        content: [{ type: "text", text: lines.join("\n") }],
-        details: { count: summary.length, subagents: summary },
-      };
-    },
-  });
+      },
+    });
+  }
 }

--- a/src/tools/orchestrator.ts
+++ b/src/tools/orchestrator.ts
@@ -101,43 +101,45 @@ const UpdateOrchestratorAgentDescriptionParams = Type.Object({
 export function registerOrchestratorTools(
   pi: ExtensionAPI,
   registrationScope?: SessionScope,
+  hideAgentsList = false,
 ): void {
   const toolToken: SessionToolToken | undefined = registrationScope
     ? { id: registrationScope.id }
     : undefined;
-
-  registerToolWithDefaultGuidance(pi, {
-    name: "list_orchestrator_agents",
-    label: "List Orchestrator Agents",
-    description:
-      "List the bounded Orchestratorv2 routing overlay joined to this parent session's current interactive runtimes. Returns metadata, status, liveness, attach/focus commands, and artifact pointers without child transcripts or output.",
-    parameters: ListOrchestratorAgentsParams,
-    async execute(_toolCallId, _params, signal, _onUpdate, ctx) {
-      const scope = resolveToolSessionScope(toolToken);
-      if (!scope) return sessionUnavailableResult();
-      try {
-        const projection = await loadOrchestratorAgentRegistryView(
-          ctx.cwd,
-          scope.interactiveStates,
-          {
-            signal,
-            authorityEntries: parentBranchEntries(ctx),
-          },
-        );
-        return {
-          content: [
+  if (!hideAgentsList) {
+    registerToolWithDefaultGuidance(pi, {
+      name: "list_orchestrator_agents",
+      label: "List Orchestrator Agents",
+      description:
+        "List the bounded Orchestratorv2 routing overlay joined to this parent session's current interactive runtimes. Returns metadata, status, liveness, attach/focus commands, and artifact pointers without child transcripts or output.",
+      parameters: ListOrchestratorAgentsParams,
+      async execute(_toolCallId, _params, signal, _onUpdate, ctx) {
+        const scope = resolveToolSessionScope(toolToken);
+        if (!scope) return sessionUnavailableResult();
+        try {
+          const projection = await loadOrchestratorAgentRegistryView(
+            ctx.cwd,
+            scope.interactiveStates,
             {
-              type: "text",
-              text: JSON.stringify(projection, null, 2),
+              signal,
+              authorityEntries: parentBranchEntries(ctx),
             },
-          ],
-          details: { status: "ok", ...projection },
-        };
-      } catch (error) {
-        return routingErrorResult(error);
-      }
-    },
-  });
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(projection, null, 2),
+              },
+            ],
+            details: { status: "ok", ...projection },
+          };
+        } catch (error) {
+          return routingErrorResult(error);
+        }
+      },
+    });
+  }
 
   registerToolWithDefaultGuidance(pi, {
     name: "update_orchestrator_agent_description",

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import registerExtension from "../src/subagent";
+import {
+  HIDE_AGENTS_LIST_FLAG,
+  MAX_DEPTH_FLAG,
+  readExtensionSettings,
+} from "../src/settings";
+import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
+
+function mockApi(getFlag: (name: string) => unknown = () => undefined) {
+  return {
+    registerTool: vi.fn(),
+    registerMessageRenderer: vi.fn(),
+    registerFlag: vi.fn(),
+    registerCommand: vi.fn(),
+    registerShortcut: vi.fn(),
+    getFlag: vi.fn(getFlag),
+    on: vi.fn(),
+  };
+}
+
+function registeredTools(api: ReturnType<typeof mockApi>): string[] {
+  return api.registerTool.mock.calls.map(([tool]: any[]) => tool.name);
+}
+
+describe("generic extension settings", () => {
+  it("registers validated settings with V2-safe defaults", () => {
+    const api = mockApi();
+    registerExtension(api as any);
+
+    expect(api.registerFlag).toHaveBeenCalledWith(MAX_DEPTH_FLAG, {
+      description: expect.stringContaining("Orchestratorv2"),
+      type: "string",
+      default: "2",
+    });
+    expect(api.registerFlag).toHaveBeenCalledWith(HIDE_AGENTS_LIST_FLAG, {
+      description: expect.stringContaining("agent list"),
+      type: "boolean",
+      default: false,
+    });
+    expect(readExtensionSettings(api as any)).toEqual({
+      maxDepth: 2,
+      hideAgentsList: false,
+    });
+  });
+
+  it.each(["", "-1", "1.5", "nope", "65", true])(
+    "rejects invalid max depth %p",
+    (value) => {
+      const api = mockApi((name) =>
+        name === MAX_DEPTH_FLAG ? value : undefined,
+      );
+      expect(() => readExtensionSettings(api as any)).toThrow(/max depth/i);
+    },
+  );
+
+  it("rejects invalid hide-agents-list values", () => {
+    const api = mockApi((name) =>
+      name === HIDE_AGENTS_LIST_FLAG ? "true" : undefined,
+    );
+    expect(() => readExtensionSettings(api as any)).toThrow(
+      /hide agents list/i,
+    );
+  });
+
+  it("uses the configured depth only for V2 roots", () => {
+    const api = mockApi((name) => (name === MAX_DEPTH_FLAG ? "4" : undefined));
+    const settings = readExtensionSettings(api as any);
+
+    expect(
+      createRootSpawnTreeContext("v2", "/tmp", false, true, settings.maxDepth)
+        .maxDepth,
+    ).toBe(4);
+    expect(
+      createRootSpawnTreeContext(
+        "legacy",
+        "/tmp",
+        true,
+        false,
+        settings.maxDepth,
+      ).maxDepth,
+    ).toBe(8);
+  });
+
+  it("hides list tools and the visual supervisor without hiding operations", () => {
+    const api = mockApi((name) =>
+      name === HIDE_AGENTS_LIST_FLAG ? true : undefined,
+    );
+    registerExtension(api as any);
+    const tools = registeredTools(api);
+
+    expect(tools).not.toContain("list_orchestrator_agents");
+    expect(tools).not.toContain("list_subagent_artifacts");
+    expect(tools).toContain("subagent_interactive");
+    expect(tools).toContain("cancel_interactive_subagent");
+    expect(tools).toContain("read_subagent_artifact");
+    expect(api.registerCommand).not.toHaveBeenCalledWith(
+      "subagents",
+      expect.anything(),
+    );
+    expect(api.registerShortcut).not.toHaveBeenCalledWith(
+      "ctrl+alt+a",
+      expect.anything(),
+    );
+  });
+
+  it("preserves list tools and visual supervisor visibility by default", () => {
+    const api = mockApi();
+    registerExtension(api as any);
+    const tools = registeredTools(api);
+
+    expect(tools).toContain("list_orchestrator_agents");
+    expect(tools).toContain("list_subagent_artifacts");
+    expect(api.registerCommand).toHaveBeenCalledWith(
+      "subagents",
+      expect.anything(),
+    );
+    expect(api.registerShortcut).toHaveBeenCalledWith(
+      "ctrl+alt+a",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -203,6 +203,22 @@ describe("session handler lifecycle callbacks", () => {
     });
   });
 
+  it.each([
+    ["orchestratorv2", 2],
+    ["orchestrator", 8],
+  ] as const)(
+    "applies the mode-specific root maxDepth on session_start (%s)",
+    (flag, maxDepth) => {
+      const registration = registerHandlers(undefined, true, flag);
+      startSession(registration, root, `${flag}-session`);
+
+      expect(registration.sessionScope.spawnTreeContext).toMatchObject({
+        role: "root",
+        maxDepth,
+      });
+    },
+  );
+
   it("keeps a child without a bootstrap in direct-only mode", () => {
     const registration = registerHandlers(undefined, false);
 

--- a/tests/spawn-tree-context.test.ts
+++ b/tests/spawn-tree-context.test.ts
@@ -44,6 +44,31 @@ afterEach(() => {
 });
 
 describe("explicit lineage context", () => {
+  it("uses maxDepth 2 for Orchestrator V2 roots", () => {
+    const root = createRootSpawnTreeContext(
+      "orchestrator-root",
+      tempDir(),
+      true,
+      true,
+    );
+
+    expect(root.maxDepth).toBe(2);
+  });
+
+  it("keeps the default maxDepth for legacy roots", () => {
+    expect(createRootSpawnTreeContext("legacy-root", tempDir()).maxDepth).toBe(
+      8,
+    );
+    expect(
+      createRootSpawnTreeContext("legacy-root-explicit", tempDir(), false)
+        .maxDepth,
+    ).toBe(8);
+    expect(
+      createRootSpawnTreeContext("legacy-orchestrator", tempDir(), true)
+        .maxDepth,
+    ).toBe(8);
+  });
+
   it("consumes a one-use bootstrap and retains context only in this process", () => {
     const root = tempDir();
     const artifactDir = join(root, "child-agent");


### PR DESCRIPTION
## Summary
- cap root Orchestrator V2 lineage depth at the configurable default of 2, while preserving legacy orchestration depth 8
- add validated `subagentura-max-depth` and `subagentura-hide-agents-list` settings
- hide agent-list tools and the visual supervisor when requested without disabling spawn, cancellation, or artifact-result operations

## Tests
- `npm run typecheck`
- `npm test`
- `npm run format:check`
- `npm run pack:check`