### PR TITLE
test(zellij): isolate retried integration sessions

### DIFF
--- a/tests/zellij.integration.test.ts
+++ b/tests/zellij.integration.test.ts
@@ -92,12 +92,15 @@ async function waitFor(
  * until the pane is reported alive.
  */
 async function spawnPane(mux: ZellijMultiplexer, name: string) {
-  const id = `it${process.pid}x${spawnCounter++}`;
   const cwd = mkdtempSync(join(tempRoot, "ws-"));
   let created: ReturnType<ZellijMultiplexer["createPane"]> | undefined;
-  // `attach --create-background` returns before the server is guaranteed to
-  // have materialized the session's panes, so retry the whole create.
+  // A failed create can leave the background session behind (for example,
+  // when zellij accepts attach but is not ready for the first action). Use a
+  // fresh session per attempt and register it before calling createPane so a
+  // failed attempt is still cleaned up by afterEach.
   await waitFor(() => {
+    const id = `it${process.pid}x${spawnCounter++}`;
+    sessions.push(`pi-subagent-${id}`);
     try {
       created = mux.createPane({ name, cwd, background: true, id });
       return true;
@@ -106,7 +109,8 @@ async function spawnPane(mux: ZellijMultiplexer, name: string) {
     }
   }, `timed out creating a zellij pane for ${name}`);
   const pane = created!;
-  if (pane.session) sessions.push(pane.session);
+  if (pane.session && !sessions.includes(pane.session))
+    sessions.push(pane.session);
   await waitFor(
     () => mux.getPaneLiveness(pane.paneId, pane.session) === "alive",
     `pane ${pane.paneId} never reported alive in ${pane.session}`,


### PR DESCRIPTION
## Summary

- Use a fresh background-session ID for each retry in the real Zellij integration helper.
- Register each attempted session before `createPane()` so failed startup attempts are cleaned up.
- Avoid duplicate cleanup registration for the successful returned session.

A Zellij 0.44.3 startup/action race can leave the session created while a subsequent pane action fails. Retrying `attach --create-background` with the same ID then loops on `Session already exists` until Vitest times out. This is test-only; no production behavior changes.

## Verification

- Focused Zellij create test with Zellij 0.44.3
- `npm test` (75 files, 1740 tests)
- `npm run typecheck`
- `npm run format:check`
- `npm run pack:check`

All passed in the dedicated worktree.