### PR TITLE
feat(settings): add shared extension settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,22 +263,22 @@ Install the optional settings panel once with:
 pi install npm:@juanibiapina/pi-extension-settings
 ```
 
-Use `/extension-settings` for global settings; a project value overrides
-the global value when read from the Pi session's authoritative cwd. The optional
-package's `/extension-settings-local` command is not session-cwd-correct in the
-pinned `@juanibiapina/pi-extension-settings@0.9.1`: it resolves local settings
-from Node's process cwd instead of Pi's command context. Do not use that command
-for cross-project sessions. For a session-local value, edit
-`<session-cwd>/.pi/settings-extensions.json` manually, using the exact cwd of
-the Pi session. `max-depth` controls Orchestratorv2 lineage depth and defaults
-to `2`; `hide-agent-list` defaults to `false` and only hides the compact
-per-agent activity widget rows. The running footer, list/status tools, and visual
-agent supervisor remain available.
+Use `/extension-settings` for global settings. Whether a project value can
+override the global one is per-setting — see the scope rules below; only
+`max-depth` is project-overridable. The optional package's
+`/extension-settings-local` command is not session-cwd-correct in the pinned
+`@juanibiapina/pi-extension-settings@0.9.1`: it resolves local settings from
+Node's process cwd instead of Pi's command context. Do not use that command for
+cross-project sessions. It also still renders a `hide-agent-list` row, but
+setting it there is a no-op because that setting is global-only. For a
+session-local `max-depth`, edit `<session-cwd>/.pi/settings-extensions.json`
+manually, using the exact cwd of the Pi session. `max-depth` controls
+Orchestratorv2 lineage depth and defaults to `2`; `hide-agent-list` defaults to
+`false` and only hides the compact per-agent activity widget rows. The running
+footer, list/status tools, and visual agent supervisor remain available.
 
-The same setting can be configured without the panel by creating either the
-global file `~/.pi/agent/settings-extensions.json` or the project-local file
-`<project>/.pi/settings-extensions.json`. The project-local value is read first
-and overrides the global value:
+Both settings can also be configured without the panel. The global file
+`~/.pi/agent/settings-extensions.json` accepts either key:
 
 ```json
 {
@@ -289,11 +289,34 @@ and overrides the global value:
 }
 ```
 
+The project-local file `<project>/.pi/settings-extensions.json` is read for
+`max-depth` only:
+
+```json
+{
+  "pi-subagentura": {
+    "max-depth": "6"
+  }
+}
+```
+
+Scope rules:
+
+- `max-depth` is read project-local first, with the global file as fallback.
+- `hide-agent-list` is read **only** from the global file. A checked-out
+  repository must not be able to hide agent activity from whoever opens it, so a
+  project-local `hide-agent-list` is ignored.
+
+An invalid persisted value never aborts a session: the extension keeps the
+documented default (`max-depth` `2`, `hide-agent-list` `false`) and reports the
+ignored value in the TUI at the start of a root session, and to the debug log
+otherwise.
+
 The extension also exposes these validated launch flags for advanced
 configurations:
 
-- `--subagentura-max-depth <n>` — override `max-depth` for the current run; legacy orchestration keeps its existing depth of `8`.
-- `--subagentura-hide-agent-list` — force `hide-agent-list` on for the current run without changing the persisted global or project setting. It also works without the optional settings panel.
+- `--subagentura-max-depth <n>` — override `max-depth` for the current run; legacy orchestration keeps its existing depth of `8`. Unlike the persisted setting, an invalid value here fails fast.
+- `--subagentura-hide-agent-list` — force `hide-agent-list` on for the current run without changing the persisted global setting. It also works without the optional settings panel. The flag is on-only: it cannot override a persisted `hide-agent-list` of `true`, so to show the rows again clear the global setting.
 
 #### See the thin-router flow
 

--- a/README.md
+++ b/README.md
@@ -257,10 +257,24 @@ project-local routing cache.
 
 ### Extension settings
 
-The extension exposes these validated flags for advanced configurations:
+Install the optional settings panel once with:
+
+```bash
+pi install npm:@juanibiapina/pi-extension-settings
+```
+
+Then use `/extension-settings` for global settings or
+`/extension-settings-local` for the current project; a project value overrides
+the global value. The
+`hide-agent-list` setting defaults to `false` and only hides the compact
+per-agent activity widget rows. The running footer, list/status tools, and
+visual agent supervisor remain available.
+
+The extension also exposes these validated launch flags for advanced
+configurations:
 
 - `--subagentura-max-depth <n>` — Orchestratorv2 lineage depth, default `2`; legacy orchestration keeps its existing depth of `8`.
-- `--subagentura-hide-agent-list` — hide only the compact per-agent activity widget rows; the running footer, list/status tools, and visual agent supervisor remain available. It defaults to `false`.
+- `--subagentura-hide-agent-list` — force `hide-agent-list` on for the current run without changing the persisted global or project setting. It also works without the optional settings panel.
 
 #### See the thin-router flow
 

--- a/README.md
+++ b/README.md
@@ -263,9 +263,14 @@ Install the optional settings panel once with:
 pi install npm:@juanibiapina/pi-extension-settings
 ```
 
-Then use `/extension-settings` for global settings or
-`/extension-settings-local` for the current project; a project value overrides
-the global value. `max-depth` controls Orchestratorv2 lineage depth and defaults
+Use `/extension-settings` for global settings; a project value overrides
+the global value when read from the Pi session's authoritative cwd. The optional
+package's `/extension-settings-local` command is not session-cwd-correct in the
+pinned `@juanibiapina/pi-extension-settings@0.9.1`: it resolves local settings
+from Node's process cwd instead of Pi's command context. Do not use that command
+for cross-project sessions. For a session-local value, edit
+`<session-cwd>/.pi/settings-extensions.json` manually, using the exact cwd of
+the Pi session. `max-depth` controls Orchestratorv2 lineage depth and defaults
 to `2`; `hide-agent-list` defaults to `false` and only hides the compact
 per-agent activity widget rows. The running footer, list/status tools, and visual
 agent supervisor remain available.

--- a/README.md
+++ b/README.md
@@ -265,10 +265,10 @@ pi install npm:@juanibiapina/pi-extension-settings
 
 Then use `/extension-settings` for global settings or
 `/extension-settings-local` for the current project; a project value overrides
-the global value. The
-`hide-agent-list` setting defaults to `false` and only hides the compact
-per-agent activity widget rows. The running footer, list/status tools, and
-visual agent supervisor remain available.
+the global value. `max-depth` controls Orchestratorv2 lineage depth and defaults
+to `2`; `hide-agent-list` defaults to `false` and only hides the compact
+per-agent activity widget rows. The running footer, list/status tools, and visual
+agent supervisor remain available.
 
 The same setting can be configured without the panel by creating either the
 global file `~/.pi/agent/settings-extensions.json` or the project-local file
@@ -278,6 +278,7 @@ and overrides the global value:
 ```json
 {
   "pi-subagentura": {
+    "max-depth": "4",
     "hide-agent-list": "true"
   }
 }
@@ -286,7 +287,7 @@ and overrides the global value:
 The extension also exposes these validated launch flags for advanced
 configurations:
 
-- `--subagentura-max-depth <n>` — Orchestratorv2 lineage depth, default `2`; legacy orchestration keeps its existing depth of `8`.
+- `--subagentura-max-depth <n>` — override `max-depth` for the current run; legacy orchestration keeps its existing depth of `8`.
 - `--subagentura-hide-agent-list` — force `hide-agent-list` on for the current run without changing the persisted global or project setting. It also works without the optional settings panel.
 
 #### See the thin-router flow

--- a/README.md
+++ b/README.md
@@ -270,6 +270,19 @@ the global value. The
 per-agent activity widget rows. The running footer, list/status tools, and
 visual agent supervisor remain available.
 
+The same setting can be configured without the panel by creating either the
+global file `~/.pi/agent/settings-extensions.json` or the project-local file
+`<project>/.pi/settings-extensions.json`. The project-local value is read first
+and overrides the global value:
+
+```json
+{
+  "pi-subagentura": {
+    "hide-agent-list": "true"
+  }
+}
+```
+
 The extension also exposes these validated launch flags for advanced
 configurations:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
+        "@juanibiapina/pi-extension-settings": "^0.9.1",
         "acorn": "^8.14.0",
         "is-path-inside": "^4.0.0",
         "ndjson": "^2.0.0"
@@ -3321,6 +3322,15 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@juanibiapina/pi-extension-settings": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@juanibiapina/pi-extension-settings/-/pi-extension-settings-0.9.1.tgz",
+      "integrity": "sha512-CPt6zwYLxwwndrIsd4/IwZlm2SxWJIgmGL5a3b1paVl0Vm6TcppTn8LPA+AfoQPZZVoP6/VH/aiozqNWXdc7Mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@stryker-mutator/core": {

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
+    "@juanibiapina/pi-extension-settings": "^0.9.1",
     "acorn": "^8.14.0",
     "is-path-inside": "^4.0.0",
     "ndjson": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      "@juanibiapina/pi-extension-settings":
+        specifier: ^0.9.1
+        version: 0.9.1
       acorn:
         specifier: ^8.14.0
         version: 8.18.0
@@ -583,6 +586,13 @@ packages:
       {
         integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
       }
+
+  "@juanibiapina/pi-extension-settings@0.9.1":
+    resolution:
+      {
+        integrity: sha512-CPt6zwYLxwwndrIsd4/IwZlm2SxWJIgmGL5a3b1paVl0Vm6TcppTn8LPA+AfoQPZZVoP6/VH/aiozqNWXdc7Mg==,
+      }
+    engines: { node: ">=20.0.0" }
 
   "@mariozechner/clipboard-darwin-arm64@0.3.9":
     resolution:
@@ -2873,6 +2883,8 @@ snapshots:
     dependencies:
       "@jridgewell/resolve-uri": 3.1.2
       "@jridgewell/sourcemap-codec": 1.5.5
+
+  "@juanibiapina/pi-extension-settings@0.9.1": {}
 
   "@mariozechner/clipboard-darwin-arm64@0.3.9":
     optional: true

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -769,6 +769,9 @@ async function runPollArtifactChanges(
       const hideAgentList =
         widgetRows.length > 0 &&
         ownerContext !== undefined &&
+        // Pass the session cwd, if any, and let the setting own its scope:
+        // hide-agent-list is read globally, so a missing cwd never degrades
+        // into a lookup against Node's process cwd.
         isAgentListHidden(ownerContext.pi, { cwd: ownerContext.cwd });
       updateRunningSubagentFooter(ui, owner);
       updateWidgetRows(ui, WIDGET_KEY, hideAgentList ? [] : widgetRows, owner);

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -769,7 +769,7 @@ async function runPollArtifactChanges(
       const hideAgentList =
         widgetRows.length > 0 &&
         ownerContext !== undefined &&
-        isAgentListHidden(ownerContext.pi);
+        isAgentListHidden(ownerContext.pi, { cwd: ownerContext.cwd });
       updateRunningSubagentFooter(ui, owner);
       updateWidgetRows(ui, WIDGET_KEY, hideAgentList ? [] : widgetRows, owner);
       // Workflow TUI footer + widget: show running async workflows.

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -767,7 +767,9 @@ async function runPollArtifactChanges(
     if (ui) {
       const ownerContext = resolveLiveSessionScope(owner);
       const hideAgentList =
-        ownerContext !== undefined && isAgentListHidden(ownerContext.pi);
+        widgetRows.length > 0 &&
+        ownerContext !== undefined &&
+        isAgentListHidden(ownerContext.pi);
       updateRunningSubagentFooter(ui, owner);
       updateWidgetRows(ui, WIDGET_KEY, hideAgentList ? [] : widgetRows, owner);
       // Workflow TUI footer + widget: show running async workflows.

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -69,7 +69,10 @@ import {
   recoverCompletionTurnWakes,
   settleCompletionTurnWake,
 } from "./completion-turn";
-import { readExtensionSettings } from "./settings";
+import {
+  emitExtensionSettingsRegistration,
+  readExtensionSettings,
+} from "./settings";
 
 function getGlobalState() {
   return typeof global !== "undefined" ? global : globalThis;
@@ -279,6 +282,7 @@ export function registerSessionHandlers(
   });
 
   pi.on("session_start", (event, ctx) => {
+    if (allowRootLineage) emitExtensionSettingsRegistration(pi);
     // A replacement session must never inherit an old wake request or its
     // watchdog while branch recovery reconstructs durable state.
     clearCompletionTurnWake(pi);

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -313,7 +313,9 @@ export function registerSessionHandlers(
       sessionId &&
       scope.spawnTreeContext?.role !== "descendant"
     ) {
-      const maxDepth = readExtensionSettings(pi, { cwd: ctx.cwd }).maxDepth;
+      const maxDepth = readExtensionSettings(pi, { cwd: ctx.cwd }, (message) =>
+        ctx.ui?.notify?.(message, "warning"),
+      ).maxDepth;
       scope.spawnTreeContext = createRootSpawnTreeContext(
         sessionId,
         undefined,

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -313,7 +313,7 @@ export function registerSessionHandlers(
       sessionId &&
       scope.spawnTreeContext?.role !== "descendant"
     ) {
-      const maxDepth = readExtensionSettings(pi).maxDepth;
+      const maxDepth = readExtensionSettings(pi, { cwd: ctx.cwd }).maxDepth;
       scope.spawnTreeContext = createRootSpawnTreeContext(
         sessionId,
         undefined,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,9 +1,23 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  getSetting,
+  type SettingDefinition,
+  type SettingStorageOptions,
+} from "@juanibiapina/pi-extension-settings";
 
 export const MAX_DEPTH_FLAG = "subagentura-max-depth";
 export const HIDE_AGENT_LIST_FLAG = "subagentura-hide-agent-list";
 export const DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH = 2;
 const MAX_CONFIGURED_DEPTH = 64;
+const SETTINGS_EXTENSION_NAME = "pi-subagentura";
+const HIDE_AGENT_LIST_SETTING = "hide-agent-list";
+const HIDE_AGENT_LIST_DEFINITION = {
+  id: HIDE_AGENT_LIST_SETTING,
+  label: "Hide agent list",
+  description: "Hide compact per-agent activity widget rows",
+  defaultValue: "false",
+  values: ["false", "true"],
+} satisfies SettingDefinition;
 
 export interface ExtensionSettings {
   maxDepth: number;
@@ -22,14 +36,37 @@ export function registerExtensionSettings(pi: ExtensionAPI): void {
     type: "boolean",
     default: false,
   });
+  emitExtensionSettingsRegistration(pi);
 }
 
-export function readExtensionSettings(pi: ExtensionAPI): ExtensionSettings {
+export function emitExtensionSettingsRegistration(pi: ExtensionAPI): void {
+  const events = (pi as Partial<ExtensionAPI>).events;
+  if (events && typeof events.emit === "function") {
+    events.emit("pi-extension-settings:register", {
+      name: SETTINGS_EXTENSION_NAME,
+      settings: [HIDE_AGENT_LIST_DEFINITION],
+    });
+  }
+}
+
+export function readExtensionSettings(
+  pi: ExtensionAPI,
+  storageOptions: SettingStorageOptions = {},
+): ExtensionSettings {
   const maxDepthValue = readFlag(pi, MAX_DEPTH_FLAG);
   const hideAgentListValue = readFlag(pi, HIDE_AGENT_LIST_FLAG);
   return {
     maxDepth: parseMaxDepth(maxDepthValue),
-    hideAgentList: parseHideAgentList(hideAgentListValue),
+    hideAgentList:
+      parseHideAgentList(hideAgentListValue) ||
+      parsePersistedHideAgentList(
+        getSetting(
+          SETTINGS_EXTENSION_NAME,
+          HIDE_AGENT_LIST_SETTING,
+          HIDE_AGENT_LIST_DEFINITION.defaultValue,
+          storageOptions,
+        ),
+      ),
   };
 }
 
@@ -61,6 +98,14 @@ function parseHideAgentList(value: unknown): boolean {
   if (value === undefined || typeof value === "boolean") return value ?? false;
   throw new Error(
     `${HIDE_AGENT_LIST_FLAG} (hide agent list) must be a boolean`,
+  );
+}
+
+function parsePersistedHideAgentList(value: string | undefined): boolean {
+  if (value === "true") return true;
+  if (value === "false" || value === undefined) return false;
+  throw new Error(
+    `${HIDE_AGENT_LIST_SETTING} setting must be either "true" or "false"`,
   );
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -125,6 +125,9 @@ function parsePersistedHideAgentList(value: string | undefined): boolean {
   );
 }
 
-export function isAgentListHidden(pi: ExtensionAPI): boolean {
-  return readExtensionSettings(pi).hideAgentList;
+export function isAgentListHidden(
+  pi: ExtensionAPI,
+  storageOptions: SettingStorageOptions = {},
+): boolean {
+  return readExtensionSettings(pi, storageOptions).hideAgentList;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import {
   type SettingDefinition,
   type SettingStorageOptions,
 } from "@juanibiapina/pi-extension-settings";
+import { debugLog } from "./helpers";
 
 export const MAX_DEPTH_FLAG = "subagentura-max-depth";
 export const HIDE_AGENT_LIST_FLAG = "subagentura-hide-agent-list";
@@ -21,7 +22,8 @@ const MAX_DEPTH_DEFINITION = {
 const HIDE_AGENT_LIST_DEFINITION = {
   id: HIDE_AGENT_LIST_SETTING,
   label: "Hide agent list",
-  description: "Hide compact per-agent activity widget rows",
+  description:
+    "Hide compact per-agent activity widget rows (global only; ignored by /extension-settings-local)",
   defaultValue: "false",
   values: ["false", "true"],
 } satisfies SettingDefinition;
@@ -31,14 +33,17 @@ export interface ExtensionSettings {
   hideAgentList: boolean;
 }
 
+/** Reports a persisted value that was ignored, so the TUI can surface it. */
+export type InvalidSettingReporter = (message: string) => void;
+
 export function registerExtensionSettings(pi: ExtensionAPI): void {
   pi.registerFlag(MAX_DEPTH_FLAG, {
-    description:
-      "Maximum Orchestratorv2 lineage depth (default: 2; legacy stays at 8)",
+    description: `Override the persisted Orchestratorv2 max-depth setting for this run (0-${MAX_CONFIGURED_DEPTH}); legacy orchestration stays at 8`,
     type: "string",
   });
   pi.registerFlag(HIDE_AGENT_LIST_FLAG, {
-    description: "Hide compact per-agent activity widget rows",
+    description:
+      "Force-hide the compact per-agent activity widget rows for this run; it can only turn hiding on, so it cannot override a persisted hide-agent-list of true",
     type: "boolean",
     default: false,
   });
@@ -55,34 +60,33 @@ export function emitExtensionSettingsRegistration(pi: ExtensionAPI): void {
   }
 }
 
+/**
+ * Resolve the effective settings. CLI flags are still validated strictly —
+ * a bad flag is an operator typo worth failing on — but persisted values are
+ * parsed defensively: a hand-edited or panel-written file must never abort
+ * session start, so an invalid value degrades to the documented default and is
+ * reported through `onInvalidSetting`.
+ */
 export function readExtensionSettings(
   pi: ExtensionAPI,
   storageOptions: SettingStorageOptions = {},
+  onInvalidSetting?: InvalidSettingReporter,
 ): ExtensionSettings {
   const maxDepthValue = readFlag(pi, MAX_DEPTH_FLAG);
   const hideAgentListValue = readFlag(pi, HIDE_AGENT_LIST_FLAG);
-  const persistedMaxDepthValue = getSetting(
-    SETTINGS_EXTENSION_NAME,
-    MAX_DEPTH_SETTING,
-    MAX_DEPTH_DEFINITION.defaultValue,
+  // Parsed unconditionally so persisted validation never depends on whether a
+  // flag happened to short-circuit the check.
+  const persistedHideAgentList = readPersistedHideAgentList(
     storageOptions,
+    onInvalidSetting,
   );
   return {
-    maxDepth: parseMaxDepth(
+    maxDepth:
       maxDepthValue === undefined || maxDepthValue === false
-        ? persistedMaxDepthValue
-        : maxDepthValue,
-    ),
+        ? readPersistedMaxDepth(storageOptions, onInvalidSetting)
+        : parseMaxDepth(maxDepthValue),
     hideAgentList:
-      parseHideAgentList(hideAgentListValue) ||
-      parsePersistedHideAgentList(
-        getSetting(
-          SETTINGS_EXTENSION_NAME,
-          HIDE_AGENT_LIST_SETTING,
-          HIDE_AGENT_LIST_DEFINITION.defaultValue,
-          storageOptions,
-        ),
-      ),
+      parseHideAgentList(hideAgentListValue) || persistedHideAgentList,
   };
 }
 
@@ -90,6 +94,18 @@ function readFlag(pi: ExtensionAPI, name: string): unknown {
   const getFlag = (pi as Partial<ExtensionAPI>).getFlag;
   if (typeof getFlag !== "function") return undefined;
   return getFlag.call(pi, name);
+}
+
+/**
+ * Without an authoritative session cwd, local lookups would silently resolve
+ * against the Node process cwd — an unrelated directory for a resumed session.
+ * Degrade explicitly to the global file instead.
+ */
+function resolveStorageOptions(
+  options: SettingStorageOptions,
+): SettingStorageOptions {
+  if (options.scope !== undefined || options.cwd !== undefined) return options;
+  return { ...options, scope: "global" };
 }
 
 function parseMaxDepth(value: unknown): number {
@@ -117,17 +133,91 @@ function parseHideAgentList(value: unknown): boolean {
   );
 }
 
-function parsePersistedHideAgentList(value: string | undefined): boolean {
-  if (value === "true") return true;
-  if (value === "false" || value === undefined) return false;
-  throw new Error(
-    `${HIDE_AGENT_LIST_SETTING} setting must be either "true" or "false"`,
+function readPersistedMaxDepth(
+  storageOptions: SettingStorageOptions,
+  onInvalidSetting?: InvalidSettingReporter,
+): number {
+  const raw = getSetting(
+    SETTINGS_EXTENSION_NAME,
+    MAX_DEPTH_SETTING,
+    MAX_DEPTH_DEFINITION.defaultValue,
+    resolveStorageOptions(storageOptions),
+  );
+  try {
+    return parseMaxDepth(raw);
+  } catch {
+    reportInvalidPersistedSetting(
+      MAX_DEPTH_SETTING,
+      raw,
+      `must be an integer between 0 and ${MAX_CONFIGURED_DEPTH}; using ${DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH}`,
+      onInvalidSetting,
+    );
+    return DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH;
+  }
+}
+
+/**
+ * Read only `hide-agent-list`, from the global file. A checked-in project
+ * `.pi/settings-extensions.json` must not be able to hide agent activity from
+ * whoever opens the repo, so the local scope is deliberately ignored here.
+ */
+function readPersistedHideAgentList(
+  storageOptions: SettingStorageOptions,
+  onInvalidSetting?: InvalidSettingReporter,
+): boolean {
+  const raw = getSetting(
+    SETTINGS_EXTENSION_NAME,
+    HIDE_AGENT_LIST_SETTING,
+    HIDE_AGENT_LIST_DEFINITION.defaultValue,
+    { ...storageOptions, scope: "global" },
+  );
+  if (raw === "true") return true;
+  if (raw === "false" || raw === undefined) return false;
+  reportInvalidPersistedSetting(
+    HIDE_AGENT_LIST_SETTING,
+    raw,
+    'must be either "true" or "false"; using "false"',
+    onInvalidSetting,
+  );
+  return false;
+}
+
+function reportInvalidPersistedSetting(
+  setting: string,
+  value: unknown,
+  detail: string,
+  onInvalidSetting?: InvalidSettingReporter,
+): void {
+  debugLog("warn", "extension_setting_invalid", { setting, value });
+  onInvalidSetting?.(
+    `Ignoring invalid ${SETTINGS_EXTENSION_NAME} ${setting} setting ${JSON.stringify(value)}: it ${detail}.`,
   );
 }
 
+/**
+ * Narrow, non-throwing read used by the 5s poll tick: a malformed persisted
+ * value must never escape into the poller, where it would freeze the footer
+ * and widgets for the rest of the session.
+ */
 export function isAgentListHidden(
   pi: ExtensionAPI,
   storageOptions: SettingStorageOptions = {},
 ): boolean {
-  return readExtensionSettings(pi, storageOptions).hideAgentList;
+  try {
+    if (parseHideAgentList(readFlag(pi, HIDE_AGENT_LIST_FLAG))) return true;
+  } catch (error) {
+    debugLog("warn", "extension_setting_flag_invalid", {
+      setting: HIDE_AGENT_LIST_FLAG,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  try {
+    return readPersistedHideAgentList(storageOptions);
+  } catch (error) {
+    debugLog("warn", "extension_setting_read_failed", {
+      setting: HIDE_AGENT_LIST_SETTING,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,7 +10,14 @@ export const HIDE_AGENT_LIST_FLAG = "subagentura-hide-agent-list";
 export const DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH = 2;
 const MAX_CONFIGURED_DEPTH = 64;
 const SETTINGS_EXTENSION_NAME = "pi-subagentura";
+const MAX_DEPTH_SETTING = "max-depth";
 const HIDE_AGENT_LIST_SETTING = "hide-agent-list";
+const MAX_DEPTH_DEFINITION = {
+  id: MAX_DEPTH_SETTING,
+  label: "Maximum depth",
+  description: `Maximum Orchestratorv2 lineage depth (0-${MAX_CONFIGURED_DEPTH})`,
+  defaultValue: String(DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH),
+} satisfies SettingDefinition;
 const HIDE_AGENT_LIST_DEFINITION = {
   id: HIDE_AGENT_LIST_SETTING,
   label: "Hide agent list",
@@ -29,7 +36,6 @@ export function registerExtensionSettings(pi: ExtensionAPI): void {
     description:
       "Maximum Orchestratorv2 lineage depth (default: 2; legacy stays at 8)",
     type: "string",
-    default: String(DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH),
   });
   pi.registerFlag(HIDE_AGENT_LIST_FLAG, {
     description: "Hide compact per-agent activity widget rows",
@@ -44,7 +50,7 @@ export function emitExtensionSettingsRegistration(pi: ExtensionAPI): void {
   if (events && typeof events.emit === "function") {
     events.emit("pi-extension-settings:register", {
       name: SETTINGS_EXTENSION_NAME,
-      settings: [HIDE_AGENT_LIST_DEFINITION],
+      settings: [MAX_DEPTH_DEFINITION, HIDE_AGENT_LIST_DEFINITION],
     });
   }
 }
@@ -55,8 +61,18 @@ export function readExtensionSettings(
 ): ExtensionSettings {
   const maxDepthValue = readFlag(pi, MAX_DEPTH_FLAG);
   const hideAgentListValue = readFlag(pi, HIDE_AGENT_LIST_FLAG);
+  const persistedMaxDepthValue = getSetting(
+    SETTINGS_EXTENSION_NAME,
+    MAX_DEPTH_SETTING,
+    MAX_DEPTH_DEFINITION.defaultValue,
+    storageOptions,
+  );
   return {
-    maxDepth: parseMaxDepth(maxDepthValue),
+    maxDepth: parseMaxDepth(
+      maxDepthValue === undefined || maxDepthValue === false
+        ? persistedMaxDepthValue
+        : maxDepthValue,
+    ),
     hideAgentList:
       parseHideAgentList(hideAgentListValue) ||
       parsePersistedHideAgentList(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -137,13 +137,14 @@ function readPersistedMaxDepth(
   storageOptions: SettingStorageOptions,
   onInvalidSetting?: InvalidSettingReporter,
 ): number {
-  const raw = getSetting(
-    SETTINGS_EXTENSION_NAME,
-    MAX_DEPTH_SETTING,
-    MAX_DEPTH_DEFINITION.defaultValue,
-    resolveStorageOptions(storageOptions),
-  );
+  let raw: unknown = undefined;
   try {
+    raw = getSetting(
+      SETTINGS_EXTENSION_NAME,
+      MAX_DEPTH_SETTING,
+      MAX_DEPTH_DEFINITION.defaultValue,
+      resolveStorageOptions(storageOptions),
+    );
     return parseMaxDepth(raw);
   } catch {
     reportInvalidPersistedSetting(
@@ -165,12 +166,23 @@ function readPersistedHideAgentList(
   storageOptions: SettingStorageOptions,
   onInvalidSetting?: InvalidSettingReporter,
 ): boolean {
-  const raw = getSetting(
-    SETTINGS_EXTENSION_NAME,
-    HIDE_AGENT_LIST_SETTING,
-    HIDE_AGENT_LIST_DEFINITION.defaultValue,
-    { ...storageOptions, scope: "global" },
-  );
+  let raw: unknown = undefined;
+  try {
+    raw = getSetting(
+      SETTINGS_EXTENSION_NAME,
+      HIDE_AGENT_LIST_SETTING,
+      HIDE_AGENT_LIST_DEFINITION.defaultValue,
+      { ...storageOptions, scope: "global" },
+    );
+  } catch {
+    reportInvalidPersistedSetting(
+      HIDE_AGENT_LIST_SETTING,
+      raw,
+      'must be either "true" or "false"; using "false"',
+      onInvalidSetting,
+    );
+    return false;
+  }
   if (raw === "true") return true;
   if (raw === "false" || raw === undefined) return false;
   reportInvalidPersistedSetting(

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import registerSettingsPanel from "@juanibiapina/pi-extension-settings";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import registerExtension from "../src/subagent";
 import {
   HIDE_AGENT_LIST_FLAG,
@@ -6,9 +16,26 @@ import {
   readExtensionSettings,
 } from "../src/settings";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
-import { getSessionScopes } from "../src/session-scope";
+import { clearSessionScopes, getSessionScopes } from "../src/session-scope";
 
-function mockApi(getFlag: (name: string) => unknown = () => undefined) {
+function sharedEventBus() {
+  const handlers = new Map<string, Array<(data: unknown) => void>>();
+  return {
+    emit: vi.fn((name: string, data: unknown) => {
+      for (const handler of handlers.get(name) ?? []) handler(data);
+    }),
+    on: vi.fn((name: string, handler: (data: unknown) => void) => {
+      const registered = handlers.get(name) ?? [];
+      registered.push(handler);
+      handlers.set(name, registered);
+    }),
+  };
+}
+
+function mockApi(
+  getFlag: (name: string) => unknown = () => undefined,
+  events = sharedEventBus(),
+) {
   return {
     registerTool: vi.fn(),
     registerMessageRenderer: vi.fn(),
@@ -17,6 +44,7 @@ function mockApi(getFlag: (name: string) => unknown = () => undefined) {
     registerShortcut: vi.fn(),
     getFlag: vi.fn(getFlag),
     on: vi.fn(),
+    events,
   };
 }
 
@@ -25,6 +53,10 @@ function registeredTools(api: ReturnType<typeof mockApi>): string[] {
 }
 
 describe("generic extension settings", () => {
+  afterEach(() => {
+    clearSessionScopes();
+  });
+
   it("registers validated settings with V2-safe defaults", () => {
     const api = mockApi();
     registerExtension(api as any);
@@ -39,10 +71,150 @@ describe("generic extension settings", () => {
       type: "boolean",
       default: false,
     });
+    expect(api.events.emit).toHaveBeenCalledWith(
+      "pi-extension-settings:register",
+      {
+        name: "pi-subagentura",
+        settings: [
+          {
+            id: "hide-agent-list",
+            label: "Hide agent list",
+            description: expect.stringContaining("activity widget"),
+            defaultValue: "false",
+            values: ["false", "true"],
+          },
+        ],
+      },
+    );
     expect(readExtensionSettings(api as any)).toEqual({
       maxDepth: 2,
       hideAgentList: false,
     });
+  });
+
+  it("depends on the settings helpers without autoloading the panel", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    );
+
+    expect(manifest.dependencies).toMatchObject({
+      "@juanibiapina/pi-extension-settings": "^0.9.1",
+    });
+    expect(manifest.bundledDependencies).toBeUndefined();
+    expect(manifest.pi.extensions).toEqual(["./src/subagent.ts"]);
+  });
+
+  it.each([
+    ["panel before consumer", true],
+    ["panel after consumer", false],
+  ])("registers a non-empty schema with the %s", async (_name, panelFirst) => {
+    const events = sharedEventBus();
+    const panelApi = mockApi(() => undefined, events);
+    const sessionHandlers = new Map<string, Function[]>();
+    const rootApi = {
+      ...mockApi(() => false, events),
+      on: vi.fn((name: string, handler: Function) => {
+        const registered = sessionHandlers.get(name) ?? [];
+        registered.push(handler);
+        sessionHandlers.set(name, registered);
+      }),
+    };
+
+    if (panelFirst) registerSettingsPanel(panelApi as any);
+    registerExtension(rootApi as any);
+    if (!panelFirst) registerSettingsPanel(panelApi as any);
+
+    const ctx = {
+      cwd: process.cwd(),
+      ui: {
+        setStatus: vi.fn(),
+        setWidget: vi.fn(),
+        notify: vi.fn(),
+      },
+      sessionManager: {
+        getSessionId: () => undefined,
+        getEntries: () => [],
+        getBranch: () => [],
+      },
+      isIdle: () => true,
+    };
+    for (const handler of sessionHandlers.get("session_start") ?? []) {
+      await handler({ reason: "new" }, ctx);
+    }
+
+    const panelCommands = panelApi.registerCommand.mock.calls.filter(
+      ([name]) =>
+        name === "extension-settings" || name === "extension-settings-local",
+    );
+    expect(panelCommands.map(([name]) => name)).toEqual([
+      "extension-settings",
+      "extension-settings-local",
+    ]);
+
+    const notify = vi.fn();
+    const custom = vi.fn(async () => undefined);
+    const globalCommand = panelCommands.find(
+      ([name]) => name === "extension-settings",
+    )?.[1];
+    await globalCommand.handler("", { ui: { notify, custom } });
+    expect(notify).not.toHaveBeenCalled();
+    expect(custom).toHaveBeenCalledOnce();
+  });
+
+  it("reads global and project-local hide-agent-list settings", () => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      writeFileSync(
+        join(agentDir, "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "hide-agent-list": "true" },
+        }),
+      );
+      expect(
+        readExtensionSettings(mockApi() as any, { agentDir, cwd }),
+      ).toMatchObject({ hideAgentList: true });
+
+      writeFileSync(
+        join(cwd, ".pi", "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "hide-agent-list": "false" },
+        }),
+      );
+      expect(
+        readExtensionSettings(mockApi() as any, { agentDir, cwd }),
+      ).toMatchObject({ hideAgentList: false });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lets the legacy flag force a persisted false setting on for one run", () => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      writeFileSync(
+        join(agentDir, "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "hide-agent-list": "false" },
+        }),
+      );
+      const api = mockApi((name) =>
+        name === HIDE_AGENT_LIST_FLAG ? true : undefined,
+      );
+      expect(
+        readExtensionSettings(api as any, { agentDir, cwd }),
+      ).toMatchObject({ hideAgentList: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it.each(["", "-1", "1.5", "nope", "65", true])(

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import registerSettingsPanel from "@juanibiapina/pi-extension-settings";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import registerExtension from "../src/subagent";
 import {
   HIDE_AGENT_LIST_FLAG,
@@ -17,6 +17,33 @@ import {
 } from "../src/settings";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
 import { clearSessionScopes, getSessionScopes } from "../src/session-scope";
+
+interface SettingsSandbox {
+  root: string;
+  cwd: string;
+  agentDir: string;
+}
+
+function makeSettingsSandbox(): SettingsSandbox {
+  const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+  const cwd = join(root, "project");
+  const agentDir = join(root, "agent");
+  mkdirSync(join(cwd, ".pi"), { recursive: true });
+  mkdirSync(agentDir, { recursive: true });
+  return { root, cwd, agentDir };
+}
+
+let settingsSandbox!: SettingsSandbox;
+let previousAgentDir: string | undefined;
+
+function readTestSettings(
+  pi: Parameters<typeof readExtensionSettings>[0],
+): ReturnType<typeof readExtensionSettings> {
+  return readExtensionSettings(pi, {
+    cwd: settingsSandbox.cwd,
+    agentDir: settingsSandbox.agentDir,
+  });
+}
 
 function sharedEventBus() {
   const handlers = new Map<string, Array<(data: unknown) => void>>();
@@ -53,8 +80,21 @@ function registeredTools(api: ReturnType<typeof mockApi>): string[] {
 }
 
 describe("generic extension settings", () => {
+  beforeEach(() => {
+    settingsSandbox = makeSettingsSandbox();
+    vi.spyOn(process, "cwd").mockReturnValue(
+      join(settingsSandbox.root, "ambient"),
+    );
+    previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = settingsSandbox.agentDir;
+  });
+
   afterEach(() => {
     clearSessionScopes();
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    vi.restoreAllMocks();
+    rmSync(settingsSandbox.root, { recursive: true, force: true });
   });
 
   it("registers validated settings with V2-safe defaults", () => {
@@ -91,7 +131,7 @@ describe("generic extension settings", () => {
         ],
       },
     );
-    expect(readExtensionSettings(api as any)).toEqual({
+    expect(readTestSettings(api as any)).toEqual({
       maxDepth: 2,
       hideAgentList: false,
     });
@@ -130,7 +170,7 @@ describe("generic extension settings", () => {
     if (!panelFirst) registerSettingsPanel(panelApi as any);
 
     const ctx = {
-      cwd: process.cwd(),
+      cwd: settingsSandbox.cwd,
       ui: {
         setStatus: vi.fn(),
         setWidget: vi.fn(),
@@ -258,7 +298,7 @@ describe("generic extension settings", () => {
       const api = mockApi((name) =>
         name === MAX_DEPTH_FLAG ? value : undefined,
       );
-      expect(() => readExtensionSettings(api as any)).toThrow(/max depth/i);
+      expect(() => readTestSettings(api as any)).toThrow(/max depth/i);
     },
   );
 
@@ -287,12 +327,12 @@ describe("generic extension settings", () => {
     const api = mockApi((name) =>
       name === HIDE_AGENT_LIST_FLAG ? "true" : undefined,
     );
-    expect(() => readExtensionSettings(api as any)).toThrow(/hide agent list/i);
+    expect(() => readTestSettings(api as any)).toThrow(/hide agent list/i);
   });
 
   it("uses the configured depth only for V2 roots", () => {
     const api = mockApi((name) => (name === MAX_DEPTH_FLAG ? "4" : undefined));
-    const settings = readExtensionSettings(api as any);
+    const settings = readTestSettings(api as any);
 
     expect(
       createRootSpawnTreeContext("v2", "/tmp", false, true, settings.maxDepth)
@@ -334,7 +374,7 @@ describe("generic extension settings", () => {
     flags.set(MAX_DEPTH_FLAG, "4");
     flags.set("orchestratorv2", true);
     const ctx = {
-      cwd: process.cwd(),
+      cwd: settingsSandbox.cwd,
       ui: {
         setStatus: vi.fn(),
         setWidget: vi.fn(),
@@ -354,6 +394,55 @@ describe("generic extension settings", () => {
     expect(scope?.spawnTreeContext).toMatchObject({
       role: "root",
       maxDepth: 4,
+    });
+
+    handlers.get("session_shutdown")![0]({ reason: "quit" }, ctx);
+  });
+
+  it("resolves max-depth from the resumed session cwd", () => {
+    expect(settingsSandbox.cwd).not.toBe(process.cwd());
+    writeFileSync(
+      join(settingsSandbox.cwd, ".pi", "settings-extensions.json"),
+      JSON.stringify({
+        "pi-subagentura": { "max-depth": "7" },
+      }),
+    );
+
+    const handlers = new Map<string, Function[]>();
+    const api = {
+      ...mockApi((name) => name === "orchestratorv2"),
+      on: vi.fn((name: string, handler: Function) => {
+        const registered = handlers.get(name) ?? [];
+        registered.push(handler);
+        handlers.set(name, registered);
+      }),
+    };
+    const extensionApi = api as unknown as Parameters<
+      typeof registerExtension
+    >[0];
+    registerExtension(extensionApi);
+
+    const ctx = {
+      cwd: settingsSandbox.cwd,
+      ui: {
+        setStatus: vi.fn(),
+        setWidget: vi.fn(),
+        notify: vi.fn(),
+      },
+      sessionManager: {
+        getSessionId: () => "resumed-project-session",
+        getEntries: () => [],
+        getBranch: () => [],
+      },
+    };
+    handlers.get("session_start")![0]({ reason: "resume" }, ctx);
+
+    const scope = getSessionScopes().find(
+      (candidate) => candidate.pi === extensionApi,
+    );
+    expect(scope?.spawnTreeContext).toMatchObject({
+      role: "root",
+      maxDepth: 7,
     });
 
     handlers.get("session_shutdown")![0]({ reason: "quit" }, ctx);

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -15,6 +15,8 @@ import {
   isAgentListHidden,
   MAX_DEPTH_FLAG,
   readExtensionSettings,
+  type ExtensionSettings,
+  type InvalidSettingReporter,
 } from "../src/settings";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
 import {
@@ -43,11 +45,16 @@ let previousAgentDir: string | undefined;
 
 function readTestSettings(
   pi: Parameters<typeof readExtensionSettings>[0],
-): ReturnType<typeof readExtensionSettings> {
-  return readExtensionSettings(pi, {
-    cwd: settingsSandbox.cwd,
-    agentDir: settingsSandbox.agentDir,
-  });
+  onInvalidSetting?: InvalidSettingReporter,
+): ExtensionSettings {
+  return readExtensionSettings(
+    pi,
+    {
+      cwd: settingsSandbox.cwd,
+      agentDir: settingsSandbox.agentDir,
+    },
+    onInvalidSetting,
+  );
 }
 
 function sharedEventBus() {
@@ -461,68 +468,110 @@ describe("generic extension settings", () => {
     }
   });
 
-  it("keeps session_start functional when persisted settings are malformed", () => {
-    writeFileSync(
-      join(settingsSandbox.agentDir, "settings-extensions.json"),
+  it.each([
+    ["a top-level null", "null"],
+    ["a primitive extension value", '{"pi-subagentura":"bad"}'],
+  ])(
+    "falls back to defaults and reports structurally malformed settings (%s)",
+    (_description, settingsDocument) => {
+      writeFileSync(
+        join(settingsSandbox.agentDir, "settings-extensions.json"),
+        settingsDocument,
+      );
+      const onInvalid = vi.fn();
+      let settings: ExtensionSettings | undefined;
+
+      expect(() => {
+        settings = readTestSettings(
+          mockApi() as unknown as Parameters<typeof readExtensionSettings>[0],
+          onInvalid,
+        );
+      }).not.toThrow();
+      expect(settings).toEqual({
+        maxDepth: 2,
+        hideAgentList: false,
+      });
+      expect(onInvalid).toHaveBeenCalledWith(
+        expect.stringContaining("max-depth"),
+      );
+      expect(onInvalid).toHaveBeenCalledWith(
+        expect.stringContaining("hide-agent-list"),
+      );
+    },
+  );
+
+  it.each([
+    [
+      "malformed values",
       JSON.stringify({
         "pi-subagentura": {
           "max-depth": "not-a-number",
           "hide-agent-list": "sometimes",
         },
       }),
-    );
+    ],
+    ["a top-level null", "null"],
+    ["a primitive extension value", '{"pi-subagentura":"bad"}'],
+  ])(
+    "keeps session_start functional when persisted settings are %s",
+    (_description, settingsDocument) => {
+      writeFileSync(
+        join(settingsSandbox.agentDir, "settings-extensions.json"),
+        settingsDocument,
+      );
 
-    const handlers = new Map<string, Function[]>();
-    const api = {
-      ...mockApi((name) => name === "orchestratorv2"),
-      on: vi.fn((name: string, handler: Function) => {
-        const registered = handlers.get(name) ?? [];
-        registered.push(handler);
-        handlers.set(name, registered);
-      }),
-    };
-    const extensionApi = api as unknown as Parameters<
-      typeof registerExtension
-    >[0];
-    registerExtension(extensionApi);
+      const handlers = new Map<string, Function[]>();
+      const api = {
+        ...mockApi((name) => name === "orchestratorv2"),
+        on: vi.fn((name: string, handler: Function) => {
+          const registered = handlers.get(name) ?? [];
+          registered.push(handler);
+          handlers.set(name, registered);
+        }),
+      };
+      const extensionApi = api as unknown as Parameters<
+        typeof registerExtension
+      >[0];
+      registerExtension(extensionApi);
 
-    const notify = vi.fn();
-    const ctx = {
-      cwd: settingsSandbox.cwd,
-      ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify },
-      sessionManager: {
-        getSessionId: () => "malformed-settings-session",
-        getEntries: () => [],
-        getBranch: () => [],
-      },
-    };
+      const notify = vi.fn();
+      const ctx = {
+        cwd: settingsSandbox.cwd,
+        ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify },
+        sessionManager: {
+          getSessionId: () => "malformed-settings-session",
+          getEntries: () => [],
+          getBranch: () => [],
+        },
+      };
 
-    expect(() =>
-      handlers.get("session_start")![0]({ reason: "startup" }, ctx),
-    ).not.toThrow();
+      expect(() =>
+        handlers.get("session_start")![0]({ reason: "startup" }, ctx),
+      ).not.toThrow();
 
-    const scope = getSessionScopes().find(
-      (candidate) => candidate.pi === extensionApi,
-    );
-    // Init completed past the settings read: scope registered and live.
-    expect(scope?.lifecycle).toBe("started");
-    expect(scope?.ui).toBe(ctx.ui);
-    expect(scope?.spawnTreeContext).toMatchObject({
-      role: "root",
-      maxDepth: 2,
-    });
-    expect(getActiveSessionScopeId()).toBe(scope?.id);
-    expect(notify).toHaveBeenCalledWith(
-      expect.stringContaining("max-depth"),
-      "warning",
-    );
-    expect(notify).toHaveBeenCalledWith(
-      expect.stringContaining("hide-agent-list"),
-      "warning",
-    );
+      const scope = getSessionScopes().find(
+        (candidate) => candidate.pi === extensionApi,
+      );
+      // Init completed past the settings read: scope registered and live.
+      expect(scope?.lifecycle).toBe("started");
+      expect(scope?.ui).toBe(ctx.ui);
+      expect(scope?.spawnTreeContext).toMatchObject({
+        role: "root",
+        maxDepth: 2,
+      });
+      expect(getActiveSessionScopeId()).toBe(scope?.id);
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("max-depth"),
+        "warning",
+      );
+      expect(notify).toHaveBeenCalledWith(
+        expect.stringContaining("hide-agent-list"),
+        "warning",
+      );
 
-    handlers.get("session_shutdown")![0]({ reason: "quit" }, ctx);
-  });
+      handlers.get("session_shutdown")![0]({ reason: "quit" }, ctx);
+    },
+  );
 
   it("rejects invalid hide-agent-list values", () => {
     const api = mockApi((name) =>

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -64,7 +64,6 @@ describe("generic extension settings", () => {
     expect(api.registerFlag).toHaveBeenCalledWith(MAX_DEPTH_FLAG, {
       description: expect.stringContaining("Orchestratorv2"),
       type: "string",
-      default: "2",
     });
     expect(api.registerFlag).toHaveBeenCalledWith(HIDE_AGENT_LIST_FLAG, {
       description: expect.stringContaining("activity widget"),
@@ -76,6 +75,12 @@ describe("generic extension settings", () => {
       {
         name: "pi-subagentura",
         settings: [
+          {
+            id: "max-depth",
+            label: "Maximum depth",
+            description: expect.stringContaining("0-64"),
+            defaultValue: "2",
+          },
           {
             id: "hide-agent-list",
             label: "Hide agent list",
@@ -161,7 +166,7 @@ describe("generic extension settings", () => {
     expect(custom).toHaveBeenCalledOnce();
   });
 
-  it("reads global and project-local hide-agent-list settings", () => {
+  it("reads global and project-local extension settings", () => {
     const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
     const agentDir = join(root, "agent");
     const cwd = join(root, "project");
@@ -172,22 +177,52 @@ describe("generic extension settings", () => {
       writeFileSync(
         join(agentDir, "settings-extensions.json"),
         JSON.stringify({
-          "pi-subagentura": { "hide-agent-list": "true" },
+          "pi-subagentura": {
+            "max-depth": "5",
+            "hide-agent-list": "true",
+          },
         }),
       );
       expect(
         readExtensionSettings(mockApi() as any, { agentDir, cwd }),
-      ).toMatchObject({ hideAgentList: true });
+      ).toEqual({ maxDepth: 5, hideAgentList: true });
 
       writeFileSync(
         join(cwd, ".pi", "settings-extensions.json"),
         JSON.stringify({
-          "pi-subagentura": { "hide-agent-list": "false" },
+          "pi-subagentura": {
+            "max-depth": "3",
+            "hide-agent-list": "false",
+          },
         }),
       );
       expect(
         readExtensionSettings(mockApi() as any, { agentDir, cwd }),
-      ).toMatchObject({ hideAgentList: false });
+      ).toEqual({ maxDepth: 3, hideAgentList: false });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lets the CLI max-depth flag override the persisted setting", () => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      writeFileSync(
+        join(agentDir, "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "max-depth": "6" },
+        }),
+      );
+      const api = mockApi((name) =>
+        name === MAX_DEPTH_FLAG ? "4" : undefined,
+      );
+      expect(
+        readExtensionSettings(api as any, { agentDir, cwd }),
+      ).toMatchObject({ maxDepth: 4 });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -226,6 +261,27 @@ describe("generic extension settings", () => {
       expect(() => readExtensionSettings(api as any)).toThrow(/max depth/i);
     },
   );
+
+  it("validates persisted max-depth with the same bounds", () => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      writeFileSync(
+        join(agentDir, "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "max-depth": "65" },
+        }),
+      );
+      expect(() =>
+        readExtensionSettings(mockApi() as any, { agentDir, cwd }),
+      ).toThrow(/max depth/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 
   it("rejects invalid hide-agent-list values", () => {
     const api = mockApi((name) =>
@@ -273,7 +329,7 @@ describe("generic extension settings", () => {
       typeof registerExtension
     >[0];
     registerExtension(extensionApi);
-    expect(flags.get(MAX_DEPTH_FLAG)).toBe("2");
+    expect(flags.get(MAX_DEPTH_FLAG)).toBeUndefined();
 
     flags.set(MAX_DEPTH_FLAG, "4");
     flags.set("orchestratorv2", true);

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -12,11 +12,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import registerExtension from "../src/subagent";
 import {
   HIDE_AGENT_LIST_FLAG,
+  isAgentListHidden,
   MAX_DEPTH_FLAG,
   readExtensionSettings,
 } from "../src/settings";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
-import { clearSessionScopes, getSessionScopes } from "../src/session-scope";
+import {
+  clearSessionScopes,
+  getActiveSessionScopeId,
+  getSessionScopes,
+} from "../src/session-scope";
 
 interface SettingsSandbox {
   root: string;
@@ -131,6 +136,16 @@ describe("generic extension settings", () => {
         ],
       },
     );
+    const flagDescription = (name: string): string =>
+      api.registerFlag.mock.calls.find(([flag]) => flag === name)?.[1]
+        .description ?? "";
+    // registerFlag no longer supplies a default, so the text must not claim one.
+    expect(flagDescription(MAX_DEPTH_FLAG)).not.toMatch(/default/i);
+    // The boolean flag is on-only; say so where operators read it.
+    expect(flagDescription(HIDE_AGENT_LIST_FLAG)).toMatch(
+      /cannot override a persisted/i,
+    );
+
     expect(readTestSettings(api as any)).toEqual({
       maxDepth: 2,
       hideAgentList: false,
@@ -206,7 +221,7 @@ describe("generic extension settings", () => {
     expect(custom).toHaveBeenCalledOnce();
   });
 
-  it("reads global and project-local extension settings", () => {
+  it("reads global settings and lets a project override max-depth only", () => {
     const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
     const agentDir = join(root, "agent");
     const cwd = join(root, "project");
@@ -236,9 +251,68 @@ describe("generic extension settings", () => {
           },
         }),
       );
+      // max-depth follows the project; hide-agent-list stays global-only.
       expect(
         readExtensionSettings(mockApi() as any, { agentDir, cwd }),
-      ).toEqual({ maxDepth: 3, hideAgentList: false });
+      ).toEqual({ maxDepth: 3, hideAgentList: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores a repo-controlled project-local hide-agent-list", () => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      writeFileSync(
+        join(cwd, ".pi", "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "hide-agent-list": "true" },
+        }),
+      );
+
+      expect(
+        readExtensionSettings(mockApi() as any, { agentDir, cwd }),
+      ).toMatchObject({ hideAgentList: false });
+      expect(isAgentListHidden(mockApi() as any, { agentDir, cwd })).toBe(
+        false,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the global file when no session cwd is known", () => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+    const agentDir = join(root, "agent");
+    const ambientCwd = join(root, "ambient");
+    mkdirSync(join(ambientCwd, ".pi"), { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(ambientCwd);
+
+    try {
+      writeFileSync(
+        join(agentDir, "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "max-depth": "5" },
+        }),
+      );
+      // The ambient process cwd must not leak into a cwd-less read.
+      writeFileSync(
+        join(ambientCwd, ".pi", "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "max-depth": "9" },
+        }),
+      );
+
+      expect(readExtensionSettings(mockApi() as any, { agentDir })).toEqual({
+        maxDepth: 5,
+        hideAgentList: false,
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -302,7 +376,35 @@ describe("generic extension settings", () => {
     },
   );
 
-  it("validates persisted max-depth with the same bounds", () => {
+  it.each(["", "-1", "1.5", "nope", "65"])(
+    "degrades a malformed persisted max-depth %p to the default",
+    (value) => {
+      const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+      const agentDir = join(root, "agent");
+      const cwd = join(root, "project");
+      mkdirSync(agentDir, { recursive: true });
+
+      try {
+        writeFileSync(
+          join(agentDir, "settings-extensions.json"),
+          JSON.stringify({
+            "pi-subagentura": { "max-depth": value },
+          }),
+        );
+        const onInvalid = vi.fn();
+        expect(
+          readExtensionSettings(mockApi() as any, { agentDir, cwd }, onInvalid),
+        ).toEqual({ maxDepth: 2, hideAgentList: false });
+        expect(onInvalid).toHaveBeenCalledWith(
+          expect.stringContaining("max-depth"),
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("degrades a malformed persisted hide-agent-list to false", () => {
     const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
     const agentDir = join(root, "agent");
     const cwd = join(root, "project");
@@ -312,15 +414,114 @@ describe("generic extension settings", () => {
       writeFileSync(
         join(agentDir, "settings-extensions.json"),
         JSON.stringify({
-          "pi-subagentura": { "max-depth": "65" },
+          "pi-subagentura": { "hide-agent-list": "yes please" },
         }),
       );
-      expect(() =>
-        readExtensionSettings(mockApi() as any, { agentDir, cwd }),
-      ).toThrow(/max depth/i);
+      const onInvalid = vi.fn();
+      expect(
+        readExtensionSettings(mockApi() as any, { agentDir, cwd }, onInvalid),
+      ).toEqual({ maxDepth: 2, hideAgentList: false });
+      expect(onInvalid).toHaveBeenCalledWith(
+        expect.stringContaining("hide-agent-list"),
+      );
+      expect(isAgentListHidden(mockApi() as any, { agentDir, cwd })).toBe(
+        false,
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("validates a malformed persisted hide-agent-list even when the flag is set", () => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-settings-"));
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      writeFileSync(
+        join(agentDir, "settings-extensions.json"),
+        JSON.stringify({
+          "pi-subagentura": { "hide-agent-list": "yes please" },
+        }),
+      );
+      const api = mockApi((name) =>
+        name === HIDE_AGENT_LIST_FLAG ? true : undefined,
+      );
+      const onInvalid = vi.fn();
+      // The flag wins, but the persisted value is still parsed and reported.
+      expect(
+        readExtensionSettings(api as any, { agentDir, cwd }, onInvalid),
+      ).toMatchObject({ hideAgentList: true });
+      expect(onInvalid).toHaveBeenCalledWith(
+        expect.stringContaining("hide-agent-list"),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps session_start functional when persisted settings are malformed", () => {
+    writeFileSync(
+      join(settingsSandbox.agentDir, "settings-extensions.json"),
+      JSON.stringify({
+        "pi-subagentura": {
+          "max-depth": "not-a-number",
+          "hide-agent-list": "sometimes",
+        },
+      }),
+    );
+
+    const handlers = new Map<string, Function[]>();
+    const api = {
+      ...mockApi((name) => name === "orchestratorv2"),
+      on: vi.fn((name: string, handler: Function) => {
+        const registered = handlers.get(name) ?? [];
+        registered.push(handler);
+        handlers.set(name, registered);
+      }),
+    };
+    const extensionApi = api as unknown as Parameters<
+      typeof registerExtension
+    >[0];
+    registerExtension(extensionApi);
+
+    const notify = vi.fn();
+    const ctx = {
+      cwd: settingsSandbox.cwd,
+      ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify },
+      sessionManager: {
+        getSessionId: () => "malformed-settings-session",
+        getEntries: () => [],
+        getBranch: () => [],
+      },
+    };
+
+    expect(() =>
+      handlers.get("session_start")![0]({ reason: "startup" }, ctx),
+    ).not.toThrow();
+
+    const scope = getSessionScopes().find(
+      (candidate) => candidate.pi === extensionApi,
+    );
+    // Init completed past the settings read: scope registered and live.
+    expect(scope?.lifecycle).toBe("started");
+    expect(scope?.ui).toBe(ctx.ui);
+    expect(scope?.spawnTreeContext).toMatchObject({
+      role: "root",
+      maxDepth: 2,
+    });
+    expect(getActiveSessionScopeId()).toBe(scope?.id);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("max-depth"),
+      "warning",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("hide-agent-list"),
+      "warning",
+    );
+
+    handlers.get("session_shutdown")![0]({ reason: "quit" }, ctx);
   });
 
   it("rejects invalid hide-agent-list values", () => {

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -195,6 +195,52 @@ describe("pollArtifactChanges", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not read hide-agent-list settings when there are no activity rows", async () => {
+    const root = makeTmp();
+    const agentDir = join(root, "agent");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "settings-extensions.json"),
+      JSON.stringify({
+        "pi-subagentura": { "hide-agent-list": "invalid" },
+      }),
+    );
+    const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+
+    try {
+      const mod =
+        await importFresh<typeof import("../src/subagent")>("../src/subagent");
+      const setWidget = vi.fn();
+      const owner = { id: 700, generation: 1 };
+      const pi = { getFlag: () => false } as any;
+      registerSessionScope({
+        ...owner,
+        pi,
+        ui: {
+          notify: vi.fn(),
+          setStatus: vi.fn(),
+          setWidget,
+        } as any,
+      });
+
+      await mod.pollArtifactChanges(pi, owner);
+
+      expect(setWidget).toHaveBeenCalledWith(
+        "subagentura-activity",
+        undefined,
+        { placement: "belowEditor" },
+      );
+    } finally {
+      if (previousAgentDir === undefined) {
+        delete process.env.PI_CODING_AGENT_DIR;
+      } else {
+        process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("registers the activity widget as an adaptive grid component", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -40,10 +40,26 @@ import {
   removeSessionScope,
 } from "../src/session-scope";
 import { responsiveFlowMinimumWidth } from "../src/rendering";
-import { HIDE_AGENT_LIST_FLAG } from "../src/settings";
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
+}
+
+interface SessionSettingsSandbox {
+  root: string;
+  cwd: string;
+}
+
+let temporarySettingsRoot: string | undefined;
+let temporaryProcessCwd: string | undefined;
+let temporaryAgentDir: string | undefined;
+let previousAgentDir: string | undefined;
+
+function makeSessionSettingsSandbox(root = makeTmp()): SessionSettingsSandbox {
+  const cwd = join(root, "project");
+  mkdirSync(join(cwd, ".pi"), { recursive: true });
+  temporarySettingsRoot = root;
+  return { root, cwd };
 }
 
 function makeState(): {
@@ -111,6 +127,12 @@ describe("pollArtifactChanges", () => {
     g.__piSubagenturaUi = undefined;
     g.__piSubagenturaParentStreaming = false;
     clearSessionScopes();
+    temporarySettingsRoot = undefined;
+    temporaryProcessCwd = makeTmp();
+    vi.spyOn(process, "cwd").mockReturnValue(temporaryProcessCwd);
+    temporaryAgentDir = makeTmp();
+    previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = temporaryAgentDir;
   });
 
   afterEach(() => {
@@ -119,6 +141,18 @@ describe("pollArtifactChanges", () => {
     delete process.env.SUBAGENT_DEBUG_LOG_DIR;
     vi.doUnmock("node:child_process");
     vi.useRealTimers();
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    vi.restoreAllMocks();
+    if (temporarySettingsRoot !== undefined) {
+      rmSync(temporarySettingsRoot, { recursive: true, force: true });
+    }
+    if (temporaryProcessCwd !== undefined) {
+      rmSync(temporaryProcessCwd, { recursive: true, force: true });
+    }
+    if (temporaryAgentDir !== undefined) {
+      rmSync(temporaryAgentDir, { recursive: true, force: true });
+    }
   });
 
   async function pollUntilOwnerInvalidation(
@@ -290,19 +324,29 @@ describe("pollArtifactChanges", () => {
     expect(wideRows.every((line) => !line.includes("\n"))).toBe(true);
   });
 
-  it("hides owner-scoped activity rows while keeping the running footer", async () => {
+  it("hides owner-scoped activity rows using the session cwd", async () => {
+    const item = makeState();
+    const testRoot = join(item.artifactDir, "..");
+    const settings = makeSessionSettingsSandbox(testRoot);
+    writeFileSync(
+      join(settings.cwd, ".pi", "settings-extensions.json"),
+      JSON.stringify({
+        "pi-subagentura": { "hide-agent-list": "true" },
+      }),
+    );
+    expect(settings.cwd).not.toBe(process.cwd());
+
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const multiplexer = await import("../src/multiplexer");
-    const item = makeState();
     item.state.name = "hidden-agent";
     item.state.parentSessionId = "session-hidden";
+    item.state.cwd = testRoot;
     const setStatus = vi.fn();
     const setWidget = vi.fn();
     const pi = {
       sendMessage: vi.fn(),
-      getFlag: (name: string) =>
-        name === HIDE_AGENT_LIST_FLAG ? true : undefined,
+      getFlag: () => undefined,
     } as unknown as ExtensionAPI;
     const ui = {
       notify: vi.fn(),
@@ -314,6 +358,7 @@ describe("pollArtifactChanges", () => {
       generation: 1,
       pi,
       ui,
+      cwd: settings.cwd,
       sessionManager: {
         getSessionId: () => "session-hidden",
         getEntries: () => [],

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -62,6 +62,14 @@ function makeSessionSettingsSandbox(root = makeTmp()): SessionSettingsSandbox {
   return { root, cwd };
 }
 
+/** Write the global (agent-dir) settings file the current test reads from. */
+function writeGlobalSettings(settings: Record<string, string>): void {
+  writeFileSync(
+    join(temporaryAgentDir!, "settings-extensions.json"),
+    JSON.stringify({ "pi-subagentura": settings }),
+  );
+}
+
 function makeState(): {
   id: string;
   artifactDir: string;
@@ -229,50 +237,136 @@ describe("pollArtifactChanges", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("does not read hide-agent-list settings when there are no activity rows", async () => {
-    const root = makeTmp();
-    const agentDir = join(root, "agent");
-    mkdirSync(agentDir, { recursive: true });
+  it("clears the activity widget on an empty tick with a malformed setting", async () => {
+    writeGlobalSettings({ "hide-agent-list": "invalid" });
+
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const setWidget = vi.fn();
+    const owner = { id: 700, generation: 1 };
+    const pi = { getFlag: () => false } as any;
+    registerSessionScope({
+      ...owner,
+      pi,
+      ui: {
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+        setWidget,
+      } as any,
+    });
+
+    await mod.pollArtifactChanges(pi, owner);
+
+    expect(setWidget).toHaveBeenCalledWith("subagentura-activity", undefined, {
+      placement: "belowEditor",
+    });
+  });
+
+  it("keeps painting rows when a persisted setting is malformed", async () => {
+    // A bad persisted value used to throw inside the tick, where the outer
+    // catch swallowed it and froze the footer + widgets for the session.
+    writeGlobalSettings({
+      "hide-agent-list": "invalid",
+      "max-depth": "not-a-number",
+    });
+
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const item = makeState();
+    item.state.name = "resilient-agent";
+    item.state.parentSessionId = "session-malformed";
+    item.state.cwd = join(item.artifactDir, "..");
+    const setStatus = vi.fn();
+    const setWidget = vi.fn();
+    const pi = {
+      sendMessage: vi.fn(),
+      getFlag: () => undefined,
+    } as unknown as ExtensionAPI;
+    const scope = registerSessionScope({
+      id: 506,
+      generation: 1,
+      pi,
+      ui: {
+        notify: vi.fn(),
+        setStatus,
+        setWidget,
+      } as unknown as ExtensionUIContext,
+      cwd: item.state.cwd,
+      sessionManager: {
+        getSessionId: () => "session-malformed",
+        getEntries: () => [],
+      },
+    });
+    scope.interactiveStates.set(item.id, item.state);
+    multiplexer.__setTmuxMultiplexer({
+      getPaneLivenessAsync: async () => "alive" as const,
+    } as unknown as Multiplexer);
+
+    await mod.pollArtifactChanges(pi, {
+      id: scope.id,
+      generation: scope.generation,
+    });
+
+    expect(setStatus).toHaveBeenCalledWith(
+      "subagentura-running",
+      "⚡ 1 sub-agent alive · 1 working",
+    );
+    expect(
+      renderedWidgetRows(setWidget, "subagentura-activity", 80).join("\n"),
+    ).toContain("resilient-agent");
+  });
+
+  it("reads hide-agent-list globally when the scope has no cwd", async () => {
+    // A cwd-less scope must not silently resolve against Node's process cwd.
+    mkdirSync(join(temporaryProcessCwd!, ".pi"), { recursive: true });
     writeFileSync(
-      join(agentDir, "settings-extensions.json"),
+      join(temporaryProcessCwd!, ".pi", "settings-extensions.json"),
       JSON.stringify({
-        "pi-subagentura": { "hide-agent-list": "invalid" },
+        "pi-subagentura": { "hide-agent-list": "true" },
       }),
     );
-    const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
-    process.env.PI_CODING_AGENT_DIR = agentDir;
 
-    try {
-      const mod =
-        await importFresh<typeof import("../src/subagent")>("../src/subagent");
-      const setWidget = vi.fn();
-      const owner = { id: 700, generation: 1 };
-      const pi = { getFlag: () => false } as any;
-      registerSessionScope({
-        ...owner,
-        pi,
-        ui: {
-          notify: vi.fn(),
-          setStatus: vi.fn(),
-          setWidget,
-        } as any,
-      });
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const item = makeState();
+    item.state.name = "ambient-agent";
+    item.state.parentSessionId = "session-no-cwd";
+    item.state.cwd = join(item.artifactDir, "..");
+    const setWidget = vi.fn();
+    const pi = {
+      sendMessage: vi.fn(),
+      getFlag: () => undefined,
+    } as unknown as ExtensionAPI;
+    const scope = registerSessionScope({
+      id: 507,
+      generation: 1,
+      pi,
+      ui: {
+        notify: vi.fn(),
+        setStatus: vi.fn(),
+        setWidget,
+      } as unknown as ExtensionUIContext,
+      sessionManager: {
+        getSessionId: () => "session-no-cwd",
+        getEntries: () => [],
+      },
+    });
+    expect(scope.cwd).toBeUndefined();
+    scope.interactiveStates.set(item.id, item.state);
+    multiplexer.__setTmuxMultiplexer({
+      getPaneLivenessAsync: async () => "alive" as const,
+    } as unknown as Multiplexer);
 
-      await mod.pollArtifactChanges(pi, owner);
+    await mod.pollArtifactChanges(pi, {
+      id: scope.id,
+      generation: scope.generation,
+    });
 
-      expect(setWidget).toHaveBeenCalledWith(
-        "subagentura-activity",
-        undefined,
-        { placement: "belowEditor" },
-      );
-    } finally {
-      if (previousAgentDir === undefined) {
-        delete process.env.PI_CODING_AGENT_DIR;
-      } else {
-        process.env.PI_CODING_AGENT_DIR = previousAgentDir;
-      }
-      rmSync(root, { recursive: true, force: true });
-    }
+    expect(
+      renderedWidgetRows(setWidget, "subagentura-activity", 80).join("\n"),
+    ).toContain("ambient-agent");
   });
 
   it("registers the activity widget as an adaptive grid component", async () => {
@@ -324,14 +418,16 @@ describe("pollArtifactChanges", () => {
     expect(wideRows.every((line) => !line.includes("\n"))).toBe(true);
   });
 
-  it("hides owner-scoped activity rows using the session cwd", async () => {
+  it("hides owner-scoped activity rows from the global setting only", async () => {
     const item = makeState();
     const testRoot = join(item.artifactDir, "..");
     const settings = makeSessionSettingsSandbox(testRoot);
+    writeGlobalSettings({ "hide-agent-list": "true" });
+    // A repo-controlled project file must not be able to flip this setting.
     writeFileSync(
       join(settings.cwd, ".pi", "settings-extensions.json"),
       JSON.stringify({
-        "pi-subagentura": { "hide-agent-list": "true" },
+        "pi-subagentura": { "hide-agent-list": "false" },
       }),
     );
     expect(settings.cwd).not.toBe(process.cwd());


### PR DESCRIPTION
Summary:
- use @juanibiapina/pi-extension-settings for global/project max-depth and hide-agent-list persistence
- resolve project-local settings from Pi's authoritative session cwd across reload/resume
- register the schema safely for either extension load order
- keep CLI flags as per-run overrides without changing persisted values
- validate persisted max-depth with the existing 0-64 parser and default it to 2
- skip persisted hide-agent-list reads during idle poll ticks
- isolate settings tests from real global/project user configuration
- document the optional global panel plus manual session-cwd local settings path

Notes:
- the panel is not bundled or auto-loaded, preventing duplicate settings commands
- project-local settings override global settings
- @juanibiapina/pi-extension-settings 0.9.1 `/extension-settings-local` resolves `process.cwd()` rather than Pi's command cwd, so it is not advertised for cross-project resumed sessions; use `<session-cwd>/.pi/settings-extensions.json`
- Node remains >=22.23.2
- production dependency audit reports 0 vulnerabilities

Verification:
- npm test: 79 files, 1,766 tests passed
- npm run typecheck
- npm run format:check
- npm run pack:check
- published clean-consumer test
- npm audit --omit=dev
- independent read-only review completed with no remaining findings
