### PR TITLE
feat(settings): add persisted telemetry control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,22 +66,30 @@ These are non-obvious behaviors that have bitten people. Read them before touchi
 
 Configuration has three source families: environment variables, persisted
 extension settings, and launch flags. Persisted extension settings use
-`~/.pi/agent/settings-extensions.json` globally; only `max-depth` also reads
-`<cwd>/.pi/settings-extensions.json`, with the project-local value taking
-precedence over the global fallback. `hide-agent-list` and `telemetry` are
-global-only; project-local values for either are ignored. `telemetry` accepts
-only the persisted strings `"true"` and `"false"` and defaults to `"true"`.
+`~/.pi/agent/settings-extensions.json` globally and
+`<authoritative-session-cwd>/.pi/settings-extensions.json` locally when an
+authoritative cwd is available. Without an authoritative cwd, read only the
+global file; never fall back to Node's process cwd.
 
-The `--subagentura-telemetry` launch flag is presence-only and enabled by
-default; it is not an opt-out. Use only the presence-only
-`--no-subagentura-telemetry` flag to disable telemetry at launch.
+Persisted settings use these precedence rules:
 
-Telemetry opt-outs are monotone: any environment opt-out, persisted global
-`telemetry: "false"`, or the presence-only `--no-subagentura-telemetry` flag
-disables telemetry; no source may force-enable it. Invalid persisted values are
-non-fatal: report them and use the documented defaults. Invalid
-`--subagentura-max-depth` values fail fast; boolean launch flags are
-presence-only.
+- `telemetry`: project-local value, then global value, then the default
+  `"true"`. Both persisted strings `"true"` and `"false"` are valid; a local
+  `"true"` can explicitly override a global `"false"`, and a local `"false"`
+  can override a global `"true"`.
+- `max-depth`: project-local value, then global value, then the default `2`.
+- `hide-agent-list`: global-only; any project-local value is ignored.
+
+Environment opt-outs and the `--no-subagentura-telemetry` negative launch flag
+are evaluated before persisted telemetry settings and cannot be overridden by a
+persisted `"true"` value. The positive `--subagentura-telemetry` launch flag is
+not an opt-out. The `--subagentura-max-depth` launch flag overrides persisted
+`max-depth` for the current run, while `--subagentura-hide-agent-list` can only
+turn hiding on.
+
+Malformed persisted files or values are non-fatal in every scope that is read:
+report the validation failure without exposing file contents, ignore the
+invalid candidate, and continue to the next applicable scope or default.
 
 ### Physical byte order is authoritative
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,27 @@ The pre-commit hook (`simple-git-hooks` → `lint-staged` → `prettier --write`
 
 These are non-obvious behaviors that have bitten people. Read them before touching the relevant code.
 
+### Configuration sources and telemetry opt-outs
+
+Configuration has three source families: environment variables, persisted
+extension settings, and launch flags. Persisted extension settings use
+`~/.pi/agent/settings-extensions.json` globally; only `max-depth` also reads
+`<cwd>/.pi/settings-extensions.json`, with the project-local value taking
+precedence over the global fallback. `hide-agent-list` and `telemetry` are
+global-only; project-local values for either are ignored. `telemetry` accepts
+only the persisted strings `"true"` and `"false"` and defaults to `"true"`.
+
+The `--subagentura-telemetry` launch flag is presence-only and enabled by
+default; it is not an opt-out. Use only the presence-only
+`--no-subagentura-telemetry` flag to disable telemetry at launch.
+
+Telemetry opt-outs are monotone: any environment opt-out, persisted global
+`telemetry: "false"`, or the presence-only `--no-subagentura-telemetry` flag
+disables telemetry; no source may force-enable it. Invalid persisted values are
+non-fatal: report them and use the documented defaults. Invalid
+`--subagentura-max-depth` values fail fast; boolean launch flags are
+presence-only.
+
 ### Physical byte order is authoritative
 
 Protocol-v2 event identity is `eventId` plus Pi-derived `turnId`. The poller

--- a/README.md
+++ b/README.md
@@ -264,9 +264,10 @@ Install the optional settings panel once with:
 pi install npm:@juanibiapina/pi-extension-settings
 ```
 
-Use `/extension-settings` for global settings. Whether a project value can
-override the global one is per-setting — see the scope rules below; only
-`max-depth` is project-overridable. The optional package's
+The extension exposes three settings: `max-depth`, `hide-agent-list`, and
+`telemetry`. Use `/extension-settings` for global settings. Whether a project
+value can override the global one is per-setting — see the scope rules below;
+only `max-depth` is project-overridable. The optional package's
 `/extension-settings-local` command is not session-cwd-correct in the pinned
 `@juanibiapina/pi-extension-settings@0.9.1`: it resolves local settings from
 Node's process cwd instead of Pi's command context. Do not use that command for
@@ -275,17 +276,22 @@ setting it there is a no-op because that setting is global-only. For a
 session-local `max-depth`, edit `<session-cwd>/.pi/settings-extensions.json`
 manually, using the exact cwd of the Pi session. `max-depth` controls
 Orchestratorv2 lineage depth and defaults to `2`; `hide-agent-list` defaults to
-`false` and only hides the compact per-agent activity widget rows. The running
-footer, list/status tools, and visual agent supervisor remain available.
+`false` and only hides the compact per-agent activity widget rows. `telemetry`
+controls anonymous product analytics, defaults to the string `"true"` (enabled),
+and is global-only. Persisted `telemetry` values must be `"true"` or `"false"`.
 
-Both settings can also be configured without the panel. The global file
-`~/.pi/agent/settings-extensions.json` accepts either key:
+The running footer, list/status tools, and visual agent supervisor remain
+available.
+
+All three settings can also be configured without the panel. The global file
+`~/.pi/agent/settings-extensions.json` accepts these keys:
 
 ```json
 {
   "pi-subagentura": {
     "max-depth": "4",
-    "hide-agent-list": "true"
+    "hide-agent-list": "true",
+    "telemetry": "false"
   }
 }
 ```
@@ -307,19 +313,28 @@ Scope rules:
 - `hide-agent-list` is read **only** from the global file. A checked-out
   repository must not be able to hide agent activity from whoever opens it, so a
   project-local `hide-agent-list` is ignored.
+- `telemetry` is read **only** from the global file. A project-local
+  `telemetry` value is ignored, so a checked-out repository cannot change the
+  user's telemetry choice.
 
 An invalid persisted value never aborts a session: the extension keeps the
-documented default (`max-depth` `2`, `hide-agent-list` `false`) and reports the
-ignored value in the TUI at the start of a root session, and to the debug log
-otherwise.
+documented defaults (`max-depth` `2`, `hide-agent-list` `false`, `telemetry`
+`"true"`) and reports the ignored value in the TUI at the start of a root
+session, and to the debug log otherwise.
 
-The extension also exposes these validated launch flags for advanced
-configurations:
+Telemetry configuration has three source families: environment variables,
+persisted extension settings, and launch flags. The extension also exposes these
+validated launch flags for advanced configurations:
 
 - `--subagentura-max-depth <n>` — override `max-depth` for the current run; legacy orchestration keeps its existing depth of `8`. Unlike the persisted setting, an invalid value here fails fast.
 - `--subagentura-hide-agent-list` — force `hide-agent-list` on for the current run without changing the persisted global setting. It also works without the optional settings panel. The flag is on-only: it cannot override a persisted `hide-agent-list` of `true`, so to show the rows again clear the global setting.
-- `--subagentura-telemetry` — anonymous product analytics, enabled by default. Extension booleans are presence-only; `--subagentura-telemetry=false` is not an opt-out.
+- `--subagentura-telemetry` — presence-only boolean flag, enabled by default; it
+  is not an opt-out.
 - `--no-subagentura-telemetry` — presence-only opt-out for anonymous product analytics. The exact events and other opt-outs are documented in [Anonymous product telemetry](#anonymous-product-telemetry).
+
+Telemetry opt-outs are monotone: any environment opt-out, persisted global
+`telemetry: "false"`, or the presence-only `--no-subagentura-telemetry` flag
+disables telemetry; no source can force-enable it.
 
 #### See the thin-router flow
 
@@ -973,17 +988,32 @@ never affect extension behavior.
 
 ### Disable telemetry
 
-For a persistent opt-out across Pi sessions, set
-`PI_SUBAGENTURA_TELEMETRY=0` in the environment that launches Pi. For example,
-add this to `~/.zshrc`, `~/.bashrc`, or the equivalent shell profile:
+For a persistent opt-out across Pi sessions, set the global `telemetry` setting
+to `"false"` with `/extension-settings`, or edit
+`~/.pi/agent/settings-extensions.json` directly:
+
+```json
+{
+  "pi-subagentura": {
+    "telemetry": "false"
+  }
+}
+```
+
+`telemetry` is global-only. Do not put it in
+`<project>/.pi/settings-extensions.json`: project-local telemetry values are
+ignored, so a checked-out repository cannot change your telemetry choice.
+
+You can also make the opt-out persistent through the shell environment that
+launches Pi. For example, add this to `~/.zshrc`, `~/.bashrc`, or the
+equivalent shell profile:
 
 ```bash
 export PI_SUBAGENTURA_TELEMETRY=0
 ```
 
-Reload the profile and restart Pi. The opt-out is inherited by recursive
-interactive children. It is not read from `settings-extensions.json`; that file
-only configures `max-depth` and `hide-agent-list`.
+Reload the profile and restart Pi. The environment opt-out is inherited by
+recursive interactive children.
 
 For a single invocation, use any of:
 

--- a/README.md
+++ b/README.md
@@ -267,18 +267,21 @@ pi install npm:@juanibiapina/pi-extension-settings
 The extension exposes three settings: `max-depth`, `hide-agent-list`, and
 `telemetry`. Use `/extension-settings` for global settings. Whether a project
 value can override the global one is per-setting — see the scope rules below;
-only `max-depth` is project-overridable. The optional package's
+`max-depth` and `telemetry` are project-overridable, while `hide-agent-list`
+alone remains global-only. The optional package's
 `/extension-settings-local` command is not session-cwd-correct in the pinned
 `@juanibiapina/pi-extension-settings@0.9.1`: it resolves local settings from
 Node's process cwd instead of Pi's command context. Do not use that command for
 cross-project sessions. It also still renders a `hide-agent-list` row, but
 setting it there is a no-op because that setting is global-only. For a
-session-local `max-depth`, edit `<session-cwd>/.pi/settings-extensions.json`
-manually, using the exact cwd of the Pi session. `max-depth` controls
-Orchestratorv2 lineage depth and defaults to `2`; `hide-agent-list` defaults to
-`false` and only hides the compact per-agent activity widget rows. `telemetry`
-controls anonymous product analytics, defaults to the string `"true"` (enabled),
-and is global-only. Persisted `telemetry` values must be `"true"` or `"false"`.
+session-local `max-depth` or `telemetry`, edit
+`<session-cwd>/.pi/settings-extensions.json` manually, using the exact cwd of
+the Pi session. `max-depth` controls Orchestratorv2 lineage depth and defaults
+to `2`; `hide-agent-list` defaults to `false` and only hides the compact
+per-agent activity widget rows. `telemetry` controls anonymous product
+analytics, defaults to the string `"true"` (enabled), and is
+project-overridable. Persisted `telemetry` values must be `"true"` or
+`"false"`.
 
 The running footer, list/status tools, and visual agent supervisor remain
 available.
@@ -297,15 +300,20 @@ All three settings can also be configured without the panel. The global file
 ```
 
 The project-local file `<project>/.pi/settings-extensions.json` is read for
-`max-depth` only:
+`max-depth` and `telemetry`; `hide-agent-list` remains global-only:
 
 ```json
 {
   "pi-subagentura": {
-    "max-depth": "6"
+    "max-depth": "6",
+    "telemetry": "true"
   }
 }
 ```
+
+Here `<project>` must be the authoritative Pi session cwd. When no
+authoritative cwd is available, only the global file is read; the extension
+never uses Node's process cwd for a local lookup.
 
 Scope rules:
 
@@ -313,14 +321,18 @@ Scope rules:
 - `hide-agent-list` is read **only** from the global file. A checked-out
   repository must not be able to hide agent activity from whoever opens it, so a
   project-local `hide-agent-list` is ignored.
-- `telemetry` is read **only** from the global file. A project-local
-  `telemetry` value is ignored, so a checked-out repository cannot change the
-  user's telemetry choice.
+- `telemetry` is read project-local first, with the global file as fallback, and
+  defaults to `"true"` when neither scope supplies a valid value. Both
+  persisted values are authoritative at project scope: local `"true"` and local
+  `"false"` each override the global value.
 
-An invalid persisted value never aborts a session: the extension keeps the
-documented defaults (`max-depth` `2`, `hide-agent-list` `false`, `telemetry`
-`"true"`) and reports the ignored value in the TUI at the start of a root
-session, and to the debug log otherwise.
+An invalid persisted value never aborts a session. Every global or project
+file that is read is validated; malformed files or values are reported without
+exposing file contents, the invalid candidate is ignored, and resolution
+continues to the next applicable scope or documented defaults (`max-depth` `2`,
+`hide-agent-list` `false`, `telemetry` `"true"`). The extension reports the
+ignored setting in the TUI at the start of a root session, and to the debug log
+otherwise.
 
 Telemetry configuration has three source families: environment variables,
 persisted extension settings, and launch flags. The extension also exposes these
@@ -329,12 +341,15 @@ validated launch flags for advanced configurations:
 - `--subagentura-max-depth <n>` — override `max-depth` for the current run; legacy orchestration keeps its existing depth of `8`. Unlike the persisted setting, an invalid value here fails fast.
 - `--subagentura-hide-agent-list` — force `hide-agent-list` on for the current run without changing the persisted global setting. It also works without the optional settings panel. The flag is on-only: it cannot override a persisted `hide-agent-list` of `true`, so to show the rows again clear the global setting.
 - `--subagentura-telemetry` — presence-only boolean flag, enabled by default; it
-  is not an opt-out.
+  is not an opt-out and does not bypass persisted telemetry precedence.
 - `--no-subagentura-telemetry` — presence-only opt-out for anonymous product analytics. The exact events and other opt-outs are documented in [Anonymous product telemetry](#anonymous-product-telemetry).
 
-Telemetry opt-outs are monotone: any environment opt-out, persisted global
-`telemetry: "false"`, or the presence-only `--no-subagentura-telemetry` flag
-disables telemetry; no source can force-enable it.
+Telemetry precedence is explicit: environment opt-outs and the
+presence-only `--no-subagentura-telemetry` flag are evaluated first and cannot
+be overridden. If neither applies, persisted telemetry resolves from the
+project-local value, then the global value, then the default `"true"`. A
+project-local `telemetry: "true"` deliberately overrides a global persisted
+`telemetry: "false"`; local `"false"` likewise overrides global `"true"`.
 
 #### See the thin-router flow
 
@@ -1000,9 +1015,28 @@ to `"false"` with `/extension-settings`, or edit
 }
 ```
 
-`telemetry` is global-only. Do not put it in
-`<project>/.pi/settings-extensions.json`: project-local telemetry values are
-ignored, so a checked-out repository cannot change your telemetry choice.
+To disable telemetry for one project, add the same setting to
+`<project>/.pi/settings-extensions.json`, using the authoritative session cwd:
+
+```json
+{
+  "pi-subagentura": {
+    "telemetry": "false"
+  }
+}
+```
+
+Project-local persisted telemetry is resolved before the global value. Both
+local `"true"` and local `"false"` override whatever global value is stored.
+Consequently, a checked-in project-local `"true"` can re-enable telemetry in
+that project even when the global persisted value is `"false"`; this is an
+explicit privacy tradeoff. A local `"false"` can conversely disable telemetry
+when the global value is `"true"`. If neither scope has a valid value,
+telemetry defaults to `"true"`.
+
+Environment opt-outs and `--no-subagentura-telemetry` are higher-priority than
+persisted settings and are evaluated first. They still disable telemetry even
+when either global or project-local persistence says `"true"`.
 
 You can also make the opt-out persistent through the shell environment that
 launches Pi. For example, add this to `~/.zshrc`, `~/.bashrc`, or the

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -369,7 +369,7 @@ export function registerSessionHandlers(
    * false under vitest, which would otherwise leave every enabled-telemetry
    * branch below unreachable.
    */
-  resolveTelemetryEnabled: (pi: ExtensionAPI) => boolean = isTelemetryEnabled,
+  resolveTelemetryEnabled: typeof isTelemetryEnabled = isTelemetryEnabled,
 ): SessionScope {
   const scope = createSessionScope(
     pi,
@@ -482,7 +482,9 @@ export function registerSessionHandlers(
         ? (activeSpawnTelemetry?.mode ?? "straight")
         : resolveTelemetryMode(orchestratorMode, orchestratorV2Mode));
     scope.telemetry = createTelemetrySession(
-      resolveTelemetryEnabled(pi),
+      resolveTelemetryEnabled(pi, { cwd: ctx.cwd }, (message) =>
+        ctx.ui?.notify?.(message, "warning"),
+      ),
       mode,
       recoveredTelemetry?.correlationId,
     );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ const SETTINGS_FILE_NAME = "settings-extensions.json";
 const MAX_DEPTH_SETTING = "max-depth";
 const HIDE_AGENT_LIST_SETTING = "hide-agent-list";
 const TELEMETRY_SETTING = "telemetry";
+const REDACTED_TELEMETRY_VALUE = "<redacted invalid telemetry value>";
 const MAX_DEPTH_DEFINITION = {
   id: MAX_DEPTH_SETTING,
   label: "Maximum depth",
@@ -41,7 +42,7 @@ const TELEMETRY_DEFINITION = {
   id: TELEMETRY_SETTING,
   label: "Telemetry",
   description:
-    "Send anonymous session-level product analytics (global only; ignored by /extension-settings-local)",
+    "Send anonymous session-level product analytics (project-local value overrides global value)",
   defaultValue: "true",
   values: ["false", "true"],
 } satisfies SettingDefinition;
@@ -95,8 +96,8 @@ export function emitExtensionSettingsRegistration(pi: ExtensionAPI): void {
  * Resolve the effective settings. CLI flags are still validated strictly —
  * a bad flag is an operator typo worth failing on — but persisted values are
  * parsed defensively: a hand-edited or panel-written file must never abort
- * session start, so an invalid value degrades to the documented default and is
- * reported through `onInvalidSetting`.
+ * session start, so an invalid candidate is ignored and resolution continues
+ * through the remaining scopes before using the documented default.
  */
 export function readExtensionSettings(
   pi: ExtensionAPI,
@@ -135,7 +136,7 @@ function readFlag(pi: ExtensionAPI, name: string): unknown {
 function resolveStorageOptions(
   options: SettingStorageOptions,
 ): SettingStorageOptions {
-  if (options.scope !== undefined || options.cwd !== undefined) return options;
+  if (options.cwd !== undefined || options.scope === "global") return options;
   return { ...options, scope: "global" };
 }
 
@@ -226,59 +227,145 @@ function readPersistedHideAgentList(
 }
 
 /**
- * Read only `telemetry`, from the global file. A checked-in project
- * `.pi/settings-extensions.json` must not be able to change the telemetry
- * choice of whoever opens the repo, so the local scope is deliberately
- * ignored here.
+ * Read `telemetry` project-local first, with the global file as fallback when an
+ * authoritative cwd is available. Without one, only the global file is read.
  */
 function readPersistedTelemetry(
   storageOptions: SettingStorageOptions,
   onInvalidSetting?: InvalidSettingReporter,
 ): boolean {
-  if (!validateGlobalSettingsFile(storageOptions, onInvalidSetting)) {
-    return true;
+  const resolvedStorageOptions = resolveStorageOptions(storageOptions);
+  const validations = validateSettingsFiles(
+    resolvedStorageOptions,
+    onInvalidSetting,
+  );
+
+  if (
+    resolvedStorageOptions.scope === "global" ||
+    resolvedStorageOptions.cwd === undefined
+  ) {
+    return (
+      readTelemetryCandidate(
+        resolvedStorageOptions,
+        validations[0],
+        onInvalidSetting,
+      ) ?? true
+    );
   }
-  let raw: unknown = undefined;
+
+  const localValidation = validations[0];
+  const globalValidation = validations[1];
+  if (!localValidation || !globalValidation) return true;
+
+  // With two structurally valid files and no invalid candidate, let the
+  // settings helper apply its normal local-over-global precedence.
+  if (
+    isUsableTelemetryFile(localValidation) &&
+    isUsableTelemetryFile(globalValidation)
+  ) {
+    const raw = readTelemetrySetting(resolvedStorageOptions);
+    return parseTelemetryValue(raw, onInvalidSetting) ?? true;
+  }
+
+  // A malformed or invalid local candidate is ignored so the global candidate
+  // can still win. Conversely, a malformed global file must not erase a valid
+  // local choice.
+  const localValue = readTelemetryCandidate(
+    { ...resolvedStorageOptions, scope: "local" },
+    localValidation,
+    onInvalidSetting,
+  );
+  if (localValue !== undefined) return localValue;
+  return (
+    readTelemetryCandidate(
+      { ...resolvedStorageOptions, scope: "global" },
+      globalValidation,
+      onInvalidSetting,
+    ) ?? true
+  );
+}
+
+interface SettingsFileValidation {
+  valid: boolean;
+  telemetry: "missing" | "valid" | "invalid";
+}
+
+function isUsableTelemetryFile(validation: SettingsFileValidation): boolean {
+  return validation.valid && validation.telemetry !== "invalid";
+}
+
+function readTelemetryCandidate(
+  storageOptions: SettingStorageOptions,
+  validation: SettingsFileValidation | undefined,
+  onInvalidSetting?: InvalidSettingReporter,
+): boolean | undefined {
+  if (!validation || !isUsableTelemetryFile(validation)) return undefined;
+  return parseTelemetryValue(
+    readTelemetrySetting(storageOptions),
+    onInvalidSetting,
+  );
+}
+
+function readTelemetrySetting(storageOptions: SettingStorageOptions): unknown {
   try {
-    raw = getSetting(
+    return getSetting(
       SETTINGS_EXTENSION_NAME,
       TELEMETRY_SETTING,
-      TELEMETRY_DEFINITION.defaultValue,
-      { ...storageOptions, scope: "global" },
+      undefined,
+      storageOptions,
     );
   } catch {
-    reportInvalidPersistedSetting(
-      TELEMETRY_SETTING,
-      raw,
-      'must be either "true" or "false"; using "true"',
-      onInvalidSetting,
-    );
-    return true;
+    // Structural failures are reported by validateSettingsFiles. Treat a
+    // concurrent file replacement as an absent candidate rather than aborting.
+    return undefined;
   }
-  if (raw === "true" || raw === undefined) return true;
+}
+
+function parseTelemetryValue(
+  raw: unknown,
+  onInvalidSetting?: InvalidSettingReporter,
+): boolean | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === "true") return true;
   if (raw === "false") return false;
   reportInvalidPersistedSetting(
     TELEMETRY_SETTING,
-    raw,
-    'must be either "true" or "false"; using "true"',
+    REDACTED_TELEMETRY_VALUE,
+    'must be either "true" or "false"; ignoring this candidate',
     onInvalidSetting,
   );
-  return true;
+  return undefined;
 }
 
-/**
- * The settings helper intentionally treats unreadable and syntactically invalid
- * files as empty. Preflight the global file so those failures remain visible
- * while leaving structural validation and setting precedence to the helper.
- */
-function validateGlobalSettingsFile(
-  storageOptions: SettingStorageOptions,
-  onInvalidSetting?: InvalidSettingReporter,
-): boolean {
-  const path = join(
+function settingsFilePaths(storageOptions: SettingStorageOptions): string[] {
+  const globalPath = join(
     storageOptions.agentDir ?? getAgentDir(),
     SETTINGS_FILE_NAME,
   );
+  if (storageOptions.scope === "global" || storageOptions.cwd === undefined) {
+    return [globalPath];
+  }
+  return [join(storageOptions.cwd, ".pi", SETTINGS_FILE_NAME), globalPath];
+}
+
+/**
+ * The settings helper treats unreadable and syntactically invalid files as
+ * empty. Preflight every file in the resolver's scope order so those failures
+ * remain visible without exposing file contents.
+ */
+function validateSettingsFiles(
+  storageOptions: SettingStorageOptions,
+  onInvalidSetting?: InvalidSettingReporter,
+): SettingsFileValidation[] {
+  return settingsFilePaths(storageOptions).map((path) =>
+    validateSettingsFile(path, onInvalidSetting),
+  );
+}
+
+function validateSettingsFile(
+  path: string,
+  onInvalidSetting?: InvalidSettingReporter,
+): SettingsFileValidation {
   let content: string;
   try {
     content = readFileSync(path, "utf8");
@@ -289,16 +376,17 @@ function validateGlobalSettingsFile(
       "code" in error &&
       (error as { code?: unknown }).code === "ENOENT"
     ) {
-      return true;
+      return { valid: true, telemetry: "missing" };
     }
     reportInvalidPersistedSetting(
       TELEMETRY_SETTING,
       undefined,
-      'could not be read; using "true"',
+      "could not be read; ignoring this candidate",
       onInvalidSetting,
     );
-    return false;
+    return { valid: false, telemetry: "missing" };
   }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
@@ -306,11 +394,12 @@ function validateGlobalSettingsFile(
     reportInvalidPersistedSetting(
       TELEMETRY_SETTING,
       "<invalid JSON document>",
-      'must be valid JSON; using "true"',
+      "must be valid JSON; ignoring this candidate",
       onInvalidSetting,
     );
-    return false;
+    return { valid: false, telemetry: "missing" };
   }
+
   const invalidRoot =
     typeof parsed !== "object" || parsed === null || Array.isArray(parsed);
   const extensionSettings = invalidRoot
@@ -326,12 +415,29 @@ function validateGlobalSettingsFile(
     reportInvalidPersistedSetting(
       TELEMETRY_SETTING,
       "<invalid settings document shape>",
-      'must be stored in an object-shaped settings document; using "true"',
+      "must be stored in an object-shaped settings document; ignoring this candidate",
       onInvalidSetting,
     );
-    return false;
+    return { valid: false, telemetry: "missing" };
   }
-  return true;
+
+  const telemetryValue =
+    extensionSettings === undefined
+      ? undefined
+      : (extensionSettings as Record<string, unknown>)[TELEMETRY_SETTING];
+  if (telemetryValue === undefined) {
+    return { valid: true, telemetry: "missing" };
+  }
+  if (telemetryValue === "true" || telemetryValue === "false") {
+    return { valid: true, telemetry: "valid" };
+  }
+  reportInvalidPersistedSetting(
+    TELEMETRY_SETTING,
+    REDACTED_TELEMETRY_VALUE,
+    'must be either "true" or "false"; ignoring this candidate',
+    onInvalidSetting,
+  );
+  return { valid: true, telemetry: "invalid" };
 }
 
 function reportInvalidPersistedSetting(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,9 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  getAgentDir,
+  type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
 import {
   getSetting,
   type SettingDefinition,
@@ -14,8 +19,10 @@ export const TELEMETRY_ENV = "PI_SUBAGENTURA_TELEMETRY";
 export const DEFAULT_ORCHESTRATOR_V2_MAX_DEPTH = 2;
 const MAX_CONFIGURED_DEPTH = 64;
 const SETTINGS_EXTENSION_NAME = "pi-subagentura";
+const SETTINGS_FILE_NAME = "settings-extensions.json";
 const MAX_DEPTH_SETTING = "max-depth";
 const HIDE_AGENT_LIST_SETTING = "hide-agent-list";
+const TELEMETRY_SETTING = "telemetry";
 const MAX_DEPTH_DEFINITION = {
   id: MAX_DEPTH_SETTING,
   label: "Maximum depth",
@@ -28,6 +35,14 @@ const HIDE_AGENT_LIST_DEFINITION = {
   description:
     "Hide compact per-agent activity widget rows (global only; ignored by /extension-settings-local)",
   defaultValue: "false",
+  values: ["false", "true"],
+} satisfies SettingDefinition;
+const TELEMETRY_DEFINITION = {
+  id: TELEMETRY_SETTING,
+  label: "Telemetry",
+  description:
+    "Send anonymous session-level product analytics (global only; ignored by /extension-settings-local)",
+  defaultValue: "true",
   values: ["false", "true"],
 } satisfies SettingDefinition;
 
@@ -67,7 +82,11 @@ export function emitExtensionSettingsRegistration(pi: ExtensionAPI): void {
   if (events && typeof events.emit === "function") {
     events.emit("pi-extension-settings:register", {
       name: SETTINGS_EXTENSION_NAME,
-      settings: [MAX_DEPTH_DEFINITION, HIDE_AGENT_LIST_DEFINITION],
+      settings: [
+        MAX_DEPTH_DEFINITION,
+        HIDE_AGENT_LIST_DEFINITION,
+        TELEMETRY_DEFINITION,
+      ],
     });
   }
 }
@@ -206,6 +225,115 @@ function readPersistedHideAgentList(
   return false;
 }
 
+/**
+ * Read only `telemetry`, from the global file. A checked-in project
+ * `.pi/settings-extensions.json` must not be able to change the telemetry
+ * choice of whoever opens the repo, so the local scope is deliberately
+ * ignored here.
+ */
+function readPersistedTelemetry(
+  storageOptions: SettingStorageOptions,
+  onInvalidSetting?: InvalidSettingReporter,
+): boolean {
+  if (!validateGlobalSettingsFile(storageOptions, onInvalidSetting)) {
+    return true;
+  }
+  let raw: unknown = undefined;
+  try {
+    raw = getSetting(
+      SETTINGS_EXTENSION_NAME,
+      TELEMETRY_SETTING,
+      TELEMETRY_DEFINITION.defaultValue,
+      { ...storageOptions, scope: "global" },
+    );
+  } catch {
+    reportInvalidPersistedSetting(
+      TELEMETRY_SETTING,
+      raw,
+      'must be either "true" or "false"; using "true"',
+      onInvalidSetting,
+    );
+    return true;
+  }
+  if (raw === "true" || raw === undefined) return true;
+  if (raw === "false") return false;
+  reportInvalidPersistedSetting(
+    TELEMETRY_SETTING,
+    raw,
+    'must be either "true" or "false"; using "true"',
+    onInvalidSetting,
+  );
+  return true;
+}
+
+/**
+ * The settings helper intentionally treats unreadable and syntactically invalid
+ * files as empty. Preflight the global file so those failures remain visible
+ * while leaving structural validation and setting precedence to the helper.
+ */
+function validateGlobalSettingsFile(
+  storageOptions: SettingStorageOptions,
+  onInvalidSetting?: InvalidSettingReporter,
+): boolean {
+  const path = join(
+    storageOptions.agentDir ?? getAgentDir(),
+    SETTINGS_FILE_NAME,
+  );
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ENOENT"
+    ) {
+      return true;
+    }
+    reportInvalidPersistedSetting(
+      TELEMETRY_SETTING,
+      undefined,
+      'could not be read; using "true"',
+      onInvalidSetting,
+    );
+    return false;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    reportInvalidPersistedSetting(
+      TELEMETRY_SETTING,
+      "<invalid JSON document>",
+      'must be valid JSON; using "true"',
+      onInvalidSetting,
+    );
+    return false;
+  }
+  const invalidRoot =
+    typeof parsed !== "object" || parsed === null || Array.isArray(parsed);
+  const extensionSettings = invalidRoot
+    ? undefined
+    : (parsed as Record<string, unknown>)[SETTINGS_EXTENSION_NAME];
+  if (
+    invalidRoot ||
+    (extensionSettings !== undefined &&
+      (typeof extensionSettings !== "object" ||
+        extensionSettings === null ||
+        Array.isArray(extensionSettings)))
+  ) {
+    reportInvalidPersistedSetting(
+      TELEMETRY_SETTING,
+      "<invalid settings document shape>",
+      'must be stored in an object-shaped settings document; using "true"',
+      onInvalidSetting,
+    );
+    return false;
+  }
+  return true;
+}
+
 function reportInvalidPersistedSetting(
   setting: string,
   value: unknown,
@@ -276,7 +404,11 @@ function envSwitchIsTruthy(name: string, falsy: ReadonlySet<string>): boolean {
   return value !== undefined && !falsy.has(value);
 }
 
-export function isTelemetryEnabled(pi: ExtensionAPI): boolean {
+export function isTelemetryEnabled(
+  pi: ExtensionAPI,
+  storageOptions: SettingStorageOptions = {},
+  onInvalidSetting?: InvalidSettingReporter,
+): boolean {
   const productSwitch = envSwitchValue(TELEMETRY_ENV);
   if (
     productSwitch !== undefined &&
@@ -290,5 +422,9 @@ export function isTelemetryEnabled(pi: ExtensionAPI): boolean {
   if (envSwitchIsTruthy("VITEST", PERMISSIVE_FALSY_VALUES)) return false;
   if (process.env.NODE_ENV === "test") return false;
   if (readFlag(pi, TELEMETRY_OPT_OUT_FLAG) === true) return false;
-  return readFlag(pi, TELEMETRY_FLAG) !== false;
+  const persistedTelemetryEnabled = readPersistedTelemetry(
+    storageOptions,
+    onInvalidSetting,
+  );
+  return persistedTelemetryEnabled && readFlag(pi, TELEMETRY_FLAG) !== false;
 }

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -151,6 +151,13 @@ describe("generic extension settings", () => {
             defaultValue: "false",
             values: ["false", "true"],
           },
+          {
+            id: "telemetry",
+            label: "Telemetry",
+            description: expect.stringContaining("global only"),
+            defaultValue: "true",
+            values: ["false", "true"],
+          },
         ],
       },
     );

--- a/tests/extension-settings.test.ts
+++ b/tests/extension-settings.test.ts
@@ -154,7 +154,7 @@ describe("generic extension settings", () => {
           {
             id: "telemetry",
             label: "Telemetry",
-            description: expect.stringContaining("global only"),
+            description: expect.stringContaining("project-local"),
             defaultValue: "true",
             values: ["false", "true"],
           },

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -57,6 +57,8 @@ interface HandlerRegistration {
   sessionScope: SessionScope;
 }
 
+type TelemetryResolver = Parameters<typeof registerSessionHandlers>[3];
+
 function registerHandlers(
   initialSpawnTreeContext?: ParsedSpawnTreeContext,
   allowRootLineage = true,
@@ -66,6 +68,7 @@ function registerHandlers(
    * branches of session_start are unreachable without this injection seam.
    */
   telemetryEnabled?: boolean,
+  telemetryResolver?: TelemetryResolver,
 ): HandlerRegistration {
   const handlers = new Map<string, Function[]>();
   const pi = {
@@ -85,7 +88,8 @@ function registerHandlers(
     pi as any,
     initialSpawnTreeContext,
     allowRootLineage,
-    telemetryEnabled === undefined ? undefined : () => telemetryEnabled,
+    telemetryResolver ??
+      (telemetryEnabled === undefined ? undefined : () => telemetryEnabled),
   );
   return { handlers, pi, sessionScope };
 }
@@ -223,6 +227,31 @@ describe("session handler lifecycle callbacks", () => {
     });
   });
 
+  it("passes session cwd and warning reporter to the telemetry resolver", () => {
+    const resolver: TelemetryResolver = (_pi, _storageOptions, onInvalid) => {
+      onInvalid?.("invalid telemetry");
+      return false;
+    };
+    const resolverSpy = vi.fn(resolver);
+    const registration = registerHandlers(
+      undefined,
+      true,
+      "orchestratorv2",
+      undefined,
+      resolverSpy,
+    );
+    const ui = { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() };
+
+    startSession(registration, root, "session-a", ui);
+
+    expect(resolverSpy).toHaveBeenCalledWith(
+      registration.pi,
+      { cwd: root },
+      expect.any(Function),
+    );
+    expect(ui.notify).toHaveBeenCalledWith("invalid telemetry", "warning");
+  });
+
   it.each(["reload", "resume"] as const)(
     "preserves one telemetry session across %s without another root start",
     (reason) => {
@@ -257,7 +286,12 @@ describe("session handler lifecycle callbacks", () => {
       }),
     );
     try {
-      const registration = registerHandlers();
+      const registration = registerHandlers(
+        undefined,
+        true,
+        "orchestratorv2",
+        true,
+      );
       const ctx = startSession(registration, root, "session-a");
       registration.handlers.get("session_start")![0]({ reason: "reload" }, ctx);
       registration.handlers.get("session_start")![0]({ reason: "resume" }, ctx);

--- a/tests/subagent-rehydrate-core.test.ts
+++ b/tests/subagent-rehydrate-core.test.ts
@@ -17,21 +17,28 @@ import { interactiveSubagentRegistry } from "../src/interactive-tmux";
 import { flushDeliveries } from "../src/delivery";
 import { importFresh } from "./test-utils";
 import { makeTmp, makeState } from "./subagent-rehydrate-helpers";
+type AttachCommandBuilder = (state: { windowName?: string }) => {
+  attachCommand: string;
+  focusCommand: string;
+};
+
+let buildAttachCommands: AttachCommandBuilder;
 
 describe("rehydrateInteractiveSubagents", () => {
   let cwd: string;
 
   beforeEach(() => {
+    buildAttachCommands = (state) => ({
+      attachCommand: `tmux attach -t ${state.windowName ?? "session"}`,
+      focusCommand: `tmux select-window -t ${state.windowName ?? "session"}`,
+    });
     cwd = makeTmp();
     vi.resetModules();
     vi.doMock("../src/multiplexer", () => ({
       getMux: () => ({
         name: "tmux",
         getPaneLiveness: () => "dead",
-        buildAttachCommands: (state: { windowName?: string }) => ({
-          attachCommand: `tmux attach -t ${state.windowName ?? "session"}`,
-          focusCommand: `tmux select-window -t ${state.windowName ?? "session"}`,
-        }),
+        buildAttachCommands,
       }),
       NoMultiplexerAvailableError: class extends Error {},
     }));
@@ -126,16 +133,9 @@ describe("rehydrateInteractiveSubagents", () => {
     // placeholder — but it is rendered where the UI promises a copy-pasteable
     // command ("Attach: <cmd>"). The old bare "unavailable" read as one; the
     // replacement must be unmistakably not a command, for every backend.
-    vi.doMock("../src/multiplexer", () => ({
-      getMux: () => ({
-        name: "tmux",
-        getPaneLiveness: () => "dead",
-        buildAttachCommands: () => {
-          throw new Error("pane is gone");
-        },
-      }),
-      NoMultiplexerAvailableError: class extends Error {},
-    }));
+    buildAttachCommands = () => {
+      throw new Error("pane is gone");
+    };
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const { ATTACH_UNAVAILABLE } =

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -680,16 +686,25 @@ describe("anonymous product telemetry", () => {
     ).toBe(false);
   });
 
-  it("ignores project-local telemetry values", () => {
+  it("lets a project-local false override a global true", () => {
     clearTelemetryOptOuts();
+    writeFileSync(
+      join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "true" } }),
+    );
     writeFileSync(
       join(telemetryStorageOptions.cwd, ".pi", "settings-extensions.json"),
       JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
     );
 
-    const pi = { getFlag: vi.fn(() => undefined) };
-    expect(isTelemetryEnabled(pi as any, telemetryStorageOptions)).toBe(true);
+    const pi = {
+      getFlag: vi.fn(() => undefined),
+    } as unknown as Parameters<typeof isTelemetryEnabled>[0];
+    expect(isTelemetryEnabled(pi, telemetryStorageOptions)).toBe(false);
+  });
 
+  it("lets a project-local true override a global false", () => {
+    clearTelemetryOptOuts();
     writeFileSync(
       join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
       JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
@@ -698,10 +713,51 @@ describe("anonymous product telemetry", () => {
       join(telemetryStorageOptions.cwd, ".pi", "settings-extensions.json"),
       JSON.stringify({ "pi-subagentura": { telemetry: "true" } }),
     );
-    expect(isTelemetryEnabled(pi as any, telemetryStorageOptions)).toBe(false);
+
+    const pi = {
+      getFlag: vi.fn(() => undefined),
+    } as unknown as Parameters<typeof isTelemetryEnabled>[0];
+    expect(isTelemetryEnabled(pi, telemetryStorageOptions)).toBe(true);
   });
 
-  it.each([
+  it("falls back to the global value when the project-local setting is missing", () => {
+    clearTelemetryOptOuts();
+    writeFileSync(
+      join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
+    );
+
+    const pi = {
+      getFlag: vi.fn(() => undefined),
+    } as unknown as Parameters<typeof isTelemetryEnabled>[0];
+    expect(isTelemetryEnabled(pi, telemetryStorageOptions)).toBe(false);
+  });
+
+  it("reads only the global value without an authoritative cwd", () => {
+    clearTelemetryOptOuts();
+    const ambientCwd = join(telemetrySettingsRoot!, "ambient");
+    mkdirSync(join(ambientCwd, ".pi"), { recursive: true });
+    vi.spyOn(process, "cwd").mockReturnValue(ambientCwd);
+    writeFileSync(
+      join(ambientCwd, ".pi", "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "true" } }),
+    );
+    writeFileSync(
+      join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
+    );
+
+    const pi = {
+      getFlag: vi.fn(() => undefined),
+    } as unknown as Parameters<typeof isTelemetryEnabled>[0];
+    expect(
+      isTelemetryEnabled(pi, {
+        agentDir: telemetryStorageOptions.agentDir,
+      }),
+    ).toBe(false);
+  });
+
+  const malformedTelemetryDocuments = [
     [
       "an invalid value",
       JSON.stringify({ "pi-subagentura": { telemetry: "sometimes" } }),
@@ -712,25 +768,97 @@ describe("anonymous product telemetry", () => {
     ["a numeric document", "0"],
     ["a string document", '"bad"'],
     ["a null extension object", '{"pi-subagentura":null}'],
-  ])("reports %s and keeps telemetry enabled", (_label, settingsDocument) => {
+  ] as const;
+
+  it.each(
+    (["local", "global"] as const).flatMap((scope) =>
+      malformedTelemetryDocuments.map(
+        ([label, settingsDocument]) =>
+          [scope, label, settingsDocument] as const,
+      ),
+    ),
+  )(
+    "reports malformed telemetry in the %s settings file (%s)",
+    (scope, _label, settingsDocument) => {
+      clearTelemetryOptOuts();
+      const path =
+        scope === "local"
+          ? join(telemetryStorageOptions.cwd, ".pi", "settings-extensions.json")
+          : join(telemetryStorageOptions.agentDir, "settings-extensions.json");
+      writeFileSync(path, settingsDocument);
+      const onInvalid = vi.fn();
+      const pi = {
+        getFlag: vi.fn(() => undefined),
+      } as unknown as Parameters<typeof isTelemetryEnabled>[0];
+      const storageOptions =
+        scope === "local"
+          ? telemetryStorageOptions
+          : { agentDir: telemetryStorageOptions.agentDir };
+
+      expect(isTelemetryEnabled(pi, storageOptions, onInvalid)).toBe(true);
+      expect(onInvalid).toHaveBeenCalledWith(
+        expect.stringContaining("telemetry"),
+      );
+    },
+  );
+
+  it("ignores an invalid local candidate and falls back to the global value", () => {
     clearTelemetryOptOuts();
     writeFileSync(
       join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
-      settingsDocument,
+      JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
+    );
+    writeFileSync(
+      join(telemetryStorageOptions.cwd, ".pi", "settings-extensions.json"),
+      JSON.stringify({
+        "pi-subagentura": { telemetry: "secret-telemetry-value" },
+      }),
     );
     const onInvalid = vi.fn();
-    const pi = { getFlag: vi.fn(() => undefined) };
+    const pi = {
+      getFlag: vi.fn(() => undefined),
+    } as unknown as Parameters<typeof isTelemetryEnabled>[0];
 
-    expect(() =>
-      isTelemetryEnabled(pi as any, telemetryStorageOptions, onInvalid),
-    ).not.toThrow();
-    expect(
-      isTelemetryEnabled(pi as any, telemetryStorageOptions, onInvalid),
-    ).toBe(true);
+    expect(isTelemetryEnabled(pi, telemetryStorageOptions, onInvalid)).toBe(
+      false,
+    );
     expect(onInvalid).toHaveBeenCalledWith(
       expect.stringContaining("telemetry"),
     );
+    expect(JSON.stringify(onInvalid.mock.calls)).not.toContain(
+      "secret-telemetry-value",
+    );
   });
+
+  it.each(["local", "global"] as const)(
+    "reports an unreadable %s settings file without aborting",
+    (scope) => {
+      clearTelemetryOptOuts();
+      const path =
+        scope === "local"
+          ? join(telemetryStorageOptions.cwd, ".pi", "settings-extensions.json")
+          : join(telemetryStorageOptions.agentDir, "settings-extensions.json");
+      writeFileSync(path, JSON.stringify({ "pi-subagentura": {} }));
+      chmodSync(path, 0o000);
+      try {
+        const onInvalid = vi.fn();
+        const pi = {
+          getFlag: vi.fn(() => undefined),
+        } as unknown as Parameters<typeof isTelemetryEnabled>[0];
+        const storageOptions =
+          scope === "local"
+            ? telemetryStorageOptions
+            : { agentDir: telemetryStorageOptions.agentDir };
+
+        expect(isTelemetryEnabled(pi, storageOptions, onInvalid)).toBe(true);
+        expect(onInvalid).toHaveBeenCalledWith(
+          expect.stringContaining("could not be read"),
+        );
+      } finally {
+        chmodSync(path, 0o600);
+      }
+    },
+  );
 
   it("keeps telemetry enabled when the persisted setting is missing or true", () => {
     clearTelemetryOptOuts();

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildTelemetryPayload,
   captureTelemetry,
@@ -25,6 +28,7 @@ const originalEnvironment = {
   CI: process.env.CI,
   DO_NOT_TRACK: process.env.DO_NOT_TRACK,
   NODE_ENV: process.env.NODE_ENV,
+  PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
   PI_OFFLINE: process.env.PI_OFFLINE,
   TELEMETRY: process.env[TELEMETRY_ENV],
   VITEST: process.env.VITEST,
@@ -35,6 +39,7 @@ function restoreEnvironment(): void {
     CI: originalEnvironment.CI,
     DO_NOT_TRACK: originalEnvironment.DO_NOT_TRACK,
     NODE_ENV: originalEnvironment.NODE_ENV,
+    PI_CODING_AGENT_DIR: originalEnvironment.PI_CODING_AGENT_DIR,
     PI_OFFLINE: originalEnvironment.PI_OFFLINE,
     [TELEMETRY_ENV]: originalEnvironment.TELEMETRY,
     VITEST: originalEnvironment.VITEST,
@@ -53,10 +58,28 @@ function clearTelemetryOptOuts(): void {
   delete process.env.VITEST;
 }
 
+let telemetrySettingsRoot: string | undefined;
+let telemetryStorageOptions: { agentDir: string; cwd: string };
+
 describe("anonymous product telemetry", () => {
+  beforeEach(() => {
+    const root = mkdtempSync(join(tmpdir(), "subagentura-telemetry-settings-"));
+    telemetrySettingsRoot = root;
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(agentDir, { recursive: true });
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    telemetryStorageOptions = { agentDir, cwd };
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+  });
+
   afterEach(() => {
     restoreEnvironment();
     vi.restoreAllMocks();
+    if (telemetrySettingsRoot !== undefined) {
+      rmSync(telemetrySettingsRoot, { recursive: true, force: true });
+      telemetrySettingsRoot = undefined;
+    }
   });
 
   it("reuses one random personless correlation id within a session", () => {
@@ -636,6 +659,89 @@ describe("anonymous product telemetry", () => {
     expect(isTelemetryEnabled({ getFlag: vi.fn(() => undefined) } as any)).toBe(
       true,
     );
+  });
+
+  it("disables telemetry when the global persisted setting is false", () => {
+    clearTelemetryOptOuts();
+    writeFileSync(
+      join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
+    );
+
+    expect(
+      isTelemetryEnabled(
+        {
+          getFlag: vi.fn((name) =>
+            name === TELEMETRY_FLAG ? true : undefined,
+          ),
+        } as unknown as Parameters<typeof isTelemetryEnabled>[0],
+        telemetryStorageOptions,
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores project-local telemetry values", () => {
+    clearTelemetryOptOuts();
+    writeFileSync(
+      join(telemetryStorageOptions.cwd, ".pi", "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
+    );
+
+    const pi = { getFlag: vi.fn(() => undefined) };
+    expect(isTelemetryEnabled(pi as any, telemetryStorageOptions)).toBe(true);
+
+    writeFileSync(
+      join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "false" } }),
+    );
+    writeFileSync(
+      join(telemetryStorageOptions.cwd, ".pi", "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "true" } }),
+    );
+    expect(isTelemetryEnabled(pi as any, telemetryStorageOptions)).toBe(false);
+  });
+
+  it.each([
+    [
+      "an invalid value",
+      JSON.stringify({ "pi-subagentura": { telemetry: "sometimes" } }),
+    ],
+    ["a malformed settings document", "null"],
+    ["syntactically invalid JSON", '{"pi-subagentura":'],
+    ["an array document", "[]"],
+    ["a numeric document", "0"],
+    ["a string document", '"bad"'],
+    ["a null extension object", '{"pi-subagentura":null}'],
+  ])("reports %s and keeps telemetry enabled", (_label, settingsDocument) => {
+    clearTelemetryOptOuts();
+    writeFileSync(
+      join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
+      settingsDocument,
+    );
+    const onInvalid = vi.fn();
+    const pi = { getFlag: vi.fn(() => undefined) };
+
+    expect(() =>
+      isTelemetryEnabled(pi as any, telemetryStorageOptions, onInvalid),
+    ).not.toThrow();
+    expect(
+      isTelemetryEnabled(pi as any, telemetryStorageOptions, onInvalid),
+    ).toBe(true);
+    expect(onInvalid).toHaveBeenCalledWith(
+      expect.stringContaining("telemetry"),
+    );
+  });
+
+  it("keeps telemetry enabled when the persisted setting is missing or true", () => {
+    clearTelemetryOptOuts();
+    const pi = { getFlag: vi.fn(() => undefined) };
+    expect(isTelemetryEnabled(pi as any, telemetryStorageOptions)).toBe(true);
+
+    writeFileSync(
+      join(telemetryStorageOptions.agentDir, "settings-extensions.json"),
+      JSON.stringify({ "pi-subagentura": { telemetry: "true" } }),
+    );
+    expect(isTelemetryEnabled(pi as any, telemetryStorageOptions)).toBe(true);
   });
 
   it("supports the default-on flag and explicit CLI opt-out", () => {


### PR DESCRIPTION
## Summary

- register a `telemetry` setting with `"true"` / `"false"` values and default `"true"`
- resolve persisted telemetry project-local first, then global, then the enabled default
- allow project-local `true` or `false` to override the global persisted value in either direction
- keep environment opt-outs and `--no-subagentura-telemetry` higher priority than persisted settings
- use global-only lookup when no authoritative session cwd is available
- report malformed local/global setting candidates without exposing their contents, then continue to the next scope
- document environment variables, persisted settings, launch flags, and exact precedence in README and AGENTS.md

## Configuration

Global default for all projects:

```json
{
  "pi-subagentura": {
    "telemetry": "false"
  }
}
```

Project override in `<project>/.pi/settings-extensions.json`:

```json
{
  "pi-subagentura": {
    "telemetry": "true"
  }
}
```

The project value overrides the global value. Environment opt-outs and `--no-subagentura-telemetry` still disable telemetry first.

## Validation

- focused settings/telemetry/session suite: 161 tests passed
- `npm run typecheck`
- `npm test`: 82 files, 2,015 tests passed
- `npm run format:check`
- `npm run pack:check`
- independent correctness/privacy/documentation review accepted