### PR TITLE
feat: add anonymous session lifecycle telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Workflow children now bind their real orchestration depth (1) instead of 0, so an in-process spawn chain started under a workflow agent has one fewer nesting level available before `SUBAGENTURA_MAX_ORCHESTRATION_DEPTH` refuses it. Previously a workflow grandchild reported the same depth as its parent and never counted against the cap. Direct workflow children are unaffected.
+
 ## [3.5.0] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ The extension exposes these validated flags for advanced configurations:
 
 - `--subagentura-max-depth <n>` — Orchestratorv2 lineage depth, default `2`; legacy orchestration keeps its existing depth of `8`.
 - `--subagentura-hide-agent-list` — hide only the compact per-agent activity widget rows; the running footer, list/status tools, and visual agent supervisor remain available. It defaults to `false`.
-- `--subagentura-telemetry` — anonymous product analytics, enabled by default; pass `--no-subagentura-telemetry` to disable it. The exact events and other opt-outs are documented in [Anonymous product telemetry](#anonymous-product-telemetry).
+- `--subagentura-telemetry` — anonymous product analytics, enabled by default. Extension booleans are presence-only; `--subagentura-telemetry=false` is not an opt-out.
+- `--no-subagentura-telemetry` — presence-only opt-out for anonymous product analytics. The exact events and other opt-outs are documented in [Anonymous product telemetry](#anonymous-product-telemetry).
 
 #### See the thin-router flow
 
@@ -854,15 +855,15 @@ unrelated anonymous correlation rather than reconstructing identity.
 
 The payload schema is versioned and contains these events:
 
-| Event                      | Properties                                                                                                                                                                                       |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `session_started`          | package version; `straight`, `orchestrator`, or `orchestrator_v2` mode                                                                                                                           |
-| `agent_created`            | once per accepted in-process agent or launched interactive pane; execution kind, closed invocation source, public/sanitized model, async, exact bounded depth plus bucket, and completion policy |
-| `task_started`             | once per accepted in-process job or authoritative interactive turn; repeats the closed agent dimensions and adds `job` or `turn`                                                                 |
-| `interactive_message_sent` | explicit parent-to-child steering/follow-up direction and bounded count only                                                                                                                     |
-| `task_completed`           | repeated closed dimensions; `success`, `error`, or `cancelled`; rounded/capped numeric duration plus bucket; bounded child-conversation message count when observable                            |
-| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                                             |
-| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                                           |
+| Event                      | Properties                                                                                                                                                                                                                                          |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session_started`          | package version; `straight`, `orchestrator`, or `orchestrator_v2` mode                                                                                                                                                                              |
+| `agent_created`            | once per accepted in-process agent or launched interactive pane; execution kind, closed mux (`none`, `tmux`, `zellij`, or `herdr`), closed invocation source, public/sanitized model, async, exact bounded depth plus bucket, and completion policy |
+| `task_started`             | once per accepted in-process job or authoritative interactive turn; repeats the closed execution and mux dimensions and adds `job` or `turn`                                                                                                        |
+| `interactive_message_sent` | explicit parent-to-child steering/follow-up direction and bounded count only                                                                                                                                                                        |
+| `task_completed`           | repeated closed execution and mux dimensions; `success`, `error`, or `cancelled`; rounded/capped numeric duration plus bucket; bounded child-conversation message count when observable                                                             |
+| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                                                                                                |
+| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                                                                                              |
 
 All events include the closed root mode and set `$process_person_profile: false`,
 `$geoip_disable: true`, and `$ip: "0.0.0.0"`. Terminal task events repeat the closed
@@ -884,6 +885,7 @@ anonymous session. The intended aggregates are:
 - delegated tasks: count `task_started`
 - maximum depth: maximum numeric `depth`
 - outcomes: count `task_completed`, broken down by `status`
+- execution/mux mix: count lifecycle events by the closed execution and mux dimensions
 - task time: average, percentile, or sum of `task_completed.duration_ms`
 - child conversation traffic: sum
   `task_completed.child_conversation_message_count`

--- a/README.md
+++ b/README.md
@@ -855,15 +855,15 @@ unrelated anonymous correlation rather than reconstructing identity.
 
 The payload schema is versioned and contains these events:
 
-| Event                      | Properties                                                                                                                                                                                                                                          |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `session_started`          | package version; `straight`, `orchestrator`, or `orchestrator_v2` mode                                                                                                                                                                              |
-| `agent_created`            | once per accepted in-process agent or launched interactive pane; execution kind, closed mux (`none`, `tmux`, `zellij`, or `herdr`), closed invocation source, public/sanitized model, async, exact bounded depth plus bucket, and completion policy |
-| `task_started`             | once per accepted in-process job or authoritative interactive turn; repeats the closed execution and mux dimensions and adds `job` or `turn`                                                                                                        |
-| `interactive_message_sent` | explicit parent-to-child steering/follow-up direction and bounded count only                                                                                                                                                                        |
-| `task_completed`           | repeated closed execution and mux dimensions; `success`, `error`, or `cancelled`; rounded/capped numeric duration plus bucket; bounded child-conversation message count when observable                                                             |
-| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                                                                                                |
-| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                                                                                              |
+| Event                      | Properties                                                                                                                                                                                                                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `session_started`          | package version; `straight`, `orchestrator`, or `orchestrator_v2` mode                                                                                                                                                                                                                                             |
+| `agent_created`            | once per accepted in-process agent or launched interactive pane; execution kind, closed mux (`none`, `tmux`, or `zellij`; `herdr` is reserved and starts being recorded when herdr support lands), closed invocation source, public/sanitized model, async, exact bounded depth plus bucket, and completion policy |
+| `task_started`             | once per accepted in-process job or authoritative interactive turn; repeats the closed execution and mux dimensions and adds `job` or `turn`                                                                                                                                                                       |
+| `interactive_message_sent` | explicit parent-to-child steering/follow-up direction and bounded count only                                                                                                                                                                                                                                       |
+| `task_completed`           | repeated closed execution and mux dimensions; `success`, `error`, or `cancelled`; rounded numeric duration plus bucket, both reported as unknown when the measured span is implausible; bounded child-conversation message count when observable                                                                   |
+| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                                                                                                                                                               |
+| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                                                                                                                                                             |
 
 All events include the closed root mode and set `$process_person_profile: false`,
 `$geoip_disable: true`, and `$ip: "0.0.0.0"`. Terminal task events repeat the closed
@@ -912,6 +912,33 @@ PI_OFFLINE=1 pi
 
 Telemetry is also disabled automatically under `PI_OFFLINE`, `CI`, `VITEST`,
 or `NODE_ENV=test`. The opt-out is inherited by recursive interactive children.
+
+For every switch below except `NODE_ENV`, surrounding whitespace and letter case
+never change how the value is read, and an unset or empty variable is never a
+decision. `NODE_ENV` is the exception: it is compared literally, so only the
+exact lower-case `test` counts. Which values mean "false" depends on which way
+the switch points:
+
+| Variable                   | Disables telemetry when                                     | Does **not** disable telemetry when        |
+| -------------------------- | ----------------------------------------------------------- | ------------------------------------------ |
+| `PI_SUBAGENTURA_TELEMETRY` | set to `0`, `false`, `off`, or `no`                         | set to anything else, or unset             |
+| `DO_NOT_TRACK`             | set to anything except `0` or `false` (`1`, `off`, `no`, …) | unset, empty, `0`, or `false`              |
+| `PI_OFFLINE`               | set to anything except `0` or `false` (`1`, `off`, `no`, …) | unset, empty, `0`, or `false`              |
+| `CI`, `VITEST`             | set to anything except `0`, `false`, `off`, or `no`         | unset, empty, `0`, `false`, `off`, or `no` |
+| `NODE_ENV`                 | exactly `test` (compared literally)                         | any other value                            |
+
+The asymmetry is deliberate. `DO_NOT_TRACK` and `PI_OFFLINE` are opt-out
+requests, so setting them to a value this code does not recognize keeps
+telemetry off — `DO_NOT_TRACK=off` and `DO_NOT_TRACK=no` still opt out, and only
+the unambiguous `DO_NOT_TRACK=false` or `DO_NOT_TRACK=0` cancels the request.
+`CI` and `VITEST` merely describe an environment, so `CI=off` reads as "not CI"
+and leaves telemetry enabled. To turn telemetry off without ambiguity, use
+`pi --no-subagentura-telemetry` or `PI_SUBAGENTURA_TELEMETRY=0`.
+
+With telemetry disabled the extension performs no telemetry-related writes: it
+does not create `.pi/`, take the state lock, or touch
+`.pi/subagentura-state.json` — except once, to clear a correlation an earlier
+opted-in run left behind.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The extension exposes these validated flags for advanced configurations:
 
 - `--subagentura-max-depth <n>` — Orchestratorv2 lineage depth, default `2`; legacy orchestration keeps its existing depth of `8`.
 - `--subagentura-hide-agent-list` — hide only the compact per-agent activity widget rows; the running footer, list/status tools, and visual agent supervisor remain available. It defaults to `false`.
+- `--subagentura-telemetry` — anonymous product analytics, enabled by default; pass `--no-subagentura-telemetry` to disable it. The exact events and other opt-outs are documented in [Anonymous product telemetry](#anonymous-product-telemetry).
 
 #### See the thin-router flow
 
@@ -829,6 +830,65 @@ Parameters:
 - “Start an interactive sub-agent in tmux for investigating the auth bug; give me the attach command.”
 - “Open an interactive sub-agent in a visible zellij pane so I can watch its tool calls live.”
 - “Attach to the existing interactive sub-agent and send it a follow-up without losing context.”
+
+## Anonymous product telemetry
+
+Anonymous product telemetry is enabled by default. The extension sends
+best-effort lifecycle events directly to PostHog's public capture endpoint so
+the maintainers can understand which execution modes are useful and where
+sub-agent completion or collection breaks down.
+
+Each logical root Pi session/tree receives one random UUID. It is not derived
+from Pi's session id and is never a stable installation, machine, user,
+repository, or project identity. The UUID and closed mode are stored only in the
+existing active-session `.pi/subagentura-state.json` file so live starts and
+later completions remain correlated across reload, resume, and matching startup
+recovery after quit. Fresh `new` and `fork` sessions replace or clear it.
+Bounded active-turn progress (closed dimensions, turn timestamps, and message
+counts) may be stored there for the same recovery purpose; prompt and output
+content is never included. Recursive interactive children receive correlation
+only through the existing mode-0600, one-use lineage bootstrap—not through
+ambient identity environment variables—and never read or write the root state
+file's telemetry metadata. A child without that explicit context starts an
+unrelated anonymous correlation rather than reconstructing identity.
+
+The payload schema is versioned and contains these events:
+
+| Event                      | Properties                                                                                                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session_started`          | package version; `manual`, `orchestrator`, or `orchestrator_v2` mode                                                                                                            |
+| `agent_started`            | `in-process` or `interactive`; `job` or `turn` unit; closed invocation source; built-in public model id, `custom`, or `default`; async boolean; depth bucket; completion policy |
+| `interactive_message_sent` | `parent_to_child` direction and bounded count only                                                                                                                              |
+| `agent_completed`          | execution kind; `job` or `turn` unit; `success`, `error`, or `cancelled`; duration bucket; per-unit bounded message count when observable                                       |
+| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                            |
+| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                          |
+
+All events include the closed root mode and set `$process_person_profile: false`
+and `$geoip_disable: true`. Terminal agent events also repeat the closed
+invocation source and completion policy so completion rates need no identifier
+join.
+They contain only closed enums, booleans, bounded counts, the package version,
+and the random runtime correlation UUID. The extension does **not** send tasks,
+personas, prompts, messages, outputs, error text, names, group ids, paths,
+repositories, artifact/agent/Pi session ids, token usage, cost, or a persistent
+installation id. PostHog can still observe the connection's source IP while
+handling the HTTP request, but GeoIP-derived event properties are disabled.
+
+Capture is fire-and-forget with a 1.5-second timeout. Event payloads are not
+queued, persisted, or retried; only the random active-session correlation and
+bounded recovery metadata described above are stored locally. Telemetry failures
+never affect extension behavior.
+Disable it with any of:
+
+```bash
+pi --no-subagentura-telemetry
+PI_SUBAGENTURA_TELEMETRY=0 pi
+DO_NOT_TRACK=1 pi
+PI_OFFLINE=1 pi
+```
+
+Telemetry is also disabled automatically under `PI_OFFLINE`, `CI`, `VITEST`,
+or `NODE_ENV=test`. The opt-out is inherited by recursive interactive children.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -854,25 +854,46 @@ unrelated anonymous correlation rather than reconstructing identity.
 
 The payload schema is versioned and contains these events:
 
-| Event                      | Properties                                                                                                                                                                      |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `session_started`          | package version; `manual`, `orchestrator`, or `orchestrator_v2` mode                                                                                                            |
-| `agent_started`            | `in-process` or `interactive`; `job` or `turn` unit; closed invocation source; built-in public model id, `custom`, or `default`; async boolean; depth bucket; completion policy |
-| `interactive_message_sent` | `parent_to_child` direction and bounded count only                                                                                                                              |
-| `agent_completed`          | execution kind; `job` or `turn` unit; `success`, `error`, or `cancelled`; duration bucket; per-unit bounded message count when observable                                       |
-| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                            |
-| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                          |
+| Event                      | Properties                                                                                                                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `session_started`          | package version; `straight`, `orchestrator`, or `orchestrator_v2` mode                                                                                                                           |
+| `agent_created`            | once per accepted in-process agent or launched interactive pane; execution kind, closed invocation source, public/sanitized model, async, exact bounded depth plus bucket, and completion policy |
+| `task_started`             | once per accepted in-process job or authoritative interactive turn; repeats the closed agent dimensions and adds `job` or `turn`                                                                 |
+| `interactive_message_sent` | explicit parent-to-child steering/follow-up direction and bounded count only                                                                                                                     |
+| `task_completed`           | repeated closed dimensions; `success`, `error`, or `cancelled`; rounded/capped numeric duration plus bucket; bounded child-conversation message count when observable                            |
+| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                                             |
+| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                                           |
 
-All events include the closed root mode and set `$process_person_profile: false`
-and `$geoip_disable: true`. Terminal agent events also repeat the closed
+All events include the closed root mode and set `$process_person_profile: false`,
+`$geoip_disable: true`, and `$ip: "0.0.0.0"`. Terminal task events repeat the closed
 invocation source and completion policy so completion rates need no identifier
 join.
 They contain only closed enums, booleans, bounded counts, the package version,
 and the random runtime correlation UUID. The extension does **not** send tasks,
-personas, prompts, messages, outputs, error text, names, group ids, paths,
+personas, prompts, message content, outputs, error text, names, group ids, paths,
 repositories, artifact/agent/Pi session ids, token usage, cost, or a persistent
 installation id. PostHog can still observe the connection's source IP while
-handling the HTTP request, but GeoIP-derived event properties are disabled.
+handling the HTTP request. The project-level **Discard client IP data** setting
+should also be enabled; direct ingestion cannot prevent PostHog's network edge
+from receiving the connection itself.
+
+In PostHog, group or filter events by `telemetry_session_id` to inspect one
+anonymous session. The intended aggregates are:
+
+- agents created: count `agent_created`
+- delegated tasks: count `task_started`
+- maximum depth: maximum numeric `depth`
+- outcomes: count `task_completed`, broken down by `status`
+- task time: average, percentile, or sum of `task_completed.duration_ms`
+- child conversation traffic: sum
+  `task_completed.child_conversation_message_count`
+- explicit interactive follow-ups: sum `interactive_message_sent.count`
+- delivery/collection reliability: compare completed tasks with
+  `completion_delivered` and `result_consumed`
+
+The observed session span is the time from `session_started` to its last event.
+There is deliberately no shutdown-only summary: crashes can skip shutdown, and
+reload/resume lifecycle transitions can occur inside one logical session.
 
 Capture is fire-and-forget with a 1.5-second timeout. Event payloads are not
 queued, persisted, or retried; only the random active-session correlation and

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "src/session-handlers.ts",
     "src/session-scope.ts",
     "src/settings.ts",
+    "src/telemetry.ts",
     "src/subagent.ts",
     "src/subagent-artifact-cli.ts",
     "src/workflow.ts",

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -73,6 +73,7 @@ import {
   resolveLiveSessionScope,
 } from "./session-scope";
 import { isAgentListHidden } from "./settings";
+import { captureTelemetry } from "./telemetry";
 // ── Footer / Widget Status Keys ────────────────────────────────────────
 
 export const FOOTER_KEY = "subagentura-running";
@@ -491,6 +492,26 @@ function persistPolledState(
   entry.pendingDeliveries = state.pendingDeliveries ?? [];
   entry.deliveryReceipts = state.deliveryReceipts ?? [];
   entry.lifecycle = state.lifecycle;
+  if (
+    entry.telemetry &&
+    entry.telemetry.correlationId === state.telemetryCorrelationId
+  ) {
+    if (state.telemetryActiveTurnId) {
+      entry.telemetry.activeTurnId = state.telemetryActiveTurnId;
+      entry.telemetry.turnStartedAt = state.telemetryTurnStartedAt;
+    } else {
+      delete entry.telemetry.activeTurnId;
+      delete entry.telemetry.turnStartedAt;
+    }
+    const messageCounts = [...(state.telemetryTurnMessageCounts ?? [])].slice(
+      -32,
+    );
+    if (messageCounts.length > 0) {
+      entry.telemetry.messageCounts = Object.fromEntries(messageCounts);
+    } else {
+      delete entry.telemetry.messageCounts;
+    }
+  }
 }
 
 function persistPolledStates(
@@ -629,6 +650,65 @@ async function runPollArtifactChanges(
         foldInteractiveLifecycle(lifecycle, ev);
         if ("version" in ev && ev.version === 2 && ev.type === "turn_started") {
           state.activeTurnId = ev.turnId;
+          const telemetryEligible =
+            state.telemetryEligible === true &&
+            state.telemetryCorrelationId ===
+              ownerContext?.telemetry?.correlationId;
+          if (telemetryEligible) {
+            state.telemetryActiveTurnId = ev.turnId;
+            state.telemetryTurnStartedAt = ev.ts;
+            captureTelemetry(
+              ownerContext?.telemetry,
+              {
+                event: "agent_started",
+                execution: "interactive",
+                unit: "turn",
+                invocation_source:
+                  state.telemetryInvocationSource ?? "interactive",
+                model: state.telemetryModel,
+                async: state.telemetryAsync ?? true,
+                depth_bucket: state.telemetryDepthBucket ?? "unknown",
+                completion_policy: state.telemetryCompletionPolicy ?? "legacy",
+              },
+              {
+                dedupeKey: `agent-started:interactive:${state.id}:${ev.eventId}`,
+              },
+            );
+          }
+        }
+        if (
+          ev.type === "completion" &&
+          state.telemetryActiveTurnId === ev.turnId &&
+          state.telemetryCorrelationId ===
+            ownerContext?.telemetry?.correlationId
+        ) {
+          const status = deliveryStatusFromEvent(ev);
+          captureTelemetry(
+            ownerContext?.telemetry,
+            {
+              event: "agent_completed",
+              execution: "interactive",
+              unit: "turn",
+              invocation_source:
+                state.telemetryInvocationSource ?? "interactive",
+              completion_policy: state.telemetryCompletionPolicy ?? "legacy",
+              status: status === "done" ? "success" : status,
+              duration_ms:
+                state.telemetryTurnStartedAt === undefined
+                  ? undefined
+                  : ev.ts - state.telemetryTurnStartedAt,
+              message_count: state.telemetryTurnMessageCounts?.get(ev.turnId),
+            },
+            {
+              dedupeKey: `agent-completed:interactive:${state.id}:${"eventId" in ev ? ev.eventId : record.startOffset}`,
+            },
+          );
+          state.telemetryActiveTurnId = undefined;
+          state.telemetryTurnStartedAt = undefined;
+          state.telemetryTurnMessageCounts?.delete(ev.turnId);
+          if (state.telemetryMessageTurnId === ev.turnId) {
+            state.telemetryMessageTurnId = undefined;
+          }
         }
         if (!queuesCompletion) continue;
         const v2 = ev.type === "completion" ? ev : undefined;
@@ -1042,10 +1122,37 @@ function processSessionLogEntry(
   art: SubagentArtifact,
   entry: Record<string, unknown>,
 ): void {
-  const e = entry as { type?: string; message?: Record<string, unknown> };
+  const e = entry as {
+    id?: unknown;
+    type?: string;
+    message?: Record<string, unknown>;
+  };
   if (e.type !== "message") return;
   const msg = e.message;
   if (!msg) return;
+  if (state.telemetryEligible && msg.role === "user") {
+    const turnId =
+      typeof e.id === "string" &&
+      e.id.length > 0 &&
+      e.id.length <= 256 &&
+      /^[A-Za-z0-9._:-]+$/.test(e.id)
+        ? e.id
+        : undefined;
+    if (turnId) {
+      const counts = (state.telemetryTurnMessageCounts ??= new Map());
+      if (!counts.has(turnId) && counts.size >= 32) {
+        counts.delete(counts.keys().next().value!);
+      }
+      counts.set(turnId, 1);
+      state.telemetryMessageTurnId = turnId;
+    }
+  } else if (state.telemetryEligible && state.telemetryMessageTurnId) {
+    const counts = (state.telemetryTurnMessageCounts ??= new Map());
+    counts.set(
+      state.telemetryMessageTurnId,
+      Math.min((counts.get(state.telemetryMessageTurnId) ?? 0) + 1, 1_000),
+    );
+  }
 
   // New user-role message = a new turn. Clear legacy per-turn session metadata.
   if (msg.role === "user") {

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -503,6 +503,11 @@ function persistPolledState(
       delete entry.telemetry.activeTurnId;
       delete entry.telemetry.turnStartedAt;
     }
+    if (state.telemetryMessageTurnId) {
+      entry.telemetry.messageTurnId = state.telemetryMessageTurnId;
+    } else {
+      delete entry.telemetry.messageTurnId;
+    }
     const messageCounts = [...(state.telemetryTurnMessageCounts ?? [])].slice(
       -32,
     );
@@ -532,6 +537,31 @@ function persistPolledStates(
       })),
     );
   }
+}
+
+/**
+ * Pi keeps Enter-during-streaming steering inside one agent run, but the child
+ * protocol gives each persisted user entry a fresh turn id. Keep that run as
+ * one telemetry task until the next persisted user entry advances it.
+ */
+function rebindTelemetryTurn(
+  state: InteractiveSubagentState,
+  nextTurnId: string,
+): void {
+  const previousTurnId = state.telemetryActiveTurnId;
+  if (previousTurnId !== undefined && previousTurnId !== nextTurnId) {
+    const counts = state.telemetryTurnMessageCounts;
+    const previousCount = counts?.get(previousTurnId);
+    if (counts && previousCount !== undefined) {
+      const nextCount = counts.get(nextTurnId) ?? 0;
+      counts.set(nextTurnId, Math.min(previousCount + nextCount, 1_000));
+      counts.delete(previousTurnId);
+    }
+    if (state.telemetryMessageTurnId === previousTurnId) {
+      state.telemetryMessageTurnId = nextTurnId;
+    }
+  }
+  state.telemetryActiveTurnId = nextTurnId;
 }
 
 /**
@@ -655,26 +685,33 @@ async function runPollArtifactChanges(
             state.telemetryCorrelationId ===
               ownerContext?.telemetry?.correlationId;
           if (telemetryEligible) {
-            state.telemetryActiveTurnId = ev.turnId;
-            state.telemetryTurnStartedAt = ev.ts;
-            captureTelemetry(
-              ownerContext?.telemetry,
-              {
-                event: "task_started",
-                execution: "interactive",
-                unit: "turn",
-                invocation_source:
-                  state.telemetryInvocationSource ?? "interactive",
-                model: state.telemetryModel,
-                async: state.telemetryAsync ?? true,
-                depth: state.telemetryDepth,
-                depth_bucket: state.telemetryDepthBucket ?? "unknown",
-                completion_policy: state.telemetryCompletionPolicy ?? "legacy",
-              },
-              {
-                dedupeKey: `task-started:interactive:${state.id}:${ev.eventId}`,
-              },
-            );
+            if (state.telemetryActiveTurnId !== undefined) {
+              rebindTelemetryTurn(state, ev.turnId);
+            } else {
+              state.telemetryActiveTurnId = ev.turnId;
+              state.telemetryTurnStartedAt = ev.ts;
+              state.telemetryMessageTurnId = ev.turnId;
+              captureTelemetry(
+                ownerContext?.telemetry,
+                {
+                  event: "task_started",
+                  execution: "interactive",
+                  mux: state.mux,
+                  unit: "turn",
+                  invocation_source:
+                    state.telemetryInvocationSource ?? "interactive",
+                  model: state.telemetryModel,
+                  async: state.telemetryAsync ?? true,
+                  depth: state.telemetryDepth,
+                  depth_bucket: state.telemetryDepthBucket ?? "unknown",
+                  completion_policy:
+                    state.telemetryCompletionPolicy ?? "legacy",
+                },
+                {
+                  dedupeKey: `task-started:interactive:${state.id}:${ev.eventId}`,
+                },
+              );
+            }
           }
         }
         if (
@@ -684,11 +721,23 @@ async function runPollArtifactChanges(
             ownerContext?.telemetry?.correlationId
         ) {
           const status = deliveryStatusFromEvent(ev);
+          const messageTurnId = state.telemetryMessageTurnId;
+          const directMessageCount = state.telemetryTurnMessageCounts?.get(
+            ev.turnId,
+          );
+          const fallbackMessageCount =
+            directMessageCount === undefined &&
+            messageTurnId !== undefined &&
+            messageTurnId !== ev.turnId
+              ? state.telemetryTurnMessageCounts?.get(messageTurnId)
+              : undefined;
+          const messageCount = directMessageCount ?? fallbackMessageCount;
           captureTelemetry(
             ownerContext?.telemetry,
             {
               event: "task_completed",
               execution: "interactive",
+              mux: state.mux,
               unit: "turn",
               invocation_source:
                 state.telemetryInvocationSource ?? "interactive",
@@ -702,8 +751,7 @@ async function runPollArtifactChanges(
                 state.telemetryTurnStartedAt === undefined
                   ? undefined
                   : ev.ts - state.telemetryTurnStartedAt,
-              child_conversation_message_count:
-                state.telemetryTurnMessageCounts?.get(ev.turnId),
+              child_conversation_message_count: messageCount,
             },
             {
               dedupeKey: `task-completed:interactive:${state.id}:${ev.turnId}`,
@@ -711,8 +759,20 @@ async function runPollArtifactChanges(
           );
           state.telemetryActiveTurnId = undefined;
           state.telemetryTurnStartedAt = undefined;
-          state.telemetryTurnMessageCounts?.delete(ev.turnId);
-          if (state.telemetryMessageTurnId === ev.turnId) {
+          if (directMessageCount !== undefined) {
+            state.telemetryTurnMessageCounts?.delete(ev.turnId);
+          } else if (
+            messageTurnId !== undefined &&
+            messageTurnId !== ev.turnId &&
+            fallbackMessageCount !== undefined
+          ) {
+            state.telemetryTurnMessageCounts?.delete(messageTurnId);
+          }
+          if (
+            messageTurnId === ev.turnId ||
+            (directMessageCount === undefined &&
+              fallbackMessageCount !== undefined)
+          ) {
             state.telemetryMessageTurnId = undefined;
           }
         }
@@ -1146,10 +1206,30 @@ function processSessionLogEntry(
         : undefined;
     if (turnId) {
       const counts = (state.telemetryTurnMessageCounts ??= new Map());
-      if (!counts.has(turnId) && counts.size >= 32) {
-        counts.delete(counts.keys().next().value!);
+      if (
+        state.telemetryActiveTurnId === turnId &&
+        state.telemetryMessageTurnId !== turnId
+      ) {
+        // Steering reuses the active agent run but persists a fresh user entry.
+        const previousTurnId = state.telemetryMessageTurnId;
+        const previousCount = previousTurnId
+          ? (counts.get(previousTurnId) ?? 0)
+          : 0;
+        const nextCount = counts.get(turnId) ?? 0;
+        counts.set(turnId, Math.min(previousCount + nextCount + 1, 1_000));
+        if (previousTurnId) counts.delete(previousTurnId);
+      } else if (state.telemetryActiveTurnId === turnId) {
+        // A rebind may have carried an earlier turn's count into this user id.
+        if (!counts.has(turnId) && counts.size >= 32) {
+          counts.delete(counts.keys().next().value!);
+        }
+        counts.set(turnId, Math.min((counts.get(turnId) ?? 0) + 1, 1_000));
+      } else {
+        if (!counts.has(turnId) && counts.size >= 32) {
+          counts.delete(counts.keys().next().value!);
+        }
+        counts.set(turnId, 1);
       }
-      counts.set(turnId, 1);
       state.telemetryMessageTurnId = turnId;
     }
   } else if (state.telemetryEligible && state.telemetryMessageTurnId) {

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -660,18 +660,19 @@ async function runPollArtifactChanges(
             captureTelemetry(
               ownerContext?.telemetry,
               {
-                event: "agent_started",
+                event: "task_started",
                 execution: "interactive",
                 unit: "turn",
                 invocation_source:
                   state.telemetryInvocationSource ?? "interactive",
                 model: state.telemetryModel,
                 async: state.telemetryAsync ?? true,
+                depth: state.telemetryDepth,
                 depth_bucket: state.telemetryDepthBucket ?? "unknown",
                 completion_policy: state.telemetryCompletionPolicy ?? "legacy",
               },
               {
-                dedupeKey: `agent-started:interactive:${state.id}:${ev.eventId}`,
+                dedupeKey: `task-started:interactive:${state.id}:${ev.eventId}`,
               },
             );
           }
@@ -686,21 +687,26 @@ async function runPollArtifactChanges(
           captureTelemetry(
             ownerContext?.telemetry,
             {
-              event: "agent_completed",
+              event: "task_completed",
               execution: "interactive",
               unit: "turn",
               invocation_source:
                 state.telemetryInvocationSource ?? "interactive",
+              model: state.telemetryModel,
+              async: state.telemetryAsync ?? true,
+              depth: state.telemetryDepth,
+              depth_bucket: state.telemetryDepthBucket ?? "unknown",
               completion_policy: state.telemetryCompletionPolicy ?? "legacy",
               status: status === "done" ? "success" : status,
               duration_ms:
                 state.telemetryTurnStartedAt === undefined
                   ? undefined
                   : ev.ts - state.telemetryTurnStartedAt,
-              message_count: state.telemetryTurnMessageCounts?.get(ev.turnId),
+              child_conversation_message_count:
+                state.telemetryTurnMessageCounts?.get(ev.turnId),
             },
             {
-              dedupeKey: `agent-completed:interactive:${state.id}:${"eventId" in ev ? ev.eventId : record.startOffset}`,
+              dedupeKey: `task-completed:interactive:${state.id}:${ev.turnId}`,
             },
           );
           state.telemetryActiveTurnId = undefined;

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -2249,6 +2249,26 @@ export function appendInteractiveState(
   });
 }
 
+/**
+ * Read-only probe for a telemetry field on disk. Opt-out must be inert: with
+ * telemetry disabled the extension must not create `.pi/`, take the state lock,
+ * or rewrite the state file — it only has work to do when a previous run left a
+ * correlation behind to clear.
+ */
+export function hasPersistedTelemetryField(cwd: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(stateFilePath(cwd), "utf8"));
+  } catch {
+    return false;
+  }
+  return (
+    !!parsed &&
+    typeof parsed === "object" &&
+    (parsed as Record<string, unknown>).telemetry !== undefined
+  );
+}
+
 /** Persist or clear the random logical-session telemetry correlation. */
 export function updatePersistedTelemetrySession(
   cwd: string,

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -1403,6 +1403,7 @@ export interface PersistedInteractiveTelemetry {
   correlationId: string;
   invocationSource: "with_context" | "isolated" | "interactive" | "workflow";
   async: boolean;
+  depth?: number;
   depthBucket: "1" | "2" | "3" | "4-7" | "8+" | "unknown";
   completionPolicy: "inline" | "each" | "group" | "legacy";
   model: string;
@@ -1413,7 +1414,7 @@ export interface PersistedInteractiveTelemetry {
 
 export interface PersistedTelemetrySession {
   correlationId: string;
-  mode: "manual" | "orchestrator" | "orchestrator_v2";
+  mode: "straight" | "orchestrator" | "orchestrator_v2";
 }
 
 export interface PersistedDeliveryIntent {
@@ -1542,18 +1543,20 @@ function migrateStatePayload(
     !Array.isArray(obj.telemetry)
       ? (obj.telemetry as Record<string, unknown>)
       : undefined;
+  const rawTelemetryMode =
+    rawTelemetry?.mode === "manual" ? "straight" : rawTelemetry?.mode;
   const telemetry: PersistedTelemetrySession | undefined =
     rawTelemetry &&
     typeof rawTelemetry.correlationId === "string" &&
     /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
       rawTelemetry.correlationId,
     ) &&
-    (rawTelemetry.mode === "manual" ||
-      rawTelemetry.mode === "orchestrator" ||
-      rawTelemetry.mode === "orchestrator_v2")
+    (rawTelemetryMode === "straight" ||
+      rawTelemetryMode === "orchestrator" ||
+      rawTelemetryMode === "orchestrator_v2")
       ? {
           correlationId: rawTelemetry.correlationId.toLowerCase(),
-          mode: rawTelemetry.mode,
+          mode: rawTelemetryMode,
         }
       : undefined;
 
@@ -1797,6 +1800,12 @@ function migrateStatePayload(
               correlationId: rawEntryTelemetry.correlationId.toLowerCase(),
               invocationSource: rawEntryTelemetry.invocationSource,
               async: rawEntryTelemetry.async,
+              ...(typeof rawEntryTelemetry.depth === "number" &&
+              Number.isSafeInteger(rawEntryTelemetry.depth) &&
+              rawEntryTelemetry.depth >= 1 &&
+              rawEntryTelemetry.depth <= 64
+                ? { depth: rawEntryTelemetry.depth }
+                : {}),
               depthBucket: rawEntryTelemetry.depthBucket,
               completionPolicy: rawEntryTelemetry.completionPolicy,
               model: sanitizeTelemetryModel(rawEntryTelemetry.model),

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -37,6 +37,7 @@ import { basename, dirname, isAbsolute, join } from "node:path";
 import isPathInside from "is-path-inside";
 import { debugLog } from "./helpers";
 import type { MuxName } from "./multiplexer";
+import { sanitizeTelemetryModel } from "./telemetry";
 
 /** Current schema version for the interactive state file. */
 export const CURRENT_STATE_SCHEMA_VERSION = 2;
@@ -1393,6 +1394,26 @@ export interface InteractiveSubagentPersistedStateV1 {
 
   /** Parent pi session id; only rehydrated when the current session matches. */
   parentSessionId?: string;
+
+  /** Closed analytics dimensions only; never task, prompt, output, or identity. */
+  telemetry?: PersistedInteractiveTelemetry;
+}
+
+export interface PersistedInteractiveTelemetry {
+  correlationId: string;
+  invocationSource: "with_context" | "isolated" | "interactive" | "workflow";
+  async: boolean;
+  depthBucket: "1" | "2" | "3" | "4-7" | "8+" | "unknown";
+  completionPolicy: "inline" | "each" | "group" | "legacy";
+  model: string;
+  activeTurnId?: string;
+  turnStartedAt?: number;
+  messageCounts?: Record<string, number>;
+}
+
+export interface PersistedTelemetrySession {
+  correlationId: string;
+  mode: "manual" | "orchestrator" | "orchestrator_v2";
 }
 
 export interface PersistedDeliveryIntent {
@@ -1445,6 +1466,9 @@ export interface InteractiveSubagentStateFile {
   /** Parent pi session id; redundant with the filename but kept for verification/debugging. */
 
   parent: string;
+
+  /** Random logical-session correlation, never a stable install identity. */
+  telemetry?: PersistedTelemetrySession;
 
   states: { [id: string]: InteractiveSubagentPersistedStateV2 };
 }
@@ -1512,6 +1536,26 @@ function migrateStatePayload(
   const rawStates = obj.states;
   const parent =
     typeof obj.parent === "string" && obj.parent.length > 0 ? obj.parent : "pi";
+  const rawTelemetry =
+    obj.telemetry &&
+    typeof obj.telemetry === "object" &&
+    !Array.isArray(obj.telemetry)
+      ? (obj.telemetry as Record<string, unknown>)
+      : undefined;
+  const telemetry: PersistedTelemetrySession | undefined =
+    rawTelemetry &&
+    typeof rawTelemetry.correlationId === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      rawTelemetry.correlationId,
+    ) &&
+    (rawTelemetry.mode === "manual" ||
+      rawTelemetry.mode === "orchestrator" ||
+      rawTelemetry.mode === "orchestrator_v2")
+      ? {
+          correlationId: rawTelemetry.correlationId.toLowerCase(),
+          mode: rawTelemetry.mode,
+        }
+      : undefined;
 
   // Helper: produce a valid states object from an untrusted value.
   const asStates = (
@@ -1720,6 +1764,78 @@ function migrateStatePayload(
               : {}),
           }
         : undefined;
+      const rawEntryTelemetry =
+        entry.telemetry &&
+        typeof entry.telemetry === "object" &&
+        !Array.isArray(entry.telemetry)
+          ? (entry.telemetry as unknown as Record<string, unknown>)
+          : undefined;
+      const entryTelemetry: PersistedInteractiveTelemetry | undefined =
+        rawEntryTelemetry &&
+        typeof rawEntryTelemetry.correlationId === "string" &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          rawEntryTelemetry.correlationId,
+        ) &&
+        (rawEntryTelemetry.invocationSource === "with_context" ||
+          rawEntryTelemetry.invocationSource === "isolated" ||
+          rawEntryTelemetry.invocationSource === "interactive" ||
+          rawEntryTelemetry.invocationSource === "workflow") &&
+        typeof rawEntryTelemetry.async === "boolean" &&
+        (rawEntryTelemetry.depthBucket === "1" ||
+          rawEntryTelemetry.depthBucket === "2" ||
+          rawEntryTelemetry.depthBucket === "3" ||
+          rawEntryTelemetry.depthBucket === "4-7" ||
+          rawEntryTelemetry.depthBucket === "8+" ||
+          rawEntryTelemetry.depthBucket === "unknown") &&
+        (rawEntryTelemetry.completionPolicy === "inline" ||
+          rawEntryTelemetry.completionPolicy === "each" ||
+          rawEntryTelemetry.completionPolicy === "group" ||
+          rawEntryTelemetry.completionPolicy === "legacy") &&
+        typeof rawEntryTelemetry.model === "string" &&
+        rawEntryTelemetry.model.length <= 128
+          ? {
+              correlationId: rawEntryTelemetry.correlationId.toLowerCase(),
+              invocationSource: rawEntryTelemetry.invocationSource,
+              async: rawEntryTelemetry.async,
+              depthBucket: rawEntryTelemetry.depthBucket,
+              completionPolicy: rawEntryTelemetry.completionPolicy,
+              model: sanitizeTelemetryModel(rawEntryTelemetry.model),
+              ...(typeof rawEntryTelemetry.activeTurnId === "string" &&
+              rawEntryTelemetry.activeTurnId.length > 0 &&
+              rawEntryTelemetry.activeTurnId.length <= MAX_TURN_ID_LENGTH &&
+              /^[A-Za-z0-9._:-]+$/.test(rawEntryTelemetry.activeTurnId)
+                ? { activeTurnId: rawEntryTelemetry.activeTurnId }
+                : {}),
+              ...(typeof rawEntryTelemetry.turnStartedAt === "number" &&
+              Number.isFinite(rawEntryTelemetry.turnStartedAt) &&
+              rawEntryTelemetry.turnStartedAt >= 0
+                ? { turnStartedAt: rawEntryTelemetry.turnStartedAt }
+                : {}),
+              ...(rawEntryTelemetry.messageCounts &&
+              typeof rawEntryTelemetry.messageCounts === "object" &&
+              !Array.isArray(rawEntryTelemetry.messageCounts)
+                ? {
+                    messageCounts: Object.fromEntries(
+                      Object.entries(rawEntryTelemetry.messageCounts)
+                        .filter(
+                          ([turnId, count]) =>
+                            turnId.length > 0 &&
+                            turnId.length <= MAX_TURN_ID_LENGTH &&
+                            /^[A-Za-z0-9._:-]+$/.test(turnId) &&
+                            typeof count === "number" &&
+                            Number.isSafeInteger(count) &&
+                            count >= 0,
+                        )
+                        .slice(-32)
+                        .map(([turnId, count]) => [
+                          turnId,
+                          Math.min(count as number, 1_000),
+                        ]),
+                    ),
+                  }
+                : {}),
+            }
+          : undefined;
       migrated[id] = {
         id,
         paneId: entry.paneId,
@@ -1771,6 +1887,7 @@ function migrateStatePayload(
         deliveryReceipts,
         legacyCutoverOffset: cursor(entry.legacyCutoverOffset, cutoverOffset),
         ...(lifecycle ? { lifecycle } : {}),
+        ...(entryTelemetry ? { telemetry: entryTelemetry } : {}),
       };
     }
     return migrated;
@@ -1810,6 +1927,7 @@ function migrateStatePayload(
     return {
       schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
       parent,
+      ...(telemetry ? { telemetry } : {}),
       states: withLegacyCatchup(asStates(rawStates, true)),
     };
   }
@@ -1819,6 +1937,7 @@ function migrateStatePayload(
     return {
       schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
       parent,
+      ...(telemetry ? { telemetry } : {}),
       states: withLegacyCatchup(asStates(rawStates, true)),
     };
   }
@@ -1827,6 +1946,7 @@ function migrateStatePayload(
     return {
       schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
       parent,
+      ...(telemetry ? { telemetry } : {}),
       states: asStates(rawStates, false),
     };
   }
@@ -1837,6 +1957,7 @@ function migrateStatePayload(
     return {
       schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
       parent,
+      ...(telemetry ? { telemetry } : {}),
       states: withLegacyCatchup(asStates(rawStates, true)),
     };
   }
@@ -2097,6 +2218,24 @@ export function appendInteractiveState(
           ? entry.legacyCutoverOffset
           : eventLogEndOffset(art),
     };
+    writeInteractiveStatesUnlocked(cwd, current);
+  });
+}
+
+/** Persist or clear the random logical-session telemetry correlation. */
+export function updatePersistedTelemetrySession(
+  cwd: string,
+  parentSessionId: string,
+  telemetry: PersistedTelemetrySession | undefined,
+): void {
+  withInteractiveStateLock(cwd, () => {
+    const current = loadInteractiveStates(cwd) ?? {
+      schemaVersion: CURRENT_STATE_SCHEMA_VERSION,
+      parent: parentSessionId,
+      states: {},
+    };
+    current.parent = parentSessionId;
+    current.telemetry = telemetry;
     writeInteractiveStatesUnlocked(cwd, current);
   });
 }

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -37,7 +37,7 @@ import { basename, dirname, isAbsolute, join } from "node:path";
 import isPathInside from "is-path-inside";
 import { debugLog } from "./helpers";
 import type { MuxName } from "./multiplexer";
-import { sanitizeTelemetryModel } from "./telemetry";
+import { sanitizeTelemetryModel, type TelemetryMux } from "./telemetry";
 
 /** Current schema version for the interactive state file. */
 export const CURRENT_STATE_SCHEMA_VERSION = 2;
@@ -1403,12 +1403,14 @@ export interface PersistedInteractiveTelemetry {
   correlationId: string;
   invocationSource: "with_context" | "isolated" | "interactive" | "workflow";
   async: boolean;
+  mux: TelemetryMux;
   depth?: number;
   depthBucket: "1" | "2" | "3" | "4-7" | "8+" | "unknown";
   completionPolicy: "inline" | "each" | "group" | "legacy";
   model: string;
   activeTurnId?: string;
   turnStartedAt?: number;
+  messageTurnId?: string;
   messageCounts?: Record<string, number>;
 }
 
@@ -1773,6 +1775,15 @@ function migrateStatePayload(
         !Array.isArray(entry.telemetry)
           ? (entry.telemetry as unknown as Record<string, unknown>)
           : undefined;
+      const telemetryMux: TelemetryMux =
+        rawEntryTelemetry?.mux === "none" ||
+        rawEntryTelemetry?.mux === "tmux" ||
+        rawEntryTelemetry?.mux === "zellij" ||
+        rawEntryTelemetry?.mux === "herdr"
+          ? rawEntryTelemetry.mux
+          : entry.mux === "tmux" || entry.mux === "zellij"
+            ? entry.mux
+            : "none";
       const entryTelemetry: PersistedInteractiveTelemetry | undefined =
         rawEntryTelemetry &&
         typeof rawEntryTelemetry.correlationId === "string" &&
@@ -1800,6 +1811,7 @@ function migrateStatePayload(
               correlationId: rawEntryTelemetry.correlationId.toLowerCase(),
               invocationSource: rawEntryTelemetry.invocationSource,
               async: rawEntryTelemetry.async,
+              mux: telemetryMux,
               ...(typeof rawEntryTelemetry.depth === "number" &&
               Number.isSafeInteger(rawEntryTelemetry.depth) &&
               rawEntryTelemetry.depth >= 1 &&
@@ -1819,6 +1831,12 @@ function migrateStatePayload(
               Number.isFinite(rawEntryTelemetry.turnStartedAt) &&
               rawEntryTelemetry.turnStartedAt >= 0
                 ? { turnStartedAt: rawEntryTelemetry.turnStartedAt }
+                : {}),
+              ...(typeof rawEntryTelemetry.messageTurnId === "string" &&
+              rawEntryTelemetry.messageTurnId.length > 0 &&
+              rawEntryTelemetry.messageTurnId.length <= MAX_TURN_ID_LENGTH &&
+              /^[A-Za-z0-9._:-]+$/.test(rawEntryTelemetry.messageTurnId)
+                ? { messageTurnId: rawEntryTelemetry.messageTurnId }
                 : {}),
               ...(rawEntryTelemetry.messageCounts &&
               typeof rawEntryTelemetry.messageCounts === "object" &&

--- a/src/completion-coordinator.ts
+++ b/src/completion-coordinator.ts
@@ -20,6 +20,7 @@ import {
 } from "./session-scope";
 import { debugLog } from "./helpers";
 import { sendCompletionTurn } from "./completion-turn";
+import { captureTelemetry } from "./telemetry";
 
 export const COMPLETION_ENTRY_TYPE = "subagentura-completion";
 export const COMPLETION_CONSUMED_ENTRY_TYPE = "subagentura-completion-consumed";
@@ -2112,6 +2113,17 @@ export function flushCompletionManifests(owner?: SessionOwnerToken): void {
     scheduleManifestRetry(state);
     return;
   }
+  captureTelemetry(
+    resolveLiveSessionScope(state.owner)?.telemetry,
+    {
+      event: "completion_delivered",
+      delivery: "manifest",
+      count: message.details.completionIds.length,
+    },
+    {
+      dedupeKey: `manifest:${message.details.completionIds.join(":")}`,
+    },
+  );
   state.manifestRetryAttempt = 0;
   state.manifestRetryExhausted = false;
   if (message.details.overflowPath === state.overflow.path) {

--- a/src/completion-coordinator.ts
+++ b/src/completion-coordinator.ts
@@ -20,7 +20,7 @@ import {
 } from "./session-scope";
 import { debugLog } from "./helpers";
 import { sendCompletionTurn } from "./completion-turn";
-import { captureTelemetry } from "./telemetry";
+import { captureTelemetry, manifestDeliveryDedupeKey } from "./telemetry";
 
 export const COMPLETION_ENTRY_TYPE = "subagentura-completion";
 export const COMPLETION_CONSUMED_ENTRY_TYPE = "subagentura-completion-consumed";
@@ -2122,7 +2122,7 @@ export function flushCompletionManifests(owner?: SessionOwnerToken): void {
       count: message.details.completionIds.length,
     },
     {
-      dedupeKey: `manifest:${message.details.completionIds.join(":")}`,
+      dedupeKey: manifestDeliveryDedupeKey(message.details.completionIds),
     },
   );
   state.manifestRetryAttempt = 0;

--- a/src/completion-coordinator.ts
+++ b/src/completion-coordinator.ts
@@ -1949,9 +1949,9 @@ export function consumeCompletionSource(
   pi: ExtensionAPI,
   selector: CompletionConsumptionSelector,
   owner?: SessionOwnerToken,
-): void {
+): boolean {
   const state = getState(owner);
-  if (!state || state.pi !== pi) return;
+  if (!state || state.pi !== pi) return false;
   reconcileState(state);
   const normalizedSourceId = selector.sourceId.slice(0, MAX_SOURCE_ID_LENGTH);
   const normalizedSelector: CompletionConsumptionSelector =
@@ -1968,13 +1968,14 @@ export function consumeCompletionSource(
             turnId: selector.turnId.slice(0, MAX_TURN_ID_LENGTH),
           }
       : { source: selector.source, sourceId: normalizedSourceId };
-  if (fallbackConsumptionMatches(state, normalizedSelector)) return;
+  if (fallbackConsumptionMatches(state, normalizedSelector)) return false;
   appendConsumption(state, {
     schemaVersion: COMPLETION_RECORD_SCHEMA_VERSION,
     ...normalizedSelector,
     consumedAt: Date.now(),
     reason: "manual",
   });
+  return true;
 }
 
 export function markCompletionHumanInput(owner?: SessionOwnerToken): void {

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -44,6 +44,7 @@ import {
 } from "./session-scope";
 import { inProcessJobOwner, inProcessJobsForOwner } from "./helpers";
 import { sendCompletionTurn } from "./completion-turn";
+import { captureTelemetry } from "./telemetry";
 
 export const MAX_DELIVERY_RECORDS = 32;
 export const MAX_DELIVERY_QUEUE_BYTES = 256 * 1024;
@@ -504,6 +505,15 @@ export function flushDeliveries(
   } catch {
     return;
   }
+  captureTelemetry(
+    resolveLiveSessionScope(owner)?.telemetry,
+    {
+      event: "completion_delivered",
+      delivery: "notification",
+      count: deliveryIds.length,
+    },
+    { dedupeKey: `notification:${deliveryIds.join(":")}` },
+  );
   notifyCompletionDelivery(
     ui,
     selected.map(({ state, intent }) => ({

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,6 +49,7 @@ import {
 } from "./session-scope";
 import {
   captureTelemetry,
+  telemetryDepth,
   telemetryDepthBucket,
   type AgentTelemetryContext,
   type TelemetryAgentStatus,
@@ -1155,20 +1156,24 @@ export async function startSubagentJob(
     if (started || disposedBeforeStart) return;
     started = true;
     telemetryStartedAt = Date.now();
-    captureTelemetry(
-      telemetry?.session,
-      {
-        event: "agent_started",
-        execution: "in-process",
-        unit: "job",
-        invocation_source: telemetry?.invocationSource ?? "isolated",
-        model: modelLabel,
-        async: telemetry?.async ?? false,
-        depth_bucket: telemetryDepthBucket(telemetry?.depth),
-        completion_policy: telemetry?.completionPolicy ?? "inline",
-      },
-      { dedupeKey: `agent-started:in-process:${jobId}` },
-    );
+    const telemetryAgentDimensions = {
+      execution: "in-process" as const,
+      invocation_source: telemetry?.invocationSource ?? ("isolated" as const),
+      model: modelLabel,
+      async: telemetry?.async ?? false,
+      depth: telemetryDepth(telemetry?.depth),
+      depth_bucket: telemetryDepthBucket(telemetry?.depth),
+      completion_policy: telemetry?.completionPolicy ?? ("inline" as const),
+    };
+    captureTelemetry(telemetry?.session, {
+      event: "agent_created",
+      ...telemetryAgentDimensions,
+    });
+    captureTelemetry(telemetry?.session, {
+      event: "task_started",
+      ...telemetryAgentDimensions,
+      unit: "job",
+    });
     startGateResolve();
   };
   const disposePreparedSession = (): void => {
@@ -1336,19 +1341,24 @@ export async function startSubagentJob(
         captureTelemetry(
           telemetry?.session,
           {
-            event: "agent_completed",
+            event: "task_completed",
             execution: "in-process",
             unit: "job",
             invocation_source: telemetry?.invocationSource ?? "isolated",
+            model: modelLabel,
+            async: telemetry?.async ?? false,
+            depth: telemetryDepth(telemetry?.depth),
+            depth_bucket: telemetryDepthBucket(telemetry?.depth),
             completion_policy: telemetry?.completionPolicy ?? "inline",
             status,
             duration_ms:
               telemetryStartedAt === undefined
                 ? undefined
                 : Date.now() - telemetryStartedAt,
-            message_count: session.agent.state.messages.length,
+            child_conversation_message_count:
+              session.agent.state.messages.length,
           },
-          { dedupeKey: `agent-completed:in-process:${jobId}` },
+          { allowInactive: true },
         );
       }
       debugLog("info", "job_complete", {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -47,6 +47,12 @@ import {
   ownerlessEntitiesVisible,
   type SessionOwnerToken,
 } from "./session-scope";
+import {
+  captureTelemetry,
+  telemetryDepthBucket,
+  type AgentTelemetryContext,
+  type TelemetryAgentStatus,
+} from "./telemetry";
 // ── Debug Logging ─────────────────────────────────────────────────
 
 const DEBUG_LOG_DIR = process.env.SUBAGENT_DEBUG_LOG_DIR
@@ -805,6 +811,8 @@ export interface StartSubagentJobParams {
   rootSessionId?: string;
   /** Exact parent lifecycle owning registry capacity for this prepared job. */
   owner?: SessionOwnerToken;
+  /** Anonymous lifecycle metadata resolved at the invoking tool boundary. */
+  telemetry?: AgentTelemetryContext;
 }
 
 export interface StartSubagentJobResult {
@@ -852,6 +860,7 @@ export async function startSubagentJob(
     depth,
     rootSessionId,
     owner,
+    telemetry,
   } = params;
 
   // Enforce the cap within this exact scope; peer sessions never evict each other.
@@ -1137,6 +1146,7 @@ export async function startSubagentJob(
   // register the job before any model or tool side effects are possible.
   let startGateResolve!: () => void;
   let started = false;
+  let telemetryStartedAt: number | undefined;
   let disposedBeforeStart = false;
   const startGate = new Promise<void>((resolve) => {
     startGateResolve = resolve;
@@ -1144,6 +1154,21 @@ export async function startSubagentJob(
   const start = (): void => {
     if (started || disposedBeforeStart) return;
     started = true;
+    telemetryStartedAt = Date.now();
+    captureTelemetry(
+      telemetry?.session,
+      {
+        event: "agent_started",
+        execution: "in-process",
+        unit: "job",
+        invocation_source: telemetry?.invocationSource ?? "isolated",
+        model: modelLabel,
+        async: telemetry?.async ?? false,
+        depth_bucket: telemetryDepthBucket(telemetry?.depth),
+        completion_policy: telemetry?.completionPolicy ?? "inline",
+      },
+      { dedupeKey: `agent-started:in-process:${jobId}` },
+    );
     startGateResolve();
   };
   const disposePreparedSession = (): void => {
@@ -1302,6 +1327,30 @@ export async function startSubagentJob(
         errorMessage: msg,
       });
     } finally {
+      if (started) {
+        const status: TelemetryAgentStatus = result.cancelled
+          ? "cancelled"
+          : result.isError
+            ? "error"
+            : "success";
+        captureTelemetry(
+          telemetry?.session,
+          {
+            event: "agent_completed",
+            execution: "in-process",
+            unit: "job",
+            invocation_source: telemetry?.invocationSource ?? "isolated",
+            completion_policy: telemetry?.completionPolicy ?? "inline",
+            status,
+            duration_ms:
+              telemetryStartedAt === undefined
+                ? undefined
+                : Date.now() - telemetryStartedAt,
+            message_count: session.agent.state.messages.length,
+          },
+          { dedupeKey: `agent-completed:in-process:${jobId}` },
+        );
+      }
       debugLog("info", "job_complete", {
         jobId,
         outputLength: result.output.length,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1158,6 +1158,7 @@ export async function startSubagentJob(
     telemetryStartedAt = Date.now();
     const telemetryAgentDimensions = {
       execution: "in-process" as const,
+      mux: "none" as const,
       invocation_source: telemetry?.invocationSource ?? ("isolated" as const),
       model: modelLabel,
       async: telemetry?.async ?? false,
@@ -1343,6 +1344,7 @@ export async function startSubagentJob(
           {
             event: "task_completed",
             execution: "in-process",
+            mux: "none",
             unit: "job",
             invocation_source: telemetry?.invocationSource ?? "isolated",
             model: modelLabel,

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -591,22 +591,7 @@ export function launchInteractiveSubagent(params: {
   const nextDepth = effectiveCurrentDepth + 1;
   const liveScope =
     params.sessionScope ?? resolveLiveSessionScope(params.supervisorOwner);
-  const telemetry = liveScope?.telemetry;
-  const telemetryMetadata = telemetry?.enabled
-    ? {
-        correlationId: telemetry.correlationId,
-        invocationSource:
-          params.telemetryInvocationSource ?? ("interactive" as const),
-        async: params.telemetryAsync ?? true,
-        depth: telemetryDepth(nextDepth),
-        depthBucket: telemetryDepthBucket(nextDepth),
-        completionPolicy:
-          params.telemetryCompletionPolicy ??
-          params.completionPolicy ??
-          ("legacy" as const),
-        model: sanitizeTelemetryModel(params.model),
-      }
-    : undefined;
+
   if (rootId && nextDepth > effectiveMaxDepth) {
     throw new Error(
       `interactive sub-agent depth ${nextDepth} exceeds max ${effectiveMaxDepth}`,
@@ -698,6 +683,24 @@ export function launchInteractiveSubagent(params: {
     }
     throw err;
   }
+
+  const telemetry = liveScope?.telemetry;
+  const telemetryMetadata = telemetry?.enabled
+    ? {
+        correlationId: telemetry.correlationId,
+        mux: mux.name,
+        invocationSource:
+          params.telemetryInvocationSource ?? ("interactive" as const),
+        async: params.telemetryAsync ?? true,
+        depth: telemetryDepth(nextDepth),
+        depthBucket: telemetryDepthBucket(nextDepth),
+        completionPolicy:
+          params.telemetryCompletionPolicy ??
+          params.completionPolicy ??
+          ("legacy" as const),
+        model: sanitizeTelemetryModel(params.model),
+      }
+    : undefined;
 
   // Create the pane FIRST (so we have a target for the launch script to attach
   // to). If any later step throws, try to kill the orphan pane and rethrow.
@@ -901,6 +904,7 @@ export function launchInteractiveSubagent(params: {
     captureTelemetry(telemetry, {
       event: "agent_created",
       execution: "interactive",
+      mux: telemetryMetadata.mux,
       invocation_source: telemetryMetadata.invocationSource,
       model: telemetryMetadata.model,
       async: telemetryMetadata.async,

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -94,6 +94,14 @@ import {
   writeLineageBootstrap,
   type ParsedSpawnTreeContext,
 } from "./spawn-tree-context";
+import { TELEMETRY_ENV } from "./settings";
+import {
+  sanitizeTelemetryModel,
+  telemetryDepthBucket,
+  type TelemetryCompletionPolicy,
+  type TelemetryDepthBucket,
+  type TelemetryInvocationSource,
+} from "./telemetry";
 
 // Re-export the tmux-specific `readPaneExitCode` for the test suite. The
 // launch script's EXIT trap still writes the @pi-exit-code pane option
@@ -219,6 +227,21 @@ export interface InteractiveSubagentState {
   completionOwner?: "standalone" | "workflow";
   /** Workflow-runner acknowledgement that this child's result was consumed; runtime-only and intentionally not persisted. */
   workflowResultConsumed?: boolean;
+  /** Matching logical-session correlation gates telemetry after rehydrate. */
+  telemetryCorrelationId?: string;
+  telemetryEligible?: boolean;
+  /** Runtime-only turn identity; a completion is emitted only after its start. */
+  telemetryActiveTurnId?: string;
+  /** Runtime-only start of the currently observed child turn. */
+  telemetryTurnStartedAt?: number;
+  /** Runtime-only bounded per-turn message counts keyed by Pi user-entry id. */
+  telemetryTurnMessageCounts?: Map<string, number>;
+  telemetryMessageTurnId?: string;
+  telemetryInvocationSource?: TelemetryInvocationSource;
+  telemetryCompletionPolicy?: TelemetryCompletionPolicy;
+  telemetryAsync?: boolean;
+  telemetryDepthBucket?: TelemetryDepthBucket;
+  telemetryModel?: string;
   model?: string;
   startedAt: number;
   /**
@@ -537,6 +560,12 @@ export function launchInteractiveSubagent(params: {
   parentCwd?: string;
   /** Thinking/reasoning level for the child Pi process. */
   thinkingLevel?: ThinkingLevel;
+  /** Closed telemetry source; never derived from user-authored names. */
+  telemetryInvocationSource?: TelemetryInvocationSource;
+  /** Whether the invoking parent operation runs in the background. */
+  telemetryAsync?: boolean;
+  /** Aggregate policy attributed to workflow-owned child execution. */
+  telemetryCompletionPolicy?: TelemetryCompletionPolicy;
 }): InteractiveSubagentState {
   // 8 bytes, not 4: at 32 bits a birthday collision inside one tree is not
   // remote, and the duplicate-id path only degrades gracefully — it does not
@@ -557,6 +586,23 @@ export function launchInteractiveSubagent(params: {
   const effectiveCurrentDepth = spawnTreeContext?.depth ?? 0;
   const effectiveMaxDepth = spawnTreeContext?.maxDepth ?? DEFAULT_MAX_DEPTH;
   const nextDepth = effectiveCurrentDepth + 1;
+  const liveScope =
+    params.sessionScope ?? resolveLiveSessionScope(params.supervisorOwner);
+  const telemetry = liveScope?.telemetry;
+  const telemetryMetadata = telemetry?.enabled
+    ? {
+        correlationId: telemetry.correlationId,
+        invocationSource:
+          params.telemetryInvocationSource ?? ("interactive" as const),
+        async: params.telemetryAsync ?? true,
+        depthBucket: telemetryDepthBucket(nextDepth),
+        completionPolicy:
+          params.telemetryCompletionPolicy ??
+          params.completionPolicy ??
+          ("legacy" as const),
+        model: sanitizeTelemetryModel(params.model),
+      }
+    : undefined;
   if (rootId && nextDepth > effectiveMaxDepth) {
     throw new Error(
       `interactive sub-agent depth ${nextDepth} exceeds max ${effectiveMaxDepth}`,
@@ -690,6 +736,7 @@ export function launchInteractiveSubagent(params: {
         sessionByteCursor: 0,
         pendingDeliveries: [],
         deliveryReceipts: [],
+        ...(telemetryMetadata ? { telemetry: telemetryMetadata } : {}),
       });
       persistedState = true;
     } catch (err) {
@@ -762,6 +809,7 @@ export function launchInteractiveSubagent(params: {
       ...(lineageBootstrapPath
         ? { [LINEAGE_BOOTSTRAP_ENV]: lineageBootstrapPath }
         : {}),
+      ...(!telemetry?.enabled ? { [TELEMETRY_ENV]: "0" } : {}),
     });
     const escape = (v: string) => `'${v.replace(/'/g, `'\\''`)}'`;
     mux.sendKeys(
@@ -834,11 +882,16 @@ export function launchInteractiveSubagent(params: {
     eventByteCursor: 0,
     pendingDeliveries: [],
     deliveryReceipts: [],
+    telemetryCorrelationId: telemetryMetadata?.correlationId,
+    telemetryEligible: telemetryMetadata !== undefined,
+    telemetryTurnMessageCounts: new Map(),
+    telemetryInvocationSource: telemetryMetadata?.invocationSource,
+    telemetryCompletionPolicy: telemetryMetadata?.completionPolicy,
+    telemetryAsync: telemetryMetadata?.async,
+    telemetryDepthBucket: telemetryMetadata?.depthBucket,
+    telemetryModel: telemetryMetadata?.model,
   };
-  registerInteractiveSubagentState(
-    state,
-    params.sessionScope ?? resolveLiveSessionScope(params.supervisorOwner),
-  );
+  registerInteractiveSubagentState(state, liveScope);
   return state;
 }
 

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -96,7 +96,9 @@ import {
 } from "./spawn-tree-context";
 import { TELEMETRY_ENV } from "./settings";
 import {
+  captureTelemetry,
   sanitizeTelemetryModel,
+  telemetryDepth,
   telemetryDepthBucket,
   type TelemetryCompletionPolicy,
   type TelemetryDepthBucket,
@@ -240,6 +242,7 @@ export interface InteractiveSubagentState {
   telemetryInvocationSource?: TelemetryInvocationSource;
   telemetryCompletionPolicy?: TelemetryCompletionPolicy;
   telemetryAsync?: boolean;
+  telemetryDepth?: number;
   telemetryDepthBucket?: TelemetryDepthBucket;
   telemetryModel?: string;
   model?: string;
@@ -595,6 +598,7 @@ export function launchInteractiveSubagent(params: {
         invocationSource:
           params.telemetryInvocationSource ?? ("interactive" as const),
         async: params.telemetryAsync ?? true,
+        depth: telemetryDepth(nextDepth),
         depthBucket: telemetryDepthBucket(nextDepth),
         completionPolicy:
           params.telemetryCompletionPolicy ??
@@ -888,10 +892,23 @@ export function launchInteractiveSubagent(params: {
     telemetryInvocationSource: telemetryMetadata?.invocationSource,
     telemetryCompletionPolicy: telemetryMetadata?.completionPolicy,
     telemetryAsync: telemetryMetadata?.async,
+    telemetryDepth: telemetryMetadata?.depth,
     telemetryDepthBucket: telemetryMetadata?.depthBucket,
     telemetryModel: telemetryMetadata?.model,
   };
   registerInteractiveSubagentState(state, liveScope);
+  if (telemetryMetadata) {
+    captureTelemetry(telemetry, {
+      event: "agent_created",
+      execution: "interactive",
+      invocation_source: telemetryMetadata.invocationSource,
+      model: telemetryMetadata.model,
+      async: telemetryMetadata.async,
+      depth: telemetryMetadata.depth,
+      depth_bucket: telemetryMetadata.depthBucket,
+      completion_policy: telemetryMetadata.completionPolicy,
+    });
+  }
   return state;
 }
 

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -28,6 +28,7 @@ import {
   type SessionOwnerToken,
 } from "./session-scope";
 import { isOrchestratorV2Enabled, sendCompletionTurn } from "./completion-turn";
+import { captureTelemetry } from "./telemetry";
 interface NotificationGlobalState {
   __piSubagenturaPiRef?: ExtensionAPI;
   __piSubagenturaUi?: CompletionNotificationUi;
@@ -696,6 +697,15 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
   } catch {
     return;
   }
+  captureTelemetry(
+    resolveLiveSessionScope(effectiveOwner)?.telemetry,
+    {
+      event: "completion_delivered",
+      delivery: "notification",
+      count: deliveryIds.length,
+    },
+    { dedupeKey: `notification:${deliveryIds.join(":")}` },
+  );
   notifyCompletionDelivery(
     target.ui,
     llm.map(({ pending, mode, trigger, status }) => ({

--- a/src/rehydrate.ts
+++ b/src/rehydrate.ts
@@ -245,6 +245,14 @@ export function rehydrateInteractiveSubagents(
       }
     })();
 
+    const telemetryEligible =
+      entry.telemetry !== undefined &&
+      payload.telemetry?.correlationId === entry.telemetry.correlationId &&
+      scope?.telemetry?.correlationId === entry.telemetry.correlationId;
+    const telemetryActiveTurnId =
+      telemetryEligible && entry.telemetry?.turnStartedAt !== undefined
+        ? entry.telemetry.activeTurnId
+        : undefined;
     const rehydrated: InteractiveSubagentState = {
       id: entry.id,
       name: recoveredName,
@@ -275,6 +283,21 @@ export function rehydrateInteractiveSubagents(
       pendingDeliveries: [...entry.pendingDeliveries],
       deliveryReceipts: [...entry.deliveryReceipts],
       lifecycle: entry.lifecycle ? { ...entry.lifecycle } : {},
+      telemetryCorrelationId: entry.telemetry?.correlationId,
+      telemetryEligible,
+      telemetryActiveTurnId,
+      telemetryTurnStartedAt: telemetryActiveTurnId
+        ? entry.telemetry?.turnStartedAt
+        : undefined,
+      telemetryTurnMessageCounts: telemetryEligible
+        ? new Map(Object.entries(entry.telemetry?.messageCounts ?? {}))
+        : undefined,
+      telemetryMessageTurnId: telemetryActiveTurnId,
+      telemetryInvocationSource: entry.telemetry?.invocationSource,
+      telemetryCompletionPolicy: entry.telemetry?.completionPolicy,
+      telemetryAsync: entry.telemetry?.async,
+      telemetryDepthBucket: entry.telemetry?.depthBucket,
+      telemetryModel: entry.telemetry?.model,
       // Legacy timestamp fields remain for API compatibility only.
       lastDeliveredEventTs: undefined,
       lastInjectedEventTs: undefined,

--- a/src/rehydrate.ts
+++ b/src/rehydrate.ts
@@ -253,6 +253,10 @@ export function rehydrateInteractiveSubagents(
       telemetryEligible && entry.telemetry?.turnStartedAt !== undefined
         ? entry.telemetry.activeTurnId
         : undefined;
+    const telemetryMessageTurnId =
+      telemetryActiveTurnId === undefined
+        ? undefined
+        : (entry.telemetry?.messageTurnId ?? telemetryActiveTurnId);
     const rehydrated: InteractiveSubagentState = {
       id: entry.id,
       name: recoveredName,
@@ -292,7 +296,7 @@ export function rehydrateInteractiveSubagents(
       telemetryTurnMessageCounts: telemetryEligible
         ? new Map(Object.entries(entry.telemetry?.messageCounts ?? {}))
         : undefined,
-      telemetryMessageTurnId: telemetryActiveTurnId,
+      telemetryMessageTurnId,
       telemetryInvocationSource: entry.telemetry?.invocationSource,
       telemetryCompletionPolicy: entry.telemetry?.completionPolicy,
       telemetryAsync: entry.telemetry?.async,

--- a/src/rehydrate.ts
+++ b/src/rehydrate.ts
@@ -296,6 +296,7 @@ export function rehydrateInteractiveSubagents(
       telemetryInvocationSource: entry.telemetry?.invocationSource,
       telemetryCompletionPolicy: entry.telemetry?.completionPolicy,
       telemetryAsync: entry.telemetry?.async,
+      telemetryDepth: entry.telemetry?.depth,
       telemetryDepthBucket: entry.telemetry?.depthBucket,
       telemetryModel: entry.telemetry?.model,
       // Legacy timestamp fields remain for API compatibility only.

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -199,13 +199,19 @@ function captureInteractiveLifecycleCancellation(
     return;
   }
   const turnStartedAt = state.telemetryTurnStartedAt;
-  const messageCount = state.telemetryTurnMessageCounts?.get(turnId);
+  const messageTurnId = state.telemetryMessageTurnId;
+  const messageCount =
+    state.telemetryTurnMessageCounts?.get(turnId) ??
+    (messageTurnId === undefined
+      ? undefined
+      : state.telemetryTurnMessageCounts?.get(messageTurnId));
   state.telemetryActiveTurnId = undefined;
   state.telemetryTurnStartedAt = undefined;
   state.telemetryTurnMessageCounts?.delete(turnId);
-  if (state.telemetryMessageTurnId === turnId) {
-    state.telemetryMessageTurnId = undefined;
+  if (messageTurnId !== undefined && messageTurnId !== turnId) {
+    state.telemetryTurnMessageCounts?.delete(messageTurnId);
   }
+  state.telemetryMessageTurnId = undefined;
   try {
     updateInteractiveStates(state.cwd, [
       {
@@ -219,8 +225,12 @@ function captureInteractiveLifecycleCancellation(
           }
           delete entry.telemetry.activeTurnId;
           delete entry.telemetry.turnStartedAt;
+          delete entry.telemetry.messageTurnId;
           if (entry.telemetry.messageCounts) {
             delete entry.telemetry.messageCounts[turnId];
+            if (messageTurnId !== undefined && messageTurnId !== turnId) {
+              delete entry.telemetry.messageCounts[messageTurnId];
+            }
             if (Object.keys(entry.telemetry.messageCounts).length === 0) {
               delete entry.telemetry.messageCounts;
             }
@@ -236,6 +246,7 @@ function captureInteractiveLifecycleCancellation(
     {
       event: "task_completed",
       execution: "interactive",
+      mux: state.mux,
       unit: "turn",
       invocation_source: state.telemetryInvocationSource ?? "interactive",
       model: state.telemetryModel,

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -7,7 +7,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   deleteInteractiveStatesFile,
+  loadInteractiveStates,
   removeInteractiveState,
+  updatePersistedTelemetrySession,
 } from "./artifact";
 import {
   updateRunningSubagentFooter,
@@ -70,6 +72,13 @@ import {
   settleCompletionTurnWake,
 } from "./completion-turn";
 import { readExtensionSettings } from "./settings";
+import { isTelemetryEnabled } from "./settings";
+import {
+  captureTelemetry,
+  createTelemetrySession,
+  retireTelemetrySession,
+  resolveTelemetryMode,
+} from "./telemetry";
 
 function getGlobalState() {
   return typeof global !== "undefined" ? global : globalThis;
@@ -79,6 +88,23 @@ function logSessionError(event: string, error: unknown): void {
   const message =
     error instanceof Error ? (error.stack ?? error.message) : String(error);
   debugLog("error", event, { error: message });
+}
+
+function recordPreparedManifest(
+  scope: SessionScope,
+  message: { details?: { completionIds?: string[] } },
+): void {
+  const completionIds = message.details?.completionIds ?? [];
+  if (completionIds.length === 0) return;
+  captureTelemetry(
+    scope.telemetry,
+    {
+      event: "completion_delivered",
+      delivery: "manifest",
+      count: completionIds.length,
+    },
+    { dedupeKey: `manifest:${completionIds.join(":")}` },
+  );
 }
 
 function isInMemoryWorkflowPane(state: InteractiveSubagentState): boolean {
@@ -260,6 +286,7 @@ export function registerSessionHandlers(
     markCompletionTurnWakeStarted(pi, event.prompt);
     markCompletionTurnStarting(owner);
     const message = prepareCompletionManifest(owner);
+    if (message) recordPreparedManifest(scope, message);
     return message ? { message } : undefined;
   });
   pi.on("agent_start", () => {
@@ -282,8 +309,14 @@ export function registerSessionHandlers(
     // A replacement session must never inherit an old wake request or its
     // watchdog while branch recovery reconstructs durable state.
     clearCompletionTurnWake(pi);
+    const continuityReason =
+      event.reason === "startup" ||
+      event.reason === "reload" ||
+      event.reason === "resume";
+    const previousTelemetry = scope.telemetry;
     if (scope.lifecycle === "started") {
       const previousOwner = sessionOwner(scope);
+      retireTelemetrySession(scope.telemetry);
       closeActiveInteractiveSupervisor(previousOwner);
       clearSessionParsers(previousOwner);
       cleanupScopeGeneration(scope, previousOwner, event, "session_start", ctx);
@@ -304,6 +337,66 @@ export function registerSessionHandlers(
     const sessionId = ctx.sessionManager?.getSessionId?.();
     const orchestratorMode = isOrchestratorMode(pi);
     const orchestratorV2Mode = isOrchestratorV2Enabled(pi);
+    const isChild =
+      !allowRootLineage || process.env.PI_SUBAGENTURA_CHILD === "1";
+    const persisted =
+      allowRootLineage && continuityReason
+        ? loadInteractiveStates(ctx.cwd)
+        : undefined;
+    const persistedTelemetry =
+      persisted && sessionId && persisted.parent === sessionId
+        ? persisted.telemetry
+        : undefined;
+    const activeSpawnTelemetry =
+      scope.spawnTreeContext?.role === "descendant"
+        ? {
+            correlationId: scope.spawnTreeContext.telemetrySessionId,
+            mode: scope.spawnTreeContext.telemetryMode,
+          }
+        : undefined;
+    const recoveredTelemetry = continuityReason
+      ? previousTelemetry?.correlationId
+        ? {
+            correlationId: previousTelemetry.correlationId,
+            mode: previousTelemetry.mode,
+          }
+        : (persistedTelemetry ??
+          (activeSpawnTelemetry?.correlationId && activeSpawnTelemetry.mode
+            ? {
+                correlationId: activeSpawnTelemetry.correlationId,
+                mode: activeSpawnTelemetry.mode,
+              }
+            : undefined))
+      : undefined;
+    const mode =
+      recoveredTelemetry?.mode ??
+      (isChild
+        ? (activeSpawnTelemetry?.mode ?? "manual")
+        : resolveTelemetryMode(orchestratorMode, orchestratorV2Mode));
+    scope.telemetry = createTelemetrySession(
+      isTelemetryEnabled(pi),
+      mode,
+      recoveredTelemetry?.correlationId,
+    );
+    if (!isChild && recoveredTelemetry === undefined) {
+      captureTelemetry(scope.telemetry, { event: "session_started" });
+    }
+    if (allowRootLineage && sessionId) {
+      try {
+        updatePersistedTelemetrySession(
+          ctx.cwd,
+          sessionId,
+          scope.telemetry.enabled
+            ? {
+                correlationId: scope.telemetry.correlationId,
+                mode: scope.telemetry.mode,
+              }
+            : undefined,
+        );
+      } catch (error) {
+        logSessionError("telemetry_session_persist_failed", error);
+      }
+    }
     if (
       allowRootLineage &&
       sessionId &&
@@ -316,6 +409,8 @@ export function registerSessionHandlers(
         orchestratorMode,
         orchestratorV2Mode,
         maxDepth,
+        scope.telemetry.enabled ? scope.telemetry.correlationId : undefined,
+        scope.telemetry.mode,
       );
     }
     scope.isParentIdle =
@@ -372,6 +467,7 @@ export function registerSessionHandlers(
       if (scope.lifecycle !== "started") return;
 
       const owner = sessionOwner(scope);
+      retireTelemetrySession(scope.telemetry);
       closeActiveInteractiveSupervisor(owner);
       clearSessionParsers(owner);
       cleanupScopeGeneration(scope, owner, event, "session_shutdown", ctx);

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -9,6 +9,7 @@ import {
   deleteInteractiveStatesFile,
   loadInteractiveStates,
   removeInteractiveState,
+  updateInteractiveStates,
   updatePersistedTelemetrySession,
 } from "./artifact";
 import {
@@ -184,6 +185,76 @@ function cancellationLifecycleReason(reason: string | undefined) {
   }
 }
 
+function captureInteractiveLifecycleCancellation(
+  scope: SessionScope,
+  state: InteractiveSubagentState,
+): void {
+  const telemetry = scope.telemetry;
+  const turnId = state.telemetryActiveTurnId;
+  if (
+    !turnId ||
+    !telemetry ||
+    state.telemetryCorrelationId !== telemetry.correlationId
+  ) {
+    return;
+  }
+  const turnStartedAt = state.telemetryTurnStartedAt;
+  const messageCount = state.telemetryTurnMessageCounts?.get(turnId);
+  state.telemetryActiveTurnId = undefined;
+  state.telemetryTurnStartedAt = undefined;
+  state.telemetryTurnMessageCounts?.delete(turnId);
+  if (state.telemetryMessageTurnId === turnId) {
+    state.telemetryMessageTurnId = undefined;
+  }
+  try {
+    updateInteractiveStates(state.cwd, [
+      {
+        id: state.id,
+        update: (entry) => {
+          if (
+            entry.telemetry?.correlationId !== telemetry.correlationId ||
+            entry.telemetry.activeTurnId !== turnId
+          ) {
+            return;
+          }
+          delete entry.telemetry.activeTurnId;
+          delete entry.telemetry.turnStartedAt;
+          if (entry.telemetry.messageCounts) {
+            delete entry.telemetry.messageCounts[turnId];
+            if (Object.keys(entry.telemetry.messageCounts).length === 0) {
+              delete entry.telemetry.messageCounts;
+            }
+          }
+        },
+      },
+    ]);
+  } catch {
+    /* best effort; lifecycle cleanup must continue if state persistence fails */
+  }
+  captureTelemetry(
+    telemetry,
+    {
+      event: "task_completed",
+      execution: "interactive",
+      unit: "turn",
+      invocation_source: state.telemetryInvocationSource ?? "interactive",
+      model: state.telemetryModel,
+      async: state.telemetryAsync ?? true,
+      depth: state.telemetryDepth,
+      depth_bucket: state.telemetryDepthBucket ?? "unknown",
+      completion_policy: state.telemetryCompletionPolicy ?? "legacy",
+      status: "cancelled",
+      duration_ms:
+        turnStartedAt === undefined ? undefined : Date.now() - turnStartedAt,
+      child_conversation_message_count: messageCount,
+    },
+    {
+      allowInactive: true,
+      dedupeKey: `task-completed:interactive:${state.id}:${turnId}`,
+    },
+  );
+}
+
 function clearFreshChildLineage(
   scope: SessionScope,
   reason: string | undefined,
@@ -214,14 +285,19 @@ function cleanupScopeGeneration(
   const destroysStandalonePanes =
     event?.reason === "new" || event?.reason === "fork";
   for (const state of [...scope.interactiveStates.values()]) {
-    removeInteractiveSubagentState(state);
-    if (destroysStandalonePanes) retireLineageBootstraps(state.artifactDir);
-    if (
-      (destroysStandalonePanes || isInMemoryWorkflowPane(state)) &&
+    const destroysPane =
+      destroysStandalonePanes || isInMemoryWorkflowPane(state);
+    const cancelsActivePane =
+      destroysPane &&
       (state.status === "running" ||
         state.status === "idle" ||
-        state.status === "unknown")
-    ) {
+        state.status === "unknown");
+    if (destroysPane) {
+      captureInteractiveLifecycleCancellation(scope, state);
+    }
+    removeInteractiveSubagentState(state);
+    if (destroysStandalonePanes) retireLineageBootstraps(state.artifactDir);
+    if (cancelsActivePane) {
       try {
         cancelInteractiveSubagentByState(state, {
           origin: lifecycleOrigin,
@@ -371,7 +447,7 @@ export function registerSessionHandlers(
     const mode =
       recoveredTelemetry?.mode ??
       (isChild
-        ? (activeSpawnTelemetry?.mode ?? "manual")
+        ? (activeSpawnTelemetry?.mode ?? "straight")
         : resolveTelemetryMode(orchestratorMode, orchestratorV2Mode));
     scope.telemetry = createTelemetrySession(
       isTelemetryEnabled(pi),

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -7,6 +7,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   deleteInteractiveStatesFile,
+  hasPersistedTelemetryField,
   loadInteractiveStates,
   removeInteractiveState,
   updateInteractiveStates,
@@ -58,6 +59,7 @@ import {
   getStartedSessionScopes,
   registerSessionScope,
   removeSessionScope,
+  resolveLiveSessionScope,
   sessionOwner,
   setLegacyActiveSessionRefs,
   type SessionOwnerToken,
@@ -77,6 +79,7 @@ import { isTelemetryEnabled } from "./settings";
 import {
   captureTelemetry,
   createTelemetrySession,
+  manifestDeliveryDedupeKey,
   retireTelemetrySession,
   resolveTelemetryMode,
 } from "./telemetry";
@@ -97,14 +100,17 @@ function recordPreparedManifest(
 ): void {
   const completionIds = message.details?.completionIds ?? [];
   if (completionIds.length === 0) return;
+  // The completion coordinator emits the same event for the same manifest.
+  // Both sites must resolve the live scope the same way, or the shared dedupe
+  // key lands in two different key sets and one delivery is counted twice.
   captureTelemetry(
-    scope.telemetry,
+    resolveLiveSessionScope(sessionOwner(scope))?.telemetry,
     {
       event: "completion_delivered",
       delivery: "manifest",
       count: completionIds.length,
     },
-    { dedupeKey: `manifest:${completionIds.join(":")}` },
+    { dedupeKey: manifestDeliveryDedupeKey(completionIds) },
   );
 }
 
@@ -255,6 +261,10 @@ function captureInteractiveLifecycleCancellation(
       depth_bucket: state.telemetryDepthBucket ?? "unknown",
       completion_policy: state.telemetryCompletionPolicy ?? "legacy",
       status: "cancelled",
+      // `turnStartedAt` is an event-log `ts`, which the child writes from the
+      // same epoch clock, so this subtraction stays in one clock domain. A
+      // recovered timestamp from an old run can still be arbitrarily stale;
+      // `telemetryDurationMs` drops the result instead of reporting it.
       duration_ms:
         turnStartedAt === undefined ? undefined : Date.now() - turnStartedAt,
       child_conversation_message_count: messageCount,
@@ -350,6 +360,13 @@ export function registerSessionHandlers(
   pi: ExtensionAPI,
   initialSpawnTreeContext?: ParsedSpawnTreeContext,
   allowRootLineage = true,
+  /**
+   * Injection seam for the opt-in decision. Production always resolves it from
+   * settings; tests override it because `isTelemetryEnabled` is unconditionally
+   * false under vitest, which would otherwise leave every enabled-telemetry
+   * branch below unreachable.
+   */
+  resolveTelemetryEnabled: (pi: ExtensionAPI) => boolean = isTelemetryEnabled,
 ): SessionScope {
   const scope = createSessionScope(
     pi,
@@ -461,14 +478,22 @@ export function registerSessionHandlers(
         ? (activeSpawnTelemetry?.mode ?? "straight")
         : resolveTelemetryMode(orchestratorMode, orchestratorV2Mode));
     scope.telemetry = createTelemetrySession(
-      isTelemetryEnabled(pi),
+      resolveTelemetryEnabled(pi),
       mode,
       recoveredTelemetry?.correlationId,
     );
     if (!isChild && recoveredTelemetry === undefined) {
       captureTelemetry(scope.telemetry, { event: "session_started" });
     }
-    if (allowRootLineage && sessionId) {
+    // With telemetry off there is nothing to persist, so touching `.pi/`, the
+    // state lock, and the state file would make the opt-out observable. The one
+    // exception is a correlation an earlier opted-in run left behind: that has
+    // to be cleared.
+    if (
+      allowRootLineage &&
+      sessionId &&
+      (scope.telemetry.enabled || hasPersistedTelemetryField(ctx.cwd))
+    ) {
       try {
         updatePersistedTelemetrySession(
           ctx.cwd,

--- a/src/session-scope.ts
+++ b/src/session-scope.ts
@@ -6,6 +6,7 @@ import type { JobState } from "./helpers";
 import type { InteractiveSubagentState } from "./interactive-tmux";
 import type { ParsedSpawnTreeContext } from "./spawn-tree-context";
 import type { PendingJobDelivery } from "./notifications";
+import type { TelemetrySession } from "./telemetry";
 
 const SESSION_SCOPE_REGISTRY_KEY = "__piSubagenturaSessionScopes";
 const SESSION_SCOPE_ID_COUNTER_KEY = "__piSubagenturaSessionScopeIdCounter";
@@ -38,6 +39,8 @@ export interface SessionScope {
   inProcessJobs: Map<string, JobState>;
   pendingInProcessDeliveries: PendingJobDelivery[];
   interactiveStates: Map<string, InteractiveSubagentState>;
+  /** Anonymous correlation state for this exact lifecycle generation. */
+  telemetry?: TelemetrySession;
 }
 
 /** External registrations may omit runtime-owned collections and streaming state. */
@@ -56,6 +59,7 @@ export interface SessionScopeRegistration {
   inProcessJobs?: Map<string, JobState>;
   pendingInProcessDeliveries?: PendingJobDelivery[];
   interactiveStates?: Map<string, InteractiveSubagentState>;
+  telemetry?: TelemetrySession;
 }
 
 export interface SessionOwnerToken {
@@ -123,6 +127,7 @@ export function createSessionScope(
     inProcessJobs: new Map(),
     pendingInProcessDeliveries: [],
     interactiveStates: new Map(),
+    telemetry: undefined,
   };
 }
 
@@ -180,6 +185,9 @@ export function registerSessionScope(
     if (registration.interactiveStates !== undefined) {
       existing.interactiveStates = registration.interactiveStates;
     }
+    if (Object.hasOwn(registration, "telemetry")) {
+      existing.telemetry = registration.telemetry;
+    }
     return existing;
   }
 
@@ -201,6 +209,7 @@ export function registerSessionScope(
         pendingInProcessDeliveries:
           registration.pendingInProcessDeliveries ?? [],
         interactiveStates: registration.interactiveStates ?? new Map(),
+        telemetry: registration.telemetry,
       };
   registry.set(scope.id, scope);
   return scope;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -80,19 +80,48 @@ export function isAgentListHidden(pi: ExtensionAPI): boolean {
   return readExtensionSettings(pi).hideAgentList;
 }
 
-function envDisablesTelemetry(name: string): boolean {
+/**
+ * Reads as "false" for switches where a false answer costs nothing: the product
+ * switch (`PI_SUBAGENTURA_TELEMETRY`, where false means "do not send") and the
+ * environment probes (`CI`, `VITEST`, where false only means "not that
+ * environment"). Being generous here makes the opt-out easier to hit and the
+ * environment detection harder to trip by accident.
+ */
+const PERMISSIVE_FALSY_VALUES = new Set(["0", "false", "off", "no"]);
+
+/**
+ * `DO_NOT_TRACK` and `PI_OFFLINE` have the opposite polarity: setting them IS
+ * the opt-out, so a value this code fails to recognize must keep telemetry off,
+ * not turn it on. Only the two unambiguous negations cancel them — reading
+ * `DO_NOT_TRACK=off` as "do track" would silently convert a privacy request
+ * into consent.
+ */
+const OPT_OUT_FALSY_VALUES = new Set(["0", "false"]);
+
+/** Normalized switch value; unset and empty are both "no decision". */
+function envSwitchValue(name: string): string | undefined {
   const value = process.env[name]?.trim().toLowerCase();
-  return (
-    value !== undefined && value !== "" && value !== "0" && value !== "false"
-  );
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/** True when the switch is set to anything outside its own falsy vocabulary. */
+function envSwitchIsTruthy(name: string, falsy: ReadonlySet<string>): boolean {
+  const value = envSwitchValue(name);
+  return value !== undefined && !falsy.has(value);
 }
 
 export function isTelemetryEnabled(pi: ExtensionAPI): boolean {
-  if (process.env[TELEMETRY_ENV] === "0") return false;
-  if (envDisablesTelemetry("DO_NOT_TRACK")) return false;
-  if (envDisablesTelemetry("PI_OFFLINE")) return false;
-  if (envDisablesTelemetry("CI")) return false;
-  if (envDisablesTelemetry("VITEST")) return false;
+  const productSwitch = envSwitchValue(TELEMETRY_ENV);
+  if (
+    productSwitch !== undefined &&
+    PERMISSIVE_FALSY_VALUES.has(productSwitch)
+  ) {
+    return false;
+  }
+  if (envSwitchIsTruthy("DO_NOT_TRACK", OPT_OUT_FALSY_VALUES)) return false;
+  if (envSwitchIsTruthy("PI_OFFLINE", OPT_OUT_FALSY_VALUES)) return false;
+  if (envSwitchIsTruthy("CI", PERMISSIVE_FALSY_VALUES)) return false;
+  if (envSwitchIsTruthy("VITEST", PERMISSIVE_FALSY_VALUES)) return false;
   if (process.env.NODE_ENV === "test") return false;
   if (readFlag(pi, TELEMETRY_OPT_OUT_FLAG) === true) return false;
   return readFlag(pi, TELEMETRY_FLAG) !== false;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export const MAX_DEPTH_FLAG = "subagentura-max-depth";
 export const HIDE_AGENT_LIST_FLAG = "subagentura-hide-agent-list";
+export const TELEMETRY_FLAG = "subagentura-telemetry";
+export const TELEMETRY_ENV = "PI_SUBAGENTURA_TELEMETRY";
 export const DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH = 2;
 const MAX_CONFIGURED_DEPTH = 64;
 
@@ -21,6 +23,11 @@ export function registerExtensionSettings(pi: ExtensionAPI): void {
     description: "Hide compact per-agent activity widget rows",
     type: "boolean",
     default: false,
+  });
+  pi.registerFlag(TELEMETRY_FLAG, {
+    description: "Send anonymous session-level product analytics",
+    type: "boolean",
+    default: true,
   });
 }
 
@@ -66,4 +73,21 @@ function parseHideAgentList(value: unknown): boolean {
 
 export function isAgentListHidden(pi: ExtensionAPI): boolean {
   return readExtensionSettings(pi).hideAgentList;
+}
+
+function envDisablesTelemetry(name: string): boolean {
+  const value = process.env[name]?.trim().toLowerCase();
+  return (
+    value !== undefined && value !== "" && value !== "0" && value !== "false"
+  );
+}
+
+export function isTelemetryEnabled(pi: ExtensionAPI): boolean {
+  if (process.env[TELEMETRY_ENV] === "0") return false;
+  if (envDisablesTelemetry("DO_NOT_TRACK")) return false;
+  if (envDisablesTelemetry("PI_OFFLINE")) return false;
+  if (envDisablesTelemetry("CI")) return false;
+  if (envDisablesTelemetry("VITEST")) return false;
+  if (process.env.NODE_ENV === "test") return false;
+  return readFlag(pi, TELEMETRY_FLAG) !== false;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 export const MAX_DEPTH_FLAG = "subagentura-max-depth";
 export const HIDE_AGENT_LIST_FLAG = "subagentura-hide-agent-list";
 export const TELEMETRY_FLAG = "subagentura-telemetry";
+export const TELEMETRY_OPT_OUT_FLAG = "no-subagentura-telemetry";
 export const TELEMETRY_ENV = "PI_SUBAGENTURA_TELEMETRY";
 export const DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH = 2;
 const MAX_CONFIGURED_DEPTH = 64;
@@ -28,6 +29,10 @@ export function registerExtensionSettings(pi: ExtensionAPI): void {
     description: "Send anonymous session-level product analytics",
     type: "boolean",
     default: true,
+  });
+  pi.registerFlag(TELEMETRY_OPT_OUT_FLAG, {
+    description: "Disable anonymous session-level product analytics",
+    type: "boolean",
   });
 }
 
@@ -89,5 +94,6 @@ export function isTelemetryEnabled(pi: ExtensionAPI): boolean {
   if (envDisablesTelemetry("CI")) return false;
   if (envDisablesTelemetry("VITEST")) return false;
   if (process.env.NODE_ENV === "test") return false;
+  if (readFlag(pi, TELEMETRY_OPT_OUT_FLAG) === true) return false;
   return readFlag(pi, TELEMETRY_FLAG) !== false;
 }

--- a/src/spawn-tree-context.ts
+++ b/src/spawn-tree-context.ts
@@ -17,6 +17,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { debugLog } from "./helpers";
 import { DEFAULT_MAX_DEPTH, DEFAULT_MAX_NODES } from "./interactive-lineage";
+import type { TelemetryMode } from "./telemetry";
 
 export const LINEAGE_BOOTSTRAP_SCHEMA_VERSION = 1;
 export const LINEAGE_BOOTSTRAP_ENV = "PI_SUBAGENTURA_LINEAGE_BOOTSTRAP";
@@ -37,6 +38,10 @@ export interface SpawnTreeContext {
   artifactDir?: string;
   /** Whether this lineage belongs to an orchestrator-mode parent. */
   orchestratorMode?: boolean;
+  /** Anonymous session correlation carried only by the one-use bootstrap. */
+  telemetrySessionId?: string;
+  /** Closed analytics mode propagated with the explicit correlation context. */
+  telemetryMode?: TelemetryMode;
   currentAgentId?: string;
   parentAgentId?: string;
   depth: number;
@@ -152,6 +157,27 @@ export function parseSpawnTreeContext(value: unknown): ParsedSpawnTreeContext {
   if (orchestratorMode !== undefined && typeof orchestratorMode !== "boolean") {
     throw new Error("Invalid lineage bootstrap orchestratorMode");
   }
+  const telemetrySessionId =
+    raw.telemetrySessionId === undefined
+      ? undefined
+      : boundedString(raw.telemetrySessionId, "telemetrySessionId");
+  if (
+    telemetrySessionId !== undefined &&
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      telemetrySessionId,
+    )
+  ) {
+    throw new Error("Invalid lineage bootstrap telemetrySessionId");
+  }
+  const telemetryMode = raw.telemetryMode;
+  if (
+    telemetryMode !== undefined &&
+    telemetryMode !== "manual" &&
+    telemetryMode !== "orchestrator" &&
+    telemetryMode !== "orchestrator_v2"
+  ) {
+    throw new Error("Invalid lineage bootstrap telemetryMode");
+  }
   const depth = boundedInteger(raw.depth, "depth", 0, MAX_CONTEXT_DEPTH);
   const maxDepth = boundedInteger(
     raw.maxDepth,
@@ -170,6 +196,10 @@ export function parseSpawnTreeContext(value: unknown): ParsedSpawnTreeContext {
     sessionRoot,
     ...(artifactDir ? { artifactDir } : {}),
     ...(orchestratorMode ? { orchestratorMode } : {}),
+    ...(telemetrySessionId
+      ? { telemetrySessionId: telemetrySessionId.toLowerCase() }
+      : {}),
+    ...(telemetryMode ? { telemetryMode } : {}),
     ...(currentAgentId ? { currentAgentId } : {}),
     ...(parentAgentId ? { parentAgentId } : {}),
     depth,
@@ -191,6 +221,8 @@ export function createRootSpawnTreeContext(
   orchestratorMode = false,
   orchestratorV2Mode = false,
   configuredMaxDepth?: number,
+  telemetrySessionId?: string,
+  telemetryMode?: TelemetryMode,
 ): ParsedSpawnTreeContext {
   return parseSpawnTreeContext({
     schemaVersion: LINEAGE_BOOTSTRAP_SCHEMA_VERSION,
@@ -198,6 +230,8 @@ export function createRootSpawnTreeContext(
     rootId,
     sessionRoot,
     ...(orchestratorMode ? { orchestratorMode: true } : {}),
+    ...(telemetrySessionId ? { telemetrySessionId } : {}),
+    ...(telemetryMode ? { telemetryMode } : {}),
     depth: 0,
     maxDepth: orchestratorV2Mode
       ? (configuredMaxDepth ?? 2)

--- a/src/spawn-tree-context.ts
+++ b/src/spawn-tree-context.ts
@@ -169,10 +169,11 @@ export function parseSpawnTreeContext(value: unknown): ParsedSpawnTreeContext {
   ) {
     throw new Error("Invalid lineage bootstrap telemetrySessionId");
   }
-  const telemetryMode = raw.telemetryMode;
+  const telemetryMode =
+    raw.telemetryMode === "manual" ? "straight" : raw.telemetryMode;
   if (
     telemetryMode !== undefined &&
-    telemetryMode !== "manual" &&
+    telemetryMode !== "straight" &&
     telemetryMode !== "orchestrator" &&
     telemetryMode !== "orchestrator_v2"
   ) {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,295 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { getModel, getProviders } from "@earendil-works/pi-ai/compat";
+
+export const TELEMETRY_ENDPOINT = "https://us.i.posthog.com/i/v0/e/";
+export const TELEMETRY_SCHEMA_VERSION = 1;
+const TELEMETRY_PROJECT_TOKEN =
+  "phc_B4H7xPiFbwPJmKbdeQtk7FeP3PnQF5AMpQJXCgGYeqFR";
+const TELEMETRY_TIMEOUT_MS = 1_500;
+export const MAX_TELEMETRY_DEDUPE_KEYS = 2_048;
+
+export type TelemetryMode = "manual" | "orchestrator" | "orchestrator_v2";
+export type TelemetryExecution = "in-process" | "interactive";
+export type TelemetryInvocationSource =
+  "with_context" | "isolated" | "interactive" | "workflow";
+export type TelemetryCompletionPolicy = "inline" | "each" | "group" | "legacy";
+export type TelemetryAgentStatus = "success" | "error" | "cancelled";
+export type TelemetryResultSource = "in-process" | "interactive" | "workflow";
+export type TelemetryDelivery = "manifest" | "notification";
+export type TelemetryDepthBucket = "1" | "2" | "3" | "4-7" | "8+" | "unknown";
+export type TelemetryDurationBucket =
+  "<1s" | "1-5s" | "5-30s" | "30s-2m" | "2-10m" | "10m+" | "unknown";
+
+export type TelemetryEvent =
+  | { event: "session_started" }
+  | {
+      event: "agent_started";
+      execution: TelemetryExecution;
+      unit: "job" | "turn";
+      invocation_source: TelemetryInvocationSource;
+      model: string | undefined;
+      async: boolean;
+      depth_bucket: TelemetryDepthBucket;
+      completion_policy: TelemetryCompletionPolicy;
+    }
+  | {
+      event: "interactive_message_sent";
+      direction: "parent_to_child";
+      count: number;
+    }
+  | {
+      event: "agent_completed";
+      execution: TelemetryExecution;
+      unit: "job" | "turn";
+      invocation_source: TelemetryInvocationSource;
+      completion_policy: TelemetryCompletionPolicy;
+      status: TelemetryAgentStatus;
+      duration_ms: number | undefined;
+      message_count: number | undefined;
+    }
+  | {
+      event: "completion_delivered";
+      delivery: TelemetryDelivery;
+      count: number;
+    }
+  | { event: "result_consumed"; source: TelemetryResultSource };
+
+export interface TelemetrySession {
+  readonly enabled: boolean;
+  readonly mode: TelemetryMode;
+  readonly correlationId: string;
+  readonly capturedKeys: Set<string>;
+  active: boolean;
+}
+
+export interface AgentTelemetryContext {
+  session: TelemetrySession;
+  invocationSource: TelemetryInvocationSource;
+  async: boolean;
+  depth: number | undefined;
+  completionPolicy: TelemetryCompletionPolicy;
+}
+
+interface CaptureOptions {
+  dedupeKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface TelemetryPayload {
+  api_key: string;
+  event: `pi_subagentura_${TelemetryEvent["event"]}`;
+  distinct_id: string;
+  properties: Record<string, boolean | number | string>;
+}
+
+const packageVersion = readPackageVersion();
+
+function readPackageVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version?: unknown };
+    return typeof packageJson.version === "string"
+      ? packageJson.version
+      : "unknown";
+  } catch {
+    // Missing version metadata must never prevent the extension from loading.
+    return "unknown";
+  }
+}
+
+function validCorrelationId(value: string | undefined): string | undefined {
+  return value &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+    ? value.toLowerCase()
+    : undefined;
+}
+
+export function createTelemetrySession(
+  enabled: boolean,
+  mode: TelemetryMode = "manual",
+  inheritedCorrelationId?: string,
+): TelemetrySession {
+  return {
+    enabled,
+    mode,
+    correlationId: validCorrelationId(inheritedCorrelationId) ?? randomUUID(),
+    capturedKeys: new Set(),
+    active: true,
+  };
+}
+
+export function resolveTelemetryMode(
+  orchestratorMode: boolean,
+  orchestratorV2Mode: boolean,
+): TelemetryMode {
+  if (orchestratorV2Mode) return "orchestrator_v2";
+  return orchestratorMode ? "orchestrator" : "manual";
+}
+
+export function retireTelemetrySession(
+  session: TelemetrySession | undefined,
+): void {
+  if (session) session.active = false;
+}
+
+function builtInModel(provider: string, modelId: string): boolean {
+  try {
+    return getModel(provider as never, modelId) !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+/** Never forward arbitrary model-generated strings into telemetry. */
+export function sanitizeTelemetryModel(model: string | undefined): string {
+  if (model === undefined || model === "") return "default";
+  if (model === "default" || model === "custom") return model;
+  const separator = model.indexOf("/");
+  if (separator > 0) {
+    const provider = model.slice(0, separator);
+    const modelId = model.slice(separator + 1);
+    return builtInModel(provider, modelId) ? model : "custom";
+  }
+  for (const provider of getProviders()) {
+    if (builtInModel(provider, model)) return model;
+  }
+  return "custom";
+}
+
+export function telemetryDepthBucket(
+  depth: number | undefined,
+): TelemetryDepthBucket {
+  if (!Number.isSafeInteger(depth) || depth === undefined || depth < 1) {
+    return "unknown";
+  }
+  if (depth <= 3) return String(depth) as "1" | "2" | "3";
+  return depth <= 7 ? "4-7" : "8+";
+}
+
+export function telemetryDurationBucket(
+  durationMs: number | undefined,
+): TelemetryDurationBucket {
+  if (
+    durationMs === undefined ||
+    !Number.isFinite(durationMs) ||
+    durationMs < 0
+  ) {
+    return "unknown";
+  }
+  if (durationMs < 1_000) return "<1s";
+  if (durationMs < 5_000) return "1-5s";
+  if (durationMs < 30_000) return "5-30s";
+  if (durationMs < 120_000) return "30s-2m";
+  if (durationMs < 600_000) return "2-10m";
+  return "10m+";
+}
+
+function boundedCount(value: number | undefined, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.trunc(value!), 0), max);
+}
+
+export function buildTelemetryPayload(
+  session: TelemetrySession,
+  event: TelemetryEvent,
+): TelemetryPayload {
+  const common = {
+    $process_person_profile: false,
+    $geoip_disable: true,
+    $lib: "pi-subagentura",
+    $lib_version: packageVersion,
+    schema_version: TELEMETRY_SCHEMA_VERSION,
+    telemetry_session_id: session.correlationId,
+    mode: session.mode,
+  };
+  let properties: TelemetryPayload["properties"];
+  switch (event.event) {
+    case "session_started":
+      properties = common;
+      break;
+    case "agent_started":
+      properties = {
+        ...common,
+        execution: event.execution,
+        unit: event.unit,
+        invocation_source: event.invocation_source,
+        model: sanitizeTelemetryModel(event.model),
+        async: event.async,
+        depth_bucket: event.depth_bucket,
+        completion_policy: event.completion_policy,
+      };
+      break;
+    case "interactive_message_sent":
+      properties = {
+        ...common,
+        direction: event.direction,
+        count: boundedCount(event.count, 128),
+      };
+      break;
+    case "agent_completed":
+      properties = {
+        ...common,
+        execution: event.execution,
+        unit: event.unit,
+        invocation_source: event.invocation_source,
+        completion_policy: event.completion_policy,
+        status: event.status,
+        duration_bucket: telemetryDurationBucket(event.duration_ms),
+        ...(event.message_count === undefined
+          ? {}
+          : { message_count: boundedCount(event.message_count, 1_000) }),
+      };
+      break;
+    case "completion_delivered":
+      properties = {
+        ...common,
+        delivery: event.delivery,
+        count: boundedCount(event.count, 128),
+      };
+      break;
+    case "result_consumed":
+      properties = { ...common, source: event.source };
+  }
+  return {
+    api_key: TELEMETRY_PROJECT_TOKEN,
+    event: `pi_subagentura_${event.event}`,
+    distinct_id: session.correlationId,
+    properties,
+  };
+}
+
+export function captureTelemetry(
+  session: TelemetrySession | undefined,
+  event: TelemetryEvent,
+  options: CaptureOptions = {},
+): void {
+  if (!session?.enabled || !session.active) return;
+  if (options.dedupeKey) {
+    if (session.capturedKeys.has(options.dedupeKey)) return;
+    // Preserve first-capture semantics under the memory bound. Once the cache
+    // is full, dropping keyed analytics is safer than allowing repeated reads
+    // or delivery retries to inflate the data.
+    if (session.capturedKeys.size >= MAX_TELEMETRY_DEDUPE_KEYS) return;
+    session.capturedKeys.add(options.dedupeKey);
+  }
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let request: Promise<Response>;
+  try {
+    request = fetchImpl(TELEMETRY_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(buildTelemetryPayload(session, event)),
+      signal: AbortSignal.timeout(TELEMETRY_TIMEOUT_MS),
+    });
+  } catch {
+    // Best-effort analytics must never affect extension behavior.
+    return;
+  }
+  void request.catch(() => {
+    // Offline, blocked, and timed-out requests are intentionally not retried.
+  });
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -13,6 +13,7 @@ const MAX_TELEMETRY_DURATION_MS = 30 * 24 * 60 * 60 * 1_000;
 
 export type TelemetryMode = "straight" | "orchestrator" | "orchestrator_v2";
 export type TelemetryExecution = "in-process" | "interactive";
+export type TelemetryMux = "none" | "tmux" | "zellij" | "herdr";
 export type TelemetryInvocationSource =
   "with_context" | "isolated" | "interactive" | "workflow";
 export type TelemetryCompletionPolicy = "inline" | "each" | "group" | "legacy";
@@ -25,6 +26,7 @@ export type TelemetryDurationBucket =
 
 interface TelemetryAgentDimensions {
   execution: TelemetryExecution;
+  mux: TelemetryMux;
   invocation_source: TelemetryInvocationSource;
   model: string | undefined;
   async: boolean;
@@ -256,6 +258,7 @@ export function buildTelemetryPayload(
       properties = {
         ...common,
         execution: event.execution,
+        mux: event.mux,
         invocation_source: event.invocation_source,
         model: sanitizeTelemetryModel(event.model),
         async: event.async,
@@ -268,6 +271,7 @@ export function buildTelemetryPayload(
       properties = {
         ...common,
         execution: event.execution,
+        mux: event.mux,
         unit: event.unit,
         invocation_source: event.invocation_source,
         model: sanitizeTelemetryModel(event.model),
@@ -288,6 +292,7 @@ export function buildTelemetryPayload(
       properties = {
         ...common,
         execution: event.execution,
+        mux: event.mux,
         unit: event.unit,
         invocation_source: event.invocation_source,
         model: sanitizeTelemetryModel(event.model),

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -393,7 +393,10 @@ export function captureTelemetry(
     // Promise.resolve tolerates a patched fetch that returns a non-thenable, and
     // the attach stays inside the guard so no rejection escapes to the caller.
     // Offline, blocked, and timed-out requests are intentionally not retried.
+    // Telemetry never consumes the payload, so release the unused response body
+    // before considering the capture settled. Missing bodies are harmless.
     void Promise.resolve(request)
+      .then((response) => response?.body?.cancel())
       .catch(() => {})
       .finally(() => clearTimeout(timeout));
   } catch {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -3,13 +3,15 @@ import { readFileSync } from "node:fs";
 import { getModel, getProviders } from "@earendil-works/pi-ai/compat";
 
 export const TELEMETRY_ENDPOINT = "https://us.i.posthog.com/i/v0/e/";
-export const TELEMETRY_SCHEMA_VERSION = 1;
+export const TELEMETRY_SCHEMA_VERSION = 2;
 const TELEMETRY_PROJECT_TOKEN =
   "phc_B4H7xPiFbwPJmKbdeQtk7FeP3PnQF5AMpQJXCgGYeqFR";
 const TELEMETRY_TIMEOUT_MS = 1_500;
 export const MAX_TELEMETRY_DEDUPE_KEYS = 2_048;
+const MAX_TELEMETRY_DEPTH = 64;
+const MAX_TELEMETRY_DURATION_MS = 30 * 24 * 60 * 60 * 1_000;
 
-export type TelemetryMode = "manual" | "orchestrator" | "orchestrator_v2";
+export type TelemetryMode = "straight" | "orchestrator" | "orchestrator_v2";
 export type TelemetryExecution = "in-process" | "interactive";
 export type TelemetryInvocationSource =
   "with_context" | "isolated" | "interactive" | "workflow";
@@ -21,33 +23,32 @@ export type TelemetryDepthBucket = "1" | "2" | "3" | "4-7" | "8+" | "unknown";
 export type TelemetryDurationBucket =
   "<1s" | "1-5s" | "5-30s" | "30s-2m" | "2-10m" | "10m+" | "unknown";
 
+interface TelemetryAgentDimensions {
+  execution: TelemetryExecution;
+  invocation_source: TelemetryInvocationSource;
+  model: string | undefined;
+  async: boolean;
+  depth: number | undefined;
+  depth_bucket: TelemetryDepthBucket;
+  completion_policy: TelemetryCompletionPolicy;
+}
+
 export type TelemetryEvent =
   | { event: "session_started" }
-  | {
-      event: "agent_started";
-      execution: TelemetryExecution;
-      unit: "job" | "turn";
-      invocation_source: TelemetryInvocationSource;
-      model: string | undefined;
-      async: boolean;
-      depth_bucket: TelemetryDepthBucket;
-      completion_policy: TelemetryCompletionPolicy;
-    }
+  | ({ event: "agent_created" } & TelemetryAgentDimensions)
+  | ({ event: "task_started"; unit: "job" | "turn" } & TelemetryAgentDimensions)
   | {
       event: "interactive_message_sent";
       direction: "parent_to_child";
       count: number;
     }
-  | {
-      event: "agent_completed";
-      execution: TelemetryExecution;
+  | ({
+      event: "task_completed";
       unit: "job" | "turn";
-      invocation_source: TelemetryInvocationSource;
-      completion_policy: TelemetryCompletionPolicy;
       status: TelemetryAgentStatus;
       duration_ms: number | undefined;
-      message_count: number | undefined;
-    }
+      child_conversation_message_count: number | undefined;
+    } & TelemetryAgentDimensions)
   | {
       event: "completion_delivered";
       delivery: TelemetryDelivery;
@@ -72,6 +73,7 @@ export interface AgentTelemetryContext {
 }
 
 interface CaptureOptions {
+  allowInactive?: boolean;
   dedupeKey?: string;
   fetchImpl?: typeof fetch;
 }
@@ -110,12 +112,12 @@ function validCorrelationId(value: string | undefined): string | undefined {
 
 export function createTelemetrySession(
   enabled: boolean,
-  mode: TelemetryMode = "manual",
+  mode: TelemetryMode | "manual" = "straight",
   inheritedCorrelationId?: string,
 ): TelemetrySession {
   return {
     enabled,
-    mode,
+    mode: mode === "manual" ? "straight" : mode,
     correlationId: validCorrelationId(inheritedCorrelationId) ?? randomUUID(),
     capturedKeys: new Set(),
     active: true,
@@ -127,7 +129,7 @@ export function resolveTelemetryMode(
   orchestratorV2Mode: boolean,
 ): TelemetryMode {
   if (orchestratorV2Mode) return "orchestrator_v2";
-  return orchestratorMode ? "orchestrator" : "manual";
+  return orchestratorMode ? "orchestrator" : "straight";
 }
 
 export function retireTelemetrySession(
@@ -170,6 +172,15 @@ export function telemetryDepthBucket(
   return depth <= 7 ? "4-7" : "8+";
 }
 
+export function telemetryDepth(depth: number | undefined): number | undefined {
+  return Number.isSafeInteger(depth) &&
+    depth !== undefined &&
+    depth >= 1 &&
+    depth <= MAX_TELEMETRY_DEPTH
+    ? depth
+    : undefined;
+}
+
 export function telemetryDurationBucket(
   durationMs: number | undefined,
 ): TelemetryDurationBucket {
@@ -188,6 +199,35 @@ export function telemetryDurationBucket(
   return "10m+";
 }
 
+/** Round away meaningless precision and cap pathological or corrupt timers. */
+export function telemetryDurationMs(
+  durationMs: number | undefined,
+): number | undefined {
+  if (
+    durationMs === undefined ||
+    !Number.isFinite(durationMs) ||
+    durationMs < 0
+  ) {
+    return undefined;
+  }
+  return Math.min(
+    Math.round(durationMs / 100) * 100,
+    MAX_TELEMETRY_DURATION_MS,
+  );
+}
+
+function depthProperty(depth: number | undefined): { depth?: number } {
+  const boundedDepth = telemetryDepth(depth);
+  return boundedDepth === undefined ? {} : { depth: boundedDepth };
+}
+
+function durationProperty(durationMs: number | undefined): {
+  duration_ms?: number;
+} {
+  const boundedDuration = telemetryDurationMs(durationMs);
+  return boundedDuration === undefined ? {} : { duration_ms: boundedDuration };
+}
+
 function boundedCount(value: number | undefined, max: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.min(Math.max(Math.trunc(value!), 0), max);
@@ -200,6 +240,7 @@ export function buildTelemetryPayload(
   const common = {
     $process_person_profile: false,
     $geoip_disable: true,
+    $ip: "0.0.0.0",
     $lib: "pi-subagentura",
     $lib_version: packageVersion,
     schema_version: TELEMETRY_SCHEMA_VERSION,
@@ -211,7 +252,19 @@ export function buildTelemetryPayload(
     case "session_started":
       properties = common;
       break;
-    case "agent_started":
+    case "agent_created":
+      properties = {
+        ...common,
+        execution: event.execution,
+        invocation_source: event.invocation_source,
+        model: sanitizeTelemetryModel(event.model),
+        async: event.async,
+        ...depthProperty(event.depth),
+        depth_bucket: event.depth_bucket,
+        completion_policy: event.completion_policy,
+      };
+      break;
+    case "task_started":
       properties = {
         ...common,
         execution: event.execution,
@@ -219,6 +272,7 @@ export function buildTelemetryPayload(
         invocation_source: event.invocation_source,
         model: sanitizeTelemetryModel(event.model),
         async: event.async,
+        ...depthProperty(event.depth),
         depth_bucket: event.depth_bucket,
         completion_policy: event.completion_policy,
       };
@@ -230,18 +284,28 @@ export function buildTelemetryPayload(
         count: boundedCount(event.count, 128),
       };
       break;
-    case "agent_completed":
+    case "task_completed":
       properties = {
         ...common,
         execution: event.execution,
         unit: event.unit,
         invocation_source: event.invocation_source,
+        model: sanitizeTelemetryModel(event.model),
+        async: event.async,
+        ...depthProperty(event.depth),
+        depth_bucket: event.depth_bucket,
         completion_policy: event.completion_policy,
         status: event.status,
         duration_bucket: telemetryDurationBucket(event.duration_ms),
-        ...(event.message_count === undefined
+        ...durationProperty(event.duration_ms),
+        ...(event.child_conversation_message_count === undefined
           ? {}
-          : { message_count: boundedCount(event.message_count, 1_000) }),
+          : {
+              child_conversation_message_count: boundedCount(
+                event.child_conversation_message_count,
+                1_000,
+              ),
+            }),
       };
       break;
     case "completion_delivered":
@@ -267,13 +331,15 @@ export function captureTelemetry(
   event: TelemetryEvent,
   options: CaptureOptions = {},
 ): void {
-  if (!session?.enabled || !session.active) return;
+  if (!session?.enabled || (!session.active && !options.allowInactive)) return;
   if (options.dedupeKey) {
     if (session.capturedKeys.has(options.dedupeKey)) return;
-    // Preserve first-capture semantics under the memory bound. Once the cache
-    // is full, dropping keyed analytics is safer than allowing repeated reads
-    // or delivery retries to inflate the data.
-    if (session.capturedKeys.size >= MAX_TELEMETRY_DEDUPE_KEYS) return;
+    // Retain recent retry protection without making a long session stop
+    // reporting authoritative lifecycle events after the memory bound.
+    if (session.capturedKeys.size >= MAX_TELEMETRY_DEDUPE_KEYS) {
+      const oldest = session.capturedKeys.values().next().value;
+      if (oldest !== undefined) session.capturedKeys.delete(oldest);
+    }
     session.capturedKeys.add(options.dedupeKey);
   }
   const fetchImpl = options.fetchImpl ?? fetch;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { getModel, getProviders } from "@earendil-works/pi-ai/compat";
 
@@ -8,6 +8,7 @@ const TELEMETRY_PROJECT_TOKEN =
   "phc_B4H7xPiFbwPJmKbdeQtk7FeP3PnQF5AMpQJXCgGYeqFR";
 const TELEMETRY_TIMEOUT_MS = 1_500;
 export const MAX_TELEMETRY_DEDUPE_KEYS = 2_048;
+const MAX_TELEMETRY_DEDUPE_KEY_LENGTH = 128;
 const MAX_TELEMETRY_DEPTH = 64;
 const MAX_TELEMETRY_DURATION_MS = 30 * 24 * 60 * 60 * 1_000;
 
@@ -134,6 +135,22 @@ export function resolveTelemetryMode(
   return orchestratorMode ? "orchestrator" : "straight";
 }
 
+/**
+ * One dedupe key for a manifest delivery, shared by every emit site so two
+ * callers cannot double-count the same manifest, and hashed past a bound so a
+ * large manifest cannot grow the retained key set without limit.
+ */
+export function manifestDeliveryDedupeKey(
+  completionIds: readonly string[],
+): string {
+  const joined = completionIds.join(":");
+  if (joined.length <= MAX_TELEMETRY_DEDUPE_KEY_LENGTH) {
+    return `manifest:${joined}`;
+  }
+  const digest = createHash("sha256").update(joined).digest("hex");
+  return `manifest:${completionIds.length}:${digest}`;
+}
+
 export function retireTelemetrySession(
   session: TelemetrySession | undefined,
 ): void {
@@ -158,8 +175,15 @@ export function sanitizeTelemetryModel(model: string | undefined): string {
     const modelId = model.slice(separator + 1);
     return builtInModel(provider, modelId) ? model : "custom";
   }
-  for (const provider of getProviders()) {
-    if (builtInModel(provider, model)) return model;
+  // Provider enumeration reaches registry code owned by the host agent. A throw
+  // there must degrade the dimension, never fail the sub-agent launch that only
+  // wanted to label a model.
+  try {
+    for (const provider of getProviders()) {
+      if (builtInModel(provider, model)) return model;
+    }
+  } catch {
+    return "custom";
   }
   return "custom";
 }
@@ -189,7 +213,8 @@ export function telemetryDurationBucket(
   if (
     durationMs === undefined ||
     !Number.isFinite(durationMs) ||
-    durationMs < 0
+    durationMs < 0 ||
+    durationMs > MAX_TELEMETRY_DURATION_MS
   ) {
     return "unknown";
   }
@@ -201,21 +226,23 @@ export function telemetryDurationBucket(
   return "10m+";
 }
 
-/** Round away meaningless precision and cap pathological or corrupt timers. */
+/**
+ * Round away meaningless precision and drop implausible timers. A recovered or
+ * corrupt start timestamp produces a duration no analysis should trust, so it
+ * is reported as unknown rather than clamped to a bogus-but-plausible number.
+ */
 export function telemetryDurationMs(
   durationMs: number | undefined,
 ): number | undefined {
   if (
     durationMs === undefined ||
     !Number.isFinite(durationMs) ||
-    durationMs < 0
+    durationMs < 0 ||
+    durationMs > MAX_TELEMETRY_DURATION_MS
   ) {
     return undefined;
   }
-  return Math.min(
-    Math.round(durationMs / 100) * 100,
-    MAX_TELEMETRY_DURATION_MS,
-  );
+  return Math.round(durationMs / 100) * 100;
 }
 
 function depthProperty(depth: number | undefined): { depth?: number } {
@@ -348,19 +375,29 @@ export function captureTelemetry(
     session.capturedKeys.add(options.dedupeKey);
   }
   const fetchImpl = options.fetchImpl ?? fetch;
-  let request: Promise<Response>;
+  // An unref'd controller instead of AbortSignal.timeout: a pending capture must
+  // never hold the event loop open for up to 1.5s while the process is exiting.
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    TELEMETRY_TIMEOUT_MS,
+  ) as ReturnType<typeof setTimeout> & { unref?: () => void };
+  timeout.unref?.();
   try {
-    request = fetchImpl(TELEMETRY_ENDPOINT, {
+    const request = fetchImpl(TELEMETRY_ENDPOINT, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(buildTelemetryPayload(session, event)),
-      signal: AbortSignal.timeout(TELEMETRY_TIMEOUT_MS),
+      signal: controller.signal,
     });
+    // Promise.resolve tolerates a patched fetch that returns a non-thenable, and
+    // the attach stays inside the guard so no rejection escapes to the caller.
+    // Offline, blocked, and timed-out requests are intentionally not retried.
+    void Promise.resolve(request)
+      .catch(() => {})
+      .finally(() => clearTimeout(timeout));
   } catch {
     // Best-effort analytics must never affect extension behavior.
-    return;
+    clearTimeout(timeout);
   }
-  void request.catch(() => {
-    // Offline, blocked, and timed-out requests are intentionally not retried.
-  });
 }

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -173,6 +173,28 @@ function telemetryForAgent(
   };
 }
 
+/**
+ * A synchronous spawn hands its output straight back to the caller and is never
+ * collected through `get_subagent_result`, so the only honest place to record
+ * consumption is the return path itself. Without this, collection rates read as
+ * zero for every inline job.
+ */
+function captureSyncResultConsumed(
+  owner: SessionOwnerToken | undefined,
+  result: SubagentResult,
+): void {
+  if (result.isError || result.cancelled || result.output === "(no output)") {
+    return;
+  }
+  captureTelemetry(
+    owner ? resolveLiveSessionScope(owner)?.telemetry : undefined,
+    {
+      event: "result_consumed",
+      source: "in-process",
+    },
+  );
+}
+
 function captureDeliveryOwner(
   pi: ExtensionAPI,
   ctx: SpawnContext,
@@ -793,6 +815,7 @@ function registerSubagentWithContextTool(
         };
       }
 
+      captureSyncResultConsumed(owner, result);
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {
         status: result.isError ? "error" : "done",
@@ -1053,6 +1076,7 @@ function registerSubagentIsolatedTool(
         };
       }
 
+      captureSyncResultConsumed(owner, result);
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {
         status: result.isError ? "error" : "done",

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -1340,6 +1340,7 @@ function registerGetSubagentResultTool(
       }
       const result = waitResult.value!;
       // Only set resultRetrieved after successful completion (not on abort)
+      const firstResultRead = !job.resultRetrieved;
       job.resultRetrieved = true;
       consumeCompletionSource(
         pi,
@@ -1364,6 +1365,7 @@ function registerGetSubagentResultTool(
         };
       }
       if (
+        firstResultRead &&
         !result.isError &&
         !result.cancelled &&
         result.output !== "(no output)"
@@ -1373,7 +1375,6 @@ function registerGetSubagentResultTool(
             ? resolveLiveSessionScope(execution.owner)?.telemetry
             : undefined,
           { event: "result_consumed", source: "in-process" },
-          { dedupeKey: `result-consumed:in-process:${job.id}` },
         );
       }
       const usageStr = formatUsage(result.usage, result.model);

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -74,6 +74,12 @@ import {
   ResultParams,
   StatusParams,
 } from "../schemas";
+import {
+  captureTelemetry,
+  type AgentTelemetryContext,
+  type TelemetryCompletionPolicy,
+  type TelemetryInvocationSource,
+} from "../telemetry";
 
 interface RunningFooterContext {
   cwd?: string;
@@ -142,6 +148,29 @@ function resolveExecutionOwner(
   // A supplied token must never fall back to whichever peer registered last.
   if (token || getStartedSessionScopes().length > 0) return undefined;
   return {};
+}
+
+function telemetryForAgent(
+  owner: SessionOwnerToken | undefined,
+  invocationSource: TelemetryInvocationSource,
+  async: boolean,
+  depth: number | undefined,
+  completion: ResolvedCompletionPolicy,
+): AgentTelemetryContext | undefined {
+  const session = owner ? resolveLiveSessionScope(owner)?.telemetry : undefined;
+  if (!session) return undefined;
+  const completionPolicy: TelemetryCompletionPolicy = async
+    ? completion.legacy
+      ? "legacy"
+      : (completion.policy ?? "each")
+    : "inline";
+  return {
+    session,
+    invocationSource,
+    async,
+    depth,
+    completionPolicy,
+  };
 }
 
 function captureDeliveryOwner(
@@ -455,6 +484,7 @@ async function runSubagent(
   depth?: number,
   rootSessionId?: string,
   owner?: SessionOwnerToken,
+  telemetry?: AgentTelemetryContext,
 ): Promise<SubagentResult> {
   try {
     const { jobPromise, modelWarning, start } = await startSubagentJob({
@@ -471,6 +501,7 @@ async function runSubagent(
       depth,
       rootSessionId,
       owner,
+      telemetry,
     });
     start?.();
     const result = await jobPromise;
@@ -619,6 +650,13 @@ function registerSubagentWithContextTool(
           depth: spawn.childDepth,
           rootSessionId: spawn.rootSessionId,
           owner,
+          telemetry: telemetryForAgent(
+            owner,
+            "with_context",
+            true,
+            spawn.childDepth,
+            completion,
+          ),
         }).catch((error) => {
           releaseCompletionGroup(completionReservation);
           throw error;
@@ -739,6 +777,13 @@ function registerSubagentWithContextTool(
         spawn.childDepth,
         spawn.rootSessionId,
         owner,
+        telemetryForAgent(
+          owner,
+          "with_context",
+          false,
+          spawn.childDepth,
+          completion,
+        ),
       );
 
       if (result.cancelled) {
@@ -877,6 +922,13 @@ function registerSubagentIsolatedTool(
           depth: spawn.childDepth,
           rootSessionId: spawn.rootSessionId,
           owner,
+          telemetry: telemetryForAgent(
+            owner,
+            "isolated",
+            true,
+            spawn.childDepth,
+            completion,
+          ),
         }).catch((error) => {
           releaseCompletionGroup(completionReservation);
           throw error;
@@ -985,6 +1037,13 @@ function registerSubagentIsolatedTool(
         spawn.childDepth,
         spawn.rootSessionId,
         owner,
+        telemetryForAgent(
+          owner,
+          "isolated",
+          false,
+          spawn.childDepth,
+          completion,
+        ),
       );
 
       if (result.cancelled) {
@@ -1303,6 +1362,19 @@ function registerGetSubagentResultTool(
           details: { jobId: params.jobId, status: "cancelled" },
           isError: true,
         };
+      }
+      if (
+        !result.isError &&
+        !result.cancelled &&
+        result.output !== "(no output)"
+      ) {
+        captureTelemetry(
+          execution.owner
+            ? resolveLiveSessionScope(execution.owner)?.telemetry
+            : undefined,
+          { event: "result_consumed", source: "in-process" },
+          { dedupeKey: `result-consumed:in-process:${job.id}` },
+        );
       }
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -1316,7 +1316,7 @@ export function registerInteractiveSubagentTools(
               .join(", ")}\n`
           : "";
       if (wantsOutput && output !== null && selectedCompletion) {
-        consumeCompletionSource(
+        const firstConsumption = consumeCompletionSource(
           pi,
           {
             source: "interactive",
@@ -1325,14 +1325,15 @@ export function registerInteractiveSubagentTools(
           },
           registration?.scope ? sessionOwner(registration.scope) : undefined,
         );
-        if (output.length > 0 && selectedCompletion.outcome === "done") {
-          captureTelemetry(
-            registration?.scope?.telemetry,
-            { event: "result_consumed", source: "interactive" },
-            {
-              dedupeKey: `result-consumed:interactive:${params.id}:${selectedCompletion.turnId}`,
-            },
-          );
+        if (
+          firstConsumption &&
+          output.length > 0 &&
+          selectedCompletion.outcome === "done"
+        ) {
+          captureTelemetry(registration?.scope?.telemetry, {
+            event: "result_consumed",
+            source: "interactive",
+          });
         }
       }
       return {

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -79,6 +79,7 @@ import {
   type SessionScope,
   type SessionToolToken,
 } from "../session-scope";
+import { captureTelemetry } from "../telemetry";
 
 function isValidSubagentId(id: string): boolean {
   return isValidOrchestratorChildId(id);
@@ -328,6 +329,7 @@ function getArtifactForState(
 interface SelectedCompletion {
   turnId: string;
   protocolV2: boolean;
+  outcome: "done" | "error" | "cancelled";
 }
 
 function completionForRead(
@@ -359,8 +361,21 @@ function completionForRead(
       : completions.at(-1);
   if (!selected) return undefined;
   return selected.event.type === "completion"
-    ? { turnId: selected.event.turnId, protocolV2: true }
-    : { turnId: `legacy-${selected.startOffset}`, protocolV2: false };
+    ? {
+        turnId: selected.event.turnId,
+        protocolV2: true,
+        outcome: selected.event.outcome,
+      }
+    : {
+        turnId: `legacy-${selected.startOffset}`,
+        protocolV2: false,
+        outcome:
+          selected.event.type === "error"
+            ? "error"
+            : selected.event.type === "cancelled"
+              ? "cancelled"
+              : "done",
+      };
 }
 
 function resolveInteractiveToolStates(token: SessionToolToken | undefined):
@@ -656,6 +671,8 @@ export function registerInteractiveSubagentTools(
           sessionScope: registration.scope,
           spawnTreeContext: registration.scope?.spawnTreeContext,
           requireActivePaneForUserAttention: topLevelOrchestratorV2,
+          telemetryInvocationSource: "interactive",
+          telemetryAsync: true,
         });
         if (registration.scope && completion.policy) {
           try {
@@ -1075,6 +1092,15 @@ export function registerInteractiveSubagentTools(
           isError: true,
         };
       }
+      captureTelemetry(
+        registration?.scope?.telemetry,
+        {
+          event: "interactive_message_sent",
+          direction: "parent_to_child",
+          count: 1,
+        },
+        { dedupeKey: `interactive-message:${_toolCallId}` },
+      );
       // Reaching the send proves both workflow release conditions held at the guard above.
       if (
         state.completionOwner === "workflow" &&
@@ -1087,6 +1113,7 @@ export function registerInteractiveSubagentTools(
       let persistenceWarning: string | undefined;
       if (startsNewTurn) {
         state.completionPolicy = "each";
+        state.telemetryCompletionPolicy = "each";
         state.completionGroupId = undefined;
         state.notifyOnComplete = undefined;
         state.triggerTurnOnComplete = undefined;
@@ -1097,6 +1124,7 @@ export function registerInteractiveSubagentTools(
               delete entry.completionGroupId;
               delete entry.notifyOnComplete;
               delete entry.triggerTurnOnComplete;
+              if (entry.telemetry) entry.telemetry.completionPolicy = "each";
             });
           } catch (error) {
             persistenceWarning =
@@ -1297,6 +1325,15 @@ export function registerInteractiveSubagentTools(
           },
           registration?.scope ? sessionOwner(registration.scope) : undefined,
         );
+        if (output.length > 0 && selectedCompletion.outcome === "done") {
+          captureTelemetry(
+            registration?.scope?.telemetry,
+            { event: "result_consumed", source: "interactive" },
+            {
+              dedupeKey: `result-consumed:interactive:${params.id}:${selectedCompletion.turnId}`,
+            },
+          );
+        }
       }
       return {
         content: [

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -1099,7 +1099,10 @@ export function registerInteractiveSubagentTools(
           direction: "parent_to_child",
           count: 1,
         },
-        { dedupeKey: `interactive-message:${_toolCallId}` },
+        // Without a usable tool-call id every send collapses onto one constant
+        // key and only the first is ever recorded. Retry protection is worth
+        // having when the id exists and is worth losing when it does not.
+        _toolCallId ? { dedupeKey: `interactive-message:${_toolCallId}` } : {},
       );
       // Reaching the send proves both workflow release conditions held at the guard above.
       if (
@@ -1113,7 +1116,10 @@ export function registerInteractiveSubagentTools(
       let persistenceWarning: string | undefined;
       if (startsNewTurn) {
         state.completionPolicy = "each";
-        state.telemetryCompletionPolicy = "each";
+        // `state.telemetryCompletionPolicy` is deliberately left alone. It is an
+        // agent-creation dimension already reported by `agent_created`, and
+        // re-stamping it here would make one agent id report two values across
+        // its own lifecycle events.
         state.completionGroupId = undefined;
         state.notifyOnComplete = undefined;
         state.triggerTurnOnComplete = undefined;
@@ -1124,7 +1130,6 @@ export function registerInteractiveSubagentTools(
               delete entry.completionGroupId;
               delete entry.notifyOnComplete;
               delete entry.triggerTurnOnComplete;
-              if (entry.telemetry) entry.telemetry.completionPolicy = "each";
             });
           } catch (error) {
             persistenceWarning =

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -1050,18 +1050,18 @@ export function registerWorkflowTool(
         run.errorCount,
       );
       const usage = presentWorkflowUsage(run.usage);
+      const firstResultRead = !st.resultRetrieved;
       st.resultRetrieved = true;
       consumeCompletionSource(
         pi,
         { source: "workflow", sourceId: st.id },
         workflowOwner,
       );
-      if (st.status === "done" && resultText.length > 0) {
-        captureTelemetry(
-          resolveLiveSessionScope(workflowOwner)?.telemetry,
-          { event: "result_consumed", source: "workflow" },
-          { dedupeKey: `result-consumed:workflow:${st.id}` },
-        );
+      if (firstResultRead && st.status === "done" && resultText.length > 0) {
+        captureTelemetry(resolveLiveSessionScope(workflowOwner)?.telemetry, {
+          event: "result_consumed",
+          source: "workflow",
+        });
       }
       return {
         content: [

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -84,6 +84,7 @@ import {
   type ResolvedCompletionPolicy,
   type CompletionGroupReservation,
 } from "./completion-coordinator";
+import { captureTelemetry, type TelemetryCompletionPolicy } from "./telemetry";
 
 const WORKFLOW_SESSION_SCOPE_MESSAGE =
   "Workflow jobs are scoped to the current parent session and do not survive reload/resume/new/quit.";
@@ -183,6 +184,8 @@ export function registerWorkflowTool(
     ctx: any,
     ownedWorkflowId: string,
     supervisorOwner: SessionOwnerToken | undefined,
+    workflowAsync: boolean,
+    telemetryCompletionPolicy: TelemetryCompletionPolicy,
   ): WorkflowAgentRunner {
     return async ({
       prompt,
@@ -213,10 +216,10 @@ export function registerWorkflowTool(
         }
       };
 
+      const childScope = resolveLiveSessionScope(supervisorOwner);
       const tryProcess = isolation !== "in-process";
       if (tryProcess) {
         let state: ReturnType<typeof launchInteractiveSubagent> | undefined;
-        const childScope = resolveLiveSessionScope(supervisorOwner);
         try {
           state = launchInteractiveSubagent({
             name: (label || "wf-agent").slice(0, 40),
@@ -233,6 +236,9 @@ export function registerWorkflowTool(
             workflowId: ownedWorkflowId,
             completionOwner: "workflow",
             completionPolicy: "each",
+            telemetryInvocationSource: "workflow",
+            telemetryAsync: workflowAsync,
+            telemetryCompletionPolicy,
           });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -300,6 +306,15 @@ export function registerWorkflowTool(
         cancellationSource: "workflow",
         thinkingLevel,
         owner: childOwner,
+        telemetry: childScope?.telemetry
+          ? {
+              session: childScope.telemetry,
+              invocationSource: "workflow",
+              async: workflowAsync,
+              depth: 1,
+              completionPolicy: telemetryCompletionPolicy,
+            }
+          : undefined,
         ...(isolation === "in-process" && schema !== undefined
           ? { workflowStructuredOutputSchema: schema }
           : {}),
@@ -677,7 +692,17 @@ export function registerWorkflowTool(
         args: params.args,
         cwd: ctx.cwd,
         budgetTotal: params.budget ?? DEFAULT_WORKFLOW_OUTPUT_BUDGET,
-        runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
+        runAgent: makeRunAgent(
+          ctx,
+          workflowId,
+          workflowOwner,
+          params.async !== false,
+          params.async === false
+            ? "inline"
+            : completion.legacy
+              ? "legacy"
+              : (completion.policy ?? "each"),
+        ),
         loadWorkflow: (n: string) => loadWorkflowScript(n),
       });
 
@@ -1031,6 +1056,13 @@ export function registerWorkflowTool(
         { source: "workflow", sourceId: st.id },
         workflowOwner,
       );
+      if (st.status === "done" && resultText.length > 0) {
+        captureTelemetry(
+          resolveLiveSessionScope(workflowOwner)?.telemetry,
+          { event: "result_consumed", source: "workflow" },
+          { dedupeKey: `result-consumed:workflow:${st.id}` },
+        );
+      }
       return {
         content: [
           {
@@ -1292,7 +1324,13 @@ export function registerWorkflowTool(
           args: argsValue,
           cwd: ctx.cwd,
           budgetTotal: DEFAULT_WORKFLOW_OUTPUT_BUDGET,
-          runAgent: makeRunAgent(ctx, workflowId, workflowOwner),
+          runAgent: makeRunAgent(
+            ctx,
+            workflowId,
+            workflowOwner,
+            true,
+            sessionScope ? "each" : "legacy",
+          ),
           loadWorkflow: (n: string) => loadWorkflowScript(n),
         }),
         Date.now(),

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -63,6 +63,7 @@ import { cancellationSnapshotsEnabled } from "./cancellation-snapshots";
 import {
   getOrchestrationContext,
   resolveSpawnDepth,
+  type SpawnDepthDecision,
 } from "./orchestration-context";
 import {
   getActiveSessionOwner,
@@ -105,6 +106,27 @@ function workflowTelemetryCompletionPolicy(
   if (!runAsync) return "inline";
   if (completion.legacy) return "legacy";
   return completion.policy ?? "each";
+}
+
+/**
+ * Resolve the depth a workflow's children occupy, plus the root session id for
+ * their logs. Mirrors `resolveSpawn` in the in-process tools: the ambient
+ * orchestration context is authoritative, and the parent's own session id is
+ * the fallback when there is no ambient context to inherit from.
+ */
+function resolveWorkflowSpawn(ctx: {
+  sessionManager?: { getSessionId?: () => string };
+}): SpawnDepthDecision {
+  const spawn = resolveSpawnDepth();
+  if (spawn.rootSessionId) return spawn;
+  let rootSessionId: string | undefined;
+  try {
+    rootSessionId = ctx.sessionManager?.getSessionId?.();
+  } catch {
+    // A stale parent context has no reliable session identity.
+    rootSessionId = undefined;
+  }
+  return { ...spawn, rootSessionId };
 }
 
 function workflowNotFoundMessage(workflowId: string): string {
@@ -204,6 +226,12 @@ export function registerWorkflowTool(
     supervisorOwner: SessionOwnerToken | undefined,
     workflowAsync: boolean,
     telemetryCompletionPolicy: TelemetryCompletionPolicy,
+    /**
+     * Resolved by the caller rather than here: agents are launched later from a
+     * worker message handler, where the ambient orchestration context of the
+     * originating tool call is already gone.
+     */
+    spawn: SpawnDepthDecision,
   ): WorkflowAgentRunner {
     return async ({
       prompt,
@@ -293,10 +321,6 @@ export function registerWorkflowTool(
       // it from `supervisorOwner` instead drops every child event whenever the
       // workflow tool was registered without a session scope.
       const childTelemetry = resolveLiveSessionScope(childOwner)?.telemetry;
-      // Workflow children are not always the root's direct children; a workflow
-      // started from inside a sub-agent sits deeper. Derive it the way the
-      // in-process spawn paths do instead of asserting depth 1.
-      const childDepth = resolveSpawnDepth().childDepth;
 
       // Own the child session so its parent abort cascades to it and exact-scope
       // shutdown can drain it from the authoritative job map.
@@ -331,13 +355,20 @@ export function registerWorkflowTool(
         onCancellationSnapshot,
         cancellationSource: "workflow",
         thinkingLevel,
+        // The child binds this depth into its own orchestration context, so a
+        // sub-agent it spawns counts from here. Left unset, the child bound
+        // depth 0 and its own children reported depth 1 — the same value as
+        // their parent — so the dimension was non-monotone within one spawn
+        // tree and the depth cap never saw a workflow grandchild.
+        depth: spawn.childDepth,
+        rootSessionId: spawn.rootSessionId,
         owner: childOwner,
         telemetry: childTelemetry
           ? {
               session: childTelemetry,
               invocationSource: "workflow",
               async: workflowAsync,
-              depth: childDepth,
+              depth: spawn.childDepth,
               completionPolicy: telemetryCompletionPolicy,
             }
           : undefined,
@@ -714,6 +745,13 @@ export function registerWorkflowTool(
         };
       }
 
+      // Resolved here, inside the tool call, while the caller's orchestration
+      // context and session manager are both still reachable. The guard above
+      // refuses a workflow started from inside an in-process sub-agent (issue
+      // #62), so today the depth is always the root's own and the session id
+      // always comes from the fallback; resolving both properly keeps the
+      // values correct if that restriction is ever lifted.
+      const spawn = resolveWorkflowSpawn(ctx);
       const baseOpts = (workflowId: string) => ({
         args: params.args,
         cwd: ctx.cwd,
@@ -724,6 +762,7 @@ export function registerWorkflowTool(
           workflowOwner,
           params.async !== false,
           workflowTelemetryCompletionPolicy(params.async !== false, completion),
+          spawn,
         ),
         loadWorkflow: (n: string) => loadWorkflowScript(n),
       });
@@ -1344,6 +1383,9 @@ export function registerWorkflowTool(
       const commandCompletion: ResolvedCompletionPolicy = sessionScope
         ? { policy: "each", legacy: false }
         : { legacy: true };
+      // A slash command runs at the prompt, so this is the root's own depth,
+      // and the root's own session id is the only attribution available.
+      const spawn = resolveWorkflowSpawn(ctx);
       const job = startWorkflowJob(
         meta.name,
         script,
@@ -1357,6 +1399,7 @@ export function registerWorkflowTool(
             workflowOwner,
             true,
             workflowTelemetryCompletionPolicy(true, commandCompletion),
+            spawn,
           ),
           loadWorkflow: (n: string) => loadWorkflowScript(n),
         }),

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -60,7 +60,10 @@ import type {
   ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
 import { cancellationSnapshotsEnabled } from "./cancellation-snapshots";
-import { getOrchestrationContext } from "./orchestration-context";
+import {
+  getOrchestrationContext,
+  resolveSpawnDepth,
+} from "./orchestration-context";
 import {
   getActiveSessionOwner,
   isSessionOwnerLive,
@@ -88,6 +91,21 @@ import { captureTelemetry, type TelemetryCompletionPolicy } from "./telemetry";
 
 const WORKFLOW_SESSION_SCOPE_MESSAGE =
   "Workflow jobs are scoped to the current parent session and do not survive reload/resume/new/quit.";
+
+/**
+ * One derivation of the reported completion-policy dimension for every workflow
+ * entry point. Each caller already knows the coordination settings it is about
+ * to install, so deriving here keeps a saved-workflow command from reporting a
+ * policy the run does not actually use.
+ */
+function workflowTelemetryCompletionPolicy(
+  runAsync: boolean,
+  completion: ResolvedCompletionPolicy,
+): TelemetryCompletionPolicy {
+  if (!runAsync) return "inline";
+  if (completion.legacy) return "legacy";
+  return completion.policy ?? "each";
+}
 
 function workflowNotFoundMessage(workflowId: string): string {
   return (
@@ -271,6 +289,14 @@ export function registerWorkflowTool(
       // and session shutdown skips it outright. Prefer the live owner, and leave
       // the child unregistered rather than create an unreachable registry row.
       const childOwner = supervisorOwner ?? getActiveSessionOwner();
+      // Telemetry has to name the scope the job actually registers under. Reading
+      // it from `supervisorOwner` instead drops every child event whenever the
+      // workflow tool was registered without a session scope.
+      const childTelemetry = resolveLiveSessionScope(childOwner)?.telemetry;
+      // Workflow children are not always the root's direct children; a workflow
+      // started from inside a sub-agent sits deeper. Derive it the way the
+      // in-process spawn paths do instead of asserting depth 1.
+      const childDepth = resolveSpawnDepth().childDepth;
 
       // Own the child session so its parent abort cascades to it and exact-scope
       // shutdown can drain it from the authoritative job map.
@@ -306,12 +332,12 @@ export function registerWorkflowTool(
         cancellationSource: "workflow",
         thinkingLevel,
         owner: childOwner,
-        telemetry: childScope?.telemetry
+        telemetry: childTelemetry
           ? {
-              session: childScope.telemetry,
+              session: childTelemetry,
               invocationSource: "workflow",
               async: workflowAsync,
-              depth: 1,
+              depth: childDepth,
               completionPolicy: telemetryCompletionPolicy,
             }
           : undefined,
@@ -697,11 +723,7 @@ export function registerWorkflowTool(
           workflowId,
           workflowOwner,
           params.async !== false,
-          params.async === false
-            ? "inline"
-            : completion.legacy
-              ? "legacy"
-              : (completion.policy ?? "each"),
+          workflowTelemetryCompletionPolicy(params.async !== false, completion),
         ),
         loadWorkflow: (n: string) => loadWorkflowScript(n),
       });
@@ -1317,6 +1339,11 @@ export function registerWorkflowTool(
           "Workflow command registration is no longer attached to a live session.",
         );
       }
+      // One completion decision drives both the coordination that is installed
+      // and the dimension that is reported, so the two cannot drift apart.
+      const commandCompletion: ResolvedCompletionPolicy = sessionScope
+        ? { policy: "each", legacy: false }
+        : { legacy: true };
       const job = startWorkflowJob(
         meta.name,
         script,
@@ -1329,7 +1356,7 @@ export function registerWorkflowTool(
             workflowId,
             workflowOwner,
             true,
-            sessionScope ? "each" : "legacy",
+            workflowTelemetryCompletionPolicy(true, commandCompletion),
           ),
           loadWorkflow: (n: string) => loadWorkflowScript(n),
         }),
@@ -1337,11 +1364,7 @@ export function registerWorkflowTool(
         notifyWorkflowCompletion,
         workflowOwner,
       );
-      configureWorkflowCompletion(
-        job,
-        sessionScope ? { policy: "each", legacy: false } : { legacy: true },
-        workflowOwner,
-      );
+      configureWorkflowCompletion(job, commandCompletion, workflowOwner);
       return { job, meta };
     };
 

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -1021,6 +1021,29 @@ describe("persisted interactive state helpers", () => {
     });
   });
 
+  it("normalizes the pre-v2 telemetry mode name during recovery", () => {
+    const file = stateFilePath(root);
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: 2,
+        parent: "pi",
+        telemetry: {
+          correlationId: "11111111-1111-4111-8111-111111111111",
+          mode: "manual",
+        },
+        states: {},
+      }),
+      { mode: 0o600 },
+    );
+
+    expect(loadInteractiveStates(root)?.telemetry).toEqual({
+      correlationId: "11111111-1111-4111-8111-111111111111",
+      mode: "straight",
+    });
+  });
+
   it("loadInteractiveStates migrates a file with schemaVersion -1", () => {
     const file = stateFilePath(root);
     mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -985,6 +985,76 @@ describe("persisted interactive state helpers", () => {
     expect(loadInteractiveStates(root)).toBeNull();
   });
 
+  it("migrates safe telemetry dimensions and message-turn IDs", () => {
+    const file = stateFilePath(root);
+    mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+    const telemetry = {
+      correlationId: "11111111-1111-4111-8111-111111111111",
+      invocationSource: "interactive",
+      mux: "tmux",
+      async: true,
+      depth: 1,
+      depthBucket: "1",
+      completionPolicy: "each",
+      model: "default",
+      activeTurnId: "2",
+      turnStartedAt: 1_000,
+      messageTurnId: "2",
+      messageCounts: { "10": 1, "2": 2 },
+    };
+    writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: 2,
+        parent: "pi",
+        states: { abc12345: { ...SAMPLE, telemetry } },
+      }),
+      { mode: 0o600 },
+    );
+    expect(
+      loadInteractiveStates(root)?.states.abc12345.telemetry,
+    ).toMatchObject({
+      mux: "tmux",
+      messageTurnId: "2",
+      messageCounts: { "10": 1, "2": 2 },
+    });
+
+    const { mux: legacyMux, ...legacyTelemetry } = telemetry;
+    void legacyMux;
+    writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: 2,
+        parent: "pi",
+        states: { abc12345: { ...SAMPLE, telemetry: legacyTelemetry } },
+      }),
+      { mode: 0o600 },
+    );
+    expect(
+      loadInteractiveStates(root)?.states.abc12345.telemetry,
+    ).toMatchObject({
+      mux: "tmux",
+    });
+
+    writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: 2,
+        parent: "pi",
+        states: {
+          abc12345: {
+            ...SAMPLE,
+            telemetry: { ...telemetry, messageTurnId: "unsafe/turn" },
+          },
+        },
+      }),
+      { mode: 0o600 },
+    );
+    expect(
+      loadInteractiveStates(root)?.states.abc12345.telemetry,
+    ).not.toHaveProperty("messageTurnId");
+  });
+
   it("loadInteractiveStates migrates a file with no schemaVersion field", () => {
     const file = stateFilePath(root);
     mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -22,6 +22,7 @@ import {
   deleteInteractiveStatesFile,
   ensureArtifactDir,
   eventLogEndOffset,
+  hasPersistedTelemetryField,
   isArtifactOutputSettled,
   isCompletionEvent,
   isTurnTerminal,
@@ -34,6 +35,7 @@ import {
   MAX_EVENT_BATCH_BYTES,
   MAX_OUTPUT_SNAPSHOT_BYTES,
   MAX_TOOL_NAME_LENGTH,
+  MAX_TURN_ID_LENGTH,
   outputPathForTurn,
   readEvents,
   readEventBatch,
@@ -47,6 +49,7 @@ import {
   writeOutput,
   withInteractiveStateLock,
   updateInteractiveStates,
+  updatePersistedTelemetrySession,
   type InteractiveSubagentPersistedStateV2,
   type SubagentEvent,
 } from "../src/artifact";
@@ -1055,6 +1058,128 @@ describe("persisted interactive state helpers", () => {
     ).not.toHaveProperty("messageTurnId");
   });
 
+  describe("entry telemetry migration against a tampered state file", () => {
+    const VALID = {
+      correlationId: "11111111-1111-4111-8111-111111111111",
+      invocationSource: "interactive",
+      mux: "tmux",
+      async: true,
+      depth: 2,
+      depthBucket: "2",
+      completionPolicy: "each",
+      model: "default",
+    };
+
+    function migrate(telemetry: unknown) {
+      const file = stateFilePath(root);
+      mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+      writeFileSync(
+        file,
+        JSON.stringify({
+          schemaVersion: 2,
+          parent: "pi",
+          states: { abc12345: { ...SAMPLE, telemetry } },
+        }),
+        { mode: 0o600 },
+      );
+      return loadInteractiveStates(root)?.states.abc12345.telemetry;
+    }
+
+    it.each([
+      ["a non-UUID correlation id", { correlationId: "not-a-uuid" }],
+      [
+        "a v1 UUID correlation id",
+        { correlationId: "11111111-1111-1111-8111-111111111111" },
+      ],
+      ["a missing correlation id", { correlationId: undefined }],
+      ["an unknown invocation source", { invocationSource: "sneaky" }],
+      ["a non-boolean async flag", { async: "yes" }],
+      ["an unknown depth bucket", { depthBucket: "0" }],
+      ["an unknown completion policy", { completionPolicy: "immediate" }],
+      ["a non-string model", { model: 7 }],
+      ["an over-long model", { model: "m".repeat(129) }],
+    ])("drops the whole record for %s", (_label, override) => {
+      expect(migrate({ ...VALID, ...override })).toBeUndefined();
+    });
+
+    it.each([
+      ["an array", []],
+      ["a string", "telemetry"],
+      ["a number", 3],
+      ["null", null],
+    ])("drops telemetry stored as %s", (_label, telemetry) => {
+      expect(migrate(telemetry)).toBeUndefined();
+    });
+
+    it("lowercases an upper-case correlation id it accepts", () => {
+      expect(
+        migrate({
+          ...VALID,
+          correlationId: "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE",
+        }),
+      ).toMatchObject({
+        correlationId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      });
+    });
+
+    it.each([0, -1, 65, 1.5, Number.NaN, "2"])(
+      "keeps the record but omits an out-of-range depth of %s",
+      (depth) => {
+        const migrated = migrate({ ...VALID, depth });
+        expect(migrated).toBeDefined();
+        expect(migrated).not.toHaveProperty("depth");
+        expect(migrated?.depthBucket).toBe("2");
+      },
+    );
+
+    it.each([
+      ["a known mux", "zellij", "zellij"],
+      ["the reserved herdr mux", "herdr", "herdr"],
+      ["an unknown mux", "screen", "tmux"],
+      ["a missing mux", undefined, "tmux"],
+    ])("resolves %s to %s", (_label, mux, expected) => {
+      expect(migrate({ ...VALID, mux })?.mux).toBe(expected);
+    });
+
+    it("truncates and clamps a hostile messageCounts map", () => {
+      const messageCounts: Record<string, unknown> = {};
+      for (let index = 0; index < 40; index++) {
+        messageCounts[`t-${index}`] = 5_000;
+      }
+      messageCounts["unsafe/turn"] = 1;
+      messageCounts["negative"] = -1;
+      messageCounts["fractional"] = 1.5;
+
+      const migrated = migrate({ ...VALID, messageCounts });
+      const counts = migrated?.messageCounts ?? {};
+
+      expect(Object.keys(counts)).toHaveLength(32);
+      expect(counts).not.toHaveProperty("unsafe/turn");
+      expect(counts).not.toHaveProperty("negative");
+      expect(counts).not.toHaveProperty("fractional");
+      expect(counts["t-0"]).toBeUndefined();
+      expect(counts["t-39"]).toBe(1_000);
+    });
+
+    it.each(["", "unsafe/turn", "x".repeat(MAX_TURN_ID_LENGTH + 1)])(
+      "omits an unsafe active turn id of %s",
+      (activeTurnId) => {
+        const migrated = migrate({ ...VALID, activeTurnId });
+        expect(migrated).toBeDefined();
+        expect(migrated).not.toHaveProperty("activeTurnId");
+      },
+    );
+
+    it.each([-1, "1000", Number.NaN])(
+      "omits an implausible turnStartedAt of %s",
+      (turnStartedAt) => {
+        const migrated = migrate({ ...VALID, turnStartedAt });
+        expect(migrated).toBeDefined();
+        expect(migrated).not.toHaveProperty("turnStartedAt");
+      },
+    );
+  });
+
   it("loadInteractiveStates migrates a file with no schemaVersion field", () => {
     const file = stateFilePath(root);
     mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
@@ -1088,6 +1213,62 @@ describe("persisted interactive state helpers", () => {
       schemaVersion: 2,
       parent: "pi",
       states: { abc12345: SAMPLE },
+    });
+  });
+
+  describe("hasPersistedTelemetryField", () => {
+    function writeRaw(body: string): void {
+      mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
+      writeFileSync(stateFilePath(root), body, { mode: 0o600 });
+    }
+
+    it("reports nothing to clear when no state file exists", () => {
+      expect(hasPersistedTelemetryField(root)).toBe(false);
+      // The probe must stay read-only, or the opt-out it guards is not inert.
+      expect(existsSync(join(root, ".pi"))).toBe(false);
+    });
+
+    it.each([
+      ["corrupt JSON", "{not json"],
+      ["an empty file", ""],
+      ["a JSON array", "[]"],
+      ["a JSON scalar", '"telemetry"'],
+      ["JSON null", "null"],
+      ["a file with no telemetry key", '{"schemaVersion":2,"states":{}}'],
+    ])("reports nothing to clear for %s", (_label, body) => {
+      writeRaw(body);
+      expect(hasPersistedTelemetryField(root)).toBe(false);
+    });
+
+    it.each([
+      ["null", '{"schemaVersion":2,"states":{},"telemetry":null}'],
+      [
+        "a garbage string",
+        '{"schemaVersion":2,"states":{},"telemetry":"junk"}',
+      ],
+      ["an array", '{"schemaVersion":2,"states":{},"telemetry":[1,2]}'],
+      [
+        "an object the migration rejects",
+        '{"schemaVersion":2,"states":{},"telemetry":{"correlationId":"nope"}}',
+      ],
+      [
+        "a valid record",
+        '{"schemaVersion":2,"states":{},"telemetry":{"correlationId":"11111111-1111-4111-8111-111111111111","mode":"straight"}}',
+      ],
+    ])("reports a field to clear when telemetry is %s", (_label, body) => {
+      writeRaw(body);
+      // A value the migration drops still has to be erased from disk, so the
+      // probe looks at the raw key rather than the migrated result.
+      expect(hasPersistedTelemetryField(root)).toBe(true);
+    });
+
+    it("goes quiet after exactly one clearing write", () => {
+      writeRaw('{"schemaVersion":2,"states":{},"telemetry":"junk"}');
+      expect(hasPersistedTelemetryField(root)).toBe(true);
+
+      updatePersistedTelemetrySession(root, "session-a", undefined);
+
+      expect(hasPersistedTelemetryField(root)).toBe(false);
     });
   });
 

--- a/tests/completion-coordinator.test.ts
+++ b/tests/completion-coordinator.test.ts
@@ -442,14 +442,19 @@ describe("completion coordinator", () => {
     const setupResult = setup();
     scope = setupResult.scope;
 
-    for (let index = 0; index < 2; index++) {
-      consumeCompletionSource(
-        setupResult.pi as never,
-        { source: "interactive", sourceId: "a", turnId: "turn-a" },
-        sessionOwner(scope),
-      );
-    }
+    const first = consumeCompletionSource(
+      setupResult.pi as never,
+      { source: "interactive", sourceId: "a", turnId: "turn-a" },
+      sessionOwner(scope),
+    );
+    const repeated = consumeCompletionSource(
+      setupResult.pi as never,
+      { source: "interactive", sourceId: "a", turnId: "turn-a" },
+      sessionOwner(scope),
+    );
 
+    expect(first).toBe(true);
+    expect(repeated).toBe(false);
     expect(
       setupResult.entries.filter(
         (entry) =>

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import registerExtension from "../src/subagent";
+import { parseArgs } from "@earendil-works/pi-coding-agent";
 import {
   HIDE_AGENT_LIST_FLAG,
   MAX_DEPTH_FLAG,
+  isTelemetryEnabled,
   readExtensionSettings,
   TELEMETRY_FLAG,
+  TELEMETRY_OPT_OUT_FLAG,
 } from "../src/settings";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
-import { getSessionScopes } from "../src/session-scope";
+import { getSessionScopes, clearSessionScopes } from "../src/session-scope";
+import { createPiSessionHarness } from "./helpers/pi-session-harness";
+
+const repoRoot = new URL("..", import.meta.url).pathname;
 
 function mockApi(getFlag: (name: string) => unknown = () => undefined) {
   return {
@@ -20,6 +26,10 @@ function mockApi(getFlag: (name: string) => unknown = () => undefined) {
     on: vi.fn(),
   };
 }
+
+afterEach(() => {
+  clearSessionScopes();
+});
 
 function registeredTools(api: ReturnType<typeof mockApi>): string[] {
   return api.registerTool.mock.calls.map(([tool]: any[]) => tool.name);
@@ -45,10 +55,58 @@ describe("generic extension settings", () => {
       type: "boolean",
       default: true,
     });
+    expect(api.registerFlag).toHaveBeenCalledWith(TELEMETRY_OPT_OUT_FLAG, {
+      description: expect.stringContaining("Disable anonymous"),
+      type: "boolean",
+    });
     expect(readExtensionSettings(api as any)).toEqual({
       maxDepth: 2,
       hideAgentList: false,
     });
+  });
+
+  it("applies CLI telemetry opt-out through the Pi flag harness", async () => {
+    const names = [
+      "CI",
+      "DO_NOT_TRACK",
+      "NODE_ENV",
+      "PI_OFFLINE",
+      "VITEST",
+      "PI_SUBAGENTURA_TELEMETRY",
+    ];
+    const previous = new Map(
+      names.map((name) => [name, process.env[name]] as const),
+    );
+    for (const name of names) delete process.env[name];
+
+    const parsed = parseArgs(["--no-subagentura-telemetry"]);
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.unknownFlags).toEqual(
+      new Map([["no-subagentura-telemetry", true]]),
+    );
+    let harness: Awaited<ReturnType<typeof createPiSessionHarness>> | undefined;
+    try {
+      harness = await createPiSessionHarness(repoRoot, {
+        extensionFlags: Object.fromEntries(parsed.unknownFlags),
+      });
+      const scopes = getSessionScopes();
+      const scope =
+        scopes.find(
+          (candidate) => candidate.sessionManager === harness?.sessionManager,
+        ) ?? (scopes.length === 1 ? scopes[0] : undefined);
+      expect(scope).toBeDefined();
+      if (!scope) throw new Error("harness extension has no session scope");
+      expect(scope.pi.getFlag("no-subagentura-telemetry")).toBe(true);
+      expect(scope.pi.getFlag(TELEMETRY_FLAG)).toBe(true);
+      expect(isTelemetryEnabled(scope.pi)).toBe(false);
+    } finally {
+      harness?.dispose();
+      for (const name of names) {
+        const value = previous.get(name);
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
   });
 
   it.each(["", "-1", "1.5", "nope", "65", true])(

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -4,6 +4,7 @@ import {
   HIDE_AGENT_LIST_FLAG,
   MAX_DEPTH_FLAG,
   readExtensionSettings,
+  TELEMETRY_FLAG,
 } from "../src/settings";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
 import { getSessionScopes } from "../src/session-scope";
@@ -38,6 +39,11 @@ describe("generic extension settings", () => {
       description: expect.stringContaining("activity widget"),
       type: "boolean",
       default: false,
+    });
+    expect(api.registerFlag).toHaveBeenCalledWith(TELEMETRY_FLAG, {
+      description: expect.stringContaining("anonymous"),
+      type: "boolean",
+      default: true,
     });
     expect(readExtensionSettings(api as any)).toEqual({
       maxDepth: 2,

--- a/tests/in-process-tools.test.ts
+++ b/tests/in-process-tools.test.ts
@@ -616,6 +616,116 @@ describe("subagent_isolated tool", () => {
   });
 });
 
+// ── synchronous result consumption ───────────────────────────────────
+
+/**
+ * A synchronous spawn hands its output straight back to the caller, so there is
+ * no later `get_subagent_result` for `result_consumed` to be emitted from. Both
+ * sync tools take their own return path, so both are exercised here.
+ */
+describe("synchronous in-process result consumption", () => {
+  const SYNC_TOOLS = [
+    ["subagent_isolated", () => mockCtx()],
+    [
+      "subagent_with_context",
+      // with_context bails out early unless the branch has a message to inherit.
+      () =>
+        mockCtx({
+          sessionManager: {
+            getBranch: vi
+              .fn()
+              .mockReturnValue([
+                { type: "message", message: { role: "user", content: "hi" } },
+              ]),
+            getSessionId: vi.fn().mockReturnValue("test-session"),
+          },
+        }),
+    ],
+  ] as const;
+
+  interface TelemetryPost {
+    event?: string;
+    properties?: Record<string, unknown>;
+  }
+
+  function captureTelemetryPosts(): TelemetryPost[] {
+    const payloads: TelemetryPost[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        payloads.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    return payloads;
+  }
+
+  function consumedEvents(payloads: readonly TelemetryPost[]) {
+    return payloads.filter(
+      (payload) => payload.event === "pi_subagentura_result_consumed",
+    );
+  }
+
+  it.each(SYNC_TOOLS)("records consumption for %s", async (name, makeCtx) => {
+    const payloads = captureTelemetryPosts();
+    const scoped = setupScopedExtension(714);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const scopedTool = getToolDef(scoped.api, name);
+
+    const result = await scopedTool.execute(
+      "sync-consumed",
+      { task: "analyze code", async: false },
+      undefined,
+      undefined,
+      makeCtx(),
+    );
+
+    expect(result.details.status).toBe("done");
+    await vi.waitFor(() => expect(consumedEvents(payloads)).toHaveLength(1));
+    expect(consumedEvents(payloads)[0]?.properties?.source).toBe("in-process");
+  });
+
+  it.each(
+    SYNC_TOOLS.flatMap(([name, makeCtx]) =>
+      (
+        [
+          [
+            "a failed run",
+            { ...defaultSuccessResult, isError: true, errorMessage: "boom" },
+          ],
+          [
+            "a cancelled run",
+            { ...defaultSuccessResult, cancelled: true, output: "cancelled" },
+          ],
+          ["an empty run", { ...defaultSuccessResult, output: "(no output)" }],
+        ] as const
+      ).map(([label, jobResult]) => [name, label, jobResult, makeCtx] as const),
+    ),
+  )(
+    "records no consumption for %s on %s",
+    async (name, _label, jobResult, makeCtx) => {
+      const payloads = captureTelemetryPosts();
+      mockStartSubagentJob.mockResolvedValue({
+        ...defaultStartSubagentJobResult,
+        jobPromise: Promise.resolve(jobResult),
+      });
+      const scoped = setupScopedExtension(715);
+      scoped.scope.telemetry = createTelemetrySession(true);
+      const scopedTool = getToolDef(scoped.api, name);
+
+      await scopedTool.execute(
+        "sync-not-consumed",
+        { task: "analyze code", async: false },
+        undefined,
+        undefined,
+        makeCtx(),
+      );
+
+      expect(consumedEvents(payloads)).toHaveLength(0);
+    },
+  );
+});
+
 // ── get_subagent_status ──────────────────────────────────────────────
 
 describe("get_subagent_status tool", () => {

--- a/tests/in-process-tools.test.ts
+++ b/tests/in-process-tools.test.ts
@@ -123,6 +123,7 @@ import {
   setLegacyActiveSessionRefs,
   type SessionScope,
 } from "../src/session-scope";
+import { createTelemetrySession } from "../src/telemetry";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -274,6 +275,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   jobRegistry.clear();
   clearSessionScopes();
 });
@@ -952,6 +954,93 @@ describe("get_subagent_result tool", () => {
     expect(result.isError).toBeFalsy();
     // resultRetrieved should have been set
     expect(job.resultRetrieved).toBe(true);
+  });
+
+  it("records only the first successful output-bearing result read", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 })),
+    );
+    const scoped = setupScopedExtension(713);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const scopedTool = getToolDef(scoped.api, "get_subagent_result");
+    const owner = sessionOwner(scoped.scope);
+    const failedResult: SubagentResult = {
+      output: "failure details",
+      isError: true,
+      errorMessage: "failed",
+      usage: defaultSuccessResult.usage,
+      model: undefined,
+    };
+    const failed = createJobState({
+      id: "failed-read",
+      status: "done",
+      result: failedResult,
+      promise: Promise.resolve(failedResult),
+    });
+    registerInProcessJob(failed, owner);
+
+    await scopedTool.execute(
+      "failed",
+      { jobId: failed.id },
+      undefined,
+      undefined,
+    );
+    expect(
+      scoped.scope.telemetry.capturedKeys.has(
+        `result-consumed:in-process:${failed.id}`,
+      ),
+    ).toBe(false);
+
+    const cancelledResult: SubagentResult = {
+      ...defaultSuccessResult,
+      output: "Sub-agent cancelled before completion",
+      cancelled: true,
+    };
+    const cancelled = createJobState({
+      id: "cancelled-read",
+      status: "cancelled",
+      result: cancelledResult,
+      promise: Promise.resolve(cancelledResult),
+    });
+    registerInProcessJob(cancelled, owner);
+    await scopedTool.execute(
+      "cancelled",
+      { jobId: cancelled.id },
+      undefined,
+      undefined,
+    );
+    expect(
+      scoped.scope.telemetry.capturedKeys.has(
+        `result-consumed:in-process:${cancelled.id}`,
+      ),
+    ).toBe(false);
+
+    const successful = createJobState({
+      id: "successful-read",
+      status: "done",
+      result: defaultSuccessResult,
+      promise: Promise.resolve(defaultSuccessResult),
+    });
+    registerInProcessJob(successful, owner);
+    await scopedTool.execute(
+      "success-1",
+      { jobId: successful.id },
+      undefined,
+      undefined,
+    );
+    await scopedTool.execute(
+      "success-2",
+      { jobId: successful.id },
+      undefined,
+      undefined,
+    );
+
+    expect(
+      [...scoped.scope.telemetry.capturedKeys].filter(
+        (key) => key === `result-consumed:in-process:${successful.id}`,
+      ),
+    ).toHaveLength(1);
   });
   it("keeps a grouped result through TTL, prune, and cap pressure until collection", async () => {
     vi.useFakeTimers();

--- a/tests/in-process-tools.test.ts
+++ b/tests/in-process-tools.test.ts
@@ -957,9 +957,13 @@ describe("get_subagent_result tool", () => {
   });
 
   it("records only the first successful output-bearing result read", async () => {
+    const telemetryPayloads: Array<{ event?: string }> = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response(null, { status: 200 })),
+      vi.fn(async (_input, init) => {
+        telemetryPayloads.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 200 });
+      }),
     );
     const scoped = setupScopedExtension(713);
     scoped.scope.telemetry = createTelemetrySession(true);
@@ -986,11 +990,6 @@ describe("get_subagent_result tool", () => {
       undefined,
       undefined,
     );
-    expect(
-      scoped.scope.telemetry.capturedKeys.has(
-        `result-consumed:in-process:${failed.id}`,
-      ),
-    ).toBe(false);
 
     const cancelledResult: SubagentResult = {
       ...defaultSuccessResult,
@@ -1010,11 +1009,6 @@ describe("get_subagent_result tool", () => {
       undefined,
       undefined,
     );
-    expect(
-      scoped.scope.telemetry.capturedKeys.has(
-        `result-consumed:in-process:${cancelled.id}`,
-      ),
-    ).toBe(false);
 
     const successful = createJobState({
       id: "successful-read",
@@ -1037,8 +1031,8 @@ describe("get_subagent_result tool", () => {
     );
 
     expect(
-      [...scoped.scope.telemetry.capturedKeys].filter(
-        (key) => key === `result-consumed:in-process:${successful.id}`,
+      telemetryPayloads.filter(
+        (payload) => payload.event === "pi_subagentura_result_consumed",
       ),
     ).toHaveLength(1);
   });

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -28,7 +28,12 @@ import {
   type ParsedSpawnTreeContext,
 } from "../src/spawn-tree-context";
 import { workflowJobRegistry } from "../src/workflow-jobs";
-import { appendEvent, artifactPath } from "../src/artifact";
+import {
+  appendEvent,
+  artifactPath,
+  loadInteractiveStates,
+  updatePersistedTelemetrySession,
+} from "../src/artifact";
 import { __setTmuxMultiplexer } from "../src/multiplexer";
 import { updateRunningSubagentFooter } from "../src/artifact-poller";
 import {
@@ -59,7 +64,9 @@ function registerHandlers(
       handlers.set(name, registered);
     }),
     appendEntry: vi.fn(),
-    getFlag: vi.fn((name: string) => name === orchestratorFlag),
+    getFlag: vi.fn((name: string) =>
+      name === orchestratorFlag ? true : undefined,
+    ),
     sendMessage: vi.fn(),
     sendUserMessage: vi.fn(),
   };
@@ -76,6 +83,7 @@ function startSession(
   root: string,
   sessionId: string,
   ui = { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+  reason = "startup",
 ) {
   const sessionManager = {
     getSessionId: () => sessionId,
@@ -83,7 +91,7 @@ function startSession(
     getBranch: () => [],
   };
   const ctx = { cwd: root, ui, sessionManager };
-  registration.handlers.get("session_start")![0]({ reason: "startup" }, ctx);
+  registration.handlers.get("session_start")![0]({ reason }, ctx);
   return ctx;
 }
 
@@ -203,6 +211,98 @@ describe("session handler lifecycle callbacks", () => {
     });
   });
 
+  it.each(["reload", "resume"] as const)(
+    "preserves one telemetry session across %s without another root start",
+    (reason) => {
+      const registration = registerHandlers();
+      const ctx = startSession(registration, root, "session-a");
+      const initialId = registration.sessionScope.telemetry?.correlationId;
+
+      registration.handlers.get("session_start")![0]({ reason }, ctx);
+
+      expect(registration.sessionScope.telemetry?.correlationId).toBe(
+        initialId,
+      );
+      expect(registration.sessionScope.telemetry?.mode).toBe("orchestrator_v2");
+    },
+  );
+
+  it("emits session_started once across continuity lifecycle hooks", () => {
+    const previous = {
+      VITEST: process.env.VITEST,
+      CI: process.env.CI,
+      NODE_ENV: process.env.NODE_ENV,
+    };
+    delete process.env.VITEST;
+    delete process.env.CI;
+    delete process.env.NODE_ENV;
+    const captures: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        captures.push(JSON.parse(String(init.body)).event);
+        return new Response(null, { status: 200 });
+      }),
+    );
+    try {
+      const registration = registerHandlers();
+      const ctx = startSession(registration, root, "session-a");
+      registration.handlers.get("session_start")![0]({ reason: "reload" }, ctx);
+      registration.handlers.get("session_start")![0]({ reason: "resume" }, ctx);
+
+      expect(
+        captures.filter((event) => event === "pi_subagentura_session_started"),
+      ).toHaveLength(1);
+    } finally {
+      for (const [name, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("recovers persisted telemetry only for the matching startup session", () => {
+    const correlationId = "11111111-1111-4111-8111-111111111111";
+    updatePersistedTelemetrySession(root, "session-a", {
+      correlationId,
+      mode: "orchestrator",
+    });
+    const matching = registerHandlers();
+
+    startSession(matching, root, "session-a");
+
+    expect(matching.sessionScope.telemetry).toMatchObject({
+      correlationId,
+      mode: "orchestrator",
+    });
+
+    const mismatching = registerHandlers();
+    startSession(mismatching, root, "session-b");
+    expect(mismatching.sessionScope.telemetry?.correlationId).not.toBe(
+      correlationId,
+    );
+  });
+
+  it.each(["new", "fork"] as const)(
+    "replaces stale persisted telemetry on fresh %s",
+    (reason) => {
+      const staleId = "22222222-2222-4222-8222-222222222222";
+      updatePersistedTelemetrySession(root, "session-a", {
+        correlationId: staleId,
+        mode: "orchestrator",
+      });
+      const registration = registerHandlers();
+
+      startSession(registration, root, "session-b", undefined, reason);
+
+      expect(registration.sessionScope.telemetry?.correlationId).not.toBe(
+        staleId,
+      );
+      expect(loadInteractiveStates(root)?.telemetry).toBeUndefined();
+    },
+  );
+
   it.each([
     ["orchestratorv2", 2],
     ["orchestrator", 8],
@@ -240,10 +340,52 @@ describe("session handler lifecycle callbacks", () => {
     expect(registration.sessionScope.spawnTreeContext).toBe(initial);
   });
 
+  it("keeps child telemetry bootstrap separate from root persisted state", () => {
+    const rootCorrelation = "44444444-4444-4444-8444-444444444444";
+    const childCorrelation = "55555555-5555-4555-8555-555555555555";
+    updatePersistedTelemetrySession(root, "root-session", {
+      correlationId: rootCorrelation,
+      mode: "orchestrator_v2",
+    });
+    const initial = createDescendantSpawnTreeContext(
+      createRootSpawnTreeContext(
+        "root-session",
+        root,
+        false,
+        false,
+        8,
+        childCorrelation,
+        "orchestrator",
+      ),
+      "child-agent",
+      join(root, "child-agent"),
+    );
+    const registration = registerHandlers(initial, false);
+
+    startSession(registration, root, "child-session");
+
+    expect(registration.sessionScope.telemetry).toMatchObject({
+      correlationId: childCorrelation,
+      mode: "orchestrator",
+    });
+    expect(loadInteractiveStates(root)).toMatchObject({
+      parent: "root-session",
+      telemetry: { correlationId: rootCorrelation },
+    });
+  });
+
   it("clears descendant authority on a fresh child session", () => {
     const artifactDir = join(root, "child-agent");
     const expected = createDescendantSpawnTreeContext(
-      createRootSpawnTreeContext("lineage-root", root),
+      createRootSpawnTreeContext(
+        "lineage-root",
+        root,
+        false,
+        false,
+        8,
+        "33333333-3333-4333-8333-333333333333",
+        "orchestrator",
+      ),
       "child-agent",
       artifactDir,
     );
@@ -254,11 +396,17 @@ describe("session handler lifecycle callbacks", () => {
     const initial = acquireRuntimeSpawnTreeContext(artifactDir)!;
     const registration = registerHandlers(initial, false);
     const ctx = startSession(registration, root, "child-session");
+    expect(registration.sessionScope.telemetry?.correlationId).toBe(
+      "33333333-3333-4333-8333-333333333333",
+    );
     const abandonedPath = writeLineageBootstrap(artifactDir, expected);
 
     registration.handlers.get("session_start")![0]({ reason: "new" }, ctx);
 
     expect(registration.sessionScope.spawnTreeContext).toBeUndefined();
+    expect(registration.sessionScope.telemetry?.correlationId).not.toBe(
+      "33333333-3333-4333-8333-333333333333",
+    );
     expect(acquireRuntimeSpawnTreeContext(artifactDir)).toBeUndefined();
     expect(existsSync(abandonedPath)).toBe(false);
   });

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -61,6 +61,11 @@ function registerHandlers(
   initialSpawnTreeContext?: ParsedSpawnTreeContext,
   allowRootLineage = true,
   orchestratorFlag: "orchestrator" | "orchestratorv2" = "orchestratorv2",
+  /**
+   * `isTelemetryEnabled` is unconditionally false under vitest, so the enabled
+   * branches of session_start are unreachable without this injection seam.
+   */
+  telemetryEnabled?: boolean,
 ): HandlerRegistration {
   const handlers = new Map<string, Function[]>();
   const pi = {
@@ -80,6 +85,7 @@ function registerHandlers(
     pi as any,
     initialSpawnTreeContext,
     allowRootLineage,
+    telemetryEnabled === undefined ? undefined : () => telemetryEnabled,
   );
   return { handlers, pi, sessionScope };
 }
@@ -266,6 +272,147 @@ describe("session handler lifecycle callbacks", () => {
       }
       vi.unstubAllGlobals();
     }
+  });
+
+  describe("with telemetry enabled", () => {
+    let captured: Array<Record<string, any>>;
+
+    beforeEach(() => {
+      captured = [];
+      // These tests deliberately take the enabled path, so the transport has to
+      // be stubbed or the suite would post to the real endpoint.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string, init: RequestInit) => {
+          captured.push(JSON.parse(String(init.body)));
+          return new Response(null, { status: 200 });
+        }),
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("reports the session start against the persisted correlation", () => {
+      const registration = registerHandlers(
+        undefined,
+        true,
+        "orchestratorv2",
+        true,
+      );
+
+      startSession(registration, root, "session-a");
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]).toMatchObject({
+        event: "pi_subagentura_session_started",
+        distinct_id: loadInteractiveStates(root)?.telemetry?.correlationId,
+        properties: { mode: "orchestrator_v2" },
+      });
+    });
+
+    it("persists the correlation id and its owning session", () => {
+      const registration = registerHandlers(
+        undefined,
+        true,
+        "orchestratorv2",
+        true,
+      );
+
+      startSession(registration, root, "session-a");
+
+      const correlationId = registration.sessionScope.telemetry?.correlationId;
+      expect(correlationId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(loadInteractiveStates(root)).toMatchObject({
+        parent: "session-a",
+        telemetry: { correlationId, mode: "orchestrator_v2" },
+      });
+    });
+
+    it("hands the same correlation to the root lineage bootstrap", () => {
+      const registration = registerHandlers(
+        undefined,
+        true,
+        "orchestratorv2",
+        true,
+      );
+
+      startSession(registration, root, "session-a");
+
+      // The root's children inherit correlation only through this context, so
+      // a mismatch here silently splits one logical session into two.
+      expect(registration.sessionScope.spawnTreeContext).toMatchObject({
+        role: "root",
+        rootId: "session-a",
+        telemetrySessionId:
+          registration.sessionScope.telemetry?.correlationId ?? "missing",
+        telemetryMode: "orchestrator_v2",
+      });
+    });
+
+    it.each(["reload", "resume"] as const)(
+      "reuses the persisted correlation across %s",
+      (reason) => {
+        const registration = registerHandlers(
+          undefined,
+          true,
+          "orchestratorv2",
+          true,
+        );
+        const ctx = startSession(registration, root, "session-a");
+        const initial = registration.sessionScope.telemetry?.correlationId;
+
+        registration.handlers.get("session_start")![0]({ reason }, ctx);
+
+        expect(registration.sessionScope.telemetry?.correlationId).toBe(
+          initial,
+        );
+        expect(loadInteractiveStates(root)?.telemetry?.correlationId).toBe(
+          initial,
+        );
+        expect(registration.sessionScope.spawnTreeContext).toMatchObject({
+          telemetrySessionId: initial,
+        });
+      },
+    );
+  });
+
+  describe("with telemetry disabled", () => {
+    it("writes nothing at all when there is no correlation to clear", () => {
+      const registration = registerHandlers(
+        undefined,
+        true,
+        "orchestratorv2",
+        false,
+      );
+
+      startSession(registration, root, "session-a");
+
+      expect(registration.sessionScope.telemetry?.enabled).toBe(false);
+      // The opt-out must be inert: no `.pi/`, no state lock, no state file.
+      expect(existsSync(join(root, ".pi"))).toBe(false);
+      expect(registration.sessionScope.spawnTreeContext).not.toHaveProperty(
+        "telemetrySessionId",
+      );
+    });
+
+    it("clears a correlation an earlier opted-in run left behind", () => {
+      updatePersistedTelemetrySession(root, "session-a", {
+        correlationId: "33333333-3333-4333-8333-333333333333",
+        mode: "orchestrator",
+      });
+      const registration = registerHandlers(
+        undefined,
+        true,
+        "orchestratorv2",
+        false,
+      );
+
+      startSession(registration, root, "session-a");
+
+      expect(loadInteractiveStates(root)?.telemetry).toBeUndefined();
+    });
   });
 
   it("recovers persisted telemetry only for the matching startup session", () => {

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -29,13 +29,18 @@ import {
 } from "../src/spawn-tree-context";
 import { workflowJobRegistry } from "../src/workflow-jobs";
 import {
+  appendInteractiveState,
   appendEvent,
   artifactPath,
+  eventLogEndOffset,
   loadInteractiveStates,
   updatePersistedTelemetrySession,
 } from "../src/artifact";
 import { __setTmuxMultiplexer } from "../src/multiplexer";
-import { updateRunningSubagentFooter } from "../src/artifact-poller";
+import {
+  pollArtifactChanges,
+  updateRunningSubagentFooter,
+} from "../src/artifact-poller";
 import {
   advanceSessionScopeGeneration,
   clearSessionScopes,
@@ -44,6 +49,7 @@ import {
   type SessionScope,
 } from "../src/session-scope";
 import { publishCompletion } from "../src/completion-coordinator";
+import { createTelemetrySession } from "../src/telemetry";
 
 interface HandlerRegistration {
   handlers: Map<string, Function[]>;
@@ -567,6 +573,138 @@ describe("session handler lifecycle callbacks", () => {
       (globalThis as any).__piSubagenturaInteractivePollerHandle,
     ).toBeUndefined();
   });
+
+  it.each([
+    ["fresh shutdown", "new", false, "running"],
+    ["workflow-pane shutdown", "reload", true, "running"],
+    ["fresh shutdown after manual cancellation", "new", false, "cancelled"],
+  ] as const)(
+    "balances an active interactive task during %s",
+    async (_label, reason, workflowOwned, status) => {
+      vi.setSystemTime(5_000);
+      const telemetryPayloads: Array<{
+        event?: string;
+        properties?: Record<string, unknown>;
+      }> = [];
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (_input, init) => {
+          telemetryPayloads.push(JSON.parse(String(init?.body)));
+          return new Response(null, { status: 200 });
+        });
+      const registration = registerHandlers();
+      const ctx = startSession(registration, root, "session-a");
+      registration.sessionScope.telemetry = createTelemetrySession(
+        true,
+        "orchestrator_v2",
+      );
+      const state = ownedInteractive(
+        registration.sessionScope,
+        root,
+        "active-state",
+        "session-a",
+      );
+      state.status = status;
+      state.telemetryEligible = true;
+      state.telemetryCorrelationId =
+        registration.sessionScope.telemetry.correlationId;
+      state.telemetryActiveTurnId = "active-turn";
+      state.telemetryTurnStartedAt = 1_000;
+      state.telemetryTurnMessageCounts = new Map([["active-turn", 6]]);
+      state.telemetryInvocationSource = "interactive";
+      state.telemetryCompletionPolicy = "each";
+      state.telemetryAsync = true;
+      state.telemetryDepth = 3;
+      state.telemetryDepthBucket = "3";
+      state.telemetryModel = "default";
+      if (workflowOwned) {
+        state.completionOwner = "workflow";
+        const art = artifactPath(root, state.id);
+        appendEvent(art, {
+          version: 2,
+          eventId: "active-turn-start",
+          turnId: "active-turn",
+          ts: 1_000,
+          type: "turn_started",
+          status: "running",
+        });
+        writeFileSync(
+          join(state.artifactDir, "active-turn.json"),
+          JSON.stringify({ turnId: "active-turn" }),
+        );
+        appendInteractiveState(root, {
+          id: state.id,
+          paneId: state.paneId,
+          mux: "tmux",
+          artifactDir: state.artifactDir,
+          sessionFile: state.sessionFile,
+          parentSessionId: "session-a",
+          eventByteCursor: eventLogEndOffset(art),
+          sessionByteCursor: 0,
+          pendingDeliveries: [],
+          deliveryReceipts: [],
+          telemetry: {
+            correlationId: state.telemetryCorrelationId!,
+            invocationSource: "interactive",
+            async: true,
+            depth: 3,
+            depthBucket: "3",
+            completionPolicy: "each",
+            model: "default",
+            activeTurnId: "active-turn",
+            turnStartedAt: 1_000,
+            messageCounts: { "active-turn": 6 },
+          },
+        });
+      }
+      __setTmuxMultiplexer({
+        getPaneLiveness: () => "dead",
+        getPaneLivenessAsync: async () => "dead",
+      } as any);
+
+      registration.handlers.get("session_shutdown")![0]({ reason }, ctx);
+
+      if (workflowOwned) {
+        const persisted = loadInteractiveStates(root);
+        expect(persisted?.states[state.id].telemetry).not.toHaveProperty(
+          "activeTurnId",
+        );
+        registration.handlers.get("session_start")![0](
+          { reason: "reload" },
+          ctx,
+        );
+        const recoveredCorrelation =
+          registration.sessionScope.telemetry?.correlationId;
+        registration.sessionScope.telemetry = createTelemetrySession(
+          true,
+          "orchestrator_v2",
+          recoveredCorrelation,
+        );
+        await pollArtifactChanges(
+          registration.pi,
+          sessionOwner(registration.sessionScope),
+        );
+      }
+
+      expect(
+        telemetryPayloads.filter(
+          (payload) => payload.event === "pi_subagentura_task_completed",
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            status: "cancelled",
+            execution: "interactive",
+            unit: "turn",
+            depth: 3,
+            duration_ms: 4_000,
+            child_conversation_message_count: 6,
+          }),
+        }),
+      ]);
+      fetchMock.mockRestore();
+    },
+  );
   it.each([
     ["A-first", "a"],
     ["B-first", "b"],

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -610,7 +610,11 @@ describe("session handler lifecycle callbacks", () => {
         registration.sessionScope.telemetry.correlationId;
       state.telemetryActiveTurnId = "active-turn";
       state.telemetryTurnStartedAt = 1_000;
-      state.telemetryTurnMessageCounts = new Map([["active-turn", 6]]);
+      state.telemetryMessageTurnId = "active-message";
+      state.telemetryTurnMessageCounts = new Map([
+        ["active-message", 4],
+        ["active-turn", 6],
+      ]);
       state.telemetryInvocationSource = "interactive";
       state.telemetryCompletionPolicy = "each";
       state.telemetryAsync = true;
@@ -646,6 +650,7 @@ describe("session handler lifecycle callbacks", () => {
           telemetry: {
             correlationId: state.telemetryCorrelationId!,
             invocationSource: "interactive",
+            mux: "tmux",
             async: true,
             depth: 3,
             depthBucket: "3",
@@ -653,7 +658,8 @@ describe("session handler lifecycle callbacks", () => {
             model: "default",
             activeTurnId: "active-turn",
             turnStartedAt: 1_000,
-            messageCounts: { "active-turn": 6 },
+            messageTurnId: "active-message",
+            messageCounts: { "active-message": 4, "active-turn": 6 },
           },
         });
       }
@@ -668,6 +674,12 @@ describe("session handler lifecycle callbacks", () => {
         const persisted = loadInteractiveStates(root);
         expect(persisted?.states[state.id].telemetry).not.toHaveProperty(
           "activeTurnId",
+        );
+        expect(persisted?.states[state.id].telemetry).not.toHaveProperty(
+          "messageTurnId",
+        );
+        expect(persisted?.states[state.id].telemetry).not.toHaveProperty(
+          "messageCounts",
         );
         registration.handlers.get("session_start")![0](
           { reason: "reload" },
@@ -695,6 +707,7 @@ describe("session handler lifecycle callbacks", () => {
           properties: expect.objectContaining({
             status: "cancelled",
             execution: "interactive",
+            mux: "tmux",
             unit: "turn",
             depth: 3,
             duration_ms: 4_000,

--- a/tests/subagent-launch-script.test.ts
+++ b/tests/subagent-launch-script.test.ts
@@ -369,6 +369,7 @@ describe("spawn-time state persistence", () => {
       properties: {
         mode: "orchestrator_v2",
         execution: "interactive",
+        mux: "tmux",
         invocation_source: "interactive",
         depth: 1,
         completion_policy: "each",
@@ -377,7 +378,7 @@ describe("spawn-time state persistence", () => {
     expect(JSON.stringify(payloads)).not.toContain("never sent to telemetry");
     expect(
       loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
-    ).toMatchObject({ depth: 1, depthBucket: "1" });
+    ).toMatchObject({ depth: 1, depthBucket: "1", mux: "tmux" });
   });
 
   it("launchInteractiveSubagent without parentSessionId does NOT write the state file", async () => {

--- a/tests/subagent-launch-script.test.ts
+++ b/tests/subagent-launch-script.test.ts
@@ -30,6 +30,7 @@ import {
 import { stateFilePath, loadInteractiveStates } from "../src/artifact";
 import { importFresh } from "./test-utils";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
+import { createTelemetrySession } from "../src/telemetry";
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-launch-"));
@@ -345,7 +346,15 @@ describe("spawn-time state persistence", () => {
       task: "t",
       cwd,
       parentSessionId: "pi",
-      spawnTreeContext: createRootSpawnTreeContext("pi", cwd),
+      spawnTreeContext: createRootSpawnTreeContext(
+        "pi",
+        cwd,
+        false,
+        false,
+        undefined,
+        "123e4567-e89b-42d3-a456-426614174000",
+        "orchestrator_v2",
+      ),
     });
 
     const script = readFileSync(state.launchScriptFile, "utf8");
@@ -354,6 +363,7 @@ describe("spawn-time state persistence", () => {
     expect(script).not.toContain("PI_SUBAGENTURA_LINEAGE_SESSION_ROOT=");
     expect(script).not.toContain("PI_SUBAGENTURA_AGENT_ID=");
     expect(script).not.toContain("PI_SUBAGENTURA_DEPTH=");
+    expect(script).not.toContain("PI_SUBAGENTURA_TELEMETRY_SESSION_ID=");
     const bootstrapName = readdirSync(state.artifactDir).find((name) =>
       name.startsWith(".lineage-bootstrap-"),
     );
@@ -366,6 +376,8 @@ describe("spawn-time state persistence", () => {
       rootId: "pi",
       currentAgentId: state.id,
       depth: 1,
+      telemetrySessionId: "123e4567-e89b-42d3-a456-426614174000",
+      telemetryMode: "orchestrator_v2",
     });
   });
 
@@ -385,6 +397,32 @@ describe("spawn-time state persistence", () => {
     expect(entry?.mux).toBe(state.mux);
     expect(entry?.artifactDir).toBe(state.artifactDir);
     expect(entry?.sessionFile).toBe(state.sessionFile);
+  });
+
+  it("persists only a sanitized custom model telemetry dimension", async () => {
+    const { launchInteractiveSubagent } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+    const state = launchInteractiveSubagent({
+      name: "Demo",
+      task: "t",
+      cwd,
+      parentSessionId: "pi",
+      model: "private-provider/customer-deployment-secret",
+      sessionScope: {
+        id: 1,
+        generation: 1,
+        interactiveStates: new Map(),
+        telemetry: createTelemetrySession(true),
+      } as any,
+    });
+
+    expect(loadInteractiveStates(cwd)?.states[state.id]?.telemetry?.model).toBe(
+      "custom",
+    );
+    expect(readFileSync(stateFilePath(cwd), "utf8")).not.toContain(
+      "customer-deployment-secret",
+    );
   });
 
   it("the state has parentSessionId populated for terminal cleanup", async () => {

--- a/tests/subagent-launch-script.test.ts
+++ b/tests/subagent-launch-script.test.ts
@@ -31,6 +31,7 @@ import { stateFilePath, loadInteractiveStates } from "../src/artifact";
 import { importFresh } from "./test-utils";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
 import { createTelemetrySession } from "../src/telemetry";
+import { clearSessionScopes, registerSessionScope } from "../src/session-scope";
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-launch-"));
@@ -290,6 +291,8 @@ describe("spawn-time state persistence", () => {
   afterEach(() => {
     rmSync(cwd, { recursive: true, force: true });
     vi.doUnmock("node:child_process");
+    vi.unstubAllGlobals();
+    clearSessionScopes();
     for (const name of SPAWN_ENV_NAMES) {
       const value = savedEnv[name];
       if (value === undefined) delete process.env[name];
@@ -315,6 +318,66 @@ describe("spawn-time state persistence", () => {
     // accept an unintended sibling such as `${cwd}-other/...`.
     expect(relative(cwd, state.artifactDir).split(sep)[0]).not.toBe("..");
     expect(isAbsolute(relative(cwd, state.artifactDir))).toBe(false);
+  });
+
+  it("records one created agent when an interactive pane launches", async () => {
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const spawnTreeContext = createRootSpawnTreeContext(
+      SESSION,
+      cwd,
+      false,
+      true,
+      4,
+    );
+    const scope = registerSessionScope({
+      id: 777,
+      generation: 1,
+      lifecycle: "started",
+      pi: {} as never,
+      telemetry: createTelemetrySession(true, "orchestrator_v2"),
+      spawnTreeContext,
+    });
+    const { launchInteractiveSubagent } = await importFresh<
+      typeof import("../src/interactive-tmux")
+    >("../src/interactive-tmux");
+
+    const state = launchInteractiveSubagent({
+      name: "Demo",
+      task: "never sent to telemetry",
+      cwd,
+      parentSessionId: SESSION,
+      sessionScope: scope,
+      spawnTreeContext,
+      telemetryInvocationSource: "interactive",
+      telemetryAsync: true,
+      completionPolicy: "each",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      event: "pi_subagentura_agent_created",
+      properties: {
+        mode: "orchestrator_v2",
+        execution: "interactive",
+        invocation_source: "interactive",
+        depth: 1,
+        completion_policy: "each",
+      },
+    });
+    expect(JSON.stringify(payloads)).not.toContain("never sent to telemetry");
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).toMatchObject({ depth: 1, depthBucket: "1" });
   });
 
   it("launchInteractiveSubagent without parentSessionId does NOT write the state file", async () => {

--- a/tests/subagent-notify.test.ts
+++ b/tests/subagent-notify.test.ts
@@ -26,6 +26,7 @@ import {
   type SessionScope,
 } from "../src/session-scope";
 import { settleCompletionParentTurn } from "../src/completion-coordinator";
+import { createTelemetrySession } from "../src/telemetry";
 
 // ── Hoisted mock: startSubagentJob must be mocked before any imports ──────
 const { mockStartSubagentJob } = vi.hoisted(() => ({
@@ -1828,6 +1829,53 @@ describe("read_subagent_artifact (output reporting)", () => {
       rmSync(parent, { recursive: true, force: true });
     }
   });
+
+  it.each(["error", "cancelled"] as const)(
+    "does not report an inspected %s snapshot as a successful telemetry consumption",
+    async (outcome) => {
+      const id = outcome === "error" ? "ab12cd3800000012" : "ab12cd3800000013";
+      const parent = tmp();
+      try {
+        const { state, art } = makeArtifactWithDone(id, parent, false);
+        writeOutput(art, `${outcome} diagnostic output`);
+        appendCompletionEvent(art, {
+          turnId: `${outcome}-turn`,
+          eventId: `${outcome}-event`,
+          outcome,
+          source: "agent_settled",
+          ts: 2,
+        });
+        const mod =
+          await importFresh<typeof import("../src/subagent")>(
+            "../src/subagent",
+          );
+        const readTool = makeReadTool(mod, state);
+        const telemetry = createTelemetrySession(true);
+        getSessionScopes().at(-1)!.telemetry = telemetry;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async () => new Response(null, { status: 200 })),
+        );
+
+        await readTool.execute(
+          `read-${outcome}`,
+          { id },
+          undefined,
+          undefined,
+          {} as any,
+        );
+
+        expect(
+          telemetry.capturedKeys.has(
+            `result-consumed:interactive:${id}:${outcome}-turn`,
+          ),
+        ).toBe(false);
+      } finally {
+        vi.unstubAllGlobals();
+        rmSync(parent, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("reads the latest terminal snapshot instead of active staging output", async () => {
     const id = "ab12cd3800000011";

--- a/tests/subagent-notify.test.ts
+++ b/tests/subagent-notify.test.ts
@@ -1850,11 +1850,14 @@ describe("read_subagent_artifact (output reporting)", () => {
             "../src/subagent",
           );
         const readTool = makeReadTool(mod, state);
-        const telemetry = createTelemetrySession(true);
-        getSessionScopes().at(-1)!.telemetry = telemetry;
+        getSessionScopes().at(-1)!.telemetry = createTelemetrySession(true);
+        const telemetryPayloads: Array<{ event?: string }> = [];
         vi.stubGlobal(
           "fetch",
-          vi.fn(async () => new Response(null, { status: 200 })),
+          vi.fn(async (_input, init) => {
+            telemetryPayloads.push(JSON.parse(String(init?.body)));
+            return new Response(null, { status: 200 });
+          }),
         );
 
         await readTool.execute(
@@ -1866,16 +1869,68 @@ describe("read_subagent_artifact (output reporting)", () => {
         );
 
         expect(
-          telemetry.capturedKeys.has(
-            `result-consumed:interactive:${id}:${outcome}-turn`,
+          telemetryPayloads.filter(
+            (payload) => payload.event === "pi_subagentura_result_consumed",
           ),
-        ).toBe(false);
+        ).toHaveLength(0);
       } finally {
         vi.unstubAllGlobals();
         rmSync(parent, { recursive: true, force: true });
       }
     },
   );
+
+  it("reports a successful interactive result only on its first read", async () => {
+    const id = "ab12cd3800000014";
+    const parent = tmp();
+    try {
+      const { state, art } = makeArtifactWithDone(id, parent, false);
+      writeOutput(art, "successful output");
+      appendCompletionEvent(art, {
+        turnId: "successful-turn",
+        eventId: "successful-event",
+        outcome: "done",
+        source: "agent_settled",
+        ts: 2,
+      });
+      const mod =
+        await importFresh<typeof import("../src/subagent")>("../src/subagent");
+      const readTool = makeReadTool(mod, state);
+      getSessionScopes().at(-1)!.telemetry = createTelemetrySession(true);
+      const telemetryPayloads: Array<{ event?: string }> = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_input, init) => {
+          telemetryPayloads.push(JSON.parse(String(init?.body)));
+          return new Response(null, { status: 200 });
+        }),
+      );
+
+      await readTool.execute(
+        "read-first",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
+      await readTool.execute(
+        "read-again",
+        { id },
+        undefined,
+        undefined,
+        {} as any,
+      );
+
+      expect(
+        telemetryPayloads.filter(
+          (payload) => payload.event === "pi_subagentura_result_consumed",
+        ),
+      ).toHaveLength(1);
+    } finally {
+      vi.unstubAllGlobals();
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
 
   it("reads the latest terminal snapshot instead of active staging output", async () => {
     const id = "ab12cd3800000011";

--- a/tests/subagent-session-log.test.ts
+++ b/tests/subagent-session-log.test.ts
@@ -190,6 +190,7 @@ describe("session-log tail-read", () => {
     state.telemetryInvocationSource = "interactive";
     state.telemetryCompletionPolicy = "each";
     state.telemetryAsync = true;
+    state.telemetryDepth = 1;
     state.telemetryDepthBucket = "1";
     state.telemetryModel = "default";
     scope.interactiveStates.set(state.id, state);
@@ -243,10 +244,10 @@ describe("session-log tail-read", () => {
     await mod.pollArtifactChanges({} as any, sessionOwner(scope));
 
     const starts = payloads.filter(
-      (payload) => payload.event === "pi_subagentura_agent_started",
+      (payload) => payload.event === "pi_subagentura_task_started",
     );
     const completions = payloads.filter(
-      (payload) => payload.event === "pi_subagentura_agent_completed",
+      (payload) => payload.event === "pi_subagentura_task_completed",
     );
     expect(starts).toHaveLength(2);
     expect(completions).toHaveLength(2);
@@ -255,7 +256,9 @@ describe("session-log tail-read", () => {
       "turn",
     ]);
     expect(
-      completions.map(({ properties }) => properties.message_count),
+      completions.map(
+        ({ properties }) => properties.child_conversation_message_count,
+      ),
     ).toEqual([2, 3]);
   });
 
@@ -289,6 +292,7 @@ describe("session-log tail-read", () => {
       telemetryInvocationSource: "interactive",
       telemetryCompletionPolicy: "each",
       telemetryAsync: true,
+      telemetryDepth: 1,
       telemetryDepthBucket: "1",
       telemetryModel: "default",
       telemetryTurnMessageCounts: new Map(),
@@ -312,6 +316,7 @@ describe("session-log tail-read", () => {
         correlationId,
         invocationSource: "interactive",
         async: true,
+        depth: 1,
         depthBucket: "1",
         completionPolicy: "each",
         model: "default",
@@ -376,14 +381,15 @@ describe("session-log tail-read", () => {
     await mod.pollArtifactChanges({} as any, sessionOwner(recoveredScope));
 
     expect(
-      payloads.filter(({ event }) => event === "pi_subagentura_agent_started"),
+      payloads.filter(({ event }) => event === "pi_subagentura_task_started"),
     ).toHaveLength(1);
     const completions = payloads.filter(
-      ({ event }) => event === "pi_subagentura_agent_completed",
+      ({ event }) => event === "pi_subagentura_task_completed",
     );
     expect(completions).toHaveLength(1);
     expect(completions[0]?.properties).toMatchObject({
-      message_count: 3,
+      child_conversation_message_count: 3,
+      duration_ms: 100,
       duration_bucket: "<1s",
     });
   });

--- a/tests/subagent-session-log.test.ts
+++ b/tests/subagent-session-log.test.ts
@@ -21,8 +21,21 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { appendEvent, artifactPath, readEvents } from "../src/artifact";
+import {
+  appendEvent,
+  appendInteractiveState,
+  artifactPath,
+  readEvents,
+  updatePersistedTelemetrySession,
+} from "../src/artifact";
 import type { InteractiveSubagentState } from "../src/interactive-tmux";
+import {
+  clearSessionScopes,
+  registerSessionScope,
+  sessionOwner,
+} from "../src/session-scope";
+import { createTelemetrySession } from "../src/telemetry";
+import { rehydrateInteractiveSubagents } from "../src/rehydrate";
 import { importFresh } from "./test-utils";
 
 function makeTmp(): string {
@@ -85,6 +98,8 @@ describe("session-log tail-read", () => {
   });
 
   afterEach(() => {
+    clearSessionScopes();
+    vi.unstubAllGlobals();
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -145,6 +160,232 @@ describe("session-log tail-read", () => {
     expect(event.status).toBe("running");
     // Cursor advanced.
     expect(state.lastDeliveredSessionByte).toBeGreaterThan(0);
+  });
+
+  it("pairs telemetry starts and completions for every interactive turn", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { state, artifactDir } = makeState({});
+    const telemetry = createTelemetrySession(true, "orchestrator_v2");
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const scope = registerSessionScope({
+      id: 901,
+      generation: 1,
+      lifecycle: "started",
+      pi: {} as any,
+      telemetry,
+    });
+    state.telemetryEligible = true;
+    state.telemetryCorrelationId = telemetry.correlationId;
+    state.telemetryInvocationSource = "interactive";
+    state.telemetryCompletionPolicy = "each";
+    state.telemetryAsync = true;
+    state.telemetryDepthBucket = "1";
+    state.telemetryModel = "default";
+    scope.interactiveStates.set(state.id, state);
+    const art = artifactPath(join(artifactDir, ".."), state.id);
+
+    for (const [index, messages] of [
+      [
+        { role: "user", content: "first" },
+        { role: "assistant", content: "first result" },
+      ],
+      [
+        { role: "user", content: "follow-up" },
+        { role: "assistant", content: "working" },
+        { role: "assistant", content: "follow-up result" },
+      ],
+    ].entries()) {
+      appendFileSync(
+        state.sessionFile,
+        messages
+          .map((message, messageIndex) =>
+            JSON.stringify({
+              id:
+                message.role === "user"
+                  ? `turn-${index}`
+                  : `assistant-${index}-${messageIndex}`,
+              type: "message",
+              message,
+            }),
+          )
+          .join("\n") + "\n",
+      );
+      appendEvent(art, {
+        version: 2,
+        eventId: `start-${index}`,
+        turnId: `turn-${index}`,
+        ts: 1_000 + index * 100,
+        type: "turn_started",
+        status: "running",
+      });
+      appendEvent(art, {
+        version: 2,
+        eventId: `done-${index}`,
+        turnId: `turn-${index}`,
+        ts: 1_050 + index * 100,
+        type: "completion",
+        status: "done",
+        outcome: "done",
+        source: "agent_settled",
+      });
+    }
+    await mod.pollArtifactChanges({} as any, sessionOwner(scope));
+
+    const starts = payloads.filter(
+      (payload) => payload.event === "pi_subagentura_agent_started",
+    );
+    const completions = payloads.filter(
+      (payload) => payload.event === "pi_subagentura_agent_completed",
+    );
+    expect(starts).toHaveLength(2);
+    expect(completions).toHaveLength(2);
+    expect(starts.map(({ properties }) => properties.unit)).toEqual([
+      "turn",
+      "turn",
+    ]);
+    expect(
+      completions.map(({ properties }) => properties.message_count),
+    ).toEqual([2, 3]);
+  });
+
+  it("preserves active-turn telemetry progress across rehydrate", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { state, artifactDir } = makeState({});
+    const cwd = join(artifactDir, "..");
+    const correlationId = "66666666-6666-4666-8666-666666666666";
+    const telemetry = createTelemetrySession(
+      true,
+      "orchestrator",
+      correlationId,
+    );
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    Object.assign(state, {
+      cwd,
+      parentSessionId: "pi",
+      telemetryEligible: true,
+      telemetryCorrelationId: correlationId,
+      telemetryInvocationSource: "interactive",
+      telemetryCompletionPolicy: "each",
+      telemetryAsync: true,
+      telemetryDepthBucket: "1",
+      telemetryModel: "default",
+      telemetryTurnMessageCounts: new Map(),
+    });
+    updatePersistedTelemetrySession(cwd, "pi", {
+      correlationId,
+      mode: "orchestrator",
+    });
+    appendInteractiveState(cwd, {
+      id: state.id,
+      paneId: state.paneId,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+      parentSessionId: "pi",
+      eventByteCursor: 0,
+      sessionByteCursor: 0,
+      pendingDeliveries: [],
+      deliveryReceipts: [],
+      telemetry: {
+        correlationId,
+        invocationSource: "interactive",
+        async: true,
+        depthBucket: "1",
+        completionPolicy: "each",
+        model: "default",
+      },
+    });
+    const firstScope = registerSessionScope({
+      id: 902,
+      generation: 1,
+      lifecycle: "started",
+      pi: {} as any,
+      telemetry,
+    });
+    firstScope.interactiveStates.set(state.id, state);
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "turn-mid", role: "user", content: "begin" },
+        { id: "assistant-1", role: "assistant", content: "working" },
+        { id: "assistant-2", role: "assistant", content: "still working" },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    const art = artifactPath(cwd, state.id);
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-mid",
+      turnId: "turn-mid",
+      ts: 1_000,
+      type: "turn_started",
+      status: "running",
+    });
+
+    await mod.pollArtifactChanges({} as any, sessionOwner(firstScope));
+    clearSessionScopes();
+    const recoveredTelemetry = createTelemetrySession(
+      true,
+      "orchestrator",
+      correlationId,
+    );
+    const recoveredScope = registerSessionScope({
+      id: 903,
+      generation: 1,
+      lifecycle: "started",
+      pi: {} as any,
+      telemetry: recoveredTelemetry,
+    });
+    rehydrateInteractiveSubagents(cwd, "pi", [], recoveredScope);
+    appendEvent(art, {
+      version: 2,
+      eventId: "done-mid",
+      turnId: "turn-mid",
+      ts: 1_050,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "agent_settled",
+    });
+
+    await mod.pollArtifactChanges({} as any, sessionOwner(recoveredScope));
+
+    expect(
+      payloads.filter(({ event }) => event === "pi_subagentura_agent_started"),
+    ).toHaveLength(1);
+    const completions = payloads.filter(
+      ({ event }) => event === "pi_subagentura_agent_completed",
+    );
+    expect(completions).toHaveLength(1);
+    expect(completions[0]?.properties).toMatchObject({
+      message_count: 3,
+      duration_bucket: "<1s",
+    });
   });
 
   it("appends tool_activity for write, edit, read with file paths", async () => {

--- a/tests/subagent-session-log.test.ts
+++ b/tests/subagent-session-log.test.ts
@@ -25,6 +25,7 @@ import {
   appendEvent,
   appendInteractiveState,
   artifactPath,
+  loadInteractiveStates,
   readEvents,
   updatePersistedTelemetrySession,
 } from "../src/artifact";
@@ -262,6 +263,623 @@ describe("session-log tail-read", () => {
     ).toEqual([2, 3]);
   });
 
+  it("keeps streaming steering in one telemetry task", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { state, artifactDir } = makeState({});
+    const cwd = join(artifactDir, "..");
+    const correlationId = "77777777-7777-4777-8777-777777777777";
+    const telemetry = createTelemetrySession(
+      true,
+      "orchestrator_v2",
+      correlationId,
+    );
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const pi = {} as unknown as Parameters<typeof mod.pollArtifactChanges>[0];
+    Object.assign(state, {
+      cwd,
+      parentSessionId: "pi",
+      telemetryEligible: true,
+      telemetryCorrelationId: correlationId,
+      telemetryInvocationSource: "interactive",
+      telemetryCompletionPolicy: "each",
+      telemetryAsync: true,
+      telemetryDepth: 1,
+      telemetryDepthBucket: "1",
+      telemetryModel: "default",
+      telemetryTurnMessageCounts: new Map(),
+    });
+    updatePersistedTelemetrySession(cwd, "pi", {
+      correlationId,
+      mode: "orchestrator_v2",
+    });
+    appendInteractiveState(cwd, {
+      id: state.id,
+      paneId: state.paneId,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+      parentSessionId: "pi",
+      eventByteCursor: 0,
+      sessionByteCursor: 0,
+      pendingDeliveries: [],
+      deliveryReceipts: [],
+      telemetry: {
+        correlationId,
+        invocationSource: "interactive",
+        mux: "tmux",
+        async: true,
+        depth: 1,
+        depthBucket: "1",
+        completionPolicy: "each",
+        model: "default",
+      },
+    });
+    const scope = registerSessionScope({
+      id: 904,
+      generation: 1,
+      lifecycle: "started",
+      pi,
+      telemetry,
+    });
+    scope.interactiveStates.set(state.id, state);
+    const art = artifactPath(cwd, state.id);
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "10", role: "user", content: "initial" },
+        { id: "assistant-10", role: "assistant", content: "working" },
+        { id: "2", role: "user", content: "latest initial" },
+        { id: "assistant-2", role: "assistant", content: "still working" },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-initial",
+      turnId: "2",
+      ts: 1_000,
+      type: "turn_started",
+      status: "running",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+    expect(
+      payloads.filter(({ event }) => event === "pi_subagentura_task_started"),
+    ).toHaveLength(1);
+    expect(state.telemetryActiveTurnId).toBe("2");
+    expect(state.telemetryTurnStartedAt).toBe(1_000);
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).toMatchObject({
+      activeTurnId: "2",
+      turnStartedAt: 1_000,
+      messageTurnId: "2",
+      messageCounts: { "10": 2, "2": 2 },
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-steering",
+      turnId: "3",
+      ts: 1_100,
+      type: "turn_started",
+      status: "running",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+    expect(
+      payloads.filter(({ event }) => event === "pi_subagentura_task_started"),
+    ).toHaveLength(1);
+    expect(state.telemetryActiveTurnId).toBe("3");
+    expect(state.telemetryTurnStartedAt).toBe(1_000);
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).toMatchObject({
+      activeTurnId: "3",
+      turnStartedAt: 1_000,
+      messageTurnId: "3",
+      messageCounts: { "10": 2, "3": 2 },
+    });
+    clearSessionScopes();
+    const recoveredTelemetry = createTelemetrySession(
+      true,
+      "orchestrator_v2",
+      correlationId,
+    );
+    const recoveredScope = registerSessionScope({
+      id: 905,
+      generation: 1,
+      lifecycle: "started",
+      pi,
+      telemetry: recoveredTelemetry,
+    });
+    rehydrateInteractiveSubagents(cwd, "pi", [], recoveredScope);
+    const recoveredState = recoveredScope.interactiveStates.get(state.id);
+    expect(recoveredState).toBeDefined();
+    if (!recoveredState) throw new Error("steering state did not rehydrate");
+    expect(recoveredState.telemetryActiveTurnId).toBe("3");
+    expect(recoveredState.telemetryMessageTurnId).toBe("3");
+    expect(
+      Object.fromEntries(recoveredState.telemetryTurnMessageCounts ?? []),
+    ).toEqual({ "10": 2, "3": 2 });
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "3", role: "user", content: "steer" },
+        { id: "assistant-3", role: "assistant", content: "continued" },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    await mod.pollArtifactChanges(pi, sessionOwner(recoveredScope));
+    expect(recoveredState.telemetryActiveTurnId).toBe("3");
+    expect(recoveredState.telemetryTurnStartedAt).toBe(1_000);
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).toMatchObject({
+      activeTurnId: "3",
+      turnStartedAt: 1_000,
+      messageTurnId: "3",
+      messageCounts: { "10": 2, "3": 4 },
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "done-steering",
+      turnId: "3",
+      ts: 1_300,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "agent_settled",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(recoveredScope));
+    const starts = payloads.filter(
+      ({ event }) => event === "pi_subagentura_task_started",
+    );
+    const completions = payloads.filter(
+      ({ event }) => event === "pi_subagentura_task_completed",
+    );
+    expect(starts).toHaveLength(1);
+    expect(completions).toHaveLength(1);
+    expect(completions[0]?.properties).toMatchObject({
+      duration_ms: 300,
+      mux: "tmux",
+      child_conversation_message_count: 4,
+    });
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).not.toHaveProperty("messageTurnId");
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "4", role: "user", content: "follow up" },
+        { id: "assistant-4", role: "assistant", content: "done" },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-follow-up",
+      turnId: "4",
+      ts: 2_000,
+      type: "turn_started",
+      status: "running",
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "done-follow-up",
+      turnId: "4",
+      ts: 2_050,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "agent_settled",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(recoveredScope));
+    expect(
+      payloads.filter(({ event }) => event === "pi_subagentura_task_started"),
+    ).toHaveLength(2);
+    const allCompletions = payloads.filter(
+      ({ event }) => event === "pi_subagentura_task_completed",
+    );
+    expect(allCompletions).toHaveLength(2);
+    expect(allCompletions[1]?.properties).toMatchObject({
+      duration_ms: 100,
+      mux: "tmux",
+      child_conversation_message_count: 2,
+    });
+  });
+
+  it("folds event-ahead steering before users and starts a fresh task after completion", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { state, artifactDir } = makeState({});
+    const cwd = join(artifactDir, "..");
+    const correlationId = "88888888-8888-4888-8888-888888888888";
+    const telemetry = createTelemetrySession(
+      true,
+      "orchestrator_v2",
+      correlationId,
+    );
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const pi = {} as unknown as Parameters<typeof mod.pollArtifactChanges>[0];
+    Object.assign(state, {
+      cwd,
+      parentSessionId: "pi",
+      telemetryEligible: true,
+      telemetryCorrelationId: correlationId,
+      telemetryInvocationSource: "interactive",
+      telemetryCompletionPolicy: "each",
+      telemetryAsync: true,
+      telemetryDepth: 1,
+      telemetryDepthBucket: "1",
+      telemetryModel: "default",
+      telemetryTurnMessageCounts: new Map(),
+    });
+    updatePersistedTelemetrySession(cwd, "pi", {
+      correlationId,
+      mode: "orchestrator_v2",
+    });
+    appendInteractiveState(cwd, {
+      id: state.id,
+      paneId: state.paneId,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+      parentSessionId: "pi",
+      eventByteCursor: 0,
+      sessionByteCursor: 0,
+      pendingDeliveries: [],
+      deliveryReceipts: [],
+      telemetry: {
+        correlationId,
+        invocationSource: "interactive",
+        mux: "tmux",
+        async: true,
+        depth: 1,
+        depthBucket: "1",
+        completionPolicy: "each",
+        model: "default",
+      },
+    });
+    const scope = registerSessionScope({
+      id: 906,
+      generation: 1,
+      lifecycle: "started",
+      pi,
+      telemetry,
+    });
+    scope.interactiveStates.set(state.id, state);
+    const art = artifactPath(cwd, state.id);
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "turn-old", role: "user", content: "old" },
+        { id: "assistant-old", role: "assistant", content: "working" },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-old",
+      turnId: "turn-old",
+      ts: 1_000,
+      type: "turn_started",
+      status: "running",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+    // Both steering starts can be observed before either user entry reaches
+    // the session log. Rebinding must carry the original count through t2 and t3.
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-new",
+      turnId: "turn-new",
+      ts: 1_100,
+      type: "turn_started",
+      status: "running",
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-third",
+      turnId: "turn-third",
+      ts: 1_200,
+      type: "turn_started",
+      status: "running",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+    expect(
+      payloads.filter(({ event }) => event === "pi_subagentura_task_started"),
+    ).toHaveLength(1);
+    expect(state.telemetryActiveTurnId).toBe("turn-third");
+    expect(state.telemetryTurnStartedAt).toBe(1_000);
+    expect(state.telemetryMessageTurnId).toBe("turn-third");
+    expect(state.telemetryTurnMessageCounts).toEqual(
+      new Map([["turn-third", 2]]),
+    );
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).toMatchObject({
+      activeTurnId: "turn-third",
+      turnStartedAt: 1_000,
+      messageTurnId: "turn-third",
+      messageCounts: { "turn-third": 2 },
+    });
+
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "turn-new", role: "user", content: "steer" },
+        { id: "assistant-new", role: "assistant", content: "continued" },
+        { id: "turn-third", role: "user", content: "second steer" },
+        {
+          id: "assistant-third",
+          role: "assistant",
+          content: "continued again",
+        },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+    expect(state.telemetryActiveTurnId).toBe("turn-third");
+    expect(state.telemetryTurnStartedAt).toBe(1_000);
+    expect(state.telemetryMessageTurnId).toBe("turn-third");
+    expect(state.telemetryTurnMessageCounts).toEqual(
+      new Map([["turn-third", 6]]),
+    );
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).toMatchObject({
+      activeTurnId: "turn-third",
+      turnStartedAt: 1_000,
+      messageTurnId: "turn-third",
+      messageCounts: { "turn-third": 6 },
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "done-third",
+      turnId: "turn-third",
+      ts: 1_300,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "agent_settled",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+    expect(
+      payloads.filter(({ event }) => event === "pi_subagentura_task_completed"),
+    ).toHaveLength(1);
+    expect(
+      payloads.find(({ event }) => event === "pi_subagentura_task_completed")
+        ?.properties,
+    ).toMatchObject({
+      duration_ms: 300,
+      mux: "tmux",
+      child_conversation_message_count: 6,
+    });
+    expect(
+      loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
+    ).not.toHaveProperty("messageTurnId");
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "turn-after", role: "user", content: "after" },
+        { id: "assistant-after", role: "assistant", content: "done" },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-after",
+      turnId: "turn-after",
+      ts: 2_000,
+      type: "turn_started",
+      status: "running",
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "done-after",
+      turnId: "turn-after",
+      ts: 2_050,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "agent_settled",
+    });
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+    expect(
+      payloads.filter(({ event }) => event === "pi_subagentura_task_started"),
+    ).toHaveLength(2);
+    const completions = payloads.filter(
+      ({ event }) => event === "pi_subagentura_task_completed",
+    );
+    expect(completions).toHaveLength(2);
+    expect(completions[1]?.properties).toMatchObject({
+      duration_ms: 100,
+      mux: "tmux",
+      child_conversation_message_count: 2,
+    });
+  });
+
+  it("keeps a log-ahead user count when the prior turn completes", async () => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const { state, artifactDir } = makeState({});
+    const cwd = join(artifactDir, "..");
+    const correlationId = "99999999-9999-4999-8999-999999999999";
+    const telemetry = createTelemetrySession(
+      true,
+      "orchestrator_v2",
+      correlationId,
+    );
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const pi = {} as unknown as Parameters<typeof mod.pollArtifactChanges>[0];
+    Object.assign(state, {
+      cwd,
+      parentSessionId: "pi",
+      telemetryEligible: true,
+      telemetryCorrelationId: correlationId,
+      telemetryInvocationSource: "interactive",
+      telemetryCompletionPolicy: "each",
+      telemetryAsync: true,
+      telemetryDepth: 1,
+      telemetryDepthBucket: "1",
+      telemetryModel: "default",
+      telemetryActiveTurnId: "turn-one",
+      telemetryTurnStartedAt: 1_000,
+      telemetryMessageTurnId: "turn-two",
+      telemetryTurnMessageCounts: new Map([
+        ["turn-one", 2],
+        ["turn-two", 0],
+      ]),
+    });
+    updatePersistedTelemetrySession(cwd, "pi", {
+      correlationId,
+      mode: "orchestrator_v2",
+    });
+    appendInteractiveState(cwd, {
+      id: state.id,
+      paneId: state.paneId,
+      mux: state.mux,
+      artifactDir: state.artifactDir,
+      sessionFile: state.sessionFile,
+      parentSessionId: "pi",
+      eventByteCursor: 0,
+      sessionByteCursor: 0,
+      pendingDeliveries: [],
+      deliveryReceipts: [],
+      telemetry: {
+        correlationId,
+        invocationSource: "interactive",
+        mux: "tmux",
+        async: true,
+        depth: 1,
+        depthBucket: "1",
+        completionPolicy: "each",
+        model: "default",
+        activeTurnId: "turn-one",
+        turnStartedAt: 1_000,
+        messageTurnId: "turn-two",
+        messageCounts: { "turn-one": 2, "turn-two": 0 },
+      },
+    });
+    const scope = registerSessionScope({
+      id: 907,
+      generation: 1,
+      lifecycle: "started",
+      pi,
+      telemetry,
+    });
+    scope.interactiveStates.set(state.id, state);
+    const art = artifactPath(cwd, state.id);
+    appendFileSync(
+      state.sessionFile,
+      [
+        { id: "turn-two", role: "user", content: "steer" },
+        { id: "assistant-two", role: "assistant", content: "continued" },
+      ]
+        .map(({ id, ...message }) =>
+          JSON.stringify({ id, type: "message", message }),
+        )
+        .join("\n") + "\n",
+    );
+    appendEvent(art, {
+      version: 2,
+      eventId: "done-one",
+      turnId: "turn-one",
+      ts: 1_100,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "agent_settled",
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "start-two",
+      turnId: "turn-two",
+      ts: 1_150,
+      type: "turn_started",
+      status: "running",
+    });
+    appendEvent(art, {
+      version: 2,
+      eventId: "done-two",
+      turnId: "turn-two",
+      ts: 1_200,
+      type: "completion",
+      status: "done",
+      outcome: "done",
+      source: "agent_settled",
+    });
+
+    await mod.pollArtifactChanges(pi, sessionOwner(scope));
+
+    const starts = payloads.filter(
+      ({ event }) => event === "pi_subagentura_task_started",
+    );
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.properties).toMatchObject({ mux: "tmux" });
+    const completions = payloads.filter(
+      ({ event }) => event === "pi_subagentura_task_completed",
+    );
+    expect(completions).toHaveLength(2);
+    expect(completions.map(({ properties }) => properties.mux)).toEqual([
+      "tmux",
+      "tmux",
+    ]);
+    expect(
+      completions.map(
+        ({ properties }) => properties.child_conversation_message_count,
+      ),
+    ).toEqual([2, 2]);
+    expect(state.telemetryMessageTurnId).toBeUndefined();
+    expect(state.telemetryTurnMessageCounts).toEqual(new Map());
+  });
+
   it("preserves active-turn telemetry progress across rehydrate", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
@@ -315,6 +933,7 @@ describe("session-log tail-read", () => {
       telemetry: {
         correlationId,
         invocationSource: "interactive",
+        mux: "tmux",
         async: true,
         depth: 1,
         depthBucket: "1",
@@ -388,6 +1007,7 @@ describe("session-log tail-read", () => {
     );
     expect(completions).toHaveLength(1);
     expect(completions[0]?.properties).toMatchObject({
+      mux: "tmux",
       child_conversation_message_count: 3,
       duration_ms: 100,
       duration_bucket: "<1s",

--- a/tests/telemetry-model-registry.test.ts
+++ b/tests/telemetry-model-registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+// `sanitizeTelemetryModel` runs on the sub-agent launch path. It consults the
+// host agent's model registry, which is third-party code this extension does
+// not own, so a throw there must degrade the telemetry dimension rather than
+// fail the launch.
+vi.mock("@earendil-works/pi-ai/compat", () => ({
+  getProviders: () => {
+    throw new Error("provider registry unavailable");
+  },
+  getModel: () => {
+    throw new Error("model registry unavailable");
+  },
+}));
+
+const { sanitizeTelemetryModel } = await import("../src/telemetry");
+
+describe("model sanitization with a hostile registry", () => {
+  it.each([
+    ["gpt-5.6-sol", "custom"],
+    ["openai/gpt-5.6-sol", "custom"],
+    ["", "default"],
+    [undefined, "default"],
+    ["default", "default"],
+    ["custom", "custom"],
+  ])("maps %s to %s without throwing", (model, expected) => {
+    expect(() =>
+      sanitizeTelemetryModel(model as string | undefined),
+    ).not.toThrow();
+    expect(sanitizeTelemetryModel(model as string | undefined)).toBe(expected);
+  });
+});

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -3,6 +3,7 @@ import {
   buildTelemetryPayload,
   captureTelemetry,
   createTelemetrySession,
+  manifestDeliveryDedupeKey,
   MAX_TELEMETRY_DEDUPE_KEYS,
   resolveTelemetryMode,
   retireTelemetrySession,
@@ -145,6 +146,139 @@ describe("anonymous product telemetry", () => {
     expect(telemetryDurationBucket(700_000)).toBe("10m+");
     expect(telemetryDurationMs(12_345)).toBe(12_300);
     expect(telemetryDurationMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it("reports an implausible span as unknown instead of a capped number", () => {
+    const beyondBound = 31 * 24 * 60 * 60 * 1_000;
+
+    expect(telemetryDurationMs(beyondBound)).toBeUndefined();
+    expect(telemetryDurationBucket(beyondBound)).toBe("unknown");
+
+    const completed = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "task_completed",
+      execution: "interactive",
+      mux: "tmux",
+      unit: "turn",
+      invocation_source: "interactive",
+      model: "default",
+      async: true,
+      depth: 1,
+      depth_bucket: "1",
+      completion_policy: "each",
+      status: "success",
+      // A start timestamp recovered from a previous run yields a span no
+      // analysis should trust; a clamped value would look plausible.
+      duration_ms: beyondBound,
+      child_conversation_message_count: undefined,
+    });
+
+    expect(completed.properties).not.toHaveProperty("duration_ms");
+    expect(completed.properties.duration_bucket).toBe("unknown");
+  });
+
+  it("shares one bounded manifest dedupe key across both delivery sites", () => {
+    expect(manifestDeliveryDedupeKey(["a", "b"])).toBe("manifest:a:b");
+
+    const many = Array.from(
+      { length: 64 },
+      (_, index) => `completion-${index}`,
+    );
+    const key = manifestDeliveryDedupeKey(many);
+
+    expect(key.length).toBeLessThan(many.join(":").length);
+    expect(key).toBe(manifestDeliveryDedupeKey([...many]));
+    expect(key).not.toBe(manifestDeliveryDedupeKey(many.slice(0, 63)));
+  });
+
+  it("bounds the interactive_message_sent payload to closed dimensions", () => {
+    const session = createTelemetrySession(true, "orchestrator");
+    const payload = buildTelemetryPayload(session, {
+      event: "interactive_message_sent",
+      direction: "parent_to_child",
+      count: 5_000,
+    });
+
+    expect(payload.event).toBe("pi_subagentura_interactive_message_sent");
+    expect(Object.keys(payload.properties).sort()).toEqual(
+      [
+        "$geoip_disable",
+        "$ip",
+        "$lib",
+        "$lib_version",
+        "$process_person_profile",
+        "count",
+        "direction",
+        "mode",
+        "schema_version",
+        "telemetry_session_id",
+      ].sort(),
+    );
+    expect(payload.properties).toMatchObject({
+      direction: "parent_to_child",
+      count: 128,
+      mode: "orchestrator",
+      telemetry_session_id: session.correlationId,
+    });
+  });
+
+  it("bounds the completion_delivered payload to closed dimensions", () => {
+    const session = createTelemetrySession(true);
+    const payload = buildTelemetryPayload(session, {
+      event: "completion_delivered",
+      delivery: "manifest",
+      count: 900,
+    });
+
+    expect(payload.event).toBe("pi_subagentura_completion_delivered");
+    expect(Object.keys(payload.properties).sort()).toEqual(
+      [
+        "$geoip_disable",
+        "$ip",
+        "$lib",
+        "$lib_version",
+        "$process_person_profile",
+        "count",
+        "delivery",
+        "mode",
+        "schema_version",
+        "telemetry_session_id",
+      ].sort(),
+    );
+    expect(payload.properties).toMatchObject({
+      delivery: "manifest",
+      count: 128,
+    });
+  });
+
+  it.each([
+    [Number.NaN, 0],
+    [-7, 0],
+    [1.9, 1],
+    [128, 128],
+    [129, 128],
+  ])("clamps a bounded count of %s to %s", (count, expected) => {
+    expect(
+      buildTelemetryPayload(createTelemetrySession(true), {
+        event: "completion_delivered",
+        delivery: "notification",
+        count: count as number,
+      }).properties.count,
+    ).toBe(expected);
+  });
+
+  it("carries exactly the documented top-level payload fields", () => {
+    const payload = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "session_started",
+    });
+
+    expect(Object.keys(payload).sort()).toEqual([
+      "api_key",
+      "distinct_id",
+      "event",
+      "properties",
+    ]);
+    expect(typeof payload.api_key).toBe("string");
+    expect(payload.api_key.length).toBeGreaterThan(0);
   });
 
   it("distinguishes one created agent from its delegated tasks", () => {
@@ -322,17 +456,139 @@ describe("anonymous product telemetry", () => {
   });
 
   it.each([
+    [
+      "a fetch that throws synchronously",
+      () => {
+        throw new TypeError("fetch is not available");
+      },
+    ],
+    ["a fetch that rejects", () => Promise.reject(new Error("offline"))],
+    ["a patched fetch that returns a non-thenable", () => undefined],
+    ["a patched fetch that returns null", () => null],
+  ])("keeps the caller unaffected by %s", async (_label, impl) => {
+    const session = createTelemetrySession(true);
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      expect(() =>
+        captureTelemetry(
+          session,
+          { event: "session_started" },
+          { fetchImpl: impl as unknown as typeof fetch },
+        ),
+      ).not.toThrow();
+      // A rejection attached outside the guard would surface a turn later.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+    }
+  });
+
+  it("unrefs its abort timer so a pending capture cannot delay shutdown", () => {
+    // A capture in flight must never be the reason the process stays alive.
+    const unrefs: string[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    const spy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      ...args: Parameters<typeof setTimeout>
+    ) => {
+      const handle = realSetTimeout(...args);
+      const unref = handle.unref.bind(handle);
+      handle.unref = () => {
+        unrefs.push("unref");
+        return unref();
+      };
+      return handle;
+    }) as typeof setTimeout);
+    try {
+      captureTelemetry(
+        createTelemetrySession(true),
+        { event: "session_started" },
+        {
+          fetchImpl: vi.fn<typeof fetch>(() => new Promise<Response>(() => {})),
+        },
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(unrefs).toEqual(["unref"]);
+  });
+
+  it("clears its abort timer as soon as the capture settles", async () => {
+    const clear = vi.spyOn(globalThis, "clearTimeout");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    try {
+      captureTelemetry(
+        createTelemetrySession(true),
+        { event: "session_started" },
+        { fetchImpl },
+      );
+
+      await vi.waitFor(() => expect(clear).toHaveBeenCalled());
+    } finally {
+      clear.mockRestore();
+    }
+  });
+
+  it.each([
+    // The product switch points at telemetry, so every common spelling of
+    // "false" turns it off.
     [TELEMETRY_ENV, "0"],
+    [TELEMETRY_ENV, "0 "],
+    [TELEMETRY_ENV, "false"],
+    [TELEMETRY_ENV, "FALSE"],
+    [TELEMETRY_ENV, "off"],
+    [TELEMETRY_ENV, "no"],
+    // The opt-out switches point the other way and fail closed: only `0` and
+    // `false` cancel the request, so `off`/`no` still opt out.
     ["DO_NOT_TRACK", "1"],
+    ["DO_NOT_TRACK", "off"],
+    ["DO_NOT_TRACK", "no"],
+    ["DO_NOT_TRACK", "NO"],
     ["PI_OFFLINE", "true"],
+    ["PI_OFFLINE", "off"],
+    ["PI_OFFLINE", "no"],
+    // Environment probes.
     ["CI", "1"],
     ["VITEST", "1"],
     ["NODE_ENV", "test"],
-  ])("honors the %s opt-out", (name, value) => {
+  ])("honors the %s=%s opt-out", (name, value) => {
     clearTelemetryOptOuts();
     process.env[name] = value;
     const pi = { getFlag: vi.fn(() => true) };
     expect(isTelemetryEnabled(pi as any)).toBe(false);
+  });
+
+  it.each([
+    // A probe that says "not this environment" is permissive: `off` and `no`
+    // read as false because guessing wrong only costs an event.
+    ["CI", "false"],
+    ["CI", "0"],
+    ["CI", "OFF"],
+    ["CI", "no"],
+    ["VITEST", "false"],
+    ["VITEST", "off"],
+    // Cancelling an opt-out request must be unambiguous.
+    ["DO_NOT_TRACK", "0"],
+    ["DO_NOT_TRACK", "false"],
+    ["DO_NOT_TRACK", "FALSE"],
+    ["DO_NOT_TRACK", ""],
+    ["PI_OFFLINE", "0"],
+    ["PI_OFFLINE", "false"],
+    ["PI_OFFLINE", "  "],
+    ["PI_OFFLINE", ""],
+    ["NODE_ENV", "production"],
+    [TELEMETRY_ENV, "1"],
+  ])("leaves telemetry enabled for %s=%s", (name, value) => {
+    clearTelemetryOptOuts();
+    process.env[name] = value;
+    expect(isTelemetryEnabled({ getFlag: vi.fn(() => undefined) } as any)).toBe(
+      true,
+    );
   });
 
   it("supports the default-on flag and explicit CLI opt-out", () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -5,9 +5,12 @@ import {
   createTelemetrySession,
   MAX_TELEMETRY_DEDUPE_KEYS,
   resolveTelemetryMode,
+  retireTelemetrySession,
   sanitizeTelemetryModel,
   TELEMETRY_ENDPOINT,
+  telemetryDepth,
   telemetryDepthBucket,
+  telemetryDurationMs,
   telemetryDurationBucket,
 } from "../src/telemetry";
 import {
@@ -60,12 +63,13 @@ describe("anonymous product telemetry", () => {
       event: "session_started",
     });
     const agent = buildTelemetryPayload(session, {
-      event: "agent_started",
+      event: "task_started",
       execution: "in-process",
       unit: "job",
       invocation_source: "workflow",
       model: "openai/gpt-5.6-sol",
       async: true,
+      depth: 2,
       depth_bucket: "2",
       completion_policy: "each",
     });
@@ -76,8 +80,9 @@ describe("anonymous product telemetry", () => {
     expect(started.properties).toMatchObject({
       $process_person_profile: false,
       $geoip_disable: true,
+      $ip: "0.0.0.0",
       $lib: "pi-subagentura",
-      schema_version: 1,
+      schema_version: 2,
       mode: "orchestrator_v2",
     });
     expect(agent.properties).toMatchObject({
@@ -86,6 +91,7 @@ describe("anonymous product telemetry", () => {
       invocation_source: "workflow",
       model: "openai/gpt-5.6-sol",
       async: true,
+      depth: 2,
       depth_bucket: "2",
       completion_policy: "each",
     });
@@ -99,19 +105,21 @@ describe("anonymous product telemetry", () => {
 
   it("allows only a valid bootstrap correlation id", () => {
     const expected = "123e4567-e89b-42d3-a456-426614174000";
-    expect(createTelemetrySession(true, "manual", expected).correlationId).toBe(
-      expected,
-    );
     expect(
-      createTelemetrySession(true, "manual", "raw-pi-session-id").correlationId,
+      createTelemetrySession(true, "straight", expected).correlationId,
+    ).toBe(expected);
+    expect(
+      createTelemetrySession(true, "straight", "raw-pi-session-id")
+        .correlationId,
     ).not.toBe("raw-pi-session-id");
   });
 
   it("uses closed modes with V2 precedence", () => {
-    expect(resolveTelemetryMode(false, false)).toBe("manual");
+    expect(resolveTelemetryMode(false, false)).toBe("straight");
     expect(resolveTelemetryMode(true, false)).toBe("orchestrator");
     expect(resolveTelemetryMode(false, true)).toBe("orchestrator_v2");
     expect(resolveTelemetryMode(true, true)).toBe("orchestrator_v2");
+    expect(createTelemetrySession(true, "manual").mode).toBe("straight");
   });
 
   it("sanitizes models and buckets numeric values", () => {
@@ -128,44 +136,93 @@ describe("anonymous product telemetry", () => {
     expect(telemetryDepthBucket(4)).toBe("4-7");
     expect(telemetryDepthBucket(99)).toBe("8+");
     expect(telemetryDepthBucket(undefined)).toBe("unknown");
+    expect(telemetryDepth(4)).toBe(4);
+    expect(telemetryDepth(65)).toBeUndefined();
     expect(telemetryDurationBucket(4_999)).toBe("1-5s");
     expect(telemetryDurationBucket(700_000)).toBe("10m+");
+    expect(telemetryDurationMs(12_345)).toBe(12_300);
+    expect(telemetryDurationMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it("distinguishes one created agent from its delegated tasks", () => {
+    const session = createTelemetrySession(true, "straight");
+    const created = buildTelemetryPayload(session, {
+      event: "agent_created",
+      execution: "interactive",
+      invocation_source: "interactive",
+      model: "default",
+      async: true,
+      depth: 3,
+      depth_bucket: "3",
+      completion_policy: "each",
+    });
+    const task = buildTelemetryPayload(session, {
+      event: "task_started",
+      execution: "interactive",
+      unit: "turn",
+      invocation_source: "interactive",
+      model: "default",
+      async: true,
+      depth: 3,
+      depth_bucket: "3",
+      completion_policy: "each",
+    });
+
+    expect(created.event).toBe("pi_subagentura_agent_created");
+    expect(task.event).toBe("pi_subagentura_task_started");
+    expect(created.properties).toMatchObject({
+      execution: "interactive",
+      depth: 3,
+      depth_bucket: "3",
+    });
+    expect(task.properties.unit).toBe("turn");
   });
 
   it("contains only documented bounded lifecycle properties", () => {
     const session = createTelemetrySession(true);
     const completed = buildTelemetryPayload(session, {
-      event: "agent_completed",
+      event: "task_completed",
       execution: "interactive",
       unit: "turn",
       invocation_source: "interactive",
+      model: "default",
+      async: true,
+      depth: 1,
+      depth_bucket: "1",
       completion_policy: "each",
       status: "success",
       duration_ms: 12_345,
-      message_count: 50_000,
+      child_conversation_message_count: 50_000,
     });
 
     expect(Object.keys(completed.properties).sort()).toEqual(
       [
         "$geoip_disable",
+        "$ip",
         "$lib",
         "$lib_version",
         "$process_person_profile",
+        "async",
+        "child_conversation_message_count",
+        "completion_policy",
+        "depth",
+        "depth_bucket",
         "duration_bucket",
+        "duration_ms",
         "execution",
         "invocation_source",
-        "message_count",
+        "model",
         "mode",
-        "completion_policy",
         "schema_version",
         "status",
         "telemetry_session_id",
         "unit",
       ].sort(),
     );
-    expect(completed.properties.message_count).toBe(1_000);
+    expect(completed.properties.child_conversation_message_count).toBe(1_000);
+    expect(completed.properties.duration_ms).toBe(12_300);
     expect(JSON.stringify(completed)).not.toMatch(
-      /task|persona|prompt|output|error_text|cwd|path|artifact_id|agent_id|raw_session_id|token|cost/i,
+      /task_text|persona|prompt|output|error_text|cwd|path|artifact_id|agent_id|raw_session_id|token|cost/i,
     );
   });
 
@@ -193,7 +250,7 @@ describe("anonymous product telemetry", () => {
     });
   });
 
-  it("fails closed when the bounded dedupe cache is full", () => {
+  it("evicts the oldest dedupe key without dropping new lifecycle events", () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
       .mockResolvedValue(new Response(null, { status: 204 }));
@@ -213,7 +270,46 @@ describe("anonymous product telemetry", () => {
       { dedupeKey: "overflow", fetchImpl },
     );
 
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(session.capturedKeys.has("existing:0")).toBe(false);
+    expect(session.capturedKeys.has("overflow")).toBe(true);
+    expect(session.capturedKeys).toHaveLength(MAX_TELEMETRY_DEDUPE_KEYS);
+  });
+
+  it("allows only an explicitly terminal capture after session retirement", () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const session = createTelemetrySession(true);
+    retireTelemetrySession(session);
+
+    captureTelemetry(session, { event: "session_started" }, { fetchImpl });
+    captureTelemetry(
+      session,
+      {
+        event: "task_completed",
+        execution: "in-process",
+        unit: "job",
+        invocation_source: "isolated",
+        model: "default",
+        async: true,
+        depth: 1,
+        depth_bucket: "1",
+        completion_policy: "each",
+        status: "cancelled",
+        duration_ms: 1_000,
+        child_conversation_message_count: 0,
+      },
+      { allowInactive: true, fetchImpl },
+    );
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(
+      JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)),
+    ).toMatchObject({
+      event: "pi_subagentura_task_completed",
+      properties: { status: "cancelled" },
+    });
   });
 
   it.each([

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildTelemetryPayload,
+  captureTelemetry,
+  createTelemetrySession,
+  MAX_TELEMETRY_DEDUPE_KEYS,
+  resolveTelemetryMode,
+  sanitizeTelemetryModel,
+  TELEMETRY_ENDPOINT,
+  telemetryDepthBucket,
+  telemetryDurationBucket,
+} from "../src/telemetry";
+import {
+  isTelemetryEnabled,
+  TELEMETRY_ENV,
+  TELEMETRY_FLAG,
+} from "../src/settings";
+
+const originalEnvironment = {
+  CI: process.env.CI,
+  DO_NOT_TRACK: process.env.DO_NOT_TRACK,
+  NODE_ENV: process.env.NODE_ENV,
+  PI_OFFLINE: process.env.PI_OFFLINE,
+  TELEMETRY: process.env[TELEMETRY_ENV],
+  VITEST: process.env.VITEST,
+};
+
+function restoreEnvironment(): void {
+  for (const [name, value] of Object.entries({
+    CI: originalEnvironment.CI,
+    DO_NOT_TRACK: originalEnvironment.DO_NOT_TRACK,
+    NODE_ENV: originalEnvironment.NODE_ENV,
+    PI_OFFLINE: originalEnvironment.PI_OFFLINE,
+    [TELEMETRY_ENV]: originalEnvironment.TELEMETRY,
+    VITEST: originalEnvironment.VITEST,
+  })) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
+
+function clearTelemetryOptOuts(): void {
+  delete process.env.CI;
+  delete process.env.DO_NOT_TRACK;
+  delete process.env.NODE_ENV;
+  delete process.env.PI_OFFLINE;
+  delete process.env[TELEMETRY_ENV];
+  delete process.env.VITEST;
+}
+
+describe("anonymous product telemetry", () => {
+  afterEach(() => {
+    restoreEnvironment();
+    vi.restoreAllMocks();
+  });
+
+  it("reuses one random personless correlation id within a session", () => {
+    const session = createTelemetrySession(true, "orchestrator_v2");
+    const started = buildTelemetryPayload(session, {
+      event: "session_started",
+    });
+    const agent = buildTelemetryPayload(session, {
+      event: "agent_started",
+      execution: "in-process",
+      unit: "job",
+      invocation_source: "workflow",
+      model: "openai/gpt-5.6-sol",
+      async: true,
+      depth_bucket: "2",
+      completion_policy: "each",
+    });
+
+    expect(started.distinct_id).toBe(agent.distinct_id);
+    expect(started.distinct_id).toBe(session.correlationId);
+    expect(started.properties.telemetry_session_id).toBe(session.correlationId);
+    expect(started.properties).toMatchObject({
+      $process_person_profile: false,
+      $geoip_disable: true,
+      $lib: "pi-subagentura",
+      schema_version: 1,
+      mode: "orchestrator_v2",
+    });
+    expect(agent.properties).toMatchObject({
+      execution: "in-process",
+      unit: "job",
+      invocation_source: "workflow",
+      model: "openai/gpt-5.6-sol",
+      async: true,
+      depth_bucket: "2",
+      completion_policy: "each",
+    });
+  });
+
+  it("creates unrelated ids for unrelated root sessions", () => {
+    expect(createTelemetrySession(true).correlationId).not.toBe(
+      createTelemetrySession(true).correlationId,
+    );
+  });
+
+  it("allows only a valid bootstrap correlation id", () => {
+    const expected = "123e4567-e89b-42d3-a456-426614174000";
+    expect(createTelemetrySession(true, "manual", expected).correlationId).toBe(
+      expected,
+    );
+    expect(
+      createTelemetrySession(true, "manual", "raw-pi-session-id").correlationId,
+    ).not.toBe("raw-pi-session-id");
+  });
+
+  it("uses closed modes with V2 precedence", () => {
+    expect(resolveTelemetryMode(false, false)).toBe("manual");
+    expect(resolveTelemetryMode(true, false)).toBe("orchestrator");
+    expect(resolveTelemetryMode(false, true)).toBe("orchestrator_v2");
+    expect(resolveTelemetryMode(true, true)).toBe("orchestrator_v2");
+  });
+
+  it("sanitizes models and buckets numeric values", () => {
+    expect(sanitizeTelemetryModel("gpt-5.6-sol")).toBe("gpt-5.6-sol");
+    expect(sanitizeTelemetryModel("openai/gpt-5.6-sol")).toBe(
+      "openai/gpt-5.6-sol",
+    );
+    expect(sanitizeTelemetryModel("private/customer-deployment")).toBe(
+      "custom",
+    );
+    expect(sanitizeTelemetryModel(undefined)).toBe("default");
+    expect(sanitizeTelemetryModel("default")).toBe("default");
+    expect(sanitizeTelemetryModel("custom")).toBe("custom");
+    expect(telemetryDepthBucket(4)).toBe("4-7");
+    expect(telemetryDepthBucket(99)).toBe("8+");
+    expect(telemetryDepthBucket(undefined)).toBe("unknown");
+    expect(telemetryDurationBucket(4_999)).toBe("1-5s");
+    expect(telemetryDurationBucket(700_000)).toBe("10m+");
+  });
+
+  it("contains only documented bounded lifecycle properties", () => {
+    const session = createTelemetrySession(true);
+    const completed = buildTelemetryPayload(session, {
+      event: "agent_completed",
+      execution: "interactive",
+      unit: "turn",
+      invocation_source: "interactive",
+      completion_policy: "each",
+      status: "success",
+      duration_ms: 12_345,
+      message_count: 50_000,
+    });
+
+    expect(Object.keys(completed.properties).sort()).toEqual(
+      [
+        "$geoip_disable",
+        "$lib",
+        "$lib_version",
+        "$process_person_profile",
+        "duration_bucket",
+        "execution",
+        "invocation_source",
+        "message_count",
+        "mode",
+        "completion_policy",
+        "schema_version",
+        "status",
+        "telemetry_session_id",
+        "unit",
+      ].sort(),
+    );
+    expect(completed.properties.message_count).toBe(1_000);
+    expect(JSON.stringify(completed)).not.toMatch(
+      /task|persona|prompt|output|error_text|cwd|path|artifact_id|agent_id|raw_session_id|token|cost/i,
+    );
+  });
+
+  it("posts best-effort events once per internal dedupe key", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const session = createTelemetrySession(true);
+    const event = { event: "result_consumed", source: "workflow" } as const;
+
+    captureTelemetry(session, event, { dedupeKey: "internal", fetchImpl });
+    captureTelemetry(session, event, { dedupeKey: "internal", fetchImpl });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce());
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(TELEMETRY_ENDPOINT);
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      event: "pi_subagentura_result_consumed",
+      distinct_id: session.correlationId,
+      properties: { source: "workflow" },
+    });
+  });
+
+  it("fails closed when the bounded dedupe cache is full", () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const session = createTelemetrySession(true);
+    for (let index = 0; index < MAX_TELEMETRY_DEDUPE_KEYS; index++) {
+      session.capturedKeys.add(`existing:${index}`);
+    }
+
+    captureTelemetry(
+      session,
+      { event: "result_consumed", source: "interactive" },
+      { dedupeKey: "overflow", fetchImpl },
+    );
+    captureTelemetry(
+      session,
+      { event: "result_consumed", source: "interactive" },
+      { dedupeKey: "overflow", fetchImpl },
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [TELEMETRY_ENV, "0"],
+    ["DO_NOT_TRACK", "1"],
+    ["PI_OFFLINE", "true"],
+    ["CI", "1"],
+    ["VITEST", "1"],
+    ["NODE_ENV", "test"],
+  ])("honors the %s opt-out", (name, value) => {
+    clearTelemetryOptOuts();
+    process.env[name] = value;
+    const pi = { getFlag: vi.fn(() => true) };
+    expect(isTelemetryEnabled(pi as any)).toBe(false);
+  });
+
+  it("supports the default-on flag and explicit CLI opt-out", () => {
+    clearTelemetryOptOuts();
+    expect(isTelemetryEnabled({ getFlag: vi.fn(() => undefined) } as any)).toBe(
+      true,
+    );
+    expect(
+      isTelemetryEnabled({
+        getFlag: vi.fn((name) => (name === TELEMETRY_FLAG ? false : undefined)),
+      } as any),
+    ).toBe(false);
+  });
+});

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -17,6 +17,7 @@ import {
   isTelemetryEnabled,
   TELEMETRY_ENV,
   TELEMETRY_FLAG,
+  TELEMETRY_OPT_OUT_FLAG,
 } from "../src/settings";
 
 const originalEnvironment = {
@@ -65,6 +66,7 @@ describe("anonymous product telemetry", () => {
     const agent = buildTelemetryPayload(session, {
       event: "task_started",
       execution: "in-process",
+      mux: "none",
       unit: "job",
       invocation_source: "workflow",
       model: "openai/gpt-5.6-sol",
@@ -87,6 +89,7 @@ describe("anonymous product telemetry", () => {
     });
     expect(agent.properties).toMatchObject({
       execution: "in-process",
+      mux: "none",
       unit: "job",
       invocation_source: "workflow",
       model: "openai/gpt-5.6-sol",
@@ -149,6 +152,7 @@ describe("anonymous product telemetry", () => {
     const created = buildTelemetryPayload(session, {
       event: "agent_created",
       execution: "interactive",
+      mux: "tmux",
       invocation_source: "interactive",
       model: "default",
       async: true,
@@ -159,6 +163,7 @@ describe("anonymous product telemetry", () => {
     const task = buildTelemetryPayload(session, {
       event: "task_started",
       execution: "interactive",
+      mux: "tmux",
       unit: "turn",
       invocation_source: "interactive",
       model: "default",
@@ -172,6 +177,7 @@ describe("anonymous product telemetry", () => {
     expect(task.event).toBe("pi_subagentura_task_started");
     expect(created.properties).toMatchObject({
       execution: "interactive",
+      mux: "tmux",
       depth: 3,
       depth_bucket: "3",
     });
@@ -183,6 +189,7 @@ describe("anonymous product telemetry", () => {
     const completed = buildTelemetryPayload(session, {
       event: "task_completed",
       execution: "interactive",
+      mux: "tmux",
       unit: "turn",
       invocation_source: "interactive",
       model: "default",
@@ -210,6 +217,7 @@ describe("anonymous product telemetry", () => {
         "duration_bucket",
         "duration_ms",
         "execution",
+        "mux",
         "invocation_source",
         "model",
         "mode",
@@ -289,6 +297,7 @@ describe("anonymous product telemetry", () => {
       {
         event: "task_completed",
         execution: "in-process",
+        mux: "none",
         unit: "job",
         invocation_source: "isolated",
         model: "default",
@@ -336,5 +345,13 @@ describe("anonymous product telemetry", () => {
         getFlag: vi.fn((name) => (name === TELEMETRY_FLAG ? false : undefined)),
       } as any),
     ).toBe(false);
+    const optedOutPi = {
+      getFlag: vi.fn((name) =>
+        name === TELEMETRY_FLAG || name === TELEMETRY_OPT_OUT_FLAG
+          ? true
+          : undefined,
+      ),
+    } as unknown as Parameters<typeof isTelemetryEnabled>[0];
+    expect(isTelemetryEnabled(optedOutPi)).toBe(false);
   });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -534,6 +534,53 @@ describe("anonymous product telemetry", () => {
     }
   });
 
+  it("keeps its abort deadline armed until an unused response body settles", async () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    let resolveBodyCleanup!: () => void;
+    const bodyCleanup = new Promise<void>((resolve) => {
+      resolveBodyCleanup = resolve;
+    });
+    const bodyCancel = vi.fn(() => bodyCleanup);
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel: () => bodyCancel(),
+      }),
+    );
+    let resolveHeaders!: (value: Response) => void;
+    const headers = new Promise<Response>((resolve) => {
+      resolveHeaders = resolve;
+    });
+    const fetchImpl = vi.fn<typeof fetch>(() => headers);
+
+    try {
+      captureTelemetry(
+        createTelemetrySession(true),
+        { event: "session_started" },
+        { fetchImpl },
+      );
+
+      expect(fetchImpl).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(1);
+
+      // Fetch has resolved its headers, but cancelling the unused body remains
+      // pending. The timeout must stay armed through that cleanup.
+      resolveHeaders(response);
+      await Promise.resolve();
+      expect(bodyCancel).toHaveBeenCalledOnce();
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(1);
+
+      resolveBodyCleanup();
+      await vi.waitFor(() => expect(clearTimeoutSpy).toHaveBeenCalledOnce());
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      resolveBodyCleanup();
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     // The product switch points at telemetry, so every common spelling of
     // "false" turns it off.

--- a/tests/thinking-level-effective.test.ts
+++ b/tests/thinking-level-effective.test.ts
@@ -128,9 +128,15 @@ describe("startSubagentJob effective thinking level", () => {
         "pi_subagentura_task_started",
         "pi_subagentura_task_completed",
       ]);
+      expect(payloads.map(({ properties }) => properties.mux)).toEqual([
+        "none",
+        "none",
+        "none",
+      ]);
       expect(payloads[2]?.properties).toMatchObject({
         mode: "orchestrator_v2",
         invocation_source: "workflow",
+        mux: "none",
         depth: 2,
         status: "success",
         child_conversation_message_count: 2,
@@ -197,7 +203,10 @@ describe("startSubagentJob effective thinking level", () => {
         ),
       ).toEqual([
         expect.objectContaining({
-          properties: expect.objectContaining({ status: "cancelled" }),
+          properties: expect.objectContaining({
+            status: "cancelled",
+            mux: "none",
+          }),
         }),
       ]);
     } finally {

--- a/tests/thinking-level-effective.test.ts
+++ b/tests/thinking-level-effective.test.ts
@@ -30,6 +30,10 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
 });
 
 import { jobRegistry, startSubagentJob } from "../src/helpers";
+import {
+  createTelemetrySession,
+  retireTelemetrySession,
+} from "../src/telemetry";
 
 function createSession(thinkingLevel: string) {
   return {
@@ -84,6 +88,121 @@ describe("startSubagentJob effective thinking level", () => {
     expect(started.thinkingLevel).toBe("low");
     expect(started.liveStatus.thinkingLevel).toBe("low");
     expect(result.thinkingLevel).toBe("low");
+  });
+
+  it("records one created agent and one delegated task per started job", async () => {
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const session = createSession("low");
+    session.agent.state.messages.push(
+      { role: "user", content: "redacted before telemetry" } as never,
+      { role: "assistant", content: "also redacted" } as never,
+    );
+    mockCreateAgentSession.mockResolvedValue({ session });
+
+    try {
+      const started = await startSubagentJob({
+        ...params(),
+        telemetry: {
+          session: createTelemetrySession(true, "orchestrator_v2"),
+          invocationSource: "workflow",
+          async: true,
+          depth: 2,
+          completionPolicy: "group",
+        },
+      });
+      started.start();
+      await started.jobPromise;
+
+      expect(payloads.map(({ event }) => event)).toEqual([
+        "pi_subagentura_agent_created",
+        "pi_subagentura_task_started",
+        "pi_subagentura_task_completed",
+      ]);
+      expect(payloads[2]?.properties).toMatchObject({
+        mode: "orchestrator_v2",
+        invocation_source: "workflow",
+        depth: 2,
+        status: "success",
+        child_conversation_message_count: 2,
+      });
+      expect(JSON.stringify(payloads)).not.toContain(
+        "redacted before telemetry",
+      );
+      expect(JSON.stringify(payloads)).not.toContain("also redacted");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("records cancellation after lifecycle cleanup retires the session", async () => {
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const controller = new AbortController();
+    let releasePrompt = (): void => undefined;
+    const session = {
+      ...createSession("low"),
+      prompt: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releasePrompt = resolve;
+          }),
+      ),
+      abort: vi.fn(async () => releasePrompt()),
+    };
+    mockCreateAgentSession.mockResolvedValue({ session });
+    const telemetrySession = createTelemetrySession(true, "orchestrator_v2");
+
+    try {
+      const started = await startSubagentJob({
+        ...params(),
+        signal: controller.signal,
+        telemetry: {
+          session: telemetrySession,
+          invocationSource: "workflow",
+          async: true,
+          depth: 2,
+          completionPolicy: "group",
+        },
+      });
+      started.start();
+      await vi.waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+
+      retireTelemetrySession(telemetrySession);
+      controller.abort("session reload");
+      const result = await started.jobPromise;
+
+      expect(result.cancelled).toBe(true);
+      expect(
+        payloads.filter(
+          ({ event }) => event === "pi_subagentura_task_completed",
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          properties: expect.objectContaining({ status: "cancelled" }),
+        }),
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("keeps thinking-level details omitted when the request omits it", async () => {

--- a/tests/workflow-supervisor.integration.test.ts
+++ b/tests/workflow-supervisor.integration.test.ts
@@ -471,13 +471,27 @@ describe("workflow supervisor integration", () => {
       { script: SINGLE_AGENT_SCRIPT("fallback"), async: false },
       undefined,
       vi.fn(),
-      { cwd: "/tmp", modelRegistry: {} },
+      {
+        cwd: "/tmp",
+        modelRegistry: {},
+        sessionManager: { getSessionId: () => "session-a" },
+      },
     );
 
     await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
     expect(mockStartSubagentJob).toHaveBeenCalledWith(
       expect.objectContaining({
-        telemetry: expect.objectContaining({ completionPolicy: "inline" }),
+        telemetry: expect.objectContaining({
+          completionPolicy: "inline",
+          depth: 1,
+        }),
+        // The runtime depth must match the reported one. Left unset, the child
+        // bound depth 0, so its own nested spawns reported depth 1 — the same
+        // as their parent — and never counted against the depth cap.
+        depth: 1,
+        // No ambient orchestration context here, so the child's logs are
+        // attributed through the parent's own session id.
+        rootSessionId: "session-a",
       }),
     );
     const childJob = jobRegistry.get("fallback-child");
@@ -603,6 +617,46 @@ describe("workflow supervisor integration", () => {
     expect(result.details.status).toBe("done");
     expect(result.content[0]?.text).toContain("unowned complete");
     expect(jobRegistry.size).toBe(0);
+  });
+
+  it("leaves a workflow child unattributed when the caller has no session id", async () => {
+    const { context } = liveSessionContext({ id: 11, sessionId: "session-a" });
+    const start = vi.fn();
+    let releaseChild!: (result: SubagentResult) => void;
+    mockLaunch.mockImplementationOnce(() => {
+      throw new Error("mux unavailable");
+    });
+    mockStartSubagentJob.mockResolvedValueOnce({
+      jobId: "unattributed-child",
+      jobPromise: new Promise<SubagentResult>((resolve) => {
+        releaseChild = resolve;
+      }),
+      liveStatus: { turn: 0, output: "", usage: {} },
+      session: { abort: vi.fn() },
+      modelLabel: "test/model",
+      thinkingLevel: "medium",
+      start,
+    });
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never, context);
+
+    const execution = findTool().execute(
+      "call-unattributed",
+      { script: SINGLE_AGENT_SCRIPT("unattributed"), async: false },
+      undefined,
+      vi.fn(),
+      // No ambient orchestration context and no session manager to fall back
+      // on: the child runs, it just carries no root attribution.
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+    expect(mockStartSubagentJob).toHaveBeenCalledWith(
+      expect.objectContaining({ depth: 1, rootSessionId: undefined }),
+    );
+
+    releaseChild(subagentResult("unattributed complete"));
+    await execution;
   });
 
   it("retains a completed interactive child when the workflow later fails", async () => {

--- a/tests/workflow-supervisor.integration.test.ts
+++ b/tests/workflow-supervisor.integration.test.ts
@@ -66,6 +66,8 @@ import {
   type WorkflowJobState,
 } from "../src/workflow-jobs";
 import { registerWorkflowTool } from "../src/workflow-tool";
+import { createTelemetrySession } from "../src/telemetry";
+import { registerCompletionCoordinator } from "../src/completion-coordinator";
 
 const ACTIVITY_WIDGET_KEY = "subagentura-activity";
 const RUNNING_FOOTER_KEY = "subagentura-running";
@@ -125,6 +127,7 @@ function liveSessionContext(options: {
     inProcessJobs: new Map(),
     pendingInProcessDeliveries: [],
     interactiveStates: new Map(),
+    telemetry: createTelemetrySession(true),
   };
   registerSessionScope(context);
   setLegacyActiveSessionRefs(context);
@@ -270,6 +273,65 @@ afterEach(() => {
 });
 
 describe("workflow supervisor integration", () => {
+  it.each([
+    [{ async: true }, "each"],
+    [
+      {
+        async: true,
+        completionPolicy: "group",
+        completionGroupId: "analytics-group",
+      },
+      "group",
+    ],
+  ] as const)(
+    "threads the resolved background policy to process children (%s)",
+    async (params, expectedPolicy) => {
+      const { context } = liveSessionContext({
+        id: expectedPolicy === "each" ? 41 : 42,
+        sessionId: `session-${expectedPolicy}`,
+      });
+      const { pi, findTool } = makePi();
+      context.pi = pi as never;
+      registerCompletionCoordinator(pi as never, context);
+      registerWorkflowTool(pi as never, context);
+
+      await findTool().execute(
+        `call-${expectedPolicy}`,
+        { script: SINGLE_AGENT_SCRIPT(`policy-${expectedPolicy}`), ...params },
+        undefined,
+        vi.fn(),
+        { cwd: "/tmp", modelRegistry: {} },
+      );
+      await vi.waitFor(() => expect(mockLaunch).toHaveBeenCalledOnce());
+
+      expect(mockLaunch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          telemetryCompletionPolicy: expectedPolicy,
+        }),
+      );
+      releaseAgent(subagentResult("done"));
+    },
+  );
+
+  it("threads legacy policy to an ownerless background process child", async () => {
+    const { pi, findTool } = makePi();
+    registerWorkflowTool(pi as never);
+
+    await findTool().execute(
+      "call-legacy",
+      { script: SINGLE_AGENT_SCRIPT("policy-legacy"), async: true },
+      undefined,
+      vi.fn(),
+      { cwd: "/tmp", modelRegistry: {} },
+    );
+    await vi.waitFor(() => expect(mockLaunch).toHaveBeenCalledOnce());
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({ telemetryCompletionPolicy: "legacy" }),
+    );
+    releaseAgent(subagentResult("done"));
+  });
+
   it("shows a live process child under its tracked sync workflow", async () => {
     const { context } = liveSessionContext({ id: 7, sessionId: "session-a" });
     const owner = ownerOf(context);
@@ -296,6 +358,7 @@ describe("workflow supervisor integration", () => {
         completionOwner: "workflow",
         supervisorOwner: owner,
         workflowId: workflow?.id,
+        telemetryCompletionPolicy: "inline",
       }),
     );
     // Workflow children are never persisted, so they carry no parentSessionId —
@@ -412,6 +475,11 @@ describe("workflow supervisor integration", () => {
     );
 
     await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+    expect(mockStartSubagentJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        telemetry: expect.objectContaining({ completionPolicy: "inline" }),
+      }),
+    );
     const childJob = jobRegistry.get("fallback-child");
     expect(childJob).toBeDefined();
     expect(childJob?.status).toBe("running");

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -3942,6 +3942,14 @@ it("formats USD usage without floating-point artifacts", () => {
 });
 
 it("includes accumulated usage in async workflow error results", async () => {
+  const telemetryPayloads: Array<{ event?: string }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input, init) => {
+      telemetryPayloads.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 200 });
+    }),
+  );
   clearSessionScopes();
   const tools: Array<{ name: string; execute: Function }> = [];
   const pi = {
@@ -3993,9 +4001,67 @@ it("includes accumulated usage in async workflow error results", async () => {
     expect(result.content[0].text).toContain("↓7/20");
     expect(result.details.budgetTotal).toBe(20);
     expect(
-      scope.telemetry?.capturedKeys.has(`result-consumed:workflow:${job.id}`),
-    ).toBe(false);
+      telemetryPayloads.filter(
+        (payload) => payload.event === "pi_subagentura_result_consumed",
+      ),
+    ).toHaveLength(0);
   } finally {
+    vi.unstubAllGlobals();
+    workflowJobRegistry.delete(job.id);
+    clearSessionScopes();
+  }
+});
+
+it("records only the first successful workflow result read", async () => {
+  clearSessionScopes();
+  const telemetryPayloads: Array<{ event?: string }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input, init) => {
+      telemetryPayloads.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 200 });
+    }),
+  );
+  const tools: Array<{ name: string; execute: Function }> = [];
+  const pi = {
+    registerTool: vi.fn((def: any) => tools.push(def)),
+    registerFlag: vi.fn(),
+    registerCommand: vi.fn(),
+    on: vi.fn(),
+  };
+  const scope = registerSessionScope({
+    id: 995,
+    generation: 1,
+    lifecycle: "started",
+    pi: pi as never,
+    telemetry: createTelemetrySession(true),
+  });
+  registerWorkflowTool(pi as any, scope);
+  const job = startWorkflowJob(
+    "successful-result",
+    `export const meta = { name: "successful-result", description: "d" };\n` +
+      `return "workflow output";`,
+    { runAgent: echoRunner() },
+    undefined,
+    undefined,
+    sessionOwner(scope),
+  );
+  try {
+    await job.promise;
+    const getResult = tools.find(
+      (tool) => tool.name === "get_workflow_result",
+    )!;
+
+    await getResult.execute("first", { workflowId: job.id });
+    await getResult.execute("again", { workflowId: job.id });
+
+    expect(
+      telemetryPayloads.filter(
+        (payload) => payload.event === "pi_subagentura_result_consumed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    vi.unstubAllGlobals();
     workflowJobRegistry.delete(job.id);
     clearSessionScopes();
   }

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -66,6 +66,7 @@ import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createTelemetrySession } from "../src/telemetry";
 
 // ── Mock sub-agent runner ────────────────────────────────────────────
 function ok(output: string, outTokens = 0): SubagentResult {
@@ -3941,6 +3942,7 @@ it("formats USD usage without floating-point artifacts", () => {
 });
 
 it("includes accumulated usage in async workflow error results", async () => {
+  clearSessionScopes();
   const tools: Array<{ name: string; execute: Function }> = [];
   const pi = {
     registerTool: vi.fn((def: any) => tools.push(def)),
@@ -3948,12 +3950,22 @@ it("includes accumulated usage in async workflow error results", async () => {
     registerCommand: vi.fn(),
     on: vi.fn(),
   };
-  registerWorkflowTool(pi as any);
+  const scope = registerSessionScope({
+    id: 994,
+    generation: 1,
+    lifecycle: "started",
+    pi: pi as never,
+    telemetry: createTelemetrySession(true),
+  });
+  registerWorkflowTool(pi as any, scope);
   const job = startWorkflowJob(
     "late-error",
     `export const meta = { name: "late-error", description: "d" };\n` +
       `await agent("hello"); throw new Error("later failure");`,
     { runAgent: async ({ prompt }) => richOk(prompt), budgetTotal: 20 },
+    undefined,
+    undefined,
+    sessionOwner(scope),
   );
   try {
     await expect(job.promise).rejects.toThrow("later failure");
@@ -3980,8 +3992,12 @@ it("includes accumulated usage in async workflow error results", async () => {
     });
     expect(result.content[0].text).toContain("↓7/20");
     expect(result.details.budgetTotal).toBe(20);
+    expect(
+      scope.telemetry?.capturedKeys.has(`result-consumed:workflow:${job.id}`),
+    ).toBe(false);
   } finally {
     workflowJobRegistry.delete(job.id);
+    clearSessionScopes();
   }
 });
 


### PR DESCRIPTION
## Summary

- add default-on, personless PostHog lifecycle telemetry with no runtime dependency
- correlate one logical Pi session/tree with a random UUID across reload, resume, and matching startup recovery
- use schema v2 with the closed modes `straight`, `orchestrator`, and `orchestrator_v2`
- count every accepted physical agent exactly once and classify it as `in-process` or `interactive`
- record the closed mux dimension `none`, `tmux`, `zellij`, or `herdr` from spawn through persisted completion
- distinguish physical agents (`agent_created`) from delegated work (`task_started` / `task_completed`)
- report exact bounded depth, rounded/capped task duration, bounded child-conversation message counts, outcomes, completion delivery, explicit interactive follow-ups, and first successful result consumption
- preserve exact interactive telemetry progress across persistence and rehydration
- keep task funnels balanced through normal completion, streaming steering in either file-order, shutdown cancellation, workflow-pane reload, and manual-cancel/fresh-session races
- provide a functional presence-only `--no-subagentura-telemetry` opt-out for the minimum supported Pi runtime

## Intended PostHog analysis

Group or filter by `telemetry_session_id` to inspect one anonymous logical session:

- mode: `mode`
- agents created: count `agent_created`
- agent type and mux: break down `agent_created` by `execution` and `mux`
- tasks delegated: count `task_started`, broken down by `execution`, `mux`, and `invocation_source`
- maximum depth: maximum numeric `depth`
- outcomes: count `task_completed`, broken down by `status`
- task time: average, percentile, or sum of `task_completed.duration_ms`
- child conversation traffic: sum `task_completed.child_conversation_message_count`
- explicit interactive follow-ups: sum `interactive_message_sent.count`
- delivery/collection reliability: compare `task_completed`, `completion_delivered`, and `result_consumed`

The observed session span is `session_started` to the last correlated event. There is intentionally no shutdown-only summary because crashes can skip shutdown and reload/resume can occur within one logical session.

## Privacy and controls

- sends no tasks, personas, prompts, message content, outputs, error text, names, paths, repositories, group/agent/artifact/Pi-session IDs, token usage, cost, or stable installation ID
- sanitizes model values to a public built-in ID, `custom`, or `default`
- agent lifecycle dimensions are closed enums/booleans/bounded counts; in-process agents use `mux=none`, interactive agents retain their resolved backend
- sets `$process_person_profile=false`, `$geoip_disable=true`, and `$ip=0.0.0.0`
- opt out with `--no-subagentura-telemetry`, `PI_SUBAGENTURA_TELEMETRY=0`, `DO_NOT_TRACK`, `PI_OFFLINE`, `CI`, `VITEST`, or `NODE_ENV=test`
- capture is best-effort, timeout-bounded, unqueued, and unretried
- PostHog's network edge can still observe the request source IP; the project-level **Discard client IP data** setting should also be enabled operationally

## Verification

- npm test: 80 files, 1,804 tests passed
- npm run typecheck
- npm run format:check
- npm run pack:check
- git diff --check
- live minimum-Pi CLI smoke accepted `--no-subagentura-telemetry`
- focused independent read-only review completed with no remaining findings
- live schema-v2 test capture returned HTTP 200 and stored `$ip=0.0.0.0`
