### PR TITLE
feat(telemetry): add lifecycle outcome events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,28 @@ Malformed persisted files or values are non-fatal in every scope that is read:
 report the validation failure without exposing file contents, ignore the
 invalid candidate, and continue to the next applicable scope or default.
 
+### Telemetry schema v3 invariants
+
+- Telemetry dimensions are closed enums. Use only the literals in the schema
+  (and `unknown` only where that field permits it); never forward arbitrary
+  strings. Counts remain bounded and duration/latency numbers remain rounded
+  to the existing `0..30`-day representation.
+- Failures and content are never raw telemetry. Report only closed
+  `failure_stage`, `terminal_reason`, and result-outcome values; never send
+  exception text or stacks, prompts, tasks, personas, tool arguments, message
+  content, outputs, paths, or agent/job/workflow/session identifiers.
+- The workflow runner is the sole owner of the aggregate lifecycle pair:
+  exactly one `workflow_started` and one `workflow_completed` for an accepted
+  invocation. Child agent/task records must not emit duplicate workflow
+  lifecycle aggregates.
+- Elapsed values may subtract only Unix-ms timestamps from the same event clock
+  domain. Copy terminal event `ts` into optional `JobState.completedAt?`,
+  `WorkflowJobState.completedAt?`, and `PersistedDeliveryIntent.completedAt?`;
+  never mix monotonic/process-local readings with persisted or child event
+  timestamps. If timestamps are unavailable or untrustworthy, omit the numeric
+  value and emit the matching `unknown` bucket. Batch delivery latency is the
+  maximum known completion age in that batch.
+
 ### Physical byte order is authoritative
 
 Protocol-v2 event identity is `eventId` plus Pi-derived `turnId`. The poller

--- a/README.md
+++ b/README.md
@@ -952,45 +952,85 @@ ambient identity environment variables—and never read or write the root state
 file's telemetry metadata. A child without that explicit context starts an
 unrelated anonymous correlation rather than reconstructing identity.
 
-The payload schema is versioned and contains these events:
+The payload schema is versioned; schema version `3` contains these events:
 
-| Event                      | Properties                                                                                                                                                                                                                                          |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `session_started`          | package version; `straight`, `orchestrator`, or `orchestrator_v2` mode                                                                                                                                                                              |
-| `agent_created`            | once per accepted in-process agent or launched interactive pane; execution kind, closed mux (`none`, `tmux`, `zellij`, or `herdr`), closed invocation source, public/sanitized model, async, exact bounded depth plus bucket, and completion policy |
-| `task_started`             | once per accepted in-process job or authoritative interactive turn; repeats the closed execution and mux dimensions and adds `job` or `turn`                                                                                                        |
-| `interactive_message_sent` | explicit parent-to-child steering/follow-up direction and bounded count only                                                                                                                                                                        |
-| `task_completed`           | repeated closed execution and mux dimensions; `success`, `error`, or `cancelled`; rounded numeric duration plus bucket, both reported as unknown when the measured span is implausible; bounded child-conversation message count when observable    |
-| `completion_delivered`     | manifest or compatibility notification kind and bounded record count                                                                                                                                                                                |
-| `result_consumed`          | `in-process`, `interactive`, or `workflow` result kind                                                                                                                                                                                              |
+| Event                      | Properties                                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session_started`          | package version; `straight`, `orchestrator`, or `orchestrator_v2` mode                                                                                                                                                                                                                                                                                                                                               |
+| `agent_created`            | once per accepted in-process agent or launched interactive pane; execution kind, closed mux (`none`, `tmux`, `zellij`, or `herdr`), closed invocation source (`with_context`, `isolated`, `interactive`, or `workflow`), public/sanitized model, async, exact bounded depth plus bucket, completion policy, and optional rounded `spawn_duration_ms` plus `spawn_duration_bucket`                                    |
+| `agent_spawn_failed`       | once per observed rejected spawn attempt; the same agent dimensions, except mux may also be `unknown`, plus required `failure_stage` (`depth_limit`, `capacity`, `context`, `model_resolution`, `session_creation`, `mux_resolution`, `pane_launch`, `state_persistence`, `registration`, `parent_shutdown`, or `unknown`) and optional rounded `spawn_duration_ms` plus `spawn_duration_bucket`                     |
+| `task_started`             | once per accepted in-process job or authoritative interactive turn; repeats the closed execution and mux dimensions and adds `unit` (`job` or `turn`)                                                                                                                                                                                                                                                                |
+| `interactive_message_sent` | explicit parent-to-child steering/follow-up direction and bounded count only                                                                                                                                                                                                                                                                                                                                         |
+| `task_completed`           | repeated closed execution and mux dimensions; `unit` (`job` or `turn`), `success`, `error`, or `cancelled` status, required `terminal_reason` (`completed`, `agent_error`, `process_exit`, `timeout`, `explicit_cancel`, `parent_cancelled`, `session_shutdown`, `fresh_session`, or `unknown`), optional rounded `duration_ms` plus `duration_bucket`, and bounded child-conversation message count when observable |
+| `workflow_started`         | one aggregate record for an accepted workflow invocation: required `invocation` (`tool` or `saved_command`), `async`, and `completion_policy`                                                                                                                                                                                                                                                                        |
+| `workflow_completed`       | the same invocation dimensions plus required `status` (`success`, `partial`, `error`, or `cancelled`), required `terminal_reason` (the same closed reasons as `task_completed`), bounded `agents_spawned` and `error_count` (each `0..1000`), and optional rounded `duration_ms` plus `duration_bucket`                                                                                                              |
+| `session_recovered`        | recovery `reason` (`startup`, `reload`, or `resume`) and bounded `total_count`, `alive_count`, `terminal_count`, and `unknown_count` (each `0..1000`); `total_count` is the eligible recovered count and equals `alive_count + terminal_count + unknown_count`                                                                                                                                                       |
+| `completion_delivered`     | manifest or compatibility notification kind, bounded record count, and optional rounded `delivery_latency_ms` plus `delivery_latency_bucket`; for a batch, latency is the maximum age of its included completions when that age is known                                                                                                                                                                             |
+| `result_read`              | result `source` (`in-process`, `interactive`, or `workflow`), required `outcome` (`consumed`, `already_consumed`, `empty`, `running`, `error`, `cancelled`, `wait_timeout`, `wait_cancelled`, or `unavailable`), and optional rounded `read_latency_ms` plus `read_latency_bucket`                                                                                                                                   |
+
+All duration and latency fields use the existing bounded representation: values
+are rounded to 100 ms and accepted only from `0` through 30 days. The numeric
+field is omitted when the timestamp is unavailable, negative, non-finite, or
+otherwise not trustworthy; its companion bucket is then `unknown`. Workflow
+and recovery counts are capped at `1000`; other counts and depth keep their
+existing safe caps.
 
 All events include the closed root mode and set `$process_person_profile: false`,
-`$geoip_disable: true`, and `$ip: "0.0.0.0"`. Terminal task events repeat the closed
-invocation source and completion policy so completion rates need no identifier
-join.
-They contain only closed enums, booleans, bounded counts, the package version,
-and the random runtime correlation UUID. The extension does **not** send tasks,
-personas, prompts, message content, outputs, error text, names, group ids, paths,
+`$geoip_disable: true`, and `$ip: "0.0.0.0"`. Terminal task events repeat the
+closed invocation source and completion policy so completion rates need no
+identifier join. Workflow lifecycle records are aggregate records owned by the
+workflow runner: child agent and task events do not create another workflow
+start/completion pair.
+
+Schema v3 keeps the existing privacy model. It adds no content or stable
+identity: the random runtime correlation UUID remains scoped to the logical
+session/tree and is never a stable installation, machine, user, repository, or
+project identity. Payloads contain only closed enums, booleans, bounded counts,
+rounded numeric values, the package version, sanitized public model labels, and
+that random correlation UUID. The extension does **not** send tasks, personas,
+prompts, message content, outputs, error text or stacks, names, group ids, paths,
 repositories, artifact/agent/Pi session ids, token usage, cost, or a persistent
 installation id. PostHog can still observe the connection's source IP while
 handling the HTTP request. The project-level **Discard client IP data** setting
 should also be enabled; direct ingestion cannot prevent PostHog's network edge
 from receiving the connection itself.
 
+Coverage is intentionally bounded. A host-level schema rejection or tool
+not-found result that occurs before a telemetry session exists is not observable
+and is omitted rather than represented as a synthetic failure. Similarly,
+unavailable or untrustworthy timestamps do not produce fabricated duration or
+latency values; only the `unknown` bucket remains.
+
 In PostHog, group or filter events by `telemetry_session_id` to inspect one
 anonymous session. The intended aggregates are:
 
-- agents created: count `agent_created`
+- accepted agents: count `agent_created`
+- rejected spawns: count `agent_spawn_failed`, broken down by `failure_stage`
 - delegated tasks: count `task_started`
-- maximum depth: maximum numeric `depth`
-- outcomes: count `task_completed`, broken down by `status`
-- execution/mux mix: count lifecycle events by the closed execution and mux dimensions
-- task time: average, percentile, or sum of `task_completed.duration_ms`
+- task outcomes: count `task_completed`, broken down by `status` and
+  `terminal_reason`
+- workflow throughput and outcomes: compare `workflow_started` with
+  `workflow_completed`, broken down by `invocation`, `async`,
+  `completion_policy`, `status`, and `terminal_reason`
+- execution/mux mix: count lifecycle events by the closed execution and mux
+  dimensions
+- stage latency: average or percentile of `agent_created.spawn_duration_ms`,
+  `agent_spawn_failed.spawn_duration_ms`, `task_completed.duration_ms`,
+  `workflow_completed.duration_ms`, `completion_delivered.delivery_latency_ms`,
+  and `result_read.read_latency_ms`, using each event's companion bucket
+- workflow fan-out and failures: sum bounded `agents_spawned` and `error_count`
+- recovery: count `session_recovered` by `reason`; `total_count` is the
+  eligible recovered count (the sum of bounded live/terminal/unknown counts)
 - child conversation traffic: sum
   `task_completed.child_conversation_message_count`
 - explicit interactive follow-ups: sum `interactive_message_sent.count`
-- delivery/collection reliability: compare completed tasks with
-  `completion_delivered` and `result_consumed`
+- result-read reliability: count `result_read` by `source` and `outcome`, and
+  compare aggregate reads with delivered completions
+
+These are anonymous session-level aggregates, not per-agent, per-job, or
+per-workflow joins; those identifiers are deliberately not collected. For
+`completion_delivered` batches, the latency statistic is the maximum known age
+among the included completions, not the age of every individual completion.
 
 The observed session span is the time from `session_started` to its last event.
 There is deliberately no shutdown-only summary: crashes can skip shutdown, and

--- a/src/artifact-poller.ts
+++ b/src/artifact-poller.ts
@@ -73,7 +73,7 @@ import {
   resolveLiveSessionScope,
 } from "./session-scope";
 import { isAgentListHidden } from "./settings";
-import { captureTelemetry } from "./telemetry";
+import { captureTelemetry, type TelemetryTerminalReason } from "./telemetry";
 // ── Footer / Widget Status Keys ────────────────────────────────────────
 
 export const FOOTER_KEY = "subagentura-running";
@@ -473,6 +473,66 @@ function deliveryMessageFromEvent(ev: CompletionEvent): string | undefined {
   return ev.outputError?.message;
 }
 
+function terminalReasonFromEvent(ev: SubagentEvent): TelemetryTerminalReason {
+  switch (ev.type) {
+    case "done":
+      return "completed";
+    case "error":
+      return "agent_error";
+    case "cancelled":
+      // Legacy cancellation events carry no source or cancellation origin.
+      return "unknown";
+    case "process_exited":
+      return "process_exit";
+    case "completion":
+      if (ev.outcome === "done") return "completed";
+      if (ev.outcome === "error") {
+        return ev.source === "process_exit" ? "process_exit" : "agent_error";
+      }
+      if (ev.source === "explicit") return "explicit_cancel";
+      if (ev.source === "process_exit") return "process_exit";
+      if (ev.source === "parent") {
+        // An explicit cancel-all operation is authoritative even if a caller
+        // also supplied stale lifecycle metadata.
+        if (ev.cancellationOrigin === "cancel_all") {
+          return "explicit_cancel";
+        }
+        // New/fork replace the logical session; startup/reload/resume only
+        // recover the existing one and therefore are ordinary shutdowns.
+        if (
+          ev.cancellationLifecycleReason === "new" ||
+          ev.cancellationLifecycleReason === "fork"
+        ) {
+          return "fresh_session";
+        }
+        if (
+          ev.cancellationOrigin === "cancel_interactive_subagent" ||
+          ev.cancellationOrigin === "cancel_subagent"
+        ) {
+          return "explicit_cancel";
+        }
+        if (
+          ev.cancellationLifecycleReason === "startup" ||
+          ev.cancellationLifecycleReason === "reload" ||
+          ev.cancellationLifecycleReason === "resume" ||
+          ev.cancellationLifecycleReason === "quit" ||
+          ev.cancellationOrigin === "session_start" ||
+          ev.cancellationOrigin === "session_shutdown"
+        ) {
+          return "session_shutdown";
+        }
+        return "parent_cancelled";
+      }
+      return "unknown";
+    case "started":
+    case "tool_activity":
+    case "turn_started":
+      return "unknown";
+    default:
+      return assertNever(ev);
+  }
+}
+
 const pollsInFlight = new Map<string, Promise<void>>();
 // ── Poller ─────────────────────────────────────────────────────────────
 
@@ -714,21 +774,33 @@ async function runPollArtifactChanges(
             }
           }
         }
+        const terminalTelemetryEvent =
+          ev.type === "completion" ||
+          ev.type === "done" ||
+          ev.type === "error" ||
+          ev.type === "cancelled" ||
+          ev.type === "process_exited";
+        const terminalTurnId =
+          ev.type === "completion" ? ev.turnId : state.telemetryActiveTurnId;
         if (
-          ev.type === "completion" &&
-          state.telemetryActiveTurnId === ev.turnId &&
+          terminalTelemetryEvent &&
+          terminalTurnId !== undefined &&
+          (ev.type !== "completion" ||
+            state.telemetryActiveTurnId === ev.turnId) &&
           state.telemetryCorrelationId ===
             ownerContext?.telemetry?.correlationId
         ) {
-          const status = deliveryStatusFromEvent(ev);
+          const status =
+            ev.type === "process_exited"
+              ? ev.status
+              : deliveryStatusFromEvent(ev);
           const messageTurnId = state.telemetryMessageTurnId;
-          const directMessageCount = state.telemetryTurnMessageCounts?.get(
-            ev.turnId,
-          );
+          const directMessageCount =
+            state.telemetryTurnMessageCounts?.get(terminalTurnId);
           const fallbackMessageCount =
             directMessageCount === undefined &&
             messageTurnId !== undefined &&
-            messageTurnId !== ev.turnId
+            messageTurnId !== terminalTurnId
               ? state.telemetryTurnMessageCounts?.get(messageTurnId)
               : undefined;
           const messageCount = directMessageCount ?? fallbackMessageCount;
@@ -747,6 +819,7 @@ async function runPollArtifactChanges(
               depth_bucket: state.telemetryDepthBucket ?? "unknown",
               completion_policy: state.telemetryCompletionPolicy ?? "legacy",
               status: status === "done" ? "success" : status,
+              terminal_reason: terminalReasonFromEvent(ev),
               duration_ms:
                 state.telemetryTurnStartedAt === undefined
                   ? undefined
@@ -754,22 +827,22 @@ async function runPollArtifactChanges(
               child_conversation_message_count: messageCount,
             },
             {
-              dedupeKey: `task-completed:interactive:${state.id}:${ev.turnId}`,
+              dedupeKey: `task-completed:interactive:${state.id}:${terminalTurnId}:${ev.type}:${record.startOffset}`,
             },
           );
           state.telemetryActiveTurnId = undefined;
           state.telemetryTurnStartedAt = undefined;
           if (directMessageCount !== undefined) {
-            state.telemetryTurnMessageCounts?.delete(ev.turnId);
+            state.telemetryTurnMessageCounts?.delete(terminalTurnId);
           } else if (
             messageTurnId !== undefined &&
-            messageTurnId !== ev.turnId &&
+            messageTurnId !== terminalTurnId &&
             fallbackMessageCount !== undefined
           ) {
             state.telemetryTurnMessageCounts?.delete(messageTurnId);
           }
           if (
-            messageTurnId === ev.turnId ||
+            messageTurnId === terminalTurnId ||
             (directMessageCount === undefined &&
               fallbackMessageCount !== undefined)
           ) {
@@ -807,6 +880,7 @@ async function runPollArtifactChanges(
             triggerTurn,
             status,
             artifactDir: state.artifactDir,
+            completedAt: ev.ts,
             output: v2?.output,
             message: deliveryMessageFromEvent(ev),
             completionPolicy: state.completionPolicy,

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -1434,6 +1434,8 @@ export interface PersistedDeliveryIntent {
   artifactDir: string;
   output?: OutputSnapshot;
   message?: string;
+  /** Terminal artifact timestamp used for delivery-latency telemetry. */
+  completedAt?: number;
   state: "queued" | "dispatchAttempted";
   completionPolicy?: "each" | "group";
   completionGroupId?: string;
@@ -1707,6 +1709,11 @@ function migrateStatePayload(
                   ...(output ? { output } : {}),
                   ...(typeof rawIntent.message === "string"
                     ? { message: rawIntent.message.slice(0, 500) }
+                    : {}),
+                  ...(typeof rawIntent.completedAt === "number" &&
+                  Number.isFinite(rawIntent.completedAt) &&
+                  rawIntent.completedAt >= 0
+                    ? { completedAt: rawIntent.completedAt }
                     : {}),
                   ...(intentPolicy ? { completionPolicy: intentPolicy } : {}),
                   ...(intentPolicy === "group"

--- a/src/cancel-all-flows.ts
+++ b/src/cancel-all-flows.ts
@@ -15,6 +15,7 @@ import {
   interactiveSubagentRegistry,
 } from "./interactive-tmux";
 import {
+  cancelWorkflowJob,
   normalizeCancelledWorkflowState,
   workflowJobsForOwner,
 } from "./workflow-jobs";
@@ -87,7 +88,8 @@ export async function cancelAllFlows(
     reason: "cancel-all-flows aborted every running flow",
   };
   for (const job of jobs) {
-    job.cancellation = { ...jobCancellation, at: Date.now() };
+    const cancellationAt = Date.now();
+    job.cancellation = { ...jobCancellation, at: cancellationAt };
     job.cancellationSnapshot = snapshotInProcessSession({
       kind: "in-process",
       jobId: job.id,
@@ -112,6 +114,7 @@ export async function cancelAllFlows(
       /* session may already be disposed */
     }
     job.status = "cancelled";
+    job.completedAt ??= Date.now();
     scheduleJobCleanup(job.id, true, undefined, owner);
     result.jobsAborted++;
   }
@@ -119,9 +122,10 @@ export async function cancelAllFlows(
   // 2. Abort all running workflows
   for (const workflow of workflowJobsForOwner(owner)) {
     if (workflow.status === "running") {
+      // Cancel-all owns the aggregate notification, so retain the existing
+      // suppression while routing state changes through the shared helper.
       workflow.suppressCompletionNotification = true;
-      workflow.abort.abort();
-      workflow.status = "cancelled";
+      cancelWorkflowJob(workflow, "explicit_cancel");
       result.workflowsAborted++;
     }
     if (workflow.status === "cancelled") {

--- a/src/completion-coordinator.ts
+++ b/src/completion-coordinator.ts
@@ -72,6 +72,12 @@ export interface CompletionRecord {
   groupComplete?: boolean;
   references: CompletionReference[];
   completedAt: number;
+  /**
+   * Source completion time for delivery-latency analytics. Interactive
+   * completions recovered from legacy state may not have one; the required
+   * `completedAt` remains the coordinator publication timestamp.
+   */
+  telemetryCompletedAt?: number;
   /** Monotonic publication sequence used to retire spilled session entries. */
   sequence?: number;
   ownerSessionId?: string;
@@ -359,6 +365,12 @@ function normalizeRecord(value: unknown): CompletionRecord {
     raw.completedAt >= 0
       ? raw.completedAt
       : Date.now();
+  const telemetryCompletedAt =
+    typeof raw.telemetryCompletedAt === "number" &&
+    Number.isFinite(raw.telemetryCompletedAt) &&
+    raw.telemetryCompletedAt >= 0
+      ? raw.telemetryCompletedAt
+      : undefined;
   const sequence =
     typeof raw.sequence === "number" &&
     Number.isSafeInteger(raw.sequence) &&
@@ -388,6 +400,7 @@ function normalizeRecord(value: unknown): CompletionRecord {
     ...(groupComplete === true ? { groupComplete } : {}),
     references,
     completedAt,
+    ...(telemetryCompletedAt !== undefined ? { telemetryCompletedAt } : {}),
     ...(sequence !== undefined ? { sequence } : {}),
     ...(typeof raw.ownerSessionId === "string" && raw.ownerSessionId.length > 0
       ? { ownerSessionId: raw.ownerSessionId.slice(0, MAX_SOURCE_ID_LENGTH) }
@@ -1423,6 +1436,49 @@ function readyRecords(state: CompletionCoordinatorState): CompletionRecord[] {
   );
 }
 
+function maxKnownCompletionAge(
+  records: readonly CompletionRecord[],
+  now = Date.now(),
+): number | undefined {
+  let maximum: number | undefined;
+  for (const record of records) {
+    const timestamp =
+      record.source === "interactive"
+        ? record.telemetryCompletedAt
+        : record.completedAt;
+    if (
+      typeof timestamp !== "number" ||
+      !Number.isFinite(timestamp) ||
+      timestamp < 0
+    ) {
+      continue;
+    }
+    const age = now - timestamp;
+    if (!Number.isFinite(age) || age < 0) continue;
+    maximum = Math.max(maximum ?? 0, age);
+  }
+  return maximum;
+}
+
+/**
+ * Return the oldest known completion age for a manifest batch. The caller
+ * supplies only coordinator-owned completion ids; missing records/timestamps
+ * are deliberately ignored so unavailable latency is not reported as zero.
+ */
+export function completionLatencyForIds(
+  completionIds: readonly string[],
+  owner?: SessionOwnerToken,
+): number | undefined {
+  const state = getState(owner);
+  if (!state || completionIds.length === 0) return undefined;
+  return maxKnownCompletionAge(
+    completionIds.flatMap((completionId) => {
+      const record = state.records.get(completionId);
+      return record ? [record] : [];
+    }),
+  );
+}
+
 function retrievalCall(record: CompletionRecord): string {
   if (record.source === "interactive") {
     const turn = record.turnId
@@ -2114,12 +2170,19 @@ export function flushCompletionManifests(owner?: SessionOwnerToken): void {
     scheduleManifestRetry(state);
     return;
   }
+  const deliveryLatencyMs = completionLatencyForIds(
+    message.details.completionIds,
+    state.owner,
+  );
   captureTelemetry(
     resolveLiveSessionScope(state.owner)?.telemetry,
     {
       event: "completion_delivered",
       delivery: "manifest",
       count: message.details.completionIds.length,
+      ...(deliveryLatencyMs === undefined
+        ? {}
+        : { delivery_latency_ms: deliveryLatencyMs }),
     },
     {
       dedupeKey: manifestDeliveryDedupeKey(message.details.completionIds),

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -184,6 +184,26 @@ function queueBytes(queue: PersistedDeliveryIntent[]): number {
   return Buffer.byteLength(JSON.stringify(queue), "utf8");
 }
 
+function maxKnownCompletionAge(
+  completedAt: readonly (number | undefined)[],
+  now = Date.now(),
+): number | undefined {
+  let maximum: number | undefined;
+  for (const timestamp of completedAt) {
+    if (
+      typeof timestamp !== "number" ||
+      !Number.isFinite(timestamp) ||
+      timestamp < 0
+    ) {
+      continue;
+    }
+    const age = now - timestamp;
+    if (!Number.isFinite(age) || age < 0) continue;
+    maximum = Math.max(maximum ?? 0, age);
+  }
+  return maximum;
+}
+
 function persistOverflowIdentity(
   state: InteractiveSubagentState,
   intent: PersistedDeliveryIntent,
@@ -199,6 +219,9 @@ function persistOverflowIdentity(
       mode: intent.mode,
       triggerTurn: intent.triggerTurn,
       status: intent.status,
+      ...(intent.completedAt === undefined
+        ? {}
+        : { completedAt: intent.completedAt }),
     })}\n`,
     { mode: 0o600 },
   );
@@ -213,6 +236,12 @@ function mergeOverflowSemantics(
   if (collapsed.status === "error") summary.status = "error";
   else if (collapsed.status === "cancelled" && summary.status !== "error") {
     summary.status = "cancelled";
+  }
+  if (collapsed.completedAt !== undefined) {
+    summary.completedAt =
+      summary.completedAt === undefined
+        ? collapsed.completedAt
+        : Math.min(summary.completedAt, collapsed.completedAt);
   }
 }
 
@@ -267,6 +296,14 @@ export function enqueueDelivery(
     intent.message = undefined;
   } else if (intent.message.length > 500) {
     intent.message = `${intent.message.slice(0, 500)}…`;
+  }
+  if (
+    intent.completedAt !== undefined &&
+    (typeof intent.completedAt !== "number" ||
+      !Number.isFinite(intent.completedAt) ||
+      intent.completedAt < 0)
+  ) {
+    intent.completedAt = undefined;
   }
   const queue = (state.pendingDeliveries ??= []);
   if (
@@ -424,7 +461,10 @@ function publishCoordinatedInteractiveCompletion(
         ? { groupId: intent.completionGroupId }
         : {}),
       references,
-      completedAt: Date.now(),
+      completedAt: intent.completedAt ?? Date.now(),
+      ...(intent.completedAt === undefined
+        ? {}
+        : { telemetryCompletedAt: intent.completedAt }),
     },
     owner,
   );
@@ -505,12 +545,18 @@ export function flushDeliveries(
   } catch {
     return;
   }
+  const deliveryLatencyMs = maxKnownCompletionAge(
+    selected.map(({ intent }) => intent.completedAt),
+  );
   captureTelemetry(
     resolveLiveSessionScope(owner)?.telemetry,
     {
       event: "completion_delivered",
       delivery: "notification",
       count: deliveryIds.length,
+      ...(deliveryLatencyMs === undefined
+        ? {}
+        : { delivery_latency_ms: deliveryLatencyMs }),
     },
     { dedupeKey: `notification:${deliveryIds.join(":")}` },
   );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,6 +29,7 @@ import {
   buildSessionOptions,
   copyProviderConfig,
   createCompatibleSessionRuntime,
+  type CompatibleSessionRuntime,
 } from "./pi-sdk-compat";
 import {
   createWorkflowStructuredOutputTool,
@@ -306,6 +307,67 @@ export interface SubagentLiveStatus {
   thinkingLevel?: ThinkingLevel;
 }
 
+/** Closed stages used when an in-process spawn is observed to fail. */
+export type InProcessSpawnFailureStage =
+  | "depth_limit"
+  | "capacity"
+  | "context"
+  | "model_resolution"
+  | "session_creation"
+  | "registration"
+  | "parent_shutdown"
+  | "unknown";
+
+const SPAWN_FAILURE_STAGE_KEY = "__piSubagenturaSpawnFailureStage";
+const SPAWN_FAILURE_STAGES: readonly InProcessSpawnFailureStage[] = [
+  "depth_limit",
+  "capacity",
+  "context",
+  "model_resolution",
+  "session_creation",
+  "registration",
+  "parent_shutdown",
+  "unknown",
+];
+
+/** Attach a bounded stage to an error without exposing it in user telemetry. */
+export function annotateSpawnFailure(
+  error: unknown,
+  stage: InProcessSpawnFailureStage,
+): Error {
+  const base = error instanceof Error ? error : new Error(String(error));
+  try {
+    Object.defineProperty(base, SPAWN_FAILURE_STAGE_KEY, {
+      configurable: true,
+      enumerable: false,
+      value: stage,
+      writable: false,
+    });
+    return base;
+  } catch {
+    const wrapped = new Error(base.message);
+    Object.defineProperty(wrapped, SPAWN_FAILURE_STAGE_KEY, {
+      configurable: true,
+      enumerable: false,
+      value: stage,
+      writable: false,
+    });
+    return wrapped;
+  }
+}
+
+/** Recover a stage attached by a preparation boundary, if one is present. */
+export function spawnFailureStage(
+  error: unknown,
+): InProcessSpawnFailureStage | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const stage = (error as Record<string, unknown>)[SPAWN_FAILURE_STAGE_KEY];
+  return typeof stage === "string" &&
+    SPAWN_FAILURE_STAGES.includes(stage as InProcessSpawnFailureStage)
+    ? (stage as InProcessSpawnFailureStage)
+    : undefined;
+}
+
 // ── Async Job Types ─────────────────────────────────────────────────
 
 export type JobStatus = "running" | "done" | "error" | "cancelled";
@@ -328,11 +390,15 @@ export interface JobState {
   result?: SubagentResult;
   session: AgentSession;
   startedAt: number;
+  /** Terminal settlement time, when the job has reached a terminal state. */
+  completedAt?: number;
   cwd?: string;
   promise: Promise<SubagentResult>;
   modelLabel?: string;
   /** Effective level after Pi's model-capability clamping. */
   thinkingLevel?: ThinkingLevel;
+  /** Anonymous telemetry context retained for post-shutdown result reads. */
+  telemetry?: AgentTelemetryContext;
   /** Deprecated legacy pointer/output delivery mode. */
   notifyOnComplete?: NotifyOnComplete;
   /** Delivery owner captured at async spawn time. */
@@ -381,6 +447,59 @@ export interface CancellationInfo {
   initiator?: string;
   /** Human-readable reason preserved in logs and the snapshot. */
   reason?: string;
+}
+type InProcessTerminalReason =
+  | "completed"
+  | "agent_error"
+  | "process_exit"
+  | "timeout"
+  | "explicit_cancel"
+  | "parent_cancelled"
+  | "session_shutdown"
+  | "fresh_session"
+  | "unknown";
+
+/**
+ * Map an in-process result to a closed terminal reason. Cancellation sources
+ * are authoritative; an unannotated cancelled result is intentionally unknown.
+ */
+function terminalReasonForResult(
+  result: SubagentResult,
+  signal: AbortSignal | undefined,
+): InProcessTerminalReason {
+  if (result.cancelled) {
+    if (!signal?.aborted) return "unknown";
+    const info = readCancellationInfo(signal, "signal");
+    if (info.reason === "timeout") return "timeout";
+    switch (info.source) {
+      case "cancel_subagent":
+      case "cancel_all":
+        return "explicit_cancel";
+      case "session_shutdown":
+        switch (info.reason) {
+          case "session_start (new)":
+          case "session_start (fork)":
+          case "session_shutdown (new)":
+          case "session_shutdown (fork)":
+            return "fresh_session";
+          default:
+            return "session_shutdown";
+        }
+      case "signal":
+      case "workflow":
+      case "supervisor":
+        return "parent_cancelled";
+      default:
+        return "unknown";
+    }
+  }
+  if (result.isError) {
+    return result.errorMessage === "timeout" ||
+      result.errorMessage === "TimeoutError"
+      ? "timeout"
+      : "agent_error";
+  }
+  return "completed";
 }
 
 // ── Job Registry ────────────────────────────────────────────────────
@@ -628,10 +747,12 @@ export function cascadeChildAborts(
   for (const [childId, child] of inProcessJobsForOwner(owner)) {
     if (child.parentJobId !== ownerJobId) continue;
     if (child.status !== "running") continue;
-    child.cancellation = { ...info, at: Date.now() };
+    const cancelledAt = Date.now();
+    child.cancellation = { ...info, at: cancelledAt };
     // Mark cancelled up front so late settlement cannot flip it to done/error
     // and no completion notification fires for an aborted child.
     child.status = "cancelled";
+    child.completedAt ??= cancelledAt;
     scheduleJobCleanup(childId, true, undefined, owner);
     signalled.push(childId);
     if (child.abort) {
@@ -814,6 +935,8 @@ export interface StartSubagentJobParams {
   owner?: SessionOwnerToken;
   /** Anonymous lifecycle metadata resolved at the invoking tool boundary. */
   telemetry?: AgentTelemetryContext;
+  /** Wall-clock time captured at the tool boundary, for spawn latency only. */
+  spawnRequestedAt?: number;
 }
 
 export interface StartSubagentJobResult {
@@ -862,6 +985,7 @@ export async function startSubagentJob(
     rootSessionId,
     owner,
     telemetry,
+    spawnRequestedAt,
   } = params;
 
   // Enforce the cap within this exact scope; peer sessions never evict each other.
@@ -870,21 +994,31 @@ export async function startSubagentJob(
   }
 
   const jobId = generateJobId();
-  const sessionRuntime = await createCompatibleSessionRuntime();
+  let sessionRuntime: CompatibleSessionRuntime;
+  try {
+    sessionRuntime = await createCompatibleSessionRuntime();
+  } catch (error) {
+    throw annotateSpawnFailure(error, "session_creation");
+  }
 
   // Resolve model: exact match only, fallback to default
   // Uses parent's modelRegistry to find extension-added models (e.g. minimax)
-  const targetModel = resolveModel(
-    modelOverride,
-    defaultModel,
-    parentModelRegistry,
-  );
-  if (targetModel) {
-    copyProviderConfig(
-      sessionRuntime,
+  let targetModel: Model<any> | undefined;
+  try {
+    targetModel = resolveModel(
+      modelOverride,
+      defaultModel,
       parentModelRegistry,
-      targetModel.provider,
     );
+    if (targetModel) {
+      copyProviderConfig(
+        sessionRuntime,
+        parentModelRegistry,
+        targetModel.provider,
+      );
+    }
+  } catch (error) {
+    throw annotateSpawnFailure(error, "model_resolution");
   }
   const modelLabel = targetModel
     ? `${targetModel.provider}/${targetModel.id}`
@@ -893,14 +1027,18 @@ export async function startSubagentJob(
   // Build model warning when override was specified (helps AI discover valid models)
   let modelWarning: string | undefined;
   if (modelOverride && parentModelRegistry) {
-    const available = parentModelRegistry.getAvailable();
-    const modelList = available
-      .map((m) => `  ${m.provider}/${m.id}${m.name ? ` (${m.name})` : ""}`)
-      .join("\n");
-    modelWarning =
-      `Requested model "${modelOverride}" resolved to ${modelLabel ?? "none"}. ` +
-      `Available models:\n${modelList || "  (none)"}\n` +
-      `Use list_available_models to discover more.`;
+    try {
+      const available = parentModelRegistry.getAvailable();
+      const modelList = available
+        .map((m) => `  ${m.provider}/${m.id}${m.name ? ` (${m.name})` : ""}`)
+        .join("\n");
+      modelWarning =
+        `Requested model "${modelOverride}" resolved to ${modelLabel ?? "none"}. ` +
+        `Available models:\n${modelList || "  (none)"}\n` +
+        `Use list_available_models to discover more.`;
+    } catch (error) {
+      throw annotateSpawnFailure(error, "model_resolution");
+    }
   }
 
   let handleAbort: (() => void) | undefined;
@@ -964,20 +1102,25 @@ export async function startSubagentJob(
       ? { tool: undefined, capture: undefined }
       : createWorkflowStructuredOutputTool(workflowStructuredOutputSchema);
 
-  const sessionOptions = buildSessionOptions(sessionRuntime, {
-    sessionManager: SessionManager.inMemory(),
-    model: targetModel,
-    cwd,
-    ...(thinkingLevel ? { thinkingLevel } : {}),
-    ...(workflowStructuredOutputTool
-      ? { customTools: [workflowStructuredOutputTool] }
-      : {}),
-  });
-  const session = (
-    await createAgentSession(
-      sessionOptions as unknown as Parameters<typeof createAgentSession>[0],
-    )
-  ).session;
+  let session: AgentSession;
+  try {
+    const sessionOptions = buildSessionOptions(sessionRuntime, {
+      sessionManager: SessionManager.inMemory(),
+      model: targetModel,
+      cwd,
+      ...(thinkingLevel ? { thinkingLevel } : {}),
+      ...(workflowStructuredOutputTool
+        ? { customTools: [workflowStructuredOutputTool] }
+        : {}),
+    });
+    session = (
+      await createAgentSession(
+        sessionOptions as unknown as Parameters<typeof createAgentSession>[0],
+      )
+    ).session;
+  } catch (error) {
+    throw annotateSpawnFailure(error, "session_creation");
+  }
   const effectiveThinkingLevel =
     thinkingLevel === undefined ? undefined : session.thinkingLevel;
   liveStatus.thinkingLevel = effectiveThinkingLevel;
@@ -1155,7 +1298,8 @@ export async function startSubagentJob(
   const start = (): void => {
     if (started || disposedBeforeStart) return;
     started = true;
-    telemetryStartedAt = Date.now();
+    const startedAt = Date.now();
+    telemetryStartedAt = startedAt;
     const telemetryAgentDimensions = {
       execution: "in-process" as const,
       mux: "none" as const,
@@ -1169,6 +1313,10 @@ export async function startSubagentJob(
     captureTelemetry(telemetry?.session, {
       event: "agent_created",
       ...telemetryAgentDimensions,
+      spawn_duration_ms:
+        spawnRequestedAt === undefined
+          ? undefined
+          : startedAt - spawnRequestedAt,
     });
     captureTelemetry(telemetry?.session, {
       event: "task_started",
@@ -1324,14 +1472,31 @@ export async function startSubagentJob(
         stack: stack ?? null,
         errorName: err instanceof Error ? err.name : typeof err,
       });
-      result = attachWorkflowStructuredOutput({
-        output: `Sub-agent crashed: ${msg}`,
-        usage: currentSessionUsage(),
-        model: undefined,
-        thinkingLevel: effectiveThinkingLevel,
-        isError: true,
-        errorMessage: msg,
-      });
+      if (signal?.aborted) {
+        const info = readCancellationInfo(
+          signal,
+          cancellationSource ?? "signal",
+        );
+        result = attachWorkflowStructuredOutput({
+          output: `Sub-agent cancelled before completion${info.reason ? `: ${info.reason}` : ""}.`,
+          usage: currentSessionUsage(),
+          model: session.model
+            ? `${session.model.provider}/${session.model.id}`
+            : undefined,
+          thinkingLevel: effectiveThinkingLevel,
+          isError: false,
+          cancelled: true,
+        });
+      } else {
+        result = attachWorkflowStructuredOutput({
+          output: `Sub-agent crashed: ${msg}`,
+          usage: currentSessionUsage(),
+          model: undefined,
+          thinkingLevel: effectiveThinkingLevel,
+          isError: true,
+          errorMessage: msg,
+        });
+      }
     } finally {
       if (started) {
         const status: TelemetryAgentStatus = result.cancelled
@@ -1353,6 +1518,7 @@ export async function startSubagentJob(
             depth_bucket: telemetryDepthBucket(telemetry?.depth),
             completion_policy: telemetry?.completionPolicy ?? "inline",
             status,
+            terminal_reason: terminalReasonForResult(result, signal),
             duration_ms:
               telemetryStartedAt === undefined
                 ? undefined

--- a/src/interactive-supervisor-registration.ts
+++ b/src/interactive-supervisor-registration.ts
@@ -41,10 +41,7 @@ import {
 } from "./helpers";
 import { snapshotInProcessSession } from "./cancellation-snapshots";
 import { updateRunningSubagentFooter } from "./artifact-poller";
-import {
-  normalizeCancelledWorkflowState,
-  workflowJobsForOwner,
-} from "./workflow-jobs";
+import { cancelWorkflowJob, workflowJobsForOwner } from "./workflow-jobs";
 import {
   interactiveStateBelongsToOwner,
   ownerlessEntitiesVisible,
@@ -555,9 +552,7 @@ export function registerInteractiveSupervisor(
         },
         cancelWorkflow: (job) => {
           if (job.status !== "running") return false;
-          job.abort.abort();
-          job.status = "cancelled";
-          normalizeCancelledWorkflowState(job);
+          cancelWorkflowJob(job, "explicit_cancel");
           return true;
         },
         cancel: (id) => {
@@ -755,6 +750,7 @@ function cancelInProcessFromSupervisor(
   });
   abortJobTree(job.id, info, owner);
   job.status = "cancelled";
+  job.completedAt ??= Date.now();
   scheduleJobCleanup(job.id, true, undefined, owner);
   return true;
 }

--- a/src/interactive-tmux.ts
+++ b/src/interactive-tmux.ts
@@ -82,10 +82,11 @@ import {
   DEFAULT_MAX_NODES,
   hashLineageRoot,
   LINEAGE_SCHEMA_VERSION,
-  type LineageManifest,
   pruneTerminalLineageNodesSync,
   resolveLineageStorePathsSync,
   writeLineageManifestAtomicSync,
+  type LineageManifest,
+  type LineageStorePaths,
 } from "./interactive-lineage";
 import {
   createDescendantSpawnTreeContext,
@@ -104,6 +105,9 @@ import {
   type TelemetryCompletionPolicy,
   type TelemetryDepthBucket,
   type TelemetryInvocationSource,
+  type TelemetrySpawnFailureMux,
+  type TelemetrySession,
+  type TelemetrySpawnFailureStage,
 } from "./telemetry";
 
 // Re-export the tmux-specific `readPaneExitCode` for the test suite. The
@@ -328,6 +332,23 @@ if (!globalThis.__piSubagenturaInteractiveRegistry) {
 
 export const interactiveSubagentRegistry =
   globalThis.__piSubagenturaInteractiveRegistry!;
+
+interface InteractiveCreatedTelemetry {
+  readonly session: TelemetrySession;
+  readonly spawnStartedAt: number;
+  captured: boolean;
+}
+
+/**
+ * A coordinated interactive tool launch registers its completion member after
+ * the pane has been created. Keep the creation event pending until that
+ * registration succeeds so one attempt cannot report both `agent_created` and
+ * `agent_spawn_failed`.
+ */
+const interactiveCreatedTelemetry = new WeakMap<
+  InteractiveSubagentState,
+  InteractiveCreatedTelemetry
+>();
 /** Insert a state into its authoritative session map and the legacy aggregate index. */
 export function registerInteractiveSubagentState(
   state: InteractiveSubagentState,
@@ -523,6 +544,72 @@ export function writeLaunchScript(
   writeFileSync(path, script, { mode: 0o700 });
 }
 
+/**
+ * Record a privacy-safe failure while an interactive child is being spawned.
+ * This helper deliberately accepts only closed dimensions; the exception that
+ * caused the failure never enters the telemetry payload.
+ */
+export function captureInteractiveSpawnFailure(params: {
+  telemetry?: TelemetrySession;
+  stage: TelemetrySpawnFailureStage;
+  startedAt?: number;
+  mux?: TelemetrySpawnFailureMux;
+  invocationSource?: TelemetryInvocationSource;
+  async?: boolean;
+  depth?: number;
+  completionPolicy?: TelemetryCompletionPolicy;
+  model?: string;
+}): void {
+  let model = "custom";
+  try {
+    model = sanitizeTelemetryModel(params.model);
+  } catch {
+    // Model registry failures must not prevent the failure signal itself.
+  }
+  const depth = telemetryDepth(params.depth);
+  const duration =
+    params.startedAt === undefined ? undefined : Date.now() - params.startedAt;
+  captureTelemetry(params.telemetry, {
+    event: "agent_spawn_failed",
+    execution: "interactive",
+    mux: params.mux ?? "unknown",
+    invocation_source: params.invocationSource ?? "interactive",
+    model,
+    async: params.async ?? true,
+    depth,
+    depth_bucket: telemetryDepthBucket(params.depth),
+    completion_policy: params.completionPolicy ?? "legacy",
+    failure_stage: params.stage,
+    spawn_duration_ms: duration,
+  });
+}
+
+/**
+ * Emit the deferred creation event after the interactive tool has registered
+ * its completion member. The weak-map entry makes this safe to call more than
+ * once without double-counting a single launch.
+ */
+export function captureInteractiveSubagentCreatedTelemetry(
+  state: InteractiveSubagentState,
+): void {
+  const pending = interactiveCreatedTelemetry.get(state);
+  if (!pending || pending.captured) return;
+  pending.captured = true;
+  interactiveCreatedTelemetry.delete(state);
+  captureTelemetry(pending.session, {
+    event: "agent_created",
+    execution: "interactive",
+    mux: state.mux,
+    invocation_source: state.telemetryInvocationSource ?? "interactive",
+    model: state.telemetryModel,
+    async: state.telemetryAsync ?? true,
+    depth: state.telemetryDepth,
+    depth_bucket: state.telemetryDepthBucket ?? "unknown",
+    completion_policy: state.telemetryCompletionPolicy ?? "legacy",
+    spawn_duration_ms: Date.now() - pending.spawnStartedAt,
+  });
+}
+
 export function launchInteractiveSubagent(params: {
   name: string;
   task: string;
@@ -573,17 +660,61 @@ export function launchInteractiveSubagent(params: {
   telemetryAsync?: boolean;
   /** Aggregate policy attributed to workflow-owned child execution. */
   telemetryCompletionPolicy?: TelemetryCompletionPolicy;
+  /** Hold `agent_created` until coordinated completion registration succeeds. */
+  deferAgentCreatedTelemetry?: boolean;
+  /** Caller-observed attempt start; direct callers default to launcher entry. */
+  spawnRequestedAt?: number;
 }): InteractiveSubagentState {
+  const spawnStartedAt = params.spawnRequestedAt ?? Date.now();
+  let spawnFailureReported = false;
+  let nextDepth: number | undefined;
+  const reportSpawnFailure = (
+    stage: TelemetrySpawnFailureStage,
+    mux?: TelemetrySpawnFailureMux,
+  ): void => {
+    if (spawnFailureReported) return;
+    spawnFailureReported = true;
+    captureInteractiveSpawnFailure({
+      telemetry:
+        params.sessionScope?.telemetry ??
+        resolveLiveSessionScope(params.supervisorOwner)?.telemetry,
+      stage,
+      startedAt: spawnStartedAt,
+      mux,
+      invocationSource: params.telemetryInvocationSource,
+      async: params.telemetryAsync,
+      depth: nextDepth,
+      completionPolicy:
+        params.telemetryCompletionPolicy ?? params.completionPolicy ?? "legacy",
+      model: params.model,
+    });
+  };
   // 8 bytes, not 4: at 32 bits a birthday collision inside one tree is not
   // remote, and the duplicate-id path only degrades gracefully — it does not
   // recover the shadowed agent.
-  const id = randomBytes(8).toString("hex");
-  const cwd = resolve(params.cwd);
-  const stateCwd = params.parentCwd ? resolve(params.parentCwd) : cwd;
-  const artifactOwnerSessionId =
-    params.parentSessionId ?? sessionIdForOwner(params.supervisorOwner);
+  let id: string;
+  try {
+    id = randomBytes(8).toString("hex");
+  } catch (error) {
+    reportSpawnFailure("unknown");
+    throw error;
+  }
+  let cwd: string;
+  try {
+    cwd = resolve(params.cwd);
+  } catch (error) {
+    reportSpawnFailure("context");
+    throw error;
+  }
+  let stateCwd: string;
+  try {
+    stateCwd = params.parentCwd ? resolve(params.parentCwd) : cwd;
+  } catch (error) {
+    reportSpawnFailure("context");
+    throw error;
+  }
+  let artifactOwnerSessionId: string | undefined;
   const background = params.background !== false; // default true (hidden)
-  const paths = createInteractiveSubagentPaths({ id, name: params.name, cwd });
   // Parse-don't-validate: callers must hand us an already-parsed context.
   const spawnTreeContext = params.spawnTreeContext;
   const parentAgentId = spawnTreeContext?.currentAgentId;
@@ -592,11 +723,31 @@ export function launchInteractiveSubagent(params: {
     spawnTreeContext?.sessionRoot ?? defaultSpawnTreeSessionRoot();
   const effectiveCurrentDepth = spawnTreeContext?.depth ?? 0;
   const effectiveMaxDepth = spawnTreeContext?.maxDepth ?? DEFAULT_MAX_DEPTH;
-  const nextDepth = effectiveCurrentDepth + 1;
+  nextDepth = effectiveCurrentDepth + 1;
+  try {
+    artifactOwnerSessionId =
+      params.parentSessionId ?? sessionIdForOwner(params.supervisorOwner);
+  } catch (error) {
+    reportSpawnFailure("session_creation");
+    throw error;
+  }
+  let paths: {
+    sessionFile: string;
+    artifactDir: string;
+    promptFile: string;
+    systemPromptFile: string;
+    launchScriptFile: string;
+  };
+  try {
+    paths = createInteractiveSubagentPaths({ id, name: params.name, cwd });
+  } catch (error) {
+    reportSpawnFailure("state_persistence");
+    throw error;
+  }
   const liveScope =
     params.sessionScope ?? resolveLiveSessionScope(params.supervisorOwner);
-
   if (rootId && nextDepth > effectiveMaxDepth) {
+    reportSpawnFailure("depth_limit");
     throw new Error(
       `interactive sub-agent depth ${nextDepth} exceeds max ${effectiveMaxDepth}`,
     );
@@ -605,9 +756,15 @@ export function launchInteractiveSubagent(params: {
   // The cap applies whenever a lineage root exists, even when this spawn will
   // not persist a manifest of its own — recursion inside a tree still has to be
   // bounded by that tree's budget.
-  const lineageStore = rootId
-    ? resolveLineageStorePathsSync(sessionRoot, rootId)
-    : undefined;
+  let lineageStore: LineageStorePaths | undefined;
+  try {
+    lineageStore = rootId
+      ? resolveLineageStorePathsSync(sessionRoot, rootId)
+      : undefined;
+  } catch (error) {
+    reportSpawnFailure("state_persistence");
+    throw error;
+  }
   if (lineageStore) {
     let activeCount = existsSync(lineageStore.nodesDir)
       ? countLineageManifestsSync(lineageStore.nodesDir)
@@ -622,6 +779,7 @@ export function launchInteractiveSubagent(params: {
       ).active;
     }
     if (activeCount >= maxNodes) {
+      reportSpawnFailure("capacity");
       throw new Error(
         `interactive sub-agent tree reached max nodes ${maxNodes} (${activeCount} nodes are active or have unknown liveness)`,
       );
@@ -631,15 +789,20 @@ export function launchInteractiveSubagent(params: {
     task: params.task,
     contextText: params.contextText,
   });
-  mkdirSync(paths.artifactDir, { recursive: true });
-  if (artifactOwnerSessionId) {
-    writeFileSync(
-      join(paths.artifactDir, INTERACTIVE_ARTIFACT_OWNER_FILE),
-      artifactOwnerSessionId,
-      { encoding: "utf8", mode: 0o600 },
-    );
+  try {
+    mkdirSync(paths.artifactDir, { recursive: true });
+    if (artifactOwnerSessionId) {
+      writeFileSync(
+        join(paths.artifactDir, INTERACTIVE_ARTIFACT_OWNER_FILE),
+        artifactOwnerSessionId,
+        { encoding: "utf8", mode: 0o600 },
+      );
+    }
+    writeFileSync(paths.promptFile, prompt, { encoding: "utf8", mode: 0o600 });
+  } catch (error) {
+    reportSpawnFailure("state_persistence");
+    throw error;
   }
-  writeFileSync(paths.promptFile, prompt, { encoding: "utf8", mode: 0o600 });
 
   // Cap the persona to prevent a misbehaving parent from shipping a huge
   // system prompt to the model on every turn. 64 KiB is well above what any
@@ -650,6 +813,7 @@ export function launchInteractiveSubagent(params: {
     params.persona !== undefined &&
     Buffer.byteLength(params.persona, "utf8") > MAX_PERSONA_BYTES
   ) {
+    reportSpawnFailure("context");
     throw new Error(
       `persona too large: ${Buffer.byteLength(params.persona, "utf8")} bytes (max ${MAX_PERSONA_BYTES})`,
     );
@@ -661,19 +825,28 @@ export function launchInteractiveSubagent(params: {
   // parent-child notification loop working — is the most recent instruction
   // the LLM reads. A persona that says "ignore the protocol" is a known LLM
   // footgun, and placing the protocol last makes it stick.
-  const protocol = buildChildSubagentProtocol(
-    paths.artifactDir,
-    params.requireActivePaneForUserAttention,
-  );
-  const systemPromptContent = params.persona
-    ? `# Persona\n\n${params.persona}\n\n${protocol}`
-    : protocol;
-  writeFileSync(paths.systemPromptFile, systemPromptContent, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-
-  const systemPromptFile = paths.systemPromptFile;
+  let systemPromptFile: string;
+  try {
+    // Always write a system prompt that includes the child protocol, and place
+    // the user-supplied persona (if any) ABOVE the protocol. Recency wins for
+    // instruction-following, so the protocol — the part that keeps the parent-
+    // child notification loop working — is the most recent instruction.
+    const protocol = buildChildSubagentProtocol(
+      paths.artifactDir,
+      params.requireActivePaneForUserAttention,
+    );
+    const systemPromptContent = params.persona
+      ? `# Persona\n\n${params.persona}\n\n${protocol}`
+      : protocol;
+    writeFileSync(paths.systemPromptFile, systemPromptContent, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    systemPromptFile = paths.systemPromptFile;
+  } catch (error) {
+    reportSpawnFailure("state_persistence");
+    throw error;
+  }
 
   // Resolve the multiplexer up front so a clear error reaches the caller
   // before we start writing files. The resolver throws NoMultiplexerAvailableError
@@ -682,15 +855,28 @@ export function launchInteractiveSubagent(params: {
   try {
     mux = getMux({ preference: params.muxPreference });
   } catch (err) {
+    reportSpawnFailure("mux_resolution");
     if (err instanceof NoMultiplexerAvailableError) {
       throw new Error(`${err.message}\n${tmuxSetupHint()}`);
     }
     throw err;
   }
-
   const telemetry = liveScope?.telemetry;
-  const telemetryMetadata = telemetry?.enabled
-    ? {
+  let telemetryMetadata:
+    | {
+        correlationId: string;
+        mux: MuxName;
+        invocationSource: TelemetryInvocationSource;
+        async: boolean;
+        depth: number | undefined;
+        depthBucket: TelemetryDepthBucket;
+        completionPolicy: TelemetryCompletionPolicy;
+        model: string;
+      }
+    | undefined;
+  if (telemetry?.enabled) {
+    try {
+      telemetryMetadata = {
         correlationId: telemetry.correlationId,
         mux: mux.name,
         invocationSource:
@@ -703,25 +889,43 @@ export function launchInteractiveSubagent(params: {
           params.completionPolicy ??
           ("legacy" as const),
         model: sanitizeTelemetryModel(params.model),
-      }
-    : undefined;
+      };
+    } catch (error) {
+      reportSpawnFailure("model_resolution", mux.name);
+      throw error;
+    }
+  }
 
   // Create the pane FIRST (so we have a target for the launch script to attach
   // to). If any later step throws, try to kill the orphan pane and rethrow.
-  const {
-    paneId,
-    muxTerminalId,
-    windowName,
-    session: muxSession,
-  } = mux.createPane({
-    name: params.name,
-    cwd,
-    background,
-    parentPane:
-      mux.name === "herdr" ? process.env.HERDR_PANE_ID : process.env.TMUX_PANE,
-    windowName: safeSegment(params.name),
-    id,
-  });
+  let paneId: string;
+  let muxTerminalId: string | undefined;
+  let windowName: string | undefined;
+  let muxSession: string | undefined;
+  try {
+    const created = mux.createPane({
+      name: params.name,
+      cwd,
+      background,
+      parentPane:
+        mux.name === "herdr"
+          ? process.env.HERDR_PANE_ID
+          : process.env.TMUX_PANE,
+      windowName: safeSegment(params.name),
+      id,
+    });
+    paneId = created.paneId;
+    muxTerminalId = created.muxTerminalId;
+    windowName = created.windowName;
+    muxSession = created.session;
+  } catch (error) {
+    reportSpawnFailure("pane_launch", mux.name);
+    throw error;
+  }
+  if (typeof paneId !== "string" || paneId.length === 0) {
+    reportSpawnFailure("pane_launch", mux.name);
+    throw new Error("multiplexer returned an invalid pane id");
+  }
   let persistedState = false;
   let lineageManifestPath: string | undefined;
   let lineageBootstrapPath: string | undefined;
@@ -754,6 +958,7 @@ export function launchInteractiveSubagent(params: {
       });
       persistedState = true;
     } catch (err) {
+      reportSpawnFailure("state_persistence", mux.name);
       try {
         mux.killPane(paneId, muxSession);
       } catch {
@@ -789,6 +994,7 @@ export function launchInteractiveSubagent(params: {
         },
       );
     } catch (err) {
+      reportSpawnFailure("state_persistence", mux.name);
       if (persistedState) {
         try {
           removeInteractiveState(stateCwd, id);
@@ -801,8 +1007,37 @@ export function launchInteractiveSubagent(params: {
     }
   }
   let attach: { attachCommand: string; focusCommand: string };
+  const cleanupFailedSpawn = (): void => {
+    if (persistedState && params.parentSessionId) {
+      try {
+        removeInteractiveState(stateCwd, id);
+      } catch {
+        /* best effort — the pane kill below is the important cleanup */
+      }
+    }
+    if (lineageManifestPath) {
+      try {
+        rmSync(lineageManifestPath, { force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+    if (lineageBootstrapPath) {
+      try {
+        rmSync(lineageBootstrapPath, { force: true });
+      } catch {
+        /* best effort — the pane kill below is the important cleanup */
+      }
+    }
+    try {
+      mux.killPane(paneId, muxSession);
+    } catch {
+      /* best effort — preserve the original spawn error */
+    }
+  };
+  let command: string;
   try {
-    const command = buildPiInteractiveCommand({
+    command = buildPiInteractiveCommand({
       sessionFile: paths.sessionFile,
       name: params.name,
       promptFile: paths.promptFile,
@@ -828,6 +1063,12 @@ export function launchInteractiveSubagent(params: {
         : {}),
       ...(!telemetry?.enabled ? { [TELEMETRY_ENV]: "0" } : {}),
     });
+  } catch (err) {
+    reportSpawnFailure("state_persistence", mux.name);
+    cleanupFailedSpawn();
+    throw err;
+  }
+  try {
     const escape = (v: string) => `'${v.replace(/'/g, `'\\''`)}'`;
     mux.sendKeys(
       paneId,
@@ -842,31 +1083,8 @@ export function launchInteractiveSubagent(params: {
       session: muxSession,
     });
   } catch (err) {
-    // Orphan-pane guard. If writeLaunchScript or sendKeys throws after
-    // the pane was created, kill the pane before rethrowing so we don't
-    // leak it into the user's mux server. Also clean up persisted state.
-    if (persistedState && params.parentSessionId) {
-      try {
-        removeInteractiveState(stateCwd, id);
-      } catch {
-        /* best effort — the pane kill below is the important cleanup */
-      }
-    }
-    if (lineageManifestPath) {
-      try {
-        rmSync(lineageManifestPath, { force: true });
-      } catch {
-        /* best effort */
-      }
-    }
-    if (lineageBootstrapPath) {
-      try {
-        rmSync(lineageBootstrapPath, { force: true });
-      } catch {
-        /* best effort — the pane kill below is the important cleanup */
-      }
-    }
-    mux.killPane(paneId, muxSession);
+    reportSpawnFailure("pane_launch", mux.name);
+    cleanupFailedSpawn();
     throw err;
   }
 
@@ -911,19 +1129,42 @@ export function launchInteractiveSubagent(params: {
     telemetryDepthBucket: telemetryMetadata?.depthBucket,
     telemetryModel: telemetryMetadata?.model,
   };
-  registerInteractiveSubagentState(state, liveScope);
-  if (telemetryMetadata) {
-    captureTelemetry(telemetry, {
-      event: "agent_created",
-      execution: "interactive",
-      mux: telemetryMetadata.mux,
-      invocation_source: telemetryMetadata.invocationSource,
-      model: telemetryMetadata.model,
-      async: telemetryMetadata.async,
-      depth: telemetryMetadata.depth,
-      depth_bucket: telemetryMetadata.depthBucket,
-      completion_policy: telemetryMetadata.completionPolicy,
+  if (telemetryMetadata && telemetry) {
+    interactiveCreatedTelemetry.set(state, {
+      session: telemetry,
+      spawnStartedAt: spawnStartedAt,
+      captured: false,
     });
+  }
+  try {
+    registerInteractiveSubagentState(state, liveScope);
+  } catch (err) {
+    interactiveCreatedTelemetry.delete(state);
+    reportSpawnFailure("registration", mux.name);
+    removeInteractiveSubagentState(state);
+    if (persistedState && params.parentSessionId) {
+      try {
+        removeInteractiveState(stateCwd, id);
+      } catch {
+        /* best effort — the pane kill below is the important cleanup */
+      }
+    }
+    if (lineageManifestPath) {
+      try {
+        rmSync(lineageManifestPath, { force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+    try {
+      mux.killPane(paneId, muxSession);
+    } catch {
+      /* best effort */
+    }
+    throw err;
+  }
+  if (telemetryMetadata && !params.deferAgentCreatedTelemetry) {
+    captureInteractiveSubagentCreatedTelemetry(state);
   }
   return state;
 }

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -80,6 +80,7 @@ interface PendingJobOverflow {
   mode: NotifyOnComplete;
   triggerTurn: boolean;
   status: "done" | "error";
+  completedAt?: number;
 }
 
 export type PendingJobDelivery = PendingJobCompletion | PendingJobOverflow;
@@ -123,6 +124,26 @@ function pendingDeliveryBytes(queue: PendingJobDelivery[]): number {
   }, 0);
 }
 
+function maxKnownCompletionAge(
+  completedAt: readonly (number | undefined)[],
+  now = Date.now(),
+): number | undefined {
+  let maximum: number | undefined;
+  for (const timestamp of completedAt) {
+    if (
+      typeof timestamp !== "number" ||
+      !Number.isFinite(timestamp) ||
+      timestamp < 0
+    ) {
+      continue;
+    }
+    const age = now - timestamp;
+    if (!Number.isFinite(age) || age < 0) continue;
+    maximum = Math.max(maximum ?? 0, age);
+  }
+  return maximum;
+}
+
 function appendOverflowIdentity(
   path: string,
   pending: PendingJobCompletion,
@@ -138,6 +159,9 @@ function appendOverflowIdentity(
           ? pending.jobState.triggerTurnOnComplete !== false
           : pending.jobState.triggerTurnOnComplete === true,
       status: pending.result.isError ? "error" : "done",
+      ...(pending.jobState.completedAt === undefined
+        ? {}
+        : { completedAt: pending.jobState.completedAt }),
     })}\n`,
     { mode: 0o600 },
   );
@@ -155,6 +179,12 @@ function mergeJobOverflowSemantics(
   if (mode === "inject") summary.mode = "inject";
   if (trigger) summary.triggerTurn = true;
   if (collapsed.result.isError) summary.status = "error";
+  if (collapsed.jobState.completedAt !== undefined) {
+    summary.completedAt =
+      summary.completedAt === undefined
+        ? collapsed.jobState.completedAt
+        : Math.min(summary.completedAt, collapsed.jobState.completedAt);
+  }
 }
 
 function ownerSessionScopeOf(
@@ -697,12 +727,22 @@ export function flushInProcessDeliveries(owner?: SessionOwnerToken): void {
   } catch {
     return;
   }
+  const deliveryLatencyMs = maxKnownCompletionAge(
+    llm.map(({ pending }) =>
+      pending.kind === "completion"
+        ? pending.jobState.completedAt
+        : pending.completedAt,
+    ),
+  );
   captureTelemetry(
     resolveLiveSessionScope(effectiveOwner)?.telemetry,
     {
       event: "completion_delivered",
       delivery: "notification",
       count: deliveryIds.length,
+      ...(deliveryLatencyMs === undefined
+        ? {}
+        : { delivery_latency_ms: deliveryLatencyMs }),
     },
     { dedupeKey: `notification:${deliveryIds.join(":")}` },
   );

--- a/src/rehydrate.ts
+++ b/src/rehydrate.ts
@@ -41,6 +41,7 @@ import {
 } from "./session-scope";
 
 export const FAILED_TOMBSTONE_TTL_MS = 5 * 60 * 1000;
+const MAX_RECOVERY_COUNTS = 1_000;
 
 /**
  * Placeholder for a state whose attach/focus commands cannot be rebuilt —
@@ -173,14 +174,20 @@ export function rehydrateInteractiveSubagents(
   scope?: SessionScope,
 ): {
   total: number;
+  recovered: number;
   alive: number;
   terminal: number;
+  unknown: number;
 } {
   const payload = loadInteractiveStates(cwd);
-  if (!payload) return { total: 0, alive: 0, terminal: 0 };
+  if (!payload) {
+    return { total: 0, recovered: 0, alive: 0, terminal: 0, unknown: 0 };
+  }
 
+  let recovered = 0;
   let alive = 0;
   let terminal = 0;
+  let unknown = 0;
   const owner: SessionOwnerToken | undefined = scope
     ? sessionOwner(scope)
     : undefined;
@@ -339,8 +346,12 @@ export function rehydrateInteractiveSubagents(
     );
     rehydrated.status = next;
     recoveredStates.push({ entry, state: rehydrated });
-    if (next === "exited" || next === "cancelled") terminal++;
-    else if (next === "running" || next === "idle") alive++;
+    if (recovered < MAX_RECOVERY_COUNTS) {
+      recovered++;
+      if (next === "exited" || next === "cancelled") terminal++;
+      else if (next === "running" || next === "idle") alive++;
+      else unknown++;
+    }
     for (const intent of rehydrated.pendingDeliveries ?? []) {
       if (
         !intent.completionPolicy ||
@@ -389,5 +400,11 @@ export function rehydrateInteractiveSubagents(
     registerInteractiveSubagentState(rehydrated, scope);
   }
 
-  return { total: Object.keys(payload.states).length, alive, terminal };
+  return {
+    total: Object.keys(payload.states).length,
+    recovered,
+    alive,
+    terminal,
+    unknown,
+  };
 }

--- a/src/session-handlers.ts
+++ b/src/session-handlers.ts
@@ -28,6 +28,7 @@ import { debugLog, removeInProcessJob } from "./helpers";
 import { snapshotInProcessSession } from "./cancellation-snapshots";
 import {
   clearCompletionCoordinator,
+  completionLatencyForIds,
   markCompletionHumanInput,
   markCompletionTurnStarting,
   prepareCompletionManifest,
@@ -85,6 +86,7 @@ import {
   manifestDeliveryDedupeKey,
   retireTelemetrySession,
   resolveTelemetryMode,
+  type TelemetryTerminalReason,
 } from "./telemetry";
 
 function getGlobalState() {
@@ -103,6 +105,10 @@ function recordPreparedManifest(
 ): void {
   const completionIds = message.details?.completionIds ?? [];
   if (completionIds.length === 0) return;
+  const deliveryLatencyMs = completionLatencyForIds(
+    completionIds,
+    sessionOwner(scope),
+  );
   // The completion coordinator emits the same event for the same manifest.
   // Both sites must resolve the live scope the same way, or the shared dedupe
   // key lands in two different key sets and one delivery is counted twice.
@@ -112,6 +118,9 @@ function recordPreparedManifest(
       event: "completion_delivered",
       delivery: "manifest",
       count: completionIds.length,
+      ...(deliveryLatencyMs === undefined
+        ? {}
+        : { delivery_latency_ms: deliveryLatencyMs }),
     },
     { dedupeKey: manifestDeliveryDedupeKey(completionIds) },
   );
@@ -194,9 +203,43 @@ function cancellationLifecycleReason(reason: string | undefined) {
   }
 }
 
+function lifecycleCancellationTerminalReason(
+  state: InteractiveSubagentState,
+  lifecycleOrigin: "session_start" | "session_shutdown",
+  sessionReason: string | undefined,
+): TelemetryTerminalReason {
+  if (sessionReason === "new" || sessionReason === "fork") {
+    return "fresh_session";
+  }
+  if (lifecycleOrigin === "session_shutdown") {
+    return "session_shutdown";
+  }
+  switch (state.cancellationSnapshot?.source) {
+    case "session_shutdown":
+      return "session_shutdown";
+    case "cancel_interactive_subagent":
+    case "cancel_subagent":
+    case "cancel_all":
+      return "explicit_cancel";
+    case "signal":
+    case "workflow":
+    case "supervisor":
+      return "parent_cancelled";
+    default:
+      return state.lifecycle?.parentCancelled === true ||
+        state.lifecycle?.completionSource === "parent"
+        ? "parent_cancelled"
+        : lifecycleOrigin === "session_start"
+          ? "session_shutdown"
+          : "unknown";
+  }
+}
+
 function captureInteractiveLifecycleCancellation(
   scope: SessionScope,
   state: InteractiveSubagentState,
+  lifecycleOrigin: "session_start" | "session_shutdown",
+  sessionReason: string | undefined,
 ): void {
   const telemetry = scope.telemetry;
   const turnId = state.telemetryActiveTurnId;
@@ -207,6 +250,11 @@ function captureInteractiveLifecycleCancellation(
   ) {
     return;
   }
+  const terminalReason = lifecycleCancellationTerminalReason(
+    state,
+    lifecycleOrigin,
+    sessionReason,
+  );
   const turnStartedAt = state.telemetryTurnStartedAt;
   const messageTurnId = state.telemetryMessageTurnId;
   const messageCount =
@@ -264,6 +312,7 @@ function captureInteractiveLifecycleCancellation(
       depth_bucket: state.telemetryDepthBucket ?? "unknown",
       completion_policy: state.telemetryCompletionPolicy ?? "legacy",
       status: "cancelled",
+      terminal_reason: terminalReason,
       // `turnStartedAt` is an event-log `ts`, which the child writes from the
       // same epoch clock, so this subtraction stays in one clock domain. A
       // recovered timestamp from an old run can still be arbitrarily stale;
@@ -303,7 +352,12 @@ function cleanupScopeGeneration(
   const sessionId = sessionIdForScope(scope, ctx?.sessionManager);
   const reason = `${lifecycleOrigin} (${event?.reason ?? "unknown"})`;
   snapshotOwnedJobs(scope, sessionId, ctx?.cwd, reason);
-  cleanupWorkflowJobsForOwner(owner);
+  cleanupWorkflowJobsForOwner(
+    owner,
+    event?.reason === "new" || event?.reason === "fork"
+      ? "fresh_session"
+      : "session_shutdown",
+  );
   clearInProcessDeliveries(owner);
 
   const destroysStandalonePanes =
@@ -317,7 +371,12 @@ function cleanupScopeGeneration(
         state.status === "idle" ||
         state.status === "unknown");
     if (destroysPane) {
-      captureInteractiveLifecycleCancellation(scope, state);
+      captureInteractiveLifecycleCancellation(
+        scope,
+        state,
+        lifecycleOrigin,
+        event?.reason,
+      );
     }
     removeInteractiveSubagentState(state);
     if (destroysStandalonePanes) retireLineageBootstraps(state.artifactDir);
@@ -543,12 +602,22 @@ export function registerSessionHandlers(
     if (scope.ui && hasFooterIdentity) {
       updateRunningSubagentFooter(scope.ui, sessionOwner(scope));
     }
-
-    const shouldRehydrate =
-      event.reason === "startup" ||
-      event.reason === "reload" ||
-      event.reason === "resume";
-    if (shouldRehydrate) {
+    const recoveryReason =
+      event.reason === "startup"
+        ? "startup"
+        : event.reason === "reload"
+          ? "reload"
+          : event.reason === "resume"
+            ? "resume"
+            : undefined;
+    if (recoveryReason) {
+      let recovery = {
+        total: 0,
+        recovered: 0,
+        alive: 0,
+        terminal: 0,
+        unknown: 0,
+      };
       if (process.env.PI_SUBAGENTURA_CHILD !== "1") {
         try {
           // Tools reload on demand; startup only validates persistence so the
@@ -559,7 +628,7 @@ export function registerSessionHandlers(
         }
       }
       try {
-        rehydrateInteractiveSubagents(
+        recovery = rehydrateInteractiveSubagents(
           ctx.cwd,
           ctx.sessionManager?.getSessionId?.(),
           ctx.sessionManager?.getEntries?.() ?? [],
@@ -568,6 +637,14 @@ export function registerSessionHandlers(
       } catch {
         /* best effort — rehydrate is a recovery path */
       }
+      captureTelemetry(scope.telemetry, {
+        event: "session_recovered",
+        reason: recoveryReason,
+        total_count: recovery.recovered,
+        alive_count: recovery.alive,
+        terminal_count: recovery.terminal,
+        unknown_count: recovery.unknown,
+      });
       sealCompletionGroups(sessionOwner(scope));
       try {
         recoverCompletionTurnWakes(pi, ctx.sessionManager?.getBranch?.() ?? []);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { getModel, getProviders } from "@earendil-works/pi-ai/compat";
 
 export const TELEMETRY_ENDPOINT = "https://us.i.posthog.com/i/v0/e/";
-export const TELEMETRY_SCHEMA_VERSION = 2;
+export const TELEMETRY_SCHEMA_VERSION = 3;
 const TELEMETRY_PROJECT_TOKEN =
   "phc_B4H7xPiFbwPJmKbdeQtk7FeP3PnQF5AMpQJXCgGYeqFR";
 const TELEMETRY_TIMEOUT_MS = 1_500;
@@ -15,12 +15,49 @@ const MAX_TELEMETRY_DURATION_MS = 30 * 24 * 60 * 60 * 1_000;
 export type TelemetryMode = "straight" | "orchestrator" | "orchestrator_v2";
 export type TelemetryExecution = "in-process" | "interactive";
 export type TelemetryMux = "none" | "tmux" | "zellij" | "herdr";
+export type TelemetrySpawnFailureMux = TelemetryMux | "unknown";
 export type TelemetryInvocationSource =
   "with_context" | "isolated" | "interactive" | "workflow";
 export type TelemetryCompletionPolicy = "inline" | "each" | "group" | "legacy";
 export type TelemetryAgentStatus = "success" | "error" | "cancelled";
 export type TelemetryResultSource = "in-process" | "interactive" | "workflow";
 export type TelemetryDelivery = "manifest" | "notification";
+export type TelemetryWorkflowInvocation = "tool" | "saved_command";
+export type TelemetryWorkflowStatus =
+  "success" | "partial" | "error" | "cancelled";
+export type TelemetryRecoveryReason = "startup" | "reload" | "resume";
+export type TelemetryResultReadOutcome =
+  | "consumed"
+  | "already_consumed"
+  | "empty"
+  | "running"
+  | "error"
+  | "cancelled"
+  | "wait_timeout"
+  | "wait_cancelled"
+  | "unavailable";
+export type TelemetrySpawnFailureStage =
+  | "depth_limit"
+  | "capacity"
+  | "context"
+  | "model_resolution"
+  | "session_creation"
+  | "mux_resolution"
+  | "pane_launch"
+  | "state_persistence"
+  | "registration"
+  | "parent_shutdown"
+  | "unknown";
+export type TelemetryTerminalReason =
+  | "completed"
+  | "agent_error"
+  | "process_exit"
+  | "timeout"
+  | "explicit_cancel"
+  | "parent_cancelled"
+  | "session_shutdown"
+  | "fresh_session"
+  | "unknown";
 export type TelemetryDepthBucket = "1" | "2" | "3" | "4-7" | "8+" | "unknown";
 export type TelemetryDurationBucket =
   "<1s" | "1-5s" | "5-30s" | "30s-2m" | "2-10m" | "10m+" | "unknown";
@@ -36,9 +73,21 @@ interface TelemetryAgentDimensions {
   completion_policy: TelemetryCompletionPolicy;
 }
 
+type TelemetrySpawnFailureDimensions = Omit<TelemetryAgentDimensions, "mux"> & {
+  mux: TelemetrySpawnFailureMux;
+};
+
 export type TelemetryEvent =
   | { event: "session_started" }
-  | ({ event: "agent_created" } & TelemetryAgentDimensions)
+  | ({
+      event: "agent_created";
+      spawn_duration_ms?: number;
+    } & TelemetryAgentDimensions)
+  | ({
+      event: "agent_spawn_failed";
+      failure_stage: TelemetrySpawnFailureStage;
+      spawn_duration_ms?: number;
+    } & TelemetrySpawnFailureDimensions)
   | ({ event: "task_started"; unit: "job" | "turn" } & TelemetryAgentDimensions)
   | {
       event: "interactive_message_sent";
@@ -49,15 +98,47 @@ export type TelemetryEvent =
       event: "task_completed";
       unit: "job" | "turn";
       status: TelemetryAgentStatus;
+      terminal_reason: TelemetryTerminalReason;
       duration_ms: number | undefined;
       child_conversation_message_count: number | undefined;
     } & TelemetryAgentDimensions)
   | {
+      event: "workflow_started";
+      invocation: TelemetryWorkflowInvocation;
+      async: boolean;
+      completion_policy: TelemetryCompletionPolicy;
+    }
+  | {
+      event: "workflow_completed";
+      invocation: TelemetryWorkflowInvocation;
+      async: boolean;
+      completion_policy: TelemetryCompletionPolicy;
+      status: TelemetryWorkflowStatus;
+      terminal_reason: TelemetryTerminalReason;
+      agents_spawned: number;
+      error_count: number;
+      duration_ms?: number;
+    }
+  | {
+      event: "session_recovered";
+      reason: TelemetryRecoveryReason;
+      total_count: number;
+      alive_count: number;
+      terminal_count: number;
+      unknown_count: number;
+    }
+  | {
       event: "completion_delivered";
       delivery: TelemetryDelivery;
       count: number;
+      delivery_latency_ms?: number;
     }
-  | { event: "result_consumed"; source: TelemetryResultSource };
+  | {
+      event: "result_read";
+      source: TelemetryResultSource;
+      outcome: TelemetryResultReadOutcome;
+      read_latency_ms?: number;
+    };
 
 export interface TelemetrySession {
   readonly enabled: boolean;
@@ -250,11 +331,20 @@ function depthProperty(depth: number | undefined): { depth?: number } {
   return boundedDepth === undefined ? {} : { depth: boundedDepth };
 }
 
-function durationProperty(durationMs: number | undefined): {
-  duration_ms?: number;
-} {
+type TelemetryDurationPropertyPrefix =
+  "spawn_duration" | "duration" | "delivery_latency" | "read_latency";
+
+function durationProperties(
+  prefix: TelemetryDurationPropertyPrefix,
+  durationMs: number | undefined,
+): Record<string, number | string> {
   const boundedDuration = telemetryDurationMs(durationMs);
-  return boundedDuration === undefined ? {} : { duration_ms: boundedDuration };
+  return {
+    [`${prefix}_bucket`]: telemetryDurationBucket(durationMs),
+    ...(boundedDuration === undefined
+      ? {}
+      : { [`${prefix}_ms`]: boundedDuration }),
+  };
 }
 
 function boundedCount(value: number | undefined, max: number): number {
@@ -292,6 +382,22 @@ export function buildTelemetryPayload(
         ...depthProperty(event.depth),
         depth_bucket: event.depth_bucket,
         completion_policy: event.completion_policy,
+        ...durationProperties("spawn_duration", event.spawn_duration_ms),
+      };
+      break;
+    case "agent_spawn_failed":
+      properties = {
+        ...common,
+        execution: event.execution,
+        mux: event.mux,
+        invocation_source: event.invocation_source,
+        model: sanitizeTelemetryModel(event.model),
+        async: event.async,
+        ...depthProperty(event.depth),
+        depth_bucket: event.depth_bucket,
+        completion_policy: event.completion_policy,
+        failure_stage: event.failure_stage,
+        ...durationProperties("spawn_duration", event.spawn_duration_ms),
       };
       break;
     case "task_started":
@@ -328,8 +434,8 @@ export function buildTelemetryPayload(
         depth_bucket: event.depth_bucket,
         completion_policy: event.completion_policy,
         status: event.status,
-        duration_bucket: telemetryDurationBucket(event.duration_ms),
-        ...durationProperty(event.duration_ms),
+        terminal_reason: event.terminal_reason,
+        ...durationProperties("duration", event.duration_ms),
         ...(event.child_conversation_message_count === undefined
           ? {}
           : {
@@ -340,15 +446,53 @@ export function buildTelemetryPayload(
             }),
       };
       break;
+    case "workflow_started":
+      properties = {
+        ...common,
+        invocation: event.invocation,
+        async: event.async,
+        completion_policy: event.completion_policy,
+      };
+      break;
+    case "workflow_completed":
+      properties = {
+        ...common,
+        invocation: event.invocation,
+        async: event.async,
+        completion_policy: event.completion_policy,
+        status: event.status,
+        terminal_reason: event.terminal_reason,
+        ...durationProperties("duration", event.duration_ms),
+        agents_spawned: boundedCount(event.agents_spawned, 1_000),
+        error_count: boundedCount(event.error_count, 1_000),
+      };
+      break;
+    case "session_recovered":
+      properties = {
+        ...common,
+        reason: event.reason,
+        total_count: boundedCount(event.total_count, 1_000),
+        alive_count: boundedCount(event.alive_count, 1_000),
+        terminal_count: boundedCount(event.terminal_count, 1_000),
+        unknown_count: boundedCount(event.unknown_count, 1_000),
+      };
+      break;
     case "completion_delivered":
       properties = {
         ...common,
         delivery: event.delivery,
         count: boundedCount(event.count, 128),
+        ...durationProperties("delivery_latency", event.delivery_latency_ms),
       };
       break;
-    case "result_consumed":
-      properties = { ...common, source: event.source };
+    case "result_read":
+      properties = {
+        ...common,
+        source: event.source,
+        outcome: event.outcome,
+        ...durationProperties("read_latency", event.read_latency_ms),
+      };
+      break;
   }
   return {
     api_key: TELEMETRY_PROJECT_TOKEN,

--- a/src/tools/in-process.ts
+++ b/src/tools/in-process.ts
@@ -13,6 +13,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { abortableWait } from "../abortable-wait";
 import { updateRunningSubagentFooter } from "../artifact-poller";
 import { cleanupOldArtifacts, type CleanupResult } from "../artifact";
 import {
@@ -28,7 +29,9 @@ import {
   pruneCompletedJobs,
   registerInProcessJob,
   scheduleJobCleanup,
+  spawnFailureStage,
   startSubagentJob,
+  type InProcessSpawnFailureStage,
   type JobDeliveryOwner,
   type JobState,
   type JobStatus,
@@ -39,6 +42,7 @@ import {
 import { resolveSpawnDepth } from "../orchestration-context";
 import {
   getStartedSessionScopes,
+  findSessionScope,
   resolveLiveSessionScope,
   resolveToolSessionScope,
   sessionOwner,
@@ -46,7 +50,6 @@ import {
   type SessionScope,
   type SessionToolToken,
 } from "../session-scope";
-import { abortableWait } from "../abortable-wait";
 import { snapshotInProcessSession } from "../cancellation-snapshots";
 import {
   assertCompletionGroupOpen,
@@ -76,11 +79,12 @@ import {
 } from "../schemas";
 import {
   captureTelemetry,
+  telemetryDepth,
+  telemetryDepthBucket,
   type AgentTelemetryContext,
   type TelemetryCompletionPolicy,
   type TelemetryInvocationSource,
 } from "../telemetry";
-
 interface RunningFooterContext {
   cwd?: string;
   ui: {
@@ -173,25 +177,123 @@ function telemetryForAgent(
   };
 }
 
-/**
- * A synchronous spawn hands its output straight back to the caller and is never
- * collected through `get_subagent_result`, so the only honest place to record
- * consumption is the return path itself. Without this, collection rates read as
- * zero for every inline job.
- */
-function captureSyncResultConsumed(
+function telemetryForSpawnFailure(
+  token: SessionToolToken | undefined,
   owner: SessionOwnerToken | undefined,
+  invocationSource: TelemetryInvocationSource,
+  async: boolean,
+  depth: number | undefined,
+  completion?: ResolvedCompletionPolicy,
+): AgentTelemetryContext | undefined {
+  const scope = owner
+    ? resolveLiveSessionScope(owner)
+    : token
+      ? findSessionScope(token.id)
+      : undefined;
+  const session = scope?.telemetry;
+  if (!session) return undefined;
+  return {
+    session,
+    invocationSource,
+    async,
+    depth,
+    completionPolicy: async
+      ? completion?.legacy
+        ? "legacy"
+        : (completion?.policy ?? "each")
+      : "inline",
+  };
+}
+
+function captureSpawnFailure(
+  telemetry: AgentTelemetryContext | undefined,
+  failureStage: InProcessSpawnFailureStage,
+  spawnRequestedAt: number | undefined,
+): void {
+  captureTelemetry(
+    telemetry?.session,
+    {
+      event: "agent_spawn_failed",
+      execution: "in-process",
+      mux: "none",
+      invocation_source: telemetry?.invocationSource ?? "isolated",
+      model: undefined,
+      async: telemetry?.async ?? false,
+      depth: telemetryDepth(telemetry?.depth),
+      depth_bucket: telemetryDepthBucket(telemetry?.depth),
+      completion_policy:
+        telemetry?.completionPolicy ?? (telemetry?.async ? "each" : "inline"),
+      failure_stage: failureStage,
+      spawn_duration_ms:
+        spawnRequestedAt === undefined
+          ? undefined
+          : Date.now() - spawnRequestedAt,
+    },
+    { allowInactive: true },
+  );
+}
+
+type InProcessResultReadOutcome =
+  | "consumed"
+  | "already_consumed"
+  | "empty"
+  | "running"
+  | "error"
+  | "cancelled"
+  | "wait_timeout"
+  | "wait_cancelled"
+  | "unavailable";
+
+function captureInProcessResultRead(
+  job: JobState | undefined,
+  owner: SessionOwnerToken | undefined,
+  outcome: InProcessResultReadOutcome,
+): void {
+  const session =
+    job?.telemetry?.session ??
+    (owner ? resolveLiveSessionScope(owner)?.telemetry : undefined);
+  captureTelemetry(
+    session,
+    {
+      event: "result_read",
+      source: "in-process",
+      outcome,
+      read_latency_ms:
+        job?.completedAt === undefined
+          ? undefined
+          : Date.now() - job.completedAt,
+    },
+    { allowInactive: true },
+  );
+}
+
+function resultReadOutcome(
+  result: SubagentResult,
+  firstResultRead: boolean,
+): InProcessResultReadOutcome {
+  if (result.cancelled) return "cancelled";
+  if (result.isError) return "error";
+  if (!firstResultRead) return "already_consumed";
+  if (!result.output || result.output === "(no output)") return "empty";
+  return "consumed";
+}
+
+/**
+ * A synchronous spawn hands its output straight back to the caller, so that
+ * return path is the result read for telemetry purposes.
+ */
+function captureSyncResultRead(
+  telemetry: AgentTelemetryContext | undefined,
   result: SubagentResult,
 ): void {
-  if (result.isError || result.cancelled || result.output === "(no output)") {
-    return;
-  }
   captureTelemetry(
-    owner ? resolveLiveSessionScope(owner)?.telemetry : undefined,
+    telemetry?.session,
     {
-      event: "result_consumed",
+      event: "result_read",
       source: "in-process",
+      outcome: resultReadOutcome(result, true),
     },
+    { allowInactive: true },
   );
 }
 
@@ -409,7 +511,7 @@ function publishInProcessCompletion(
               value: `call get_subagent_result with jobId ${JSON.stringify(jobState.id)}`,
             },
           ],
-      completedAt: Date.now(),
+      completedAt: jobState.completedAt ?? Date.now(),
     },
     owner,
   );
@@ -422,6 +524,7 @@ function settleAsyncJob(
   result: SubagentResult,
   ctx: RunningFooterContext | undefined,
 ): void {
+  jobState.completedAt ??= Date.now();
   const owner = inProcessJobOwner(jobState);
   if (jobState.status === "cancelled") {
     publishInProcessCompletion(
@@ -507,7 +610,9 @@ async function runSubagent(
   rootSessionId?: string,
   owner?: SessionOwnerToken,
   telemetry?: AgentTelemetryContext,
+  spawnRequestedAt?: number,
 ): Promise<SubagentResult> {
+  let started = false;
   try {
     const { jobPromise, modelWarning, start } = await startSubagentJob({
       task,
@@ -524,14 +629,23 @@ async function runSubagent(
       rootSessionId,
       owner,
       telemetry,
+      spawnRequestedAt,
     });
     start?.();
+    started = typeof start === "function";
     const result = await jobPromise;
     if (modelWarning && !result.isError) {
       result.output = `${modelWarning}\n---\n${result.output}`;
     }
     return result;
   } catch (err) {
+    if (!started) {
+      captureSpawnFailure(
+        telemetry,
+        spawnFailureStage(err) ?? "unknown",
+        spawnRequestedAt,
+      );
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return {
       output: `Sub-agent crashed: ${msg}`,
@@ -589,8 +703,27 @@ function registerSubagentWithContextTool(
     parameters: BaseParams,
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const spawnRequestedAt = Date.now();
       const execution = resolveExecutionOwner(toolToken);
-      if (!execution) return unavailableSessionResult();
+      if (!execution) {
+        const staleScope = toolToken
+          ? findSessionScope(toolToken.id)
+          : undefined;
+        captureSpawnFailure(
+          telemetryForSpawnFailure(
+            toolToken,
+            undefined,
+            "with_context",
+            params.async ?? true,
+            undefined,
+          ),
+          staleScope?.lifecycle === "shutdown"
+            ? "parent_shutdown"
+            : "session_creation",
+          spawnRequestedAt,
+        );
+        return unavailableSessionResult();
+      }
       const { owner } = execution;
       const runAsync = params.async ?? true;
       let completion: ResolvedCompletionPolicy;
@@ -598,6 +731,17 @@ function registerSubagentWithContextTool(
         completion = resolveAsyncCompletionPolicy(params, runAsync, owner);
         assertCompletionGroupOpen(completion.policy, completion.groupId, owner);
       } catch (error) {
+        captureSpawnFailure(
+          telemetryForSpawnFailure(
+            toolToken,
+            owner,
+            "with_context",
+            runAsync,
+            undefined,
+          ),
+          "registration",
+          spawnRequestedAt,
+        );
         return completionPolicyErrorResult(error);
       }
       debugLog("info", "tool_call", {
@@ -621,10 +765,30 @@ function registerSubagentWithContextTool(
       });
 
       const spawn = resolveSpawn(ctx);
-      if (spawn.exceedsLimit) return depthLimitResult(spawn.limit);
+      const telemetry = telemetryForAgent(
+        owner,
+        "with_context",
+        runAsync,
+        spawn.childDepth,
+        completion,
+      );
+      if (spawn.exceedsLimit) {
+        captureSpawnFailure(telemetry, "depth_limit", spawnRequestedAt);
+        return depthLimitResult(spawn.limit);
+      }
 
-      const branch = ctx.sessionManager.getBranch();
-      const messages = branch
+      const branchResult = (() => {
+        try {
+          return { ok: true as const, value: ctx.sessionManager.getBranch() };
+        } catch (error) {
+          return { ok: false as const, error };
+        }
+      })();
+      if (!branchResult.ok) {
+        captureSpawnFailure(telemetry, "context", spawnRequestedAt);
+        return completionPolicyErrorResult(branchResult.error);
+      }
+      const messages = branchResult.value
         .filter(
           (e): e is typeof e & { type: "message" } => e.type === "message",
         )
@@ -633,6 +797,7 @@ function registerSubagentWithContextTool(
       const deliveryOwner = captureDeliveryOwner(pi, ctx, owner);
       if (runAsync) {
         if (messages.length === 0) {
+          captureSpawnFailure(telemetry, "context", spawnRequestedAt);
           return {
             content: [
               { type: "text", text: "No conversation history to inherit." },
@@ -641,8 +806,14 @@ function registerSubagentWithContextTool(
           };
         }
 
-        const llmMessages = convertToLlm(messages);
-        const conversationText = serializeConversation(llmMessages);
+        let conversationText: string;
+        try {
+          const llmMessages = convertToLlm(messages);
+          conversationText = serializeConversation(llmMessages);
+        } catch (error) {
+          captureSpawnFailure(telemetry, "context", spawnRequestedAt);
+          return completionPolicyErrorResult(error);
+        }
         const targetCwd = params.cwd ?? ctx.cwd;
 
         let completionReservation: CompletionGroupReservation | undefined;
@@ -653,9 +824,9 @@ function registerSubagentWithContextTool(
             owner,
           );
         } catch (error) {
+          captureSpawnFailure(telemetry, "registration", spawnRequestedAt);
           return completionPolicyErrorResult(error);
         }
-        // Own the child's session so any ancestor abort cascades to it.
         const abort = new AbortController();
         const startResult = await startSubagentJob({
           task: params.task,
@@ -672,15 +843,15 @@ function registerSubagentWithContextTool(
           depth: spawn.childDepth,
           rootSessionId: spawn.rootSessionId,
           owner,
-          telemetry: telemetryForAgent(
-            owner,
-            "with_context",
-            true,
-            spawn.childDepth,
-            completion,
-          ),
+          telemetry,
+          spawnRequestedAt,
         }).catch((error) => {
           releaseCompletionGroup(completionReservation);
+          captureSpawnFailure(
+            telemetry,
+            spawnFailureStage(error) ?? "unknown",
+            spawnRequestedAt,
+          );
           throw error;
         });
         const {
@@ -695,6 +866,7 @@ function registerSubagentWithContextTool(
           disposeBeforeStart,
         } = startResult;
         if (owner && !resolveLiveSessionScope(owner)) {
+          captureSpawnFailure(telemetry, "parent_shutdown", spawnRequestedAt);
           releaseCompletionGroup(completionReservation);
           discardAsyncSpawn(abort, session, disposeBeforeStart);
           return cancelledAsyncSpawnResult();
@@ -709,6 +881,7 @@ function registerSubagentWithContextTool(
           promise: jobPromise,
           modelLabel,
           thinkingLevel,
+          telemetry,
           abort,
           parentJobId: spawn.parentJobId,
           depth: spawn.childDepth,
@@ -725,10 +898,27 @@ function registerSubagentWithContextTool(
           maxAge: params.maxAge,
         };
 
-        if (!registerInProcessJob(jobState, owner)) {
+        let registered = false;
+        try {
+          registered = registerInProcessJob(jobState, owner);
+        } catch (error) {
+          captureSpawnFailure(telemetry, "registration", spawnRequestedAt);
           releaseCompletionGroup(completionReservation);
           discardAsyncSpawn(abort, session, disposeBeforeStart);
-          return owner && !resolveLiveSessionScope(owner)
+          return completionPolicyErrorResult(error);
+        }
+        if (!registered) {
+          const ownerLive =
+            !owner || resolveLiveSessionScope(owner) !== undefined;
+          const failureStage: InProcessSpawnFailureStage = !ownerLive
+            ? "parent_shutdown"
+            : inProcessJobsForOwner(owner).size >= MAX_REGISTRY_SIZE
+              ? "capacity"
+              : "registration";
+          captureSpawnFailure(telemetry, failureStage, spawnRequestedAt);
+          releaseCompletionGroup(completionReservation);
+          discardAsyncSpawn(abort, session, disposeBeforeStart);
+          return owner && !ownerLive
             ? cancelledAsyncSpawnResult()
             : inProcessCapacityResult();
         }
@@ -743,6 +933,7 @@ function registerSubagentWithContextTool(
               completionReservation,
             );
           } catch (error) {
+            captureSpawnFailure(telemetry, "registration", spawnRequestedAt);
             removeInProcessJob(jobId, owner);
             releaseCompletionGroup(completionReservation);
             discardAsyncSpawn(abort, session, disposeBeforeStart);
@@ -774,6 +965,7 @@ function registerSubagentWithContextTool(
       }
 
       if (messages.length === 0) {
+        captureSpawnFailure(telemetry, "context", spawnRequestedAt);
         return {
           content: [
             { type: "text", text: "No conversation history to inherit." },
@@ -782,8 +974,14 @@ function registerSubagentWithContextTool(
         };
       }
 
-      const llmMessages = convertToLlm(messages);
-      const conversationText = serializeConversation(llmMessages);
+      let conversationText: string;
+      try {
+        const llmMessages = convertToLlm(messages);
+        conversationText = serializeConversation(llmMessages);
+      } catch (error) {
+        captureSpawnFailure(telemetry, "context", spawnRequestedAt);
+        return completionPolicyErrorResult(error);
+      }
       const targetCwd = params.cwd ?? ctx.cwd;
       const result = await runSubagent(
         params.task,
@@ -799,15 +997,11 @@ function registerSubagentWithContextTool(
         spawn.childDepth,
         spawn.rootSessionId,
         owner,
-        telemetryForAgent(
-          owner,
-          "with_context",
-          false,
-          spawn.childDepth,
-          completion,
-        ),
+        telemetry,
+        spawnRequestedAt,
       );
 
+      captureSyncResultRead(telemetry, result);
       if (result.cancelled) {
         return {
           content: [{ type: "text", text: result.output }],
@@ -815,7 +1009,6 @@ function registerSubagentWithContextTool(
         };
       }
 
-      captureSyncResultConsumed(owner, result);
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {
         status: result.isError ? "error" : "done",
@@ -881,8 +1074,27 @@ function registerSubagentIsolatedTool(
     parameters: BaseParams,
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const spawnRequestedAt = Date.now();
       const execution = resolveExecutionOwner(toolToken);
-      if (!execution) return unavailableSessionResult();
+      if (!execution) {
+        const staleScope = toolToken
+          ? findSessionScope(toolToken.id)
+          : undefined;
+        captureSpawnFailure(
+          telemetryForSpawnFailure(
+            toolToken,
+            undefined,
+            "isolated",
+            params.async ?? true,
+            undefined,
+          ),
+          staleScope?.lifecycle === "shutdown"
+            ? "parent_shutdown"
+            : "session_creation",
+          spawnRequestedAt,
+        );
+        return unavailableSessionResult();
+      }
       const { owner } = execution;
       const runAsync = params.async ?? true;
       let completion: ResolvedCompletionPolicy;
@@ -890,6 +1102,17 @@ function registerSubagentIsolatedTool(
         completion = resolveAsyncCompletionPolicy(params, runAsync, owner);
         assertCompletionGroupOpen(completion.policy, completion.groupId, owner);
       } catch (error) {
+        captureSpawnFailure(
+          telemetryForSpawnFailure(
+            toolToken,
+            owner,
+            "isolated",
+            runAsync,
+            undefined,
+          ),
+          "registration",
+          spawnRequestedAt,
+        );
         return completionPolicyErrorResult(error);
       }
       debugLog("info", "tool_call", {
@@ -913,11 +1136,21 @@ function registerSubagentIsolatedTool(
       });
 
       const spawn = resolveSpawn(ctx);
-      if (spawn.exceedsLimit) return depthLimitResult(spawn.limit);
+      const telemetry = telemetryForAgent(
+        owner,
+        "isolated",
+        runAsync,
+        spawn.childDepth,
+        completion,
+      );
+      if (spawn.exceedsLimit) {
+        captureSpawnFailure(telemetry, "depth_limit", spawnRequestedAt);
+        return depthLimitResult(spawn.limit);
+      }
 
       const deliveryOwner = captureDeliveryOwner(pi, ctx, owner);
+      const targetCwd = params.cwd ?? ctx.cwd;
       if (runAsync) {
-        const targetCwd = params.cwd ?? ctx.cwd;
         let completionReservation: CompletionGroupReservation | undefined;
         try {
           completionReservation = reserveCompletionGroup(
@@ -926,6 +1159,7 @@ function registerSubagentIsolatedTool(
             owner,
           );
         } catch (error) {
+          captureSpawnFailure(telemetry, "registration", spawnRequestedAt);
           return completionPolicyErrorResult(error);
         }
         // Own the child's session so any ancestor abort cascades to it.
@@ -945,15 +1179,15 @@ function registerSubagentIsolatedTool(
           depth: spawn.childDepth,
           rootSessionId: spawn.rootSessionId,
           owner,
-          telemetry: telemetryForAgent(
-            owner,
-            "isolated",
-            true,
-            spawn.childDepth,
-            completion,
-          ),
+          telemetry,
+          spawnRequestedAt,
         }).catch((error) => {
           releaseCompletionGroup(completionReservation);
+          captureSpawnFailure(
+            telemetry,
+            spawnFailureStage(error) ?? "unknown",
+            spawnRequestedAt,
+          );
           throw error;
         });
         const {
@@ -968,6 +1202,7 @@ function registerSubagentIsolatedTool(
           disposeBeforeStart,
         } = startResult;
         if (owner && !resolveLiveSessionScope(owner)) {
+          captureSpawnFailure(telemetry, "parent_shutdown", spawnRequestedAt);
           releaseCompletionGroup(completionReservation);
           discardAsyncSpawn(abort, session, disposeBeforeStart);
           return cancelledAsyncSpawnResult();
@@ -982,6 +1217,7 @@ function registerSubagentIsolatedTool(
           promise: jobPromise,
           modelLabel,
           thinkingLevel,
+          telemetry,
           abort,
           parentJobId: spawn.parentJobId,
           depth: spawn.childDepth,
@@ -998,10 +1234,27 @@ function registerSubagentIsolatedTool(
           maxAge: params.maxAge,
         };
 
-        if (!registerInProcessJob(jobState, owner)) {
+        let registered = false;
+        try {
+          registered = registerInProcessJob(jobState, owner);
+        } catch (error) {
+          captureSpawnFailure(telemetry, "registration", spawnRequestedAt);
           releaseCompletionGroup(completionReservation);
           discardAsyncSpawn(abort, session, disposeBeforeStart);
-          return owner && !resolveLiveSessionScope(owner)
+          return completionPolicyErrorResult(error);
+        }
+        if (!registered) {
+          const ownerLive =
+            !owner || resolveLiveSessionScope(owner) !== undefined;
+          const failureStage: InProcessSpawnFailureStage = !ownerLive
+            ? "parent_shutdown"
+            : inProcessJobsForOwner(owner).size >= MAX_REGISTRY_SIZE
+              ? "capacity"
+              : "registration";
+          captureSpawnFailure(telemetry, failureStage, spawnRequestedAt);
+          releaseCompletionGroup(completionReservation);
+          discardAsyncSpawn(abort, session, disposeBeforeStart);
+          return owner && !ownerLive
             ? cancelledAsyncSpawnResult()
             : inProcessCapacityResult();
         }
@@ -1016,6 +1269,7 @@ function registerSubagentIsolatedTool(
               completionReservation,
             );
           } catch (error) {
+            captureSpawnFailure(telemetry, "registration", spawnRequestedAt);
             removeInProcessJob(jobId, owner);
             releaseCompletionGroup(completionReservation);
             discardAsyncSpawn(abort, session, disposeBeforeStart);
@@ -1060,15 +1314,11 @@ function registerSubagentIsolatedTool(
         spawn.childDepth,
         spawn.rootSessionId,
         owner,
-        telemetryForAgent(
-          owner,
-          "isolated",
-          false,
-          spawn.childDepth,
-          completion,
-        ),
+        telemetry,
+        spawnRequestedAt,
       );
 
+      captureSyncResultRead(telemetry, result);
       if (result.cancelled) {
         return {
           content: [{ type: "text", text: result.output }],
@@ -1076,7 +1326,6 @@ function registerSubagentIsolatedTool(
         };
       }
 
-      captureSyncResultConsumed(owner, result);
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {
         status: result.isError ? "error" : "done",
@@ -1224,6 +1473,7 @@ function registerGetSubagentResultTool(
       });
 
       if (!job) {
+        captureInProcessResultRead(undefined, execution.owner, "unavailable");
         return {
           content: [
             {
@@ -1237,6 +1487,7 @@ function registerGetSubagentResultTool(
       }
 
       if (job.status === "cancelled") {
+        captureInProcessResultRead(job, execution.owner, "cancelled");
         consumeCompletionSource(
           pi,
           { source: "in-process", sourceId: job.id },
@@ -1256,6 +1507,7 @@ function registerGetSubagentResultTool(
 
       // If signal is already aborted, return immediately without setting resultRetrieved
       if (signal?.aborted) {
+        captureInProcessResultRead(job, execution.owner, "wait_cancelled");
         return {
           content: [
             {
@@ -1269,10 +1521,9 @@ function registerGetSubagentResultTool(
       }
 
       if (job.status === "running" && params.wait !== true) {
+        captureInProcessResultRead(job, execution.owner, "running");
+        const currentText = job.liveStatus.output.trim();
         const live = buildLiveUpdate(job.liveStatus, job.modelLabel);
-        const currentText =
-          (live.content?.[0] as { type: "text"; text: string } | undefined)
-            ?.text || "";
         return {
           ...live,
           content: [
@@ -1336,6 +1587,7 @@ function registerGetSubagentResultTool(
       }
       if (waitResult.aborted) {
         if (timedOut) {
+          captureInProcessResultRead(job, execution.owner, "wait_timeout");
           return {
             content: [
               {
@@ -1351,6 +1603,7 @@ function registerGetSubagentResultTool(
             isError: true,
           };
         }
+        captureInProcessResultRead(job, execution.owner, "wait_cancelled");
         return {
           content: [
             { type: "text", text: `Wait for job ${params.jobId} cancelled.` },
@@ -1360,12 +1613,18 @@ function registerGetSubagentResultTool(
         };
       }
       if (execution.owner && !resolveLiveSessionScope(execution.owner)) {
+        captureInProcessResultRead(job, execution.owner, "unavailable");
         return unavailableSessionResult();
       }
       const result = waitResult.value!;
       // Only set resultRetrieved after successful completion (not on abort)
       const firstResultRead = !job.resultRetrieved;
       job.resultRetrieved = true;
+      const outcome =
+        (job.status as JobStatus) === "cancelled"
+          ? "cancelled"
+          : resultReadOutcome(result, firstResultRead);
+      captureInProcessResultRead(job, execution.owner, outcome);
       consumeCompletionSource(
         pi,
         { source: "in-process", sourceId: job.id },
@@ -1387,19 +1646,6 @@ function registerGetSubagentResultTool(
           details: { jobId: params.jobId, status: "cancelled" },
           isError: true,
         };
-      }
-      if (
-        firstResultRead &&
-        !result.isError &&
-        !result.cancelled &&
-        result.output !== "(no output)"
-      ) {
-        captureTelemetry(
-          execution.owner
-            ? resolveLiveSessionScope(execution.owner)?.telemetry
-            : undefined,
-          { event: "result_consumed", source: "in-process" },
-        );
       }
       const usageStr = formatUsage(result.usage, result.model);
       const details: InProcessSubagentDetails = {
@@ -1523,6 +1769,7 @@ function registerCancelSubagentTool(
         /* Session may already be disposed; abort is best-effort */
       }
       job.status = "cancelled";
+      job.completedAt ??= Date.now();
       publishInProcessCompletion(
         job,
         job.result ?? {

--- a/src/tools/interactive.ts
+++ b/src/tools/interactive.ts
@@ -28,6 +28,7 @@ import {
   readOutputForTurn,
   updateInteractiveState,
   type SubagentArtifact,
+  type SubagentEvent,
 } from "../artifact";
 import {
   assertCompletionGroupOpen,
@@ -41,6 +42,8 @@ import {
 } from "../completion-coordinator";
 import {
   cancelInteractiveSubagent,
+  captureInteractiveSubagentCreatedTelemetry,
+  captureInteractiveSpawnFailure,
   getCurrentPaneActivity,
   removeInteractiveSubagentState,
   formatInteractiveState,
@@ -73,13 +76,18 @@ import { InteractiveParams, MAX_INTERACTIVE_CONTEXT_BYTES } from "../schemas";
 import { registerToolWithDefaultGuidance } from "../tool-guidance";
 import { updateRunningSubagentFooter } from "../artifact-poller";
 import {
+  findSessionScope,
   getStartedSessionScopes,
   resolveToolSessionScope,
   sessionOwner,
   type SessionScope,
   type SessionToolToken,
 } from "../session-scope";
-import { captureTelemetry } from "../telemetry";
+import {
+  captureTelemetry,
+  type TelemetryResultReadOutcome,
+  type TelemetrySpawnFailureStage,
+} from "../telemetry";
 
 function isValidSubagentId(id: string): boolean {
   return isValidOrchestratorChildId(id);
@@ -330,6 +338,7 @@ interface SelectedCompletion {
   turnId: string;
   protocolV2: boolean;
   outcome: "done" | "error" | "cancelled";
+  terminalTs: number;
 }
 
 function completionForRead(
@@ -365,6 +374,7 @@ function completionForRead(
         turnId: selected.event.turnId,
         protocolV2: true,
         outcome: selected.event.outcome,
+        terminalTs: selected.event.ts,
       }
     : {
         turnId: `legacy-${selected.startOffset}`,
@@ -375,7 +385,56 @@ function completionForRead(
             : selected.event.type === "cancelled"
               ? "cancelled"
               : "done",
+        terminalTs: selected.event.ts,
       };
+}
+function readLatencyFromTerminal(
+  terminalTs: number | undefined,
+  readAt: number,
+): number | undefined {
+  if (
+    terminalTs === undefined ||
+    !Number.isSafeInteger(terminalTs) ||
+    terminalTs < 0 ||
+    !Number.isSafeInteger(readAt) ||
+    terminalTs > readAt
+  ) {
+    return undefined;
+  }
+  return readAt - terminalTs;
+}
+
+function resultReadOutcome(params: {
+  artifactAvailable: boolean;
+  wantsOutput: boolean;
+  output: string | null;
+  selectedCompletion: SelectedCompletion | undefined;
+  lastEvent: SubagentEvent | null;
+  firstConsumption: boolean | undefined;
+}): TelemetryResultReadOutcome {
+  if (!params.artifactAvailable) return "unavailable";
+  const selectedOutcome = params.selectedCompletion?.outcome;
+  if (selectedOutcome === "error") return "error";
+  if (selectedOutcome === "cancelled") return "cancelled";
+  if (!params.wantsOutput) {
+    if (params.selectedCompletion) return "unavailable";
+    if (!params.lastEvent || !isArtifactOutputSettled(params.lastEvent)) {
+      return "running";
+    }
+    if (params.lastEvent.type === "error") return "error";
+    if (params.lastEvent.type === "cancelled") return "cancelled";
+    return "unavailable";
+  }
+  if (params.output === null) {
+    if (params.lastEvent && !isArtifactOutputSettled(params.lastEvent)) {
+      return "running";
+    }
+    return "unavailable";
+  }
+  if (params.output.length === 0) return "empty";
+  if (params.firstConsumption === true) return "consumed";
+  if (params.firstConsumption === false) return "already_consumed";
+  return "running";
 }
 
 function resolveInteractiveToolStates(token: SessionToolToken | undefined):
@@ -477,14 +536,37 @@ export function registerInteractiveSubagentTools(
       "This is intentionally separate from SDK subagents: it favors observability and attachability over in-process execution.",
       "Completion coordination defaults to each: every terminal turn creates one TUI-only notice, while safely-idle results are coalesced into a compact immutable-reference manifest that resumes the parent.",
       "Use completionPolicy=group with a shared completionGroupId for related agents; the parent resumes once the spawning turn settles and every registered member is terminal.",
-      "Human input takes priority, and successful read_subagent_artifact collection consumes the matching pending delivery.",
-      "Deprecated notifyOnComplete and triggerTurnOnComplete inputs map to coordinated each delivery and cannot be combined with completionPolicy or completionGroupId.",
     ].join("\n"),
     parameters: InteractiveParams,
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const spawnStartedAt = Date.now();
       const registration = resolveInteractiveToolStates(toolToken);
+      const staleScope =
+        !registration && toolToken ? findSessionScope(toolToken.id) : undefined;
+      const spawnTreeDepth =
+        registration?.scope?.spawnTreeContext?.depth ??
+        staleScope?.spawnTreeContext?.depth;
+      const reportSpawnFailure = (
+        stage: TelemetrySpawnFailureStage,
+        mux?: "tmux" | "zellij" | "herdr",
+      ): void => {
+        captureInteractiveSpawnFailure({
+          telemetry: registration?.scope?.telemetry ?? staleScope?.telemetry,
+          stage,
+          startedAt: spawnStartedAt,
+          mux,
+          invocationSource: "interactive",
+          async: true,
+          depth: spawnTreeDepth === undefined ? undefined : spawnTreeDepth + 1,
+          completionPolicy: params.completionPolicy ?? "legacy",
+          model: params.model,
+        });
+      };
       if (!registration) {
+        if (staleScope && staleScope.lifecycle !== "started") {
+          reportSpawnFailure("parent_shutdown");
+        }
         return {
           content: [
             {
@@ -500,6 +582,7 @@ export function registerInteractiveSubagentTools(
         registration.scope?.lineageMode === "child" &&
         !registration.scope.spawnTreeContext
       ) {
+        reportSpawnFailure("context");
         return {
           content: [
             {
@@ -525,6 +608,7 @@ export function registerInteractiveSubagentTools(
         params.routingAliases,
       );
       if (routingMetadataError || routingModeError) {
+        reportSpawnFailure("context");
         const error = routingMetadataError ?? routingModeError!;
         return {
           content: [
@@ -549,6 +633,7 @@ export function registerInteractiveSubagentTools(
         Buffer.byteLength(contextParams.context, "utf8") >
           MAX_INTERACTIVE_CONTEXT_BYTES
       ) {
+        reportSpawnFailure("context");
         return {
           content: [
             {
@@ -585,6 +670,7 @@ export function registerInteractiveSubagentTools(
           );
         }
       } catch (error) {
+        reportSpawnFailure("context");
         const message = error instanceof Error ? error.message : String(error);
         return {
           content: [
@@ -608,6 +694,7 @@ export function registerInteractiveSubagentTools(
             sessionOwner(registration.scope),
           );
         } catch (error) {
+          reportSpawnFailure("registration");
           const msg = error instanceof Error ? error.message : String(error);
           return {
             content: [{ type: "text", text: `Sub-agent not started: ${msg}` }],
@@ -634,17 +721,29 @@ export function registerInteractiveSubagentTools(
           ? (contextParams.context ?? null)
           : null;
       let authorityEntries: readonly unknown[] | undefined;
-      if (contextParams.includeContext === true) {
-        const branch = ctx.sessionManager.getBranch();
-        authorityEntries = branch;
-        const messages = branch
-          .filter(
-            (e): e is typeof e & { type: "message" } => e.type === "message",
-          )
-          .map((e) => e.message);
-        contextText = serializeConversation(convertToLlm(messages));
-      } else if (topLevelOrchestratorV2) {
-        authorityEntries = parentBranchEntries(ctx);
+      try {
+        if (contextParams.includeContext === true) {
+          const branch = ctx.sessionManager.getBranch();
+          authorityEntries = branch;
+          const messages = branch
+            .filter(
+              (e): e is typeof e & { type: "message" } => e.type === "message",
+            )
+            .map((e) => e.message);
+          contextText = serializeConversation(convertToLlm(messages));
+        } else if (topLevelOrchestratorV2) {
+          authorityEntries = parentBranchEntries(ctx);
+        }
+      } catch (error) {
+        reportSpawnFailure("context");
+        throw error;
+      }
+      let parentSessionId: string;
+      try {
+        parentSessionId = ctx.sessionManager.getSessionId();
+      } catch (error) {
+        reportSpawnFailure("session_creation");
+        throw error;
       }
 
       const taskPreview = params.task.replace(/\s+/g, " ").slice(0, 48);
@@ -666,13 +765,16 @@ export function registerInteractiveSubagentTools(
           completionGroupId: completion.groupId,
           muxPreference: params.mux, // pass through user's mux preference
           parentCwd: ctx.cwd,
-          parentSessionId: ctx.sessionManager.getSessionId(),
+          parentSessionId,
           thinkingLevel: params.thinkingLevel,
           sessionScope: registration.scope,
           spawnTreeContext: registration.scope?.spawnTreeContext,
           requireActivePaneForUserAttention: topLevelOrchestratorV2,
           telemetryInvocationSource: "interactive",
           telemetryAsync: true,
+          spawnRequestedAt: spawnStartedAt,
+          deferAgentCreatedTelemetry:
+            registration.scope !== undefined && completion.policy !== undefined,
         });
         if (registration.scope && completion.policy) {
           try {
@@ -685,6 +787,21 @@ export function registerInteractiveSubagentTools(
               completionReservation,
             );
           } catch (error) {
+            captureInteractiveSpawnFailure({
+              telemetry: registration.scope.telemetry,
+              stage: "registration",
+              startedAt: spawnStartedAt,
+              mux: state.mux,
+              invocationSource:
+                state.telemetryInvocationSource ?? "interactive",
+              async: state.telemetryAsync ?? true,
+              depth: state.telemetryDepth,
+              completionPolicy:
+                state.telemetryCompletionPolicy ??
+                completion.policy ??
+                "legacy",
+              model: state.telemetryModel ?? state.model,
+            });
             releaseCompletionGroup(completionReservation);
             rollbackInteractiveSpawn(state);
             return {
@@ -698,6 +815,7 @@ export function registerInteractiveSubagentTools(
               isError: true,
             };
           }
+          captureInteractiveSubagentCreatedTelemetry(state);
         }
         const routingMetadata = persistInitialRoutingMetadata({
           cwd: ctx.cwd,
@@ -1216,9 +1334,28 @@ export function registerInteractiveSubagentTools(
     }),
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<any> {
+      const registration = resolveInteractiveToolStates(toolToken);
+      const staleScope =
+        !registration && toolToken ? findSessionScope(toolToken.id) : undefined;
+      const captureResultRead = (
+        outcome: TelemetryResultReadOutcome,
+        terminalTs?: number,
+      ): void => {
+        const readAt = Date.now();
+        captureTelemetry(
+          registration?.scope?.telemetry ?? staleScope?.telemetry,
+          {
+            event: "result_read",
+            source: "interactive",
+            outcome,
+            read_latency_ms: readLatencyFromTerminal(terminalTs, readAt),
+          },
+        );
+      };
       // Validate the id shape FIRST so a malformed id gets a precise error
       // instead of being collapsed into the generic "not found" message.
       if (!isValidSubagentId(params.id)) {
+        captureResultRead("unavailable");
         return {
           content: [
             {
@@ -1231,6 +1368,7 @@ export function registerInteractiveSubagentTools(
         };
       }
       if (params.turn !== undefined && params.turnId !== undefined) {
+        captureResultRead("unavailable");
         return {
           content: [
             {
@@ -1242,7 +1380,6 @@ export function registerInteractiveSubagentTools(
           isError: true,
         };
       }
-      const registration = resolveInteractiveToolStates(toolToken);
       const state = registration?.states.get(params.id);
       const foreignInMemoryState =
         !state && interactiveSubagentRegistry.has(params.id);
@@ -1252,6 +1389,7 @@ export function registerInteractiveSubagentTools(
           ? findOwnedDiskArtifact(ctx.cwd, params.id, registration.scope)
           : null;
       if (!art) {
+        captureResultRead("unavailable");
         return {
           content: [
             {
@@ -1263,113 +1401,121 @@ export function registerInteractiveSubagentTools(
           isError: true,
         };
       }
-      const events = readEvents(art, params.since);
-      // Historical selectors imply includeOutput: selecting a turn without its
-      // immutable content would be surprising and provides no useful mapping.
-      const wantsOutput =
-        params.includeOutput !== false ||
-        params.turn !== undefined ||
-        params.turnId !== undefined;
-      const selectedCompletion = wantsOutput
-        ? completionForRead(art, params)
-        : undefined;
-      const output = wantsOutput
-        ? params.turnId !== undefined
-          ? readOutputForTurnId(art, params.turnId)
-          : params.turn !== undefined
-            ? readOutputForTurn(art, params.turn)
-            : selectedCompletion?.protocolV2
-              ? readOutputForTurnId(art, selectedCompletion.turnId)
-              : readOutput(art)
-        : null;
-      const lastEventValue =
-        events.length > 0 ? events[events.length - 1] : null;
-      // Distinguish three cases when output is missing/empty so the caller
-      // doesn't see a misleading "not written yet" after the sub-agent has
-      // already exited (the common case: model finished without writing).
-      let outputText: string;
-      if (!wantsOutput) {
-        outputText = "(not requested)";
-      } else if (output === null) {
-        if (params.turnId !== undefined) {
-          outputText = `(no immutable snapshot for turnId ${params.turnId})`;
-        } else if (params.turn !== undefined) {
-          outputText = `(no snapshot for turn ${params.turn} — the poller may not have run yet, or this turn number is past the history)`;
+      try {
+        const events = readEvents(art, params.since);
+        // Historical selectors imply includeOutput: selecting a turn without its
+        // immutable content would be surprising and provides no useful mapping.
+        const wantsOutput =
+          params.includeOutput !== false ||
+          params.turn !== undefined ||
+          params.turnId !== undefined;
+        const selectedCompletion = wantsOutput
+          ? completionForRead(art, params)
+          : undefined;
+        const readCompletion =
+          selectedCompletion ??
+          (!wantsOutput ? completionForRead(art, {}) : undefined);
+        const output = wantsOutput
+          ? params.turnId !== undefined
+            ? readOutputForTurnId(art, params.turnId)
+            : params.turn !== undefined
+              ? readOutputForTurn(art, params.turn)
+              : selectedCompletion?.protocolV2
+                ? readOutputForTurnId(art, selectedCompletion.turnId)
+                : readOutput(art)
+          : null;
+        const lastEventValue =
+          events.length > 0 ? events[events.length - 1] : null;
+        // Distinguish three cases when output is missing/empty so the caller
+        // doesn't see a misleading "not written yet" after the sub-agent has
+        // already exited (the common case: model finished without writing).
+        let outputText: string;
+        if (!wantsOutput) {
+          outputText = "(not requested)";
+        } else if (output === null) {
+          if (params.turnId !== undefined) {
+            outputText = `(no immutable snapshot for turnId ${params.turnId})`;
+          } else if (params.turn !== undefined) {
+            outputText = `(no snapshot for turn ${params.turn} — the poller may not have run yet, or this turn number is past the history)`;
+          } else {
+            const exited =
+              lastEventValue && isArtifactOutputSettled(lastEventValue);
+            outputText = exited
+              ? `(sub-agent exited without writing output.md — last event: ${lastEventValue.type} @ ${lastEventValue.ts})`
+              : `(${events.length} events, last: ${lastEventValue ? `${lastEventValue.type} @ ${lastEventValue.ts}` : "(none)"} — output.md not written yet)`;
+          }
+        } else if (output.length === 0) {
+          outputText = "(empty — 0 chars)";
         } else {
-          const exited =
-            lastEventValue && isArtifactOutputSettled(lastEventValue);
-          outputText = exited
-            ? `(sub-agent exited without writing output.md — last event: ${lastEventValue.type} @ ${lastEventValue.ts})`
-            : `(${events.length} events, last: ${lastEventValue ? `${lastEventValue.type} @ ${lastEventValue.ts}` : "(none)"} — output.md not written yet)`;
+          outputText = `${output.length} chars`;
         }
-      } else if (output.length === 0) {
-        outputText = "(empty — 0 chars)";
-      } else {
-        outputText = `${output.length} chars`;
-      }
-      // Available turns summary so the caller knows what history exists.
-      const availableTurns = listOutputTurns(art);
-      const outputHistory = listOutputHistory(art);
-      const turnsLine =
-        availableTurns.length > 0
-          ? `Available turns: [${availableTurns.join(", ")}]\n`
-          : "";
-      const historyLine =
-        outputHistory.length > 0
-          ? `Protocol-v2 outputs: ${outputHistory
-              .map(({ turnId, eventId }) => `${turnId} → ${eventId}`)
-              .join(", ")}\n`
-          : "";
-      if (wantsOutput && output !== null && selectedCompletion) {
-        const firstConsumption = consumeCompletionSource(
-          pi,
-          {
-            source: "interactive",
-            sourceId: params.id,
-            turnId: selectedCompletion.turnId,
-          },
-          registration?.scope ? sessionOwner(registration.scope) : undefined,
-        );
-        if (
-          firstConsumption &&
-          output.length > 0 &&
-          selectedCompletion.outcome === "done"
-        ) {
-          captureTelemetry(registration?.scope?.telemetry, {
-            event: "result_consumed",
-            source: "interactive",
-          });
+        // Available turns summary so the caller knows what history exists.
+        const availableTurns = listOutputTurns(art);
+        const outputHistory = listOutputHistory(art);
+        const turnsLine =
+          availableTurns.length > 0
+            ? `Available turns: [${availableTurns.join(", ")}]\n`
+            : "";
+        const historyLine =
+          outputHistory.length > 0
+            ? `Protocol-v2 outputs: ${outputHistory
+                .map(({ turnId, eventId }) => `${turnId} → ${eventId}`)
+                .join(", ")}\n`
+            : "";
+        let firstConsumption: boolean | undefined;
+        if (wantsOutput && output !== null && selectedCompletion) {
+          firstConsumption = consumeCompletionSource(
+            pi,
+            {
+              source: "interactive",
+              sourceId: params.id,
+              turnId: selectedCompletion.turnId,
+            },
+            registration?.scope ? sessionOwner(registration.scope) : undefined,
+          );
         }
-      }
-      return {
-        content: [
-          {
-            type: "text",
-            text:
-              `Artifact for ${params.id} (${events.length} event${events.length === 1 ? "" : "s"}${params.since ? ` since ${params.since}` : ""}).\n` +
-              `Last event: ${lastEventValue ? `${lastEventValue.type} @ ${lastEventValue.ts}` : "(none)"}\n` +
-              (params.turn !== undefined
-                ? `Reading turn: ${params.turn}\n`
-                : "") +
-              (params.turnId !== undefined
-                ? `Reading turnId: ${params.turnId}\n`
-                : "") +
-              turnsLine +
-              historyLine +
-              `Output: ${outputText}` +
-              (wantsOutput ? formatArtifactProviderOutput(output) : ""),
-          },
-        ],
-        details: {
-          id: params.id,
-          artifactDir: art.dir,
-          events,
+        const readOutcome = resultReadOutcome({
+          artifactAvailable: true,
+          wantsOutput,
           output,
+          selectedCompletion: readCompletion,
           lastEvent: lastEventValue,
-          availableTurns,
-          outputHistory,
-        },
-      };
+          firstConsumption,
+        });
+        captureResultRead(readOutcome, readCompletion?.terminalTs);
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Artifact for ${params.id} (${events.length} event${events.length === 1 ? "" : "s"}${params.since ? ` since ${params.since}` : ""}).\n` +
+                `Last event: ${lastEventValue ? `${lastEventValue.type} @ ${lastEventValue.ts}` : "(none)"}\n` +
+                (params.turn !== undefined
+                  ? `Reading turn: ${params.turn}\n`
+                  : "") +
+                (params.turnId !== undefined
+                  ? `Reading turnId: ${params.turnId}\n`
+                  : "") +
+                turnsLine +
+                historyLine +
+                `Output: ${outputText}` +
+                (wantsOutput ? formatArtifactProviderOutput(output) : ""),
+            },
+          ],
+          details: {
+            id: params.id,
+            artifactDir: art.dir,
+            events,
+            output,
+            lastEvent: lastEventValue,
+            availableTurns,
+            outputHistory,
+          },
+        };
+      } catch (error) {
+        captureResultRead("error");
+        throw error;
+      }
     },
   });
 

--- a/src/workflow-core.ts
+++ b/src/workflow-core.ts
@@ -440,6 +440,18 @@ export class WorkflowExecutionError extends Error {
     this.usage = usage;
   }
 }
+/** Typed evidence for the workflow VM's exact wall-clock timeout branch. */
+export class WorkflowWallTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(
+      `Workflow timed out after ${timeoutMs}ms; the worker was terminated.`,
+    );
+    this.name = "WorkflowWallTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
 
 export interface RunWorkflowOptions {
   args?: unknown;

--- a/src/workflow-jobs.ts
+++ b/src/workflow-jobs.ts
@@ -3,6 +3,7 @@ import { debugLog } from "./helpers";
 import {
   getActiveSessionOwner,
   isSessionOwnerLive,
+  resolveLiveSessionScope,
   type SessionOwnerToken,
 } from "./session-scope";
 import type { CancellationSnapshotReceipt } from "./cancellation-snapshots";
@@ -17,12 +18,182 @@ import {
   type WorkflowRunResultWithUsage,
   type WorkflowUsage,
   WorkflowExecutionError,
+  WorkflowWallTimeoutError,
   MAX_WORKFLOW_AGENT_RECORDS,
   zeroWorkflowUsage,
 } from "./workflow-core";
+import {
+  captureTelemetry,
+  type TelemetryCompletionPolicy,
+  type TelemetrySession,
+  type TelemetryTerminalReason,
+  type TelemetryWorkflowInvocation,
+  type TelemetryWorkflowStatus,
+} from "./telemetry";
 import type { CompletionPolicy } from "./completion-coordinator";
 
 // ── Background workflow-job registry ─────────────────────────────────
+export interface WorkflowJobTelemetry {
+  /** Session captured at acceptance so settlement cannot drift to a new owner. */
+  session?: TelemetrySession;
+  invocation: TelemetryWorkflowInvocation;
+  async: boolean;
+  completionPolicy: TelemetryCompletionPolicy;
+}
+
+export type WorkflowJobTelemetryOptions = Omit<WorkflowJobTelemetry, "session">;
+
+function normalizeWorkflowInvocation(
+  value: WorkflowJobTelemetryOptions["invocation"] | undefined,
+): TelemetryWorkflowInvocation {
+  return value === "saved_command" ? "saved_command" : "tool";
+}
+
+function normalizeWorkflowCompletionPolicy(
+  value: WorkflowJobTelemetryOptions["completionPolicy"] | undefined,
+  fallback: TelemetryCompletionPolicy,
+): TelemetryCompletionPolicy {
+  return value === "inline" ||
+    value === "each" ||
+    value === "group" ||
+    value === "legacy"
+    ? value
+    : fallback;
+}
+
+function safeTelemetryNow(): number | undefined {
+  try {
+    const now = Date.now();
+    return Number.isFinite(now) && now >= 0 ? now : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function workflowTelemetryDuration(
+  startedAt: number,
+  completedAt: number | undefined,
+): number | undefined {
+  if (
+    completedAt === undefined ||
+    !Number.isFinite(startedAt) ||
+    startedAt < 0 ||
+    completedAt < startedAt
+  ) {
+    return undefined;
+  }
+  return completedAt - startedAt;
+}
+
+function boundedWorkflowTelemetryCount(value: number | undefined): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.trunc(value!), 0), 1_000);
+}
+
+function terminalReasonFromAbortReason(
+  reason: unknown,
+): TelemetryTerminalReason | undefined {
+  if (!reason || typeof reason !== "object" || !("source" in reason)) {
+    return undefined;
+  }
+  const source = reason.source;
+  switch (source) {
+    case "session_shutdown":
+      return "session_shutdown";
+    case "fresh_session":
+      return "fresh_session";
+    case "timeout":
+      return "timeout";
+    case "cancel_subagent":
+      return "explicit_cancel";
+    case "cancel_all":
+    case "signal":
+    case "workflow":
+    case "supervisor":
+      return "parent_cancelled";
+    default:
+      return undefined;
+  }
+}
+
+function workflowTelemetryStatus(
+  job: WorkflowJobState,
+  result: WorkflowRunResult | undefined,
+): TelemetryWorkflowStatus {
+  if (job.status === "cancelled" || job.abort.signal.aborted) {
+    return "cancelled";
+  }
+  if (job.status === "error") return "error";
+  return result && result.errorCount > 0 ? "partial" : "success";
+}
+
+function isWorkflowWallTimeout(error: unknown): boolean {
+  if (error instanceof WorkflowWallTimeoutError) return true;
+  if (!(error instanceof WorkflowExecutionError)) return false;
+  return (
+    (error as WorkflowExecutionError & { cause?: unknown }).cause instanceof
+    WorkflowWallTimeoutError
+  );
+}
+
+function workflowTelemetryTerminalReason(
+  job: WorkflowJobState,
+  status: TelemetryWorkflowStatus,
+): TelemetryTerminalReason {
+  if (status === "success") return "completed";
+  if (status === "partial") return "agent_error";
+  if (status === "error") return job.telemetryTerminalReason ?? "agent_error";
+  return (
+    job.telemetryTerminalReason ??
+    terminalReasonFromAbortReason(job.abort.signal.reason) ??
+    "unknown"
+  );
+}
+
+function emitWorkflowStartedTelemetry(job: WorkflowJobState): void {
+  const telemetry = job.telemetry;
+  if (!telemetry) return;
+  captureTelemetry(telemetry.session, {
+    event: "workflow_started",
+    invocation: telemetry.invocation,
+    async: telemetry.async,
+    completion_policy: telemetry.completionPolicy,
+  });
+}
+
+function emitWorkflowCompletedTelemetry(
+  job: WorkflowJobState,
+  result: WorkflowRunResult | undefined,
+): void {
+  if (job.telemetryCompleted) return;
+  job.telemetryCompleted = true;
+  if (job.completedAt === undefined) job.completedAt = safeTelemetryNow();
+  const status = workflowTelemetryStatus(job, result);
+  const telemetry = job.telemetry;
+  if (!telemetry) return;
+  const agentsSpawned = boundedWorkflowTelemetryCount(
+    result?.agentsSpawned ?? job.snapshot.agentsSpawned,
+  );
+  const errorCount = boundedWorkflowTelemetryCount(
+    result?.errorCount ?? job.snapshot.errorCount,
+  );
+  const durationMs = workflowTelemetryDuration(job.startedAt, job.completedAt);
+  captureTelemetry(
+    telemetry.session,
+    {
+      event: "workflow_completed",
+      invocation: telemetry.invocation,
+      async: telemetry.async,
+      completion_policy: telemetry.completionPolicy,
+      status,
+      terminal_reason: workflowTelemetryTerminalReason(job, status),
+      agents_spawned: agentsSpawned,
+      error_count: errorCount,
+      ...(durationMs === undefined ? {} : { duration_ms: durationMs }),
+    },
+    { allowInactive: true },
+  );
+}
 
 export type WorkflowJobStatus = "running" | "done" | "error" | "cancelled";
 
@@ -32,6 +203,7 @@ export interface WorkflowJobState {
   status: WorkflowJobStatus;
   executionMode?: "async" | "sync";
   startedAt: number;
+  completedAt?: number;
   /**
    * Settles with the runner's own result shape, where `usage` is always present.
    * Widening to {@link WorkflowRunResult} here would force every consumer to
@@ -81,8 +253,14 @@ export interface WorkflowJobState {
   notificationAttempt?: number;
   /** Parent session lifecycle that owns this workflow job. */
   parentSessionOwner?: SessionOwnerToken;
+  /** Guards the aggregate terminal event against reentrant settlement paths. */
+  telemetryCompleted?: boolean;
   completionPolicy?: CompletionPolicy;
   completionGroupId?: string;
+  /** Telemetry metadata captured at acceptance for aggregate lifecycle events. */
+  telemetry?: WorkflowJobTelemetry;
+  /** Evidence-backed cancellation reason for the aggregate terminal event. */
+  telemetryTerminalReason?: TelemetryTerminalReason;
 }
 
 function isProtectedCoordinatedResult(job: WorkflowJobState): boolean {
@@ -156,17 +334,56 @@ export function workflowJobsForOwner(
 
 export function cleanupWorkflowJobsForOwner(
   owner: SessionOwnerToken | undefined,
+  terminalReason: TelemetryTerminalReason = "session_shutdown",
 ): void {
   for (const [id, job] of workflowJobRegistry) {
     if (!workflowJobBelongsToOwner(job, owner)) continue;
     job.suppressCompletionNotification = true;
-    if (job.status === "running") {
-      job.abort.abort();
-      job.status = "cancelled";
+    if (job.status === "running" || job.status === "cancelled") {
+      cancelWorkflowJob(job, terminalReason);
     }
-    if (job.status === "cancelled") normalizeCancelledWorkflowState(job);
     workflowJobRegistry.delete(id);
   }
+}
+
+/**
+ * Cancel one workflow exactly once while retaining typed terminal evidence for
+ * settlement telemetry and result-read latency.
+ */
+export function cancelWorkflowJob(
+  job: WorkflowJobState,
+  terminalReason: TelemetryTerminalReason,
+): void {
+  if (job.status !== "running" && job.status !== "cancelled") return;
+  if (job.telemetryTerminalReason === undefined) {
+    job.telemetryTerminalReason = terminalReason;
+  }
+  if (job.completedAt === undefined) job.completedAt = safeTelemetryNow();
+  const wasRunning = job.status === "running";
+  if (wasRunning) {
+    job.status = "cancelled";
+    normalizeCancelledWorkflowState(job);
+    try {
+      job.abort.abort({
+        source:
+          terminalReason === "explicit_cancel"
+            ? "cancel_subagent"
+            : terminalReason === "session_shutdown" ||
+                terminalReason === "fresh_session"
+              ? "session_shutdown"
+              : "workflow",
+        reason:
+          terminalReason === "fresh_session"
+            ? "session_start (new)"
+            : terminalReason,
+      });
+    } catch {
+      /* The workflow may already be aborting. */
+    }
+  } else {
+    normalizeCancelledWorkflowState(job);
+  }
+  invokeWorkflowCompletionHook(job);
 }
 
 /** Roll back a just-created workflow whose completion registration failed. */
@@ -227,6 +444,7 @@ export function startWorkflowJob(
   onComplete?: (job: WorkflowJobState) => boolean | void,
   owner: SessionOwnerToken | undefined = getActiveSessionOwner(),
   executionMode: "async" | "sync" = "async",
+  telemetryOptions?: WorkflowJobTelemetryOptions,
 ): WorkflowJobState {
   const parentSessionOwner = owner;
   // A blocking sync workflow ran unconditionally before it was tracked here.
@@ -260,6 +478,23 @@ export function startWorkflowJob(
   }
 
   const id = `wf_${randomBytes(5).toString("hex")}`;
+  const defaultAsync = executionMode === "async";
+  const defaultCompletionPolicy: TelemetryCompletionPolicy = defaultAsync
+    ? "legacy"
+    : "inline";
+  const telemetryAsync =
+    typeof telemetryOptions?.async === "boolean"
+      ? telemetryOptions.async
+      : defaultAsync;
+  const telemetry: WorkflowJobTelemetry = {
+    session: resolveLiveSessionScope(parentSessionOwner)?.telemetry,
+    invocation: normalizeWorkflowInvocation(telemetryOptions?.invocation),
+    async: telemetryAsync,
+    completionPolicy: normalizeWorkflowCompletionPolicy(
+      telemetryOptions?.completionPolicy,
+      defaultCompletionPolicy,
+    ),
+  };
   const opts =
     typeof optsOrBuilder === "function" ? optsOrBuilder(id) : optsOrBuilder;
   const abort = new AbortController();
@@ -291,7 +526,9 @@ export function startWorkflowJob(
     cancellationSnapshots: [],
     activeAgentRuns: new Set(),
     parentSessionOwner,
+    telemetry,
   };
+  emitWorkflowStartedTelemetry(state);
   const liveUsageByAgent = new Map<number, WorkflowUsage>();
   state.promise = runWorkflow(script, {
     ...opts,
@@ -339,11 +576,13 @@ export function startWorkflowJob(
       state.snapshot.liveUsage = undefined;
       liveUsageByAgent.clear();
       if (state.status === "cancelled") normalizeCancelledWorkflowState(state);
+      emitWorkflowCompletedTelemetry(state, r);
       invokeWorkflowCompletionHook(state);
       return r;
     })
     .catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
+      if (isWorkflowWallTimeout(err)) state.telemetryTerminalReason = "timeout";
       state.status = abort.signal.aborted ? "cancelled" : "error";
       state.error = msg;
       if (err instanceof WorkflowExecutionError && err.usage) {
@@ -353,6 +592,7 @@ export function startWorkflowJob(
       state.snapshot.liveUsage = undefined;
       liveUsageByAgent.clear();
       if (state.status === "cancelled") normalizeCancelledWorkflowState(state);
+      emitWorkflowCompletedTelemetry(state, undefined);
       invokeWorkflowCompletionHook(state);
       throw err;
     })

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -2,11 +2,14 @@ import { Type } from "typebox";
 import { abortableWait } from "./abortable-wait";
 import {
   debugLog,
+  type InProcessSpawnFailureStage,
   MAX_REGISTRY_SIZE,
   registerInProcessJob,
   removeInProcessJob,
+  spawnFailureStage,
   startSubagentJob,
   type JobState,
+  type StartSubagentJobResult,
 } from "./helpers";
 import {
   launchInteractiveSubagent,
@@ -33,10 +36,10 @@ import {
   workflowUsageFromUsage,
 } from "./workflow-core";
 import {
+  cancelWorkflowJob,
   discardWorkflowJob,
   getWorkflowCompletionPresentation,
   getWorkflowJobForOwner,
-  invokeWorkflowCompletionHook,
   normalizeCancelledWorkflowState,
   startWorkflowJob,
   workflowJobsForOwner,
@@ -88,7 +91,13 @@ import {
   type ResolvedCompletionPolicy,
   type CompletionGroupReservation,
 } from "./completion-coordinator";
-import { captureTelemetry, type TelemetryCompletionPolicy } from "./telemetry";
+import {
+  captureTelemetry,
+  telemetryDepth,
+  telemetryDepthBucket,
+  type TelemetryCompletionPolicy,
+  type TelemetryResultReadOutcome,
+} from "./telemetry";
 
 const WORKFLOW_SESSION_SCOPE_MESSAGE =
   "Workflow jobs are scoped to the current parent session and do not survive reload/resume/new/quit.";
@@ -209,6 +218,46 @@ export function formatWorkflowNotificationSummary(
       : ""
   }`;
 }
+function workflowReadLatencyMs(job: WorkflowJobState): number | undefined {
+  if (job.completedAt === undefined) return undefined;
+  try {
+    const now = Date.now();
+    if (
+      !Number.isFinite(now) ||
+      now < 0 ||
+      !Number.isFinite(job.completedAt) ||
+      job.completedAt < 0 ||
+      now < job.completedAt
+    ) {
+      return undefined;
+    }
+    return now - job.completedAt;
+  } catch {
+    return undefined;
+  }
+}
+
+function emitWorkflowResultReadTelemetry(
+  job: WorkflowJobState | undefined,
+  owner: SessionOwnerToken | undefined,
+  outcome: TelemetryResultReadOutcome,
+): void {
+  const readLatencyMs = job ? workflowReadLatencyMs(job) : undefined;
+  const session =
+    job?.telemetry?.session ?? resolveLiveSessionScope(owner)?.telemetry;
+  captureTelemetry(
+    session,
+    {
+      event: "result_read",
+      source: "workflow",
+      outcome,
+      ...(readLatencyMs === undefined
+        ? {}
+        : { read_latency_ms: readLatencyMs }),
+    },
+    { allowInactive: true },
+  );
+}
 
 export function registerWorkflowTool(
   pi: ExtensionAPI,
@@ -321,6 +370,28 @@ export function registerWorkflowTool(
       // it from `supervisorOwner` instead drops every child event whenever the
       // workflow tool was registered without a session scope.
       const childTelemetry = resolveLiveSessionScope(childOwner)?.telemetry;
+      const captureSpawnFailure = (
+        failureStage: InProcessSpawnFailureStage,
+        attemptStartedAt: number,
+      ): void => {
+        captureTelemetry(
+          childTelemetry,
+          {
+            event: "agent_spawn_failed",
+            execution: "in-process",
+            mux: "none",
+            invocation_source: "workflow",
+            model: undefined,
+            async: workflowAsync,
+            depth: telemetryDepth(spawn.childDepth),
+            depth_bucket: telemetryDepthBucket(spawn.childDepth),
+            completion_policy: telemetryCompletionPolicy,
+            failure_stage: failureStage,
+            spawn_duration_ms: Date.now() - attemptStartedAt,
+          },
+          { allowInactive: true },
+        );
+      };
 
       // Own the child session so its parent abort cascades to it and exact-scope
       // shutdown can drain it from the authoritative job map.
@@ -328,60 +399,73 @@ export function registerWorkflowTool(
       const forwardAbort = () => abort.abort(signal?.reason);
       if (signal?.aborted) abort.abort(signal.reason);
       else signal?.addEventListener("abort", forwardAbort, { once: true });
-      const prepared = await startSubagentJob({
-        task: prompt,
-        persona,
-        modelOverride: model,
-        cwd: ctx.cwd,
-        contextText: null,
-        signal: abort.signal,
-        onUpdate: (partial) => {
-          const liveUsage = workflowUsageFromUsage(
-            partial.details?.subagentStatus?.usage,
-          );
-          const status = partial.details?.subagentStatus;
-          if (status?.activeTool) {
-            maybeEmitUpdate(`⚙ ${status.activeTool.name}`, liveUsage);
-          } else if (status?.output) {
-            const preview = (status.output || "")
-              .slice(0, 60)
-              .replace(/\s+/g, " ")
-              .trim();
-            if (preview) maybeEmitUpdate(`💭 ${preview}`, liveUsage);
-          } else if (liveUsage) maybeEmitUpdate("↻ usage", liveUsage);
-        },
-        defaultModel: ctx.model,
-        parentModelRegistry: ctx.modelRegistry,
-        onCancellationSnapshot,
-        cancellationSource: "workflow",
-        thinkingLevel,
-        // The child binds this depth into its own orchestration context, so a
-        // sub-agent it spawns counts from here. Left unset, the child bound
-        // depth 0 and its own children reported depth 1 — the same value as
-        // their parent — so the dimension was non-monotone within one spawn
-        // tree and the depth cap never saw a workflow grandchild.
-        depth: spawn.childDepth,
-        rootSessionId: spawn.rootSessionId,
-        owner: childOwner,
-        telemetry: childTelemetry
-          ? {
-              session: childTelemetry,
-              invocationSource: "workflow",
-              async: workflowAsync,
-              depth: spawn.childDepth,
-              completionPolicy: telemetryCompletionPolicy,
-            }
-          : undefined,
-        ...(isolation === "in-process" && schema !== undefined
-          ? { workflowStructuredOutputSchema: schema }
-          : {}),
-      });
+      const spawnRequestedAt = Date.now();
+      let prepared: StartSubagentJobResult;
+      try {
+        prepared = await startSubagentJob({
+          task: prompt,
+          persona,
+          modelOverride: model,
+          cwd: ctx.cwd,
+          contextText: null,
+          signal: abort.signal,
+          onUpdate: (partial) => {
+            const liveUsage = workflowUsageFromUsage(
+              partial.details?.subagentStatus?.usage,
+            );
+            const status = partial.details?.subagentStatus;
+            if (status?.activeTool) {
+              maybeEmitUpdate(`⚙ ${status.activeTool.name}`, liveUsage);
+            } else if (status?.output) {
+              const preview = (status.output || "")
+                .slice(0, 60)
+                .replace(/\s+/g, " ")
+                .trim();
+              if (preview) maybeEmitUpdate(`💭 ${preview}`, liveUsage);
+            } else if (liveUsage) maybeEmitUpdate("↻ usage", liveUsage);
+          },
+          defaultModel: ctx.model,
+          parentModelRegistry: ctx.modelRegistry,
+          onCancellationSnapshot,
+          cancellationSource: "workflow",
+          thinkingLevel,
+          // The child binds this depth into its own orchestration context, so a
+          // sub-agent it spawns counts from here. Left unset, the child bound
+          // depth 0 and its own children reported depth 1 — the same value as
+          // their parent — so the dimension was non-monotone within one spawn
+          // tree and the depth cap never saw a workflow grandchild.
+          depth: spawn.childDepth,
+          rootSessionId: spawn.rootSessionId,
+          owner: childOwner,
+          telemetry: childTelemetry
+            ? {
+                session: childTelemetry,
+                invocationSource: "workflow",
+                async: workflowAsync,
+                depth: spawn.childDepth,
+                completionPolicy: telemetryCompletionPolicy,
+              }
+            : undefined,
+          ...(isolation === "in-process" && schema !== undefined
+            ? { workflowStructuredOutputSchema: schema }
+            : {}),
+          spawnRequestedAt,
+        });
+      } catch (error) {
+        captureSpawnFailure(
+          spawnFailureStage(error) ?? "unknown",
+          spawnRequestedAt,
+        );
+        signal?.removeEventListener("abort", forwardAbort);
+        throw error;
+      }
       // The parent session can shut down while startSubagentJob is awaited above.
       // session_shutdown drains jobRegistry, so registering now would re-insert
       // into an already-drained registry and start a model turn that no abort path
       // can reach (the PR #59 shutdown-escape hole).
       if (childOwner && !isSessionOwnerLive(childOwner)) {
         signal?.removeEventListener("abort", forwardAbort);
+        captureSpawnFailure("parent_shutdown", spawnRequestedAt);
         discardWorkflowChildSpawn(abort, prepared);
         throw new Error(
           "Workflow agent cancelled: parent session shut down before the child was registered.",
@@ -410,6 +494,12 @@ export function registerWorkflowTool(
       if (childOwner) {
         if (!registerInProcessJob(childJob, childOwner)) {
           signal?.removeEventListener("abort", forwardAbort);
+          captureSpawnFailure(
+            childOwner && !isSessionOwnerLive(childOwner)
+              ? "parent_shutdown"
+              : "registration",
+            spawnRequestedAt,
+          );
           discardWorkflowChildSpawn(abort, prepared);
           throw new Error(
             `Workflow agent could not start: ${MAX_REGISTRY_SIZE} in-process sub-agent jobs are retained or running.`,
@@ -806,6 +896,14 @@ export function registerWorkflowTool(
             notifyWorkflowCompletion,
             workflowOwner,
             "async",
+            {
+              invocation: "tool",
+              async: true,
+              completionPolicy: workflowTelemetryCompletionPolicy(
+                true,
+                completion,
+              ),
+            },
           );
         } catch (err) {
           releaseCompletionGroup(completionReservation);
@@ -847,6 +945,7 @@ export function registerWorkflowTool(
       }
 
       // ── Synchronous (block-and-stream) path ──
+      let job: WorkflowJobState | undefined;
       try {
         const meta = parseWorkflow(script).meta;
         const syncProgress = (p: WorkflowProgress) => {
@@ -867,7 +966,7 @@ export function registerWorkflowTool(
             /* onUpdate is best-effort */
           }
         };
-        const job = startWorkflowJob(
+        job = startWorkflowJob(
           meta.name,
           script,
           (workflowId) => ({
@@ -879,10 +978,23 @@ export function registerWorkflowTool(
           undefined,
           workflowOwner,
           "sync",
+          {
+            invocation: "tool",
+            async: false,
+            completionPolicy: workflowTelemetryCompletionPolicy(
+              false,
+              completion,
+            ),
+          },
         );
         const run = await job.promise;
         const resultText =
           typeof run.result === "string" ? run.result : stringify(run.result);
+        emitWorkflowResultReadTelemetry(
+          job,
+          workflowOwner,
+          resultText.length > 0 ? "consumed" : "empty",
+        );
         const presentation = getWorkflowCompletionPresentation(
           "done",
           run.errorCount,
@@ -919,6 +1031,11 @@ export function registerWorkflowTool(
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        emitWorkflowResultReadTelemetry(
+          job,
+          workflowOwner,
+          job?.status === "cancelled" ? "cancelled" : "error",
+        );
         const usage = workflowErrorUsage(err);
         const usageDetails = usage ? { usage } : {};
         const budgetTotal = params.budget ?? DEFAULT_WORKFLOW_OUTPUT_BUDGET;
@@ -1028,6 +1145,11 @@ export function registerWorkflowTool(
       const workflowOwner = owner();
       const st = getWorkflowJobForOwner(params.workflowId, workflowOwner);
       if (!st) {
+        emitWorkflowResultReadTelemetry(
+          undefined,
+          workflowOwner,
+          "unavailable",
+        );
         return {
           content: [
             { type: "text", text: workflowNotFoundMessage(params.workflowId) },
@@ -1039,6 +1161,7 @@ export function registerWorkflowTool(
 
       // If signal is already aborted, return immediately
       if (signal?.aborted) {
+        emitWorkflowResultReadTelemetry(st, workflowOwner, "wait_cancelled");
         return {
           content: [
             {
@@ -1056,6 +1179,7 @@ export function registerWorkflowTool(
       try {
         const waitResult = await abortableWait(st.promise, signal);
         if (waitResult.aborted) {
+          emitWorkflowResultReadTelemetry(st, workflowOwner, "wait_cancelled");
           return {
             content: [
               {
@@ -1074,6 +1198,11 @@ export function registerWorkflowTool(
         const usage = presentWorkflowUsage(st.snapshot?.usage);
         const outputBudget = st.snapshot?.budgetTotal;
         const usageDetails = usage ? { usage } : {};
+        emitWorkflowResultReadTelemetry(
+          st,
+          workflowOwner,
+          st.status === "cancelled" ? "cancelled" : "error",
+        );
         st.resultRetrieved = true;
         consumeCompletionSource(
           pi,
@@ -1104,8 +1233,10 @@ export function registerWorkflowTool(
         };
       }
 
-      const resultText =
+      const serializedResult =
         typeof run.result === "string" ? run.result : stringify(run.result);
+      const resultText =
+        typeof serializedResult === "string" ? serializedResult : "";
       const presentation = getWorkflowCompletionPresentation(
         "done",
         run.errorCount,
@@ -1118,12 +1249,15 @@ export function registerWorkflowTool(
         { source: "workflow", sourceId: st.id },
         workflowOwner,
       );
-      if (firstResultRead && st.status === "done" && resultText.length > 0) {
-        captureTelemetry(resolveLiveSessionScope(workflowOwner)?.telemetry, {
-          event: "result_consumed",
-          source: "workflow",
-        });
-      }
+      const readOutcome: TelemetryResultReadOutcome =
+        st.status === "cancelled"
+          ? "cancelled"
+          : firstResultRead
+            ? resultText.length > 0
+              ? "consumed"
+              : "empty"
+            : "already_consumed";
+      emitWorkflowResultReadTelemetry(st, workflowOwner, readOutcome);
       return {
         content: [
           {
@@ -1214,10 +1348,7 @@ export function registerWorkflowTool(
           },
         };
       }
-      st.abort.abort();
-      st.status = "cancelled";
-      normalizeCancelledWorkflowState(st);
-      invokeWorkflowCompletionHook(st);
+      cancelWorkflowJob(st, "explicit_cancel");
       if (cancellationSnapshotsEnabled()) {
         await waitForCancellationReceipts(st);
         normalizeCancelledWorkflowState(st);
@@ -1406,6 +1537,15 @@ export function registerWorkflowTool(
         Date.now(),
         notifyWorkflowCompletion,
         workflowOwner,
+        "async",
+        {
+          invocation: "saved_command",
+          async: true,
+          completionPolicy: workflowTelemetryCompletionPolicy(
+            true,
+            commandCompletion,
+          ),
+        },
       );
       configureWorkflowCompletion(job, commandCompletion, workflowOwner);
       return { job, meta };

--- a/src/workflow-tree-ui.ts
+++ b/src/workflow-tree-ui.ts
@@ -1,7 +1,7 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import {
+  cancelWorkflowJob,
   getWorkflowCompletionPresentation,
-  normalizeCancelledWorkflowState,
   workflowJobsForOwner,
   type WorkflowJobState,
 } from "./workflow-jobs";
@@ -152,9 +152,7 @@ export class WorkflowTreeComponent {
       );
       return;
     }
-    job.abort.abort();
-    job.status = "cancelled";
-    normalizeCancelledWorkflowState(job);
+    cancelWorkflowJob(job, "explicit_cancel");
     this.opts.notify?.(`Cancelled workflow ${job.id}.`);
     this.changed();
     this.opts.done({ kind: "cancel", workflowId: job.id });

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -39,6 +39,7 @@ import {
   type WorkflowProgressUpdate,
   type WorkflowRunResultWithUsage,
   WorkflowExecutionError,
+  WorkflowWallTimeoutError,
   type WorkflowUsage,
   addWorkflowUsage,
   workflowUsageFromUsage,
@@ -542,9 +543,7 @@ function runWorkflowWorker(
     };
     const onAbort = () => fail(new Error("Workflow aborted."));
     const timeout = setTimeout(() => {
-      const err = new Error(
-        `Workflow timed out after ${engine.workflowTimeoutMs}ms; the worker was terminated.`,
-      );
+      const err = new WorkflowWallTimeoutError(engine.workflowTimeoutMs);
       fail(err);
       engine.abort.abort(err);
     }, engine.workflowTimeoutMs);

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -1346,7 +1346,7 @@ describe("persisted interactive state helpers", () => {
     expect(loaded).toEqual({ schemaVersion: 2, parent: "pi", states: {} });
   });
 
-  it("skips malformed v1 entries and normalizes untrusted fields", () => {
+  it("skips malformed v1 entries, retains valid intents, and normalizes untrusted fields", () => {
     const file = stateFilePath(root);
     mkdirSync(join(root, ".pi"), { recursive: true, mode: 0o700 });
     const validIntent = {
@@ -1359,6 +1359,7 @@ describe("persisted interactive state helpers", () => {
       status: "done",
       artifactDir: SAMPLE.artifactDir,
       state: "queued",
+      completedAt: 1234,
     };
     writeFileSync(
       file,
@@ -1378,6 +1379,11 @@ describe("persisted interactive state helpers", () => {
               { ...validIntent, deliveryId: "x".repeat(129) },
               { ...validIntent, turnId: "" },
               { ...validIntent, eventId: "../escape" },
+              {
+                ...validIntent,
+                eventId: "bad-time",
+                completedAt: "not-a-number",
+              },
               validIntent,
             ],
             deliveryReceipts: ["one", "one", 42, "two"],
@@ -1392,7 +1398,22 @@ describe("persisted interactive state helpers", () => {
     expect(Object.keys(loaded.states)).toEqual([SAMPLE.id]);
     expect(loaded.states[SAMPLE.id].eventByteCursor).toBe(0);
     expect(loaded.states[SAMPLE.id].sessionByteCursor).toBe(0);
-    expect(loaded.states[SAMPLE.id].pendingDeliveries).toEqual([validIntent]);
+    expect(loaded.states[SAMPLE.id].pendingDeliveries).toHaveLength(2);
+    expect(loaded.states[SAMPLE.id].pendingDeliveries[0]).toMatchObject({
+      deliveryId: "delivery",
+      subagentId: SAMPLE.id,
+      turnId: "turn",
+      eventId: "bad-time",
+      mode: "notify",
+      triggerTurn: false,
+      status: "done",
+      artifactDir: SAMPLE.artifactDir,
+      state: "queued",
+    });
+    expect(loaded.states[SAMPLE.id].pendingDeliveries[0]).not.toHaveProperty(
+      "completedAt",
+    );
+    expect(loaded.states[SAMPLE.id].pendingDeliveries[1]).toEqual(validIntent);
     expect(loaded.states[SAMPLE.id].deliveryReceipts).toEqual(["one", "two"]);
   });
 

--- a/tests/cancellation-flows.test.ts
+++ b/tests/cancellation-flows.test.ts
@@ -542,6 +542,8 @@ describe("cancelAllFlows helper", () => {
     // Verify status was set to cancelled (matching per-ID cancel semantics)
     expect(jobRegistry.get("job-1")!.status).toBe("cancelled");
     expect(jobRegistry.get("job-2")!.status).toBe("cancelled");
+    expect(jobRegistry.get("job-1")!.completedAt).toEqual(expect.any(Number));
+    expect(jobRegistry.get("job-2")!.completedAt).toEqual(expect.any(Number));
     // Done job should be untouched
     expect(jobRegistry.get("job-3")!.status).toBe("done");
   });
@@ -578,6 +580,18 @@ describe("cancelAllFlows helper", () => {
     // Verify status was set to cancelled
     expect(workflowJobRegistry.get("wf-1")!.status).toBe("cancelled");
     expect(workflowJobRegistry.get("wf-2")!.status).toBe("cancelled");
+    expect(workflowJobRegistry.get("wf-1")!.telemetryTerminalReason).toBe(
+      "explicit_cancel",
+    );
+    expect(workflowJobRegistry.get("wf-2")!.telemetryTerminalReason).toBe(
+      "explicit_cancel",
+    );
+    expect(workflowJobRegistry.get("wf-1")!.completedAt).toEqual(
+      expect.any(Number),
+    );
+    expect(workflowJobRegistry.get("wf-2")!.completedAt).toEqual(
+      expect.any(Number),
+    );
     expect(workflowJobRegistry.get("wf-3")!.status).toBe("done");
     expect(
       workflowJobRegistry.get("wf-1")!.suppressCompletionNotification,

--- a/tests/completion-coordinator.test.ts
+++ b/tests/completion-coordinator.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/session-scope";
 import {
   clearCompletionCoordinator,
+  completionLatencyForIds,
   MAX_COMPLETION_RECORDS,
   assertCompletionGroupOpen,
   consumeCompletionSource,
@@ -164,6 +165,28 @@ describe("completion coordinator", () => {
       .render(200)
       .join("\n");
     expect(expanded).toContain('("worker", turn "turn-worker")');
+  });
+  it("uses known interactive telemetry timestamps and omits legacy latency", () => {
+    const setupResult = setup();
+    scope = setupResult.scope;
+    const owner = sessionOwner(scope);
+    vi.setSystemTime(10_000);
+
+    publishCompletion(record("legacy-latency", { completedAt: 9_000 }), owner);
+    expect(
+      completionLatencyForIds(["completion-legacy-latency"], owner),
+    ).toBeUndefined();
+
+    publishCompletion(
+      record("known-latency", {
+        completedAt: 9_000,
+        telemetryCompletedAt: 8_000,
+      }),
+      owner,
+    );
+    expect(completionLatencyForIds(["completion-known-latency"], owner)).toBe(
+      2_000,
+    );
   });
 
   it("notifies the user once and sends one independent reference manifest", () => {

--- a/tests/in-process-tools.test.ts
+++ b/tests/in-process-tools.test.ts
@@ -102,6 +102,7 @@ import { Text } from "@earendil-works/pi-tui";
 import {
   type JobState,
   type SubagentResult,
+  annotateSpawnFailure,
   inProcessJobsForOwner,
   jobRegistry,
   MAX_REGISTRY_SIZE,
@@ -180,6 +181,22 @@ function createJobState(overrides: Partial<JobState> = {}): JobState {
     modelLabel: "test/model",
     ...overrides,
   };
+}
+interface TelemetryPayloadForTest {
+  event?: string;
+  properties?: Record<string, unknown>;
+}
+
+function captureTelemetryPayloads(): TelemetryPayloadForTest[] {
+  const payloads: TelemetryPayloadForTest[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input, init) => {
+      payloads.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 200 });
+    }),
+  );
+  return payloads;
 }
 
 function createExtensionApi() {
@@ -472,6 +489,34 @@ describe("subagent_with_context tool", () => {
     expect(mockConvertToLlm).not.toHaveBeenCalled();
   });
 
+  it("records one context-stage failure for missing history", async () => {
+    const payloads = captureTelemetryPayloads();
+    const scoped = setupScopedExtension(718);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const scopedTool = getToolDef(scoped.api, "subagent_with_context");
+    const result = await scopedTool.execute(
+      "missing-context",
+      { task: "do something", async: false },
+      undefined,
+      undefined,
+      mockCtx(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    await vi.waitFor(() =>
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+        ),
+      ).toHaveLength(1),
+    );
+    expect(
+      payloads.find(
+        (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+      )?.properties?.failure_stage,
+    ).toBe("context");
+  });
+
   it("registers with BaseParams schema", () => {
     const params = toolDef.parameters;
     const props = (params as any).properties;
@@ -602,6 +647,112 @@ describe("subagent_isolated tool", () => {
     expect(mockStartSubagentJob).not.toHaveBeenCalled();
   });
 
+  it("records exactly one bounded depth-limit spawn failure", async () => {
+    const payloads = captureTelemetryPayloads();
+    const scoped = setupScopedExtension(716);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const scopedTool = getToolDef(scoped.api, "subagent_isolated");
+    const result = await withOrchestrationContext(
+      { ownerJobId: "deep-parent", depth: DEFAULT_MAX_ORCHESTRATION_DEPTH },
+      () =>
+        scopedTool.execute(
+          "call-too-deep-telemetry",
+          { task: "spawn yet another reviewer" },
+          undefined,
+          undefined,
+          mockCtx(),
+        ),
+    );
+
+    expect(result.isError).toBe(true);
+    await vi.waitFor(() =>
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+        ),
+      ).toHaveLength(1),
+    );
+    const failure = payloads.find(
+      (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+    );
+    expect(failure?.properties).toMatchObject({
+      execution: "in-process",
+      mux: "none",
+      failure_stage: "depth_limit",
+      spawn_duration_bucket: expect.any(String),
+    });
+  });
+
+  it.each(["model_resolution", "session_creation"] as const)(
+    "records one %s failure when preparation rejects",
+    async (failureStage) => {
+      const payloads = captureTelemetryPayloads();
+      mockStartSubagentJob.mockRejectedValue(
+        annotateSpawnFailure(new Error("preparation failed"), failureStage),
+      );
+      const scoped = setupScopedExtension(717);
+      scoped.scope.telemetry = createTelemetrySession(true);
+      const scopedTool = getToolDef(scoped.api, "subagent_isolated");
+      const result = await scopedTool.execute(
+        "call-preparation-failure",
+        { task: "analyze code", async: false },
+        undefined,
+        undefined,
+        mockCtx(),
+      );
+
+      expect(result.isError).toBe(true);
+      await vi.waitFor(() =>
+        expect(
+          payloads.filter(
+            (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+          ),
+        ).toHaveLength(1),
+      );
+      expect(
+        payloads.find(
+          (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+        )?.properties?.failure_stage,
+      ).toBe(failureStage);
+    },
+  );
+
+  it("records one capacity-stage failure when the owner is full", async () => {
+    const payloads = captureTelemetryPayloads();
+    const scoped = setupScopedExtension(719);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const owner = sessionOwner(scoped.scope);
+    for (let index = 0; index < MAX_REGISTRY_SIZE; index++) {
+      const id = `capacity-${index}`;
+      const job = createJobState({ id });
+      scoped.scope.inProcessJobs.set(id, job);
+      jobRegistry.set(id, job);
+    }
+
+    const scopedTool = getToolDef(scoped.api, "subagent_isolated");
+    const result = await scopedTool.execute(
+      "capacity-failure",
+      { task: "analyze code" },
+      undefined,
+      undefined,
+      mockCtx(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(owner).toEqual(sessionOwner(scoped.scope));
+    await vi.waitFor(() =>
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+        ),
+      ).toHaveLength(1),
+    );
+    expect(
+      payloads.find(
+        (payload) => payload.event === "pi_subagentura_agent_spawn_failed",
+      )?.properties?.failure_stage,
+    ).toBe("capacity");
+  });
   it("registers with BaseParams schema", () => {
     const params = toolDef.parameters;
     const props = (params as any).properties;
@@ -616,14 +767,14 @@ describe("subagent_isolated tool", () => {
   });
 });
 
-// ── synchronous result consumption ───────────────────────────────────
+// ── synchronous in-process result reads ───────────────────────────────
 
 /**
- * A synchronous spawn hands its output straight back to the caller, so there is
- * no later `get_subagent_result` for `result_consumed` to be emitted from. Both
- * sync tools take their own return path, so both are exercised here.
+ * A synchronous spawn hands its output straight back to the caller, so that
+ * return path is the result read for telemetry purposes. Both sync tools take
+ * their own return path, so both are exercised here.
  */
-describe("synchronous in-process result consumption", () => {
+describe("synchronous in-process result reads", () => {
   const SYNC_TOOLS = [
     ["subagent_isolated", () => mockCtx()],
     [
@@ -660,31 +811,40 @@ describe("synchronous in-process result consumption", () => {
     return payloads;
   }
 
-  function consumedEvents(payloads: readonly TelemetryPost[]) {
+  function resultReadEvents(payloads: readonly TelemetryPost[]) {
     return payloads.filter(
-      (payload) => payload.event === "pi_subagentura_result_consumed",
+      (payload) => payload.event === "pi_subagentura_result_read",
     );
   }
 
-  it.each(SYNC_TOOLS)("records consumption for %s", async (name, makeCtx) => {
-    const payloads = captureTelemetryPosts();
-    const scoped = setupScopedExtension(714);
-    scoped.scope.telemetry = createTelemetrySession(true);
-    const scopedTool = getToolDef(scoped.api, name);
+  it.each(SYNC_TOOLS)(
+    "records a consumed result read for %s",
+    async (name, makeCtx) => {
+      const payloads = captureTelemetryPosts();
+      const scoped = setupScopedExtension(714);
+      scoped.scope.telemetry = createTelemetrySession(true);
+      const scopedTool = getToolDef(scoped.api, name);
 
-    const result = await scopedTool.execute(
-      "sync-consumed",
-      { task: "analyze code", async: false },
-      undefined,
-      undefined,
-      makeCtx(),
-    );
+      const result = await scopedTool.execute(
+        "sync-consumed",
+        { task: "analyze code", async: false },
+        undefined,
+        undefined,
+        makeCtx(),
+      );
 
-    expect(result.details.status).toBe("done");
-    await vi.waitFor(() => expect(consumedEvents(payloads)).toHaveLength(1));
-    expect(consumedEvents(payloads)[0]?.properties?.source).toBe("in-process");
-  });
-
+      expect(result.details.status).toBe("done");
+      await vi.waitFor(() =>
+        expect(resultReadEvents(payloads)).toHaveLength(1),
+      );
+      expect(resultReadEvents(payloads)[0]?.properties?.source).toBe(
+        "in-process",
+      );
+      expect(resultReadEvents(payloads)[0]?.properties?.outcome).toBe(
+        "consumed",
+      );
+    },
+  );
   it.each(
     SYNC_TOOLS.flatMap(([name, makeCtx]) =>
       (
@@ -702,7 +862,7 @@ describe("synchronous in-process result consumption", () => {
       ).map(([label, jobResult]) => [name, label, jobResult, makeCtx] as const),
     ),
   )(
-    "records no consumption for %s on %s",
+    "records the terminal result-read outcome for %s on %s",
     async (name, _label, jobResult, makeCtx) => {
       const payloads = captureTelemetryPosts();
       mockStartSubagentJob.mockResolvedValue({
@@ -721,7 +881,17 @@ describe("synchronous in-process result consumption", () => {
         makeCtx(),
       );
 
-      expect(consumedEvents(payloads)).toHaveLength(0);
+      await vi.waitFor(() =>
+        expect(resultReadEvents(payloads)).toHaveLength(1),
+      );
+      const expectedOutcome = jobResult.isError
+        ? "error"
+        : jobResult.cancelled
+          ? "cancelled"
+          : "empty";
+      expect(resultReadEvents(payloads)[0]?.properties?.outcome).toBe(
+        expectedOutcome,
+      );
     },
   );
 });
@@ -1006,6 +1176,54 @@ describe("get_subagent_result tool", () => {
     expect(result.details.jobId).toBe("missing");
   });
 
+  it("records unavailable reads for missing and pruned jobs", async () => {
+    const payloads = captureTelemetryPayloads();
+    const scoped = setupScopedExtension(721);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const owner = sessionOwner(scoped.scope);
+    const pruned = createJobState({
+      id: "pruned",
+      status: "done",
+      result: defaultSuccessResult,
+      promise: Promise.resolve(defaultSuccessResult),
+    });
+    registerInProcessJob(pruned, owner);
+    expect(pruneCompletedJobs(owner)).toBe(1);
+
+    const resultTool = getToolDef(scoped.api, "get_subagent_result");
+    for (const jobId of ["missing", pruned.id]) {
+      const result = await resultTool.execute(
+        `read-${jobId}`,
+        { jobId },
+        undefined,
+        undefined,
+      );
+      expect(result.details.jobId).toBe(jobId);
+      expect(result.isError).toBe(true);
+    }
+
+    await vi.waitFor(() =>
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_result_read",
+        ),
+      ).toHaveLength(2),
+    );
+    const reads = payloads.filter(
+      (payload) => payload.event === "pi_subagentura_result_read",
+    );
+    expect(reads.map((payload) => payload.properties?.outcome)).toEqual([
+      "unavailable",
+      "unavailable",
+    ]);
+    for (const read of reads) {
+      expect(read.properties).toMatchObject({
+        read_latency_bucket: "unknown",
+      });
+      expect(read.properties).not.toHaveProperty("read_latency_ms");
+    }
+  });
+
   it("returns cancelled when job status is already cancelled", async () => {
     const jobId = "cancelled-result";
     jobRegistry.set(jobId, createJobState({ id: jobId, status: "cancelled" }));
@@ -1066,8 +1284,53 @@ describe("get_subagent_result tool", () => {
     expect(job.resultRetrieved).toBe(true);
   });
 
+  it("classifies a repeated empty terminal read as already_consumed", async () => {
+    const payloads = captureTelemetryPayloads();
+    const scoped = setupScopedExtension(722);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const owner = sessionOwner(scoped.scope);
+    const completedAt = Date.now() - 1_250;
+    const emptyResult: SubagentResult = {
+      ...defaultSuccessResult,
+      output: "",
+    };
+    const job = createJobState({
+      id: "empty-read",
+      status: "done",
+      result: emptyResult,
+      promise: Promise.resolve(emptyResult),
+      completedAt,
+    });
+    registerInProcessJob(job, owner);
+    const resultTool = getToolDef(scoped.api, "get_subagent_result");
+
+    await resultTool.execute("empty-1", { jobId: job.id });
+    await resultTool.execute("empty-2", { jobId: job.id });
+
+    await vi.waitFor(() =>
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_result_read",
+        ),
+      ).toHaveLength(2),
+    );
+    const reads = payloads.filter(
+      (payload) => payload.event === "pi_subagentura_result_read",
+    );
+    expect(reads.map((payload) => payload.properties?.outcome)).toEqual([
+      "empty",
+      "already_consumed",
+    ]);
+    for (const read of reads) {
+      expect(read.properties).toMatchObject({
+        read_latency_bucket: expect.any(String),
+        read_latency_ms: expect.any(Number),
+      });
+    }
+  });
+
   it("records only the first successful output-bearing result read", async () => {
-    const telemetryPayloads: Array<{ event?: string }> = [];
+    const telemetryPayloads: TelemetryPayloadForTest[] = [];
     vi.stubGlobal(
       "fetch",
       vi.fn(async (_input, init) => {
@@ -1140,11 +1403,64 @@ describe("get_subagent_result tool", () => {
       undefined,
     );
 
-    expect(
-      telemetryPayloads.filter(
-        (payload) => payload.event === "pi_subagentura_result_consumed",
-      ),
-    ).toHaveLength(1);
+    const resultReads = telemetryPayloads.filter(
+      (payload) => payload.event === "pi_subagentura_result_read",
+    );
+    expect(resultReads).toHaveLength(4);
+    expect(resultReads.map((payload) => payload.properties?.outcome)).toEqual([
+      "error",
+      "cancelled",
+      "consumed",
+      "already_consumed",
+    ]);
+  });
+
+  it("reports rounded read latency only when completedAt is known", async () => {
+    const payloads = captureTelemetryPayloads();
+    const scoped = setupScopedExtension(720);
+    scoped.scope.telemetry = createTelemetrySession(true);
+    const owner = sessionOwner(scoped.scope);
+    const completedAt = Date.now() - 1_250;
+    const known = createJobState({
+      id: "known-completed-at",
+      status: "done",
+      result: defaultSuccessResult,
+      promise: Promise.resolve(defaultSuccessResult),
+      completedAt,
+    });
+    const unknown = createJobState({
+      id: "unknown-completed-at",
+      status: "done",
+      result: defaultSuccessResult,
+      promise: Promise.resolve(defaultSuccessResult),
+    });
+    registerInProcessJob(known, owner);
+    registerInProcessJob(unknown, owner);
+    const scopedTool = getToolDef(scoped.api, "get_subagent_result");
+
+    await scopedTool.execute("known-read", { jobId: known.id });
+    await scopedTool.execute("unknown-read", { jobId: unknown.id });
+
+    await vi.waitFor(() =>
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_result_read",
+        ),
+      ).toHaveLength(2),
+    );
+    const reads = payloads.filter(
+      (payload) => payload.event === "pi_subagentura_result_read",
+    );
+    expect(reads[0]?.properties).toMatchObject({
+      outcome: "consumed",
+      read_latency_bucket: expect.any(String),
+      read_latency_ms: expect.any(Number),
+    });
+    expect(reads[1]?.properties).toMatchObject({
+      outcome: "consumed",
+      read_latency_bucket: "unknown",
+    });
+    expect(reads[1]?.properties).not.toHaveProperty("read_latency_ms");
   });
   it("keeps a grouped result through TTL, prune, and cap pressure until collection", async () => {
     vi.useFakeTimers();

--- a/tests/interactive-supervisor.test.ts
+++ b/tests/interactive-supervisor.test.ts
@@ -1507,8 +1507,11 @@ describe("interactive supervisor", () => {
 
     expect(processAbort.signal.aborted).toBe(true);
     expect(processJob.status).toBe("cancelled");
+    expect(processJob.completedAt).toEqual(expect.any(Number));
     expect(workflowAbort).toHaveBeenCalledOnce();
     expect(workflow.status).toBe("cancelled");
+    expect(workflow.telemetryTerminalReason).toBe("explicit_cancel");
+    expect(workflow.completedAt).toEqual(expect.any(Number));
     expect(workflow.snapshot.agentRecords?.[0]?.status).toBe("cancelled");
   });
 

--- a/tests/session-handlers-coverage.test.ts
+++ b/tests/session-handlers-coverage.test.ts
@@ -338,11 +338,24 @@ describe("session handler lifecycle callbacks", () => {
 
       startSession(registration, root, "session-a");
 
-      expect(captured).toHaveLength(1);
+      expect(captured.map(({ event }) => event)).toEqual([
+        "pi_subagentura_session_started",
+        "pi_subagentura_session_recovered",
+      ]);
       expect(captured[0]).toMatchObject({
         event: "pi_subagentura_session_started",
         distinct_id: loadInteractiveStates(root)?.telemetry?.correlationId,
         properties: { mode: "orchestrator_v2" },
+      });
+      expect(captured[1]).toMatchObject({
+        event: "pi_subagentura_session_recovered",
+        properties: {
+          reason: "startup",
+          total_count: 0,
+          alive_count: 0,
+          terminal_count: 0,
+          unknown_count: 0,
+        },
       });
     });
 
@@ -726,6 +739,27 @@ describe("session handler lifecycle callbacks", () => {
     expect(getSessionScopes()).toEqual([]);
     expect((globalThis as any).__piSubagenturaPiRef).toBeUndefined();
   });
+  it.each(["new", "fork"] as const)(
+    "classifies workflow cleanup as fresh_session for %s",
+    (reason) => {
+      const registration = registerHandlers();
+      const ctx = startSession(
+        registration,
+        root,
+        `session-${reason}`,
+        undefined,
+        reason,
+      );
+      const workflow = ownedWorkflow(
+        registration.sessionScope,
+        `workflow-${reason}`,
+      ).workflow;
+
+      registration.handlers.get("session_shutdown")![0]({ reason }, ctx);
+
+      expect(workflow.telemetryTerminalReason).toBe("fresh_session");
+    },
+  );
 
   it("continues shutdown when lifecycle completion receipt persistence fails", () => {
     const registration = registerHandlers();

--- a/tests/subagent-interactive-default.test.ts
+++ b/tests/subagent-interactive-default.test.ts
@@ -341,6 +341,7 @@ describe("subagent_interactive tool lifecycle", () => {
     expect(callArgs.notifyOnComplete).toBeUndefined();
     expect(callArgs.triggerTurnOnComplete).toBeUndefined();
     expect(callArgs.completionPolicy).toBe("each");
+    expect(callArgs.deferAgentCreatedTelemetry).toBe(true);
     expect(callArgs.spawnTreeContext).toMatchObject({
       role: "root",
       rootId: "test-session-id",
@@ -591,6 +592,28 @@ describe("subagent_interactive tool lifecycle", () => {
     );
   });
 
+  it("uses the tool-entry clock for a context-inclusive spawn", async () => {
+    const now = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValue(2_000);
+    try {
+      await getInteractiveToolDef(api).execute(
+        "call-spawn-clock",
+        { task: "review context", includeContext: true },
+        undefined,
+        undefined,
+        mockCtx(),
+      );
+
+      expect(mockLaunchInteractiveSubagent).toHaveBeenCalledWith(
+        expect.objectContaining({ spawnRequestedAt: 1_000 }),
+      );
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it("forwards an explicit related completion group", async () => {
     const toolDef = getInteractiveToolDef(api);
     const result = await toolDef.execute(
@@ -609,6 +632,7 @@ describe("subagent_interactive tool lifecycle", () => {
       expect.objectContaining({
         completionPolicy: "group",
         completionGroupId: "review",
+        deferAgentCreatedTelemetry: true,
       }),
     );
     expect(result.content[0].text).toContain("group review");

--- a/tests/subagent-launch-script.test.ts
+++ b/tests/subagent-launch-script.test.ts
@@ -23,10 +23,7 @@ import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 
-import {
-  launchInteractiveSubagent,
-  writeLaunchScript,
-} from "../src/interactive-tmux";
+import { writeLaunchScript } from "../src/interactive-tmux";
 import { stateFilePath, loadInteractiveStates } from "../src/artifact";
 import { importFresh } from "./test-utils";
 import { createRootSpawnTreeContext } from "../src/spawn-tree-context";
@@ -216,12 +213,21 @@ describe("launch script EXIT trap (idempotency)", () => {
 // real bash + the wrapper and don't need a tmux mock; the spawn-persistence
 // tests below drive launchInteractiveSubagent directly and would otherwise
 // leave orphan tmux windows behind (test pollution).
-function installTmuxMock() {
+function installTmuxMock(
+  options: {
+    sendKeysError?: string;
+    attachError?: string;
+  } = {},
+) {
   vi.resetModules();
   const calls: string[][] = [];
+  let displayMessageCalls = 0;
   vi.doMock("node:child_process", () => ({
     execFileSync: (_file: string, args: string[]) => {
       calls.push(args);
+      if (args[0] === "send-keys" && options.sendKeysError) {
+        throw new Error(options.sendKeysError);
+      }
       // new-window / new-session / split-window return a pane id; everything
       // else is a no-op (display-message would otherwise throw).
       if (
@@ -232,6 +238,10 @@ function installTmuxMock() {
         return "%99\n";
       }
       if (args[0] === "display-message") {
+        displayMessageCalls += 1;
+        if (displayMessageCalls > 1 && options.attachError) {
+          throw new Error(options.attachError);
+        }
         return "sess\t1\t0\n";
       }
       return "";
@@ -291,6 +301,7 @@ describe("spawn-time state persistence", () => {
   afterEach(() => {
     rmSync(cwd, { recursive: true, force: true });
     vi.doUnmock("node:child_process");
+    vi.doUnmock("../src/spawn-tree-context");
     vi.unstubAllGlobals();
     clearSessionScopes();
     for (const name of SPAWN_ENV_NAMES) {
@@ -379,6 +390,176 @@ describe("spawn-time state persistence", () => {
     expect(
       loadInteractiveStates(cwd)?.states[state.id]?.telemetry,
     ).toMatchObject({ depth: 1, depthBucket: "1", mux: "tmux" });
+  });
+
+  it("defers creation telemetry until coordinated registration succeeds", async () => {
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const spawnTreeContext = createRootSpawnTreeContext(
+      SESSION,
+      cwd,
+      false,
+      true,
+      4,
+    );
+    const scope = registerSessionScope({
+      id: 778,
+      generation: 1,
+      lifecycle: "started",
+      pi: {} as never,
+      telemetry: createTelemetrySession(true, "orchestrator_v2"),
+      spawnTreeContext,
+    });
+    const mod = await importFresh<typeof import("../src/interactive-tmux")>(
+      "../src/interactive-tmux",
+    );
+
+    const state = mod.launchInteractiveSubagent({
+      name: "Deferred",
+      task: "never sent to telemetry",
+      cwd,
+      parentSessionId: SESSION,
+      sessionScope: scope,
+      spawnTreeContext,
+      telemetryInvocationSource: "interactive",
+      telemetryAsync: true,
+      completionPolicy: "group",
+      deferAgentCreatedTelemetry: true,
+    });
+
+    expect(payloads).toHaveLength(0);
+    mod.captureInteractiveSubagentCreatedTelemetry(state);
+    mod.captureInteractiveSubagentCreatedTelemetry(state);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      event: "pi_subagentura_agent_created",
+      properties: { execution: "interactive", completion_policy: "group" },
+    });
+  });
+
+  it("reports lineage bootstrap write failures as state_persistence", async () => {
+    tmuxCalls = installTmuxMock();
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    vi.doMock("../src/spawn-tree-context", async () => {
+      const real = await vi.importActual<
+        typeof import("../src/spawn-tree-context")
+      >("../src/spawn-tree-context");
+      return {
+        ...real,
+        writeLineageBootstrap: () => {
+          throw new Error("lineage persistence failed");
+        },
+      };
+    });
+    const spawnTreeContext = createRootSpawnTreeContext(
+      SESSION,
+      cwd,
+      false,
+      true,
+      4,
+    );
+    const scope = registerSessionScope({
+      id: 779,
+      generation: 1,
+      lifecycle: "started",
+      pi: {} as never,
+      telemetry: createTelemetrySession(true, "orchestrator_v2"),
+    });
+    const mod = await importFresh<typeof import("../src/interactive-tmux")>(
+      "../src/interactive-tmux",
+    );
+
+    expect(() =>
+      mod.launchInteractiveSubagent({
+        name: "Lineage failure",
+        task: "not sent to telemetry",
+        cwd,
+        parentSessionId: SESSION,
+        sessionScope: scope,
+        spawnTreeContext,
+        telemetryInvocationSource: "interactive",
+        telemetryAsync: true,
+      }),
+    ).toThrow(/lineage persistence failed/);
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      event: "pi_subagentura_agent_spawn_failed",
+      properties: { failure_stage: "state_persistence" },
+    });
+    expect(tmuxCalls.some((args) => args[0] === "send-keys")).toBe(false);
+  });
+
+  it.each([
+    {
+      label: "mux send",
+      options: { sendKeysError: "mux send failed" },
+      message: "send-keys failed",
+    },
+    {
+      label: "mux attach",
+      options: { attachError: "mux attach failed" },
+      message: "display-message failed",
+    },
+  ] as const)("reports $label failures as pane_launch", async (testCase) => {
+    tmuxCalls = installTmuxMock(testCase.options);
+    const payloads: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        payloads.push(JSON.parse(String(init.body)));
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const scope = registerSessionScope({
+      id: 780,
+      generation: 1,
+      lifecycle: "started",
+      pi: {} as never,
+      telemetry: createTelemetrySession(true, "orchestrator_v2"),
+    });
+    const mod = await importFresh<typeof import("../src/interactive-tmux")>(
+      "../src/interactive-tmux",
+    );
+
+    expect(() =>
+      mod.launchInteractiveSubagent({
+        name: "Mux failure",
+        task: "not sent to telemetry",
+        cwd,
+        parentSessionId: SESSION,
+        sessionScope: scope,
+        telemetryInvocationSource: "interactive",
+        telemetryAsync: true,
+      }),
+    ).toThrow(new RegExp(testCase.message));
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      event: "pi_subagentura_agent_spawn_failed",
+      properties: { failure_stage: "pane_launch" },
+    });
+    expect(tmuxCalls.some((args) => args[0] === "kill-pane")).toBe(true);
   });
 
   it("launchInteractiveSubagent without parentSessionId does NOT write the state file", async () => {

--- a/tests/subagent-launch-script.test.ts
+++ b/tests/subagent-launch-script.test.ts
@@ -213,20 +213,25 @@ describe("launch script EXIT trap (idempotency)", () => {
 // real bash + the wrapper and don't need a tmux mock; the spawn-persistence
 // tests below drive launchInteractiveSubagent directly and would otherwise
 // leave orphan tmux windows behind (test pollution).
-function installTmuxMock(
-  options: {
-    sendKeysError?: string;
-    attachError?: string;
-  } = {},
-) {
+interface TmuxMockOptions {
+  sendKeysError?: string;
+  attachError?: string;
+}
+
+let tmuxMockOptions: TmuxMockOptions = {};
+let tmuxMockCalls: string[][] = [];
+let tmuxDisplayMessageCalls = 0;
+
+function installTmuxMock(options: TmuxMockOptions = {}): string[][] {
+  tmuxMockOptions = options;
+  tmuxMockCalls = [];
+  tmuxDisplayMessageCalls = 0;
   vi.resetModules();
-  const calls: string[][] = [];
-  let displayMessageCalls = 0;
   vi.doMock("node:child_process", () => ({
     execFileSync: (_file: string, args: string[]) => {
-      calls.push(args);
-      if (args[0] === "send-keys" && options.sendKeysError) {
-        throw new Error(options.sendKeysError);
+      tmuxMockCalls.push(args);
+      if (args[0] === "send-keys" && tmuxMockOptions.sendKeysError) {
+        throw new Error(tmuxMockOptions.sendKeysError);
       }
       // new-window / new-session / split-window return a pane id; everything
       // else is a no-op (display-message would otherwise throw).
@@ -238,16 +243,16 @@ function installTmuxMock(
         return "%99\n";
       }
       if (args[0] === "display-message") {
-        displayMessageCalls += 1;
-        if (displayMessageCalls > 1 && options.attachError) {
-          throw new Error(options.attachError);
+        tmuxDisplayMessageCalls += 1;
+        if (tmuxDisplayMessageCalls > 1 && tmuxMockOptions.attachError) {
+          throw new Error(tmuxMockOptions.attachError);
         }
         return "sess\t1\t0\n";
       }
       return "";
     },
   }));
-  return calls;
+  return tmuxMockCalls;
 }
 
 const SPAWN_ENV_NAMES = [

--- a/tests/subagent-notify.test.ts
+++ b/tests/subagent-notify.test.ts
@@ -1851,7 +1851,10 @@ describe("read_subagent_artifact (output reporting)", () => {
           );
         const readTool = makeReadTool(mod, state);
         getSessionScopes().at(-1)!.telemetry = createTelemetrySession(true);
-        const telemetryPayloads: Array<{ event?: string }> = [];
+        const telemetryPayloads: Array<{
+          event?: string;
+          properties?: { outcome?: string };
+        }> = [];
         vi.stubGlobal(
           "fetch",
           vi.fn(async (_input, init) => {
@@ -1870,9 +1873,11 @@ describe("read_subagent_artifact (output reporting)", () => {
 
         expect(
           telemetryPayloads.filter(
-            (payload) => payload.event === "pi_subagentura_result_consumed",
+            (payload) =>
+              payload.event === "pi_subagentura_result_read" &&
+              payload.properties?.outcome === outcome,
           ),
-        ).toHaveLength(0);
+        ).toHaveLength(1);
       } finally {
         vi.unstubAllGlobals();
         rmSync(parent, { recursive: true, force: true });
@@ -1897,7 +1902,10 @@ describe("read_subagent_artifact (output reporting)", () => {
         await importFresh<typeof import("../src/subagent")>("../src/subagent");
       const readTool = makeReadTool(mod, state);
       getSessionScopes().at(-1)!.telemetry = createTelemetrySession(true);
-      const telemetryPayloads: Array<{ event?: string }> = [];
+      const telemetryPayloads: Array<{
+        event?: string;
+        properties?: { outcome?: string };
+      }> = [];
       vi.stubGlobal(
         "fetch",
         vi.fn(async (_input, init) => {
@@ -1922,10 +1930,10 @@ describe("read_subagent_artifact (output reporting)", () => {
       );
 
       expect(
-        telemetryPayloads.filter(
-          (payload) => payload.event === "pi_subagentura_result_consumed",
-        ),
-      ).toHaveLength(1);
+        telemetryPayloads
+          .filter((payload) => payload.event === "pi_subagentura_result_read")
+          .map((payload) => payload.properties?.outcome),
+      ).toEqual(["consumed", "already_consumed"]);
     } finally {
       vi.unstubAllGlobals();
       rmSync(parent, { recursive: true, force: true });

--- a/tests/subagent-poll.test.ts
+++ b/tests/subagent-poll.test.ts
@@ -40,6 +40,7 @@ import {
   removeSessionScope,
 } from "../src/session-scope";
 import { responsiveFlowMinimumWidth } from "../src/rendering";
+import { createTelemetrySession } from "../src/telemetry";
 
 function makeTmp(): string {
   return mkdtempSync(join(tmpdir(), "pi-subagentura-poll-"));
@@ -235,6 +236,104 @@ describe("pollArtifactChanges", () => {
     const sendMessage = installDeliverySpies();
     await mod.pollArtifactChanges({ sendMessage } as any);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "cancel_all",
+      origin: "cancel_all",
+      expected: "explicit_cancel",
+    },
+    {
+      label: "new",
+      origin: "session_shutdown",
+      lifecycleReason: "new",
+      expected: "fresh_session",
+    },
+    {
+      label: "fork",
+      origin: "session_shutdown",
+      lifecycleReason: "fork",
+      expected: "fresh_session",
+    },
+    {
+      label: "startup",
+      origin: "session_start",
+      lifecycleReason: "startup",
+      expected: "session_shutdown",
+    },
+    {
+      label: "reload",
+      origin: "session_start",
+      lifecycleReason: "reload",
+      expected: "session_shutdown",
+    },
+    {
+      label: "resume",
+      origin: "session_start",
+      lifecycleReason: "resume",
+      expected: "session_shutdown",
+    },
+  ] as const)("maps $label cancellation to $expected", async (testCase) => {
+    const mod =
+      await importFresh<typeof import("../src/subagent")>("../src/subagent");
+    const multiplexer = await import("../src/multiplexer");
+    const item = makeState();
+    const session = createTelemetrySession(true, "orchestrator_v2");
+    const owner = { id: 811, generation: 1 };
+    const scope = registerSessionScope({
+      ...owner,
+      pi: {} as unknown as ExtensionAPI,
+      telemetry: session,
+      sessionManager: { getSessionId: () => "poll-telemetry" },
+    });
+    item.state.telemetryEligible = true;
+    item.state.telemetryCorrelationId = session.correlationId;
+    item.state.telemetryActiveTurnId = "turn";
+    item.state.telemetryTurnStartedAt = 1;
+    item.state.telemetryTurnMessageCounts = new Map();
+    item.state.telemetryInvocationSource = "interactive";
+    item.state.telemetryCompletionPolicy = "each";
+    item.state.telemetryAsync = true;
+    item.state.telemetryDepth = 1;
+    item.state.telemetryDepthBucket = "1";
+    item.state.telemetryModel = "default";
+    item.state.completionOwner = "workflow";
+    scope.interactiveStates.set(item.id, item.state);
+    mod.interactiveSubagentRegistry.set(item.id, item.state);
+    const art = artifactPath(join(item.artifactDir, ".."), item.id);
+    appendEvent(art, {
+      version: 2,
+      eventId: `event-${testCase.label}`,
+      turnId: "turn",
+      ts: 2,
+      type: "completion",
+      status: "cancelled",
+      outcome: "cancelled",
+      source: "parent",
+      cancellationOrigin: testCase.origin,
+      ...(testCase.lifecycleReason
+        ? { cancellationLifecycleReason: testCase.lifecycleReason }
+        : {}),
+    });
+    multiplexer.__setTmuxMultiplexer({
+      getPaneLivenessAsync: async () => "alive" as const,
+    } as unknown as Multiplexer);
+    const payloads: Array<{
+      event?: string;
+      properties?: Record<string, unknown>;
+    }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      payloads.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 200 });
+    });
+
+    await mod.pollArtifactChanges({} as unknown as ExtensionAPI, owner);
+
+    const completed = payloads.find(
+      (payload) => payload.event === "pi_subagentura_task_completed",
+    );
+    expect(completed?.properties?.terminal_reason).toBe(testCase.expected);
   });
 
   it("clears the activity widget on an empty tick with a malformed setting", async () => {

--- a/tests/subagent-rehydrate-artifacts.test.ts
+++ b/tests/subagent-rehydrate-artifacts.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/artifact";
 import {
   clearCompletionCoordinator,
+  completionLatencyForIds,
   MAX_COMPLETION_RECORDS,
   prepareCompletionManifest,
   registerCompletionCoordinator,
@@ -328,7 +329,15 @@ describe("rehydrateInteractiveSubagents", () => {
       sourceId: id,
       policy: "group",
       groupId: "reload-group",
+      completedAt: expect.any(Number),
     });
+    expect(completion?.data).not.toHaveProperty("telemetryCompletedAt");
+    expect(
+      completionLatencyForIds(
+        ["grouped-delivery"],
+        sessionOwner(completionScope),
+      ),
+    ).toBeUndefined();
   });
 
   it("registers pending receipt expectations before scanning fallback history", async () => {

--- a/tests/subagent-rehydrate-core.test.ts
+++ b/tests/subagent-rehydrate-core.test.ts
@@ -42,7 +42,10 @@ describe("rehydrateInteractiveSubagents", () => {
       }),
       NoMultiplexerAvailableError: class extends Error {},
     }));
-    const g = globalThis as any;
+    const g = globalThis as typeof globalThis & {
+      __piSubagenturaInteractiveRegistry?: { clear?: () => void };
+      __piSubagenturaPiRef?: unknown;
+    };
     g.__piSubagenturaInteractiveRegistry?.clear?.();
     g.__piSubagenturaPiRef = undefined;
   });
@@ -52,11 +55,17 @@ describe("rehydrateInteractiveSubagents", () => {
     vi.doUnmock("../src/multiplexer");
   });
 
-  it("returns { total: 0 } when the state file is missing", async () => {
+  it("returns zero recovery counts when the state file is missing", async () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     const result = mod.rehydrateInteractiveSubagents(cwd);
-    expect(result).toEqual({ total: 0, alive: 0, terminal: 0 });
+    expect(result).toEqual({
+      total: 0,
+      recovered: 0,
+      alive: 0,
+      terminal: 0,
+      unknown: 0,
+    });
   });
 
   it("populates the registry from a state.json with one entry", async () => {
@@ -400,8 +409,7 @@ describe("rehydrateInteractiveSubagents", () => {
     const mod =
       await importFresh<typeof import("../src/subagent")>("../src/subagent");
     // Two entries: alive1 (no events, pane not alive → unknown), done1 (done event,
-    // pane not alive → exited). We can predict exact counts here because the test
-    // runs in a tmux environment and isPaneAlive returns false for fake pane IDs.
+    // pane not alive → exited). Rehydration reports both eligible entries.
     const cwdA = cwd;
     const cwdB = cwd;
     for (const id of ["alive1", "done1"]) {
@@ -427,9 +435,10 @@ describe("rehydrateInteractiveSubagents", () => {
     const result = mod.rehydrateInteractiveSubagents(cwdA);
 
     expect(result.total).toBe(2);
-    // alive1 has no events → status=unknown (not counted); done1 has done event → status=exited (terminal)
+    expect(result.recovered).toBe(2);
     expect(result.alive).toBe(0);
     expect(result.terminal).toBe(1);
+    expect(result.unknown).toBe(1);
     expect(interactiveSubagentRegistry.get("alive1")?.status).toBe("unknown");
     expect(interactiveSubagentRegistry.get("done1")?.status).toBe("exited");
   });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -22,6 +22,7 @@ import {
   telemetryDepthBucket,
   telemetryDurationMs,
   telemetryDurationBucket,
+  type TelemetryEvent,
 } from "../src/telemetry";
 import {
   isTelemetryEnabled,
@@ -114,7 +115,7 @@ describe("anonymous product telemetry", () => {
       $geoip_disable: true,
       $ip: "0.0.0.0",
       $lib: "pi-subagentura",
-      schema_version: 2,
+      schema_version: 3,
       mode: "orchestrator_v2",
     });
     expect(agent.properties).toMatchObject({
@@ -195,6 +196,7 @@ describe("anonymous product telemetry", () => {
       depth_bucket: "1",
       completion_policy: "each",
       status: "success",
+      terminal_reason: "timeout",
       // A start timestamp recovered from a previous run yields a span no
       // analysis should trust; a clamped value would look plausible.
       duration_ms: beyondBound,
@@ -268,6 +270,7 @@ describe("anonymous product telemetry", () => {
         "$process_person_profile",
         "count",
         "delivery",
+        "delivery_latency_bucket",
         "mode",
         "schema_version",
         "telemetry_session_id",
@@ -276,6 +279,7 @@ describe("anonymous product telemetry", () => {
     expect(payload.properties).toMatchObject({
       delivery: "manifest",
       count: 128,
+      delivery_latency_bucket: "unknown",
     });
   });
 
@@ -361,6 +365,7 @@ describe("anonymous product telemetry", () => {
       depth_bucket: "1",
       completion_policy: "each",
       status: "success",
+      terminal_reason: "completed",
       duration_ms: 12_345,
       child_conversation_message_count: 50_000,
     });
@@ -387,6 +392,7 @@ describe("anonymous product telemetry", () => {
         "schema_version",
         "status",
         "telemetry_session_id",
+        "terminal_reason",
         "unit",
       ].sort(),
     );
@@ -397,12 +403,491 @@ describe("anonymous product telemetry", () => {
     );
   });
 
+  it("emits the complete agent_spawn_failed shape with bounded duration", () => {
+    const session = createTelemetrySession(true, "orchestrator_v2");
+    const payload = buildTelemetryPayload(session, {
+      event: "agent_spawn_failed",
+      execution: "interactive",
+      mux: "unknown",
+      invocation_source: "isolated",
+      model: "default",
+      async: false,
+      depth: 4,
+      depth_bucket: "4-7",
+      completion_policy: "each",
+      failure_stage: "pane_launch",
+      spawn_duration_ms: 12_345,
+    });
+
+    expect(payload.event).toBe("pi_subagentura_agent_spawn_failed");
+    expect(Object.keys(payload.properties).sort()).toEqual(
+      [
+        "$geoip_disable",
+        "$ip",
+        "$lib",
+        "$lib_version",
+        "$process_person_profile",
+        "async",
+        "completion_policy",
+        "depth",
+        "depth_bucket",
+        "failure_stage",
+        "invocation_source",
+        "mode",
+        "model",
+        "mux",
+        "schema_version",
+        "spawn_duration_bucket",
+        "spawn_duration_ms",
+        "telemetry_session_id",
+        "execution",
+      ].sort(),
+    );
+    expect(payload.properties).toMatchObject({
+      execution: "interactive",
+      mux: "unknown",
+      failure_stage: "pane_launch",
+      spawn_duration_ms: 12_300,
+      spawn_duration_bucket: "5-30s",
+      schema_version: 3,
+    });
+  });
+
+  it("keeps unknown mux scoped to spawn-failure events", () => {
+    type SpawnFailureMux = Extract<
+      TelemetryEvent,
+      { event: "agent_spawn_failed" }
+    >["mux"];
+    type AgentCreatedMux = Extract<
+      TelemetryEvent,
+      { event: "agent_created" }
+    >["mux"];
+    type TaskStartedMux = Extract<
+      TelemetryEvent,
+      { event: "task_started" }
+    >["mux"];
+    type TaskCompletedMux = Extract<
+      TelemetryEvent,
+      { event: "task_completed" }
+    >["mux"];
+
+    const spawnFailureMux: SpawnFailureMux = "unknown";
+    // @ts-expect-error Unknown mux is reserved for spawn failures.
+    const agentCreatedMux: AgentCreatedMux = "unknown";
+    // @ts-expect-error Unknown mux is reserved for spawn failures.
+    const taskStartedMux: TaskStartedMux = "unknown";
+    // @ts-expect-error Unknown mux is reserved for spawn failures.
+    const taskCompletedMux: TaskCompletedMux = "unknown";
+
+    expect(spawnFailureMux).toBe("unknown");
+    void [agentCreatedMux, taskStartedMux, taskCompletedMux];
+  });
+
+  it.each([
+    "depth_limit",
+    "capacity",
+    "context",
+    "model_resolution",
+    "session_creation",
+    "mux_resolution",
+    "pane_launch",
+    "state_persistence",
+    "registration",
+    "parent_shutdown",
+    "unknown",
+  ] as const)("accepts spawn failure stage %s", (failure_stage) => {
+    const payload = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "agent_spawn_failed",
+      execution: "interactive",
+      mux: "unknown",
+      invocation_source: "interactive",
+      model: "default",
+      async: true,
+      depth: undefined,
+      depth_bucket: "unknown",
+      completion_policy: "each",
+      failure_stage,
+    });
+
+    expect(payload.properties.failure_stage).toBe(failure_stage);
+    expect(payload.properties.spawn_duration_bucket).toBe("unknown");
+    expect(payload.properties).not.toHaveProperty("spawn_duration_ms");
+  });
+
+  it("emits a paired unknown bucket when an optional spawn duration is invalid", () => {
+    const payload = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "agent_created",
+      execution: "in-process",
+      mux: "none",
+      invocation_source: "with_context",
+      model: "default",
+      async: true,
+      depth: 1,
+      depth_bucket: "1",
+      completion_policy: "inline",
+      spawn_duration_ms: Number.NaN,
+    });
+
+    expect(payload.properties).toMatchObject({
+      spawn_duration_bucket: "unknown",
+    });
+    expect(payload.properties).not.toHaveProperty("spawn_duration_ms");
+  });
+
+  it.each([
+    "completed",
+    "agent_error",
+    "process_exit",
+    "timeout",
+    "explicit_cancel",
+    "parent_cancelled",
+    "session_shutdown",
+    "fresh_session",
+    "unknown",
+  ] as const)("accepts terminal reason %s", (terminal_reason) => {
+    const payload = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "task_completed",
+      execution: "in-process",
+      mux: "none",
+      unit: "job",
+      invocation_source: "isolated",
+      model: "default",
+      async: true,
+      depth: undefined,
+      depth_bucket: "unknown",
+      completion_policy: "each",
+      status: "success",
+      terminal_reason,
+      duration_ms: undefined,
+      child_conversation_message_count: undefined,
+    });
+
+    expect(payload.properties.terminal_reason).toBe(terminal_reason);
+    expect(payload.properties.duration_bucket).toBe("unknown");
+  });
+
+  it("keeps workflow lifecycle payloads closed and bounds workflow counts", () => {
+    const session = createTelemetrySession(true, "orchestrator");
+    const started = buildTelemetryPayload(session, {
+      event: "workflow_started",
+      invocation: "saved_command",
+      async: true,
+      completion_policy: "group",
+    });
+    const completed = buildTelemetryPayload(session, {
+      event: "workflow_completed",
+      invocation: "saved_command",
+      async: true,
+      completion_policy: "group",
+      status: "partial",
+      terminal_reason: "agent_error",
+      agents_spawned: 50_000,
+      error_count: 1_001.9,
+      duration_ms: 12_345,
+    });
+
+    expect(Object.keys(started.properties).sort()).toEqual(
+      [
+        "$geoip_disable",
+        "$ip",
+        "$lib",
+        "$lib_version",
+        "$process_person_profile",
+        "async",
+        "completion_policy",
+        "invocation",
+        "mode",
+        "schema_version",
+        "telemetry_session_id",
+      ].sort(),
+    );
+    expect(Object.keys(completed.properties).sort()).toEqual(
+      [
+        "$geoip_disable",
+        "$ip",
+        "$lib",
+        "$lib_version",
+        "$process_person_profile",
+        "agents_spawned",
+        "async",
+        "completion_policy",
+        "duration_bucket",
+        "duration_ms",
+        "error_count",
+        "invocation",
+        "mode",
+        "schema_version",
+        "status",
+        "telemetry_session_id",
+        "terminal_reason",
+      ].sort(),
+    );
+    expect(completed.properties).toMatchObject({
+      invocation: "saved_command",
+      status: "partial",
+      terminal_reason: "agent_error",
+      agents_spawned: 1_000,
+      error_count: 1_000,
+      duration_ms: 12_300,
+      duration_bucket: "5-30s",
+    });
+  });
+
+  it.each(["success", "partial", "error", "cancelled"] as const)(
+    "accepts workflow status %s",
+    (status) => {
+      const payload = buildTelemetryPayload(createTelemetrySession(true), {
+        event: "workflow_completed",
+        invocation: "tool",
+        async: false,
+        completion_policy: "inline",
+        status,
+        terminal_reason: "completed",
+        agents_spawned: 0,
+        error_count: 0,
+      });
+
+      expect(payload.properties.status).toBe(status);
+      expect(payload.properties.duration_bucket).toBe("unknown");
+      expect(payload.properties).not.toHaveProperty("duration_ms");
+    },
+  );
+
+  it.each(["startup", "reload", "resume"] as const)(
+    "keeps recovery reason %s and bounds recovery counts",
+    (reason) => {
+      const payload = buildTelemetryPayload(createTelemetrySession(true), {
+        event: "session_recovered",
+        reason,
+        total_count: 5_000,
+        alive_count: 3.9,
+        terminal_count: Number.NaN,
+        unknown_count: Number.POSITIVE_INFINITY,
+      });
+
+      expect(Object.keys(payload.properties).sort()).toEqual(
+        [
+          "$geoip_disable",
+          "$ip",
+          "$lib",
+          "$lib_version",
+          "$process_person_profile",
+          "alive_count",
+          "mode",
+          "reason",
+          "schema_version",
+          "telemetry_session_id",
+          "terminal_count",
+          "total_count",
+          "unknown_count",
+        ].sort(),
+      );
+      expect(payload.properties).toMatchObject({
+        reason,
+        total_count: 1_000,
+        alive_count: 3,
+        terminal_count: 0,
+        unknown_count: 0,
+      });
+    },
+  );
+
+  it("rounds delivery latency and omits an invalid numeric value", () => {
+    const valid = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "completion_delivered",
+      delivery: "notification",
+      count: 1,
+      delivery_latency_ms: 12_345,
+    });
+    const invalid = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "completion_delivered",
+      delivery: "notification",
+      count: 1,
+      delivery_latency_ms: Number.POSITIVE_INFINITY,
+    });
+
+    expect(valid.properties).toMatchObject({
+      delivery_latency_ms: 12_300,
+      delivery_latency_bucket: "5-30s",
+    });
+    expect(invalid.properties.delivery_latency_bucket).toBe("unknown");
+    expect(invalid.properties).not.toHaveProperty("delivery_latency_ms");
+  });
+
+  it.each([
+    "consumed",
+    "already_consumed",
+    "empty",
+    "running",
+    "error",
+    "cancelled",
+    "wait_timeout",
+    "wait_cancelled",
+    "unavailable",
+  ] as const)("accepts result-read outcome %s", (outcome) => {
+    const payload = buildTelemetryPayload(createTelemetrySession(true), {
+      event: "result_read",
+      source: "workflow",
+      outcome,
+      read_latency_ms: 1_234,
+    });
+
+    expect(payload.event).toBe("pi_subagentura_result_read");
+    expect(payload.properties).toMatchObject({
+      source: "workflow",
+      outcome,
+      read_latency_ms: 1_200,
+      read_latency_bucket: "1-5s",
+    });
+  });
+
+  it("keeps every v3 event within the privacy allowlist", () => {
+    const session = createTelemetrySession(true, "orchestrator_v2");
+    const dimensions = {
+      execution: "in-process" as const,
+      mux: "none" as const,
+      invocation_source: "workflow" as const,
+      model: "default" as const,
+      async: true,
+      depth: 1,
+      depth_bucket: "1" as const,
+      completion_policy: "each" as const,
+    };
+    const payloads = [
+      buildTelemetryPayload(session, { event: "session_started" }),
+      buildTelemetryPayload(session, {
+        event: "agent_created",
+        ...dimensions,
+        spawn_duration_ms: 100,
+      }),
+      buildTelemetryPayload(session, {
+        event: "agent_spawn_failed",
+        ...dimensions,
+        mux: "unknown",
+        failure_stage: "unknown",
+      }),
+      buildTelemetryPayload(session, {
+        event: "task_started",
+        ...dimensions,
+        unit: "job",
+      }),
+      buildTelemetryPayload(session, {
+        event: "interactive_message_sent",
+        direction: "parent_to_child",
+        count: 1,
+      }),
+      buildTelemetryPayload(session, {
+        event: "task_completed",
+        ...dimensions,
+        unit: "turn",
+        status: "cancelled",
+        terminal_reason: "explicit_cancel",
+        duration_ms: 100,
+        child_conversation_message_count: 1,
+      }),
+      buildTelemetryPayload(session, {
+        event: "workflow_started",
+        invocation: "tool",
+        async: false,
+        completion_policy: "inline",
+      }),
+      buildTelemetryPayload(session, {
+        event: "workflow_completed",
+        invocation: "tool",
+        async: false,
+        completion_policy: "inline",
+        status: "cancelled",
+        terminal_reason: "session_shutdown",
+        agents_spawned: 1,
+        error_count: 1,
+      }),
+      buildTelemetryPayload(session, {
+        event: "session_recovered",
+        reason: "resume",
+        total_count: 1,
+        alive_count: 1,
+        terminal_count: 0,
+        unknown_count: 0,
+      }),
+      buildTelemetryPayload(session, {
+        event: "completion_delivered",
+        delivery: "manifest",
+        count: 1,
+        delivery_latency_ms: 100,
+      }),
+      buildTelemetryPayload(session, {
+        event: "result_read",
+        source: "in-process",
+        outcome: "consumed",
+        read_latency_ms: 100,
+      }),
+    ];
+    const allowed = new Set([
+      "$geoip_disable",
+      "$ip",
+      "$lib",
+      "$lib_version",
+      "$process_person_profile",
+      "agents_spawned",
+      "alive_count",
+      "async",
+      "child_conversation_message_count",
+      "completion_policy",
+      "count",
+      "delivery",
+      "delivery_latency_bucket",
+      "delivery_latency_ms",
+      "depth",
+      "direction",
+      "depth_bucket",
+      "duration_bucket",
+      "duration_ms",
+      "error_count",
+      "execution",
+      "failure_stage",
+      "invocation",
+      "invocation_source",
+      "mode",
+      "model",
+      "mux",
+      "outcome",
+      "read_latency_bucket",
+      "read_latency_ms",
+      "reason",
+      "schema_version",
+      "source",
+      "spawn_duration_bucket",
+      "spawn_duration_ms",
+      "status",
+      "telemetry_session_id",
+      "terminal_count",
+      "terminal_reason",
+      "total_count",
+      "unknown_count",
+      "unit",
+    ]);
+
+    for (const payload of payloads) {
+      expect(
+        Object.keys(payload.properties).every((key) => allowed.has(key)),
+      ).toBe(true);
+      expect(JSON.stringify(payload)).not.toMatch(
+        /task_text|persona|prompt|output|error_text|cwd|path|artifact_id|agent_id|raw_session_id|token|cost/i,
+      );
+      expect(payload.properties.schema_version).toBe(3);
+    }
+  });
+
   it("posts best-effort events once per internal dedupe key", async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
       .mockResolvedValue(new Response(null, { status: 204 }));
     const session = createTelemetrySession(true);
-    const event = { event: "result_consumed", source: "workflow" } as const;
+    const event = {
+      event: "result_read",
+      source: "workflow",
+      outcome: "consumed",
+    } as const;
 
     captureTelemetry(session, event, { dedupeKey: "internal", fetchImpl });
     captureTelemetry(session, event, { dedupeKey: "internal", fetchImpl });
@@ -415,9 +900,13 @@ describe("anonymous product telemetry", () => {
       headers: { "content-type": "application/json" },
     });
     expect(JSON.parse(String(init?.body))).toMatchObject({
-      event: "pi_subagentura_result_consumed",
+      event: "pi_subagentura_result_read",
       distinct_id: session.correlationId,
-      properties: { source: "workflow" },
+      properties: {
+        source: "workflow",
+        outcome: "consumed",
+        read_latency_bucket: "unknown",
+      },
     });
   });
 
@@ -432,12 +921,20 @@ describe("anonymous product telemetry", () => {
 
     captureTelemetry(
       session,
-      { event: "result_consumed", source: "interactive" },
+      {
+        event: "result_read",
+        source: "interactive",
+        outcome: "already_consumed",
+      },
       { dedupeKey: "overflow", fetchImpl },
     );
     captureTelemetry(
       session,
-      { event: "result_consumed", source: "interactive" },
+      {
+        event: "result_read",
+        source: "interactive",
+        outcome: "already_consumed",
+      },
       { dedupeKey: "overflow", fetchImpl },
     );
 
@@ -469,6 +966,7 @@ describe("anonymous product telemetry", () => {
         depth_bucket: "1",
         completion_policy: "each",
         status: "cancelled",
+        terminal_reason: "parent_cancelled",
         duration_ms: 1_000,
         child_conversation_message_count: 0,
       },

--- a/tests/thinking-level-effective.test.ts
+++ b/tests/thinking-level-effective.test.ts
@@ -214,6 +214,72 @@ describe("startSubagentJob effective thinking level", () => {
     }
   });
 
+  it.each([
+    ["session_start (new)", "fresh_session"],
+    ["session_start (fork)", "fresh_session"],
+    ["session_shutdown (new)", "fresh_session"],
+    ["session_shutdown (fork)", "fresh_session"],
+    ["session_start (new) with extra text", "session_shutdown"],
+    ["session_shutdown (fork) with extra text", "session_shutdown"],
+  ] as const)(
+    "maps the exact lifecycle reason %s to %s",
+    async (reason, expectedReason) => {
+      const payloads: Array<{
+        event: string;
+        properties: Record<string, unknown>;
+      }> = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string, init: RequestInit) => {
+          payloads.push(JSON.parse(String(init.body)));
+          return new Response(null, { status: 200 });
+        }),
+      );
+      const controller = new AbortController();
+      const promptGate = Promise.withResolvers<void>();
+      const session = {
+        ...createSession("medium"),
+        prompt: vi.fn(() => promptGate.promise),
+        abort: vi.fn(async () => {
+          promptGate.resolve();
+        }),
+      };
+      const telemetrySession = createTelemetrySession(true, "orchestrator_v2");
+      mockCreateAgentSession.mockResolvedValue({ session });
+
+      try {
+        const started = await startSubagentJob({
+          ...params(),
+          signal: controller.signal,
+          cancellationSource: "workflow",
+          telemetry: {
+            session: telemetrySession,
+            invocationSource: "workflow",
+            async: true,
+            depth: 1,
+            completionPolicy: "each",
+          },
+        });
+        started.start();
+        await vi.waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+
+        controller.abort({ source: "session_shutdown", reason });
+        const result = await started.jobPromise;
+
+        expect(result.cancelled).toBe(true);
+        const completions = payloads.filter(
+          ({ event }) => event === "pi_subagentura_task_completed",
+        );
+        expect(completions).toHaveLength(1);
+        expect(completions[0]?.properties?.terminal_reason).toBe(
+          expectedReason,
+        );
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    },
+  );
+
   it("keeps thinking-level details omitted when the request omits it", async () => {
     const session = createSession("medium");
     mockCreateAgentSession.mockResolvedValue({ session });

--- a/tests/workflow-ownership.test.ts
+++ b/tests/workflow-ownership.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   registerWorkflowTool,
   MAX_WORKFLOW_JOBS,
+  cancelWorkflowJob,
   cleanupWorkflowJobsForOwner,
   discardWorkflowJob,
   getWorkflowJobForActiveSession,
@@ -107,6 +108,35 @@ describe("workflow parent session ownership", () => {
     discardWorkflowJob(workflow);
     expect(workflow.abort.signal.aborted).toBe(true);
     expect(workflow.suppressCompletionNotification).toBe(true);
+    expect(workflowJobRegistry.has(workflow.id)).toBe(false);
+  });
+  it("records cancellation evidence and invokes the completion hook once", () => {
+    const workflow = makeJob("cancel", "running", owner(6, 1));
+    workflow.parentSessionOwner = undefined;
+    const onComplete = vi.fn();
+    workflow.completionNotification = onComplete;
+    const abort = vi.spyOn(workflow.abort, "abort");
+
+    cancelWorkflowJob(workflow, "explicit_cancel");
+    cancelWorkflowJob(workflow, "parent_cancelled");
+
+    expect(workflow.status).toBe("cancelled");
+    expect(workflow.telemetryTerminalReason).toBe("explicit_cancel");
+    expect(workflow.completedAt).toEqual(expect.any(Number));
+    expect(workflow.snapshot.runningCount).toBe(0);
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the requested terminal reason when cleaning up workflow jobs", () => {
+    const workflow = makeJob("fresh", "running", owner(6, 1));
+    workflowJobRegistry.set(workflow.id, workflow);
+
+    cleanupWorkflowJobsForOwner(owner(6, 1), "fresh_session");
+
+    expect(workflow.status).toBe("cancelled");
+    expect(workflow.telemetryTerminalReason).toBe("fresh_session");
+    expect(workflow.completedAt).toEqual(expect.any(Number));
     expect(workflowJobRegistry.has(workflow.id)).toBe(false);
   });
 

--- a/tests/workflow-supervisor.integration.test.ts
+++ b/tests/workflow-supervisor.integration.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SubagentResult } from "../src/helpers";
+import { annotateSpawnFailure, type SubagentResult } from "../src/helpers";
 
 const { mockAwaitInteractiveResult, mockLaunch, mockStartSubagentJob } =
   vi.hoisted(() => ({
@@ -213,6 +213,22 @@ function makePi() {
 const SINGLE_AGENT_SCRIPT = (name: string) =>
   `export const meta = { name: "${name}", description: "d" };\n` +
   'return await agent("inspect", { label: "reviewer" });';
+type TelemetryPayload = {
+  event?: string;
+  properties?: Record<string, unknown>;
+};
+
+function captureTelemetryPayloads(): TelemetryPayload[] {
+  const payloads: TelemetryPayload[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_input, init) => {
+      payloads.push(JSON.parse(String(init?.body)) as TelemetryPayload);
+      return new Response(null, { status: 204 });
+    }),
+  );
+  return payloads;
+}
 
 beforeEach(() => {
   clearSessionScopes();
@@ -270,6 +286,7 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+  vi.unstubAllGlobals();
 });
 
 describe("workflow supervisor integration", () => {
@@ -529,7 +546,59 @@ describe("workflow supervisor integration", () => {
     expect(jobRegistry.has("fallback-child")).toBe(false);
   });
 
+  it.each(["model_resolution", "session_creation"] as const)(
+    "emits one in-process failure when %s preparation rejects",
+    async (failureStage) => {
+      const payloads = captureTelemetryPayloads();
+      const { context } = liveSessionContext({
+        id: 6,
+        sessionId: "session-a",
+      });
+      mockLaunch.mockImplementationOnce(() => {
+        throw new Error("mux unavailable");
+      });
+      mockStartSubagentJob.mockRejectedValueOnce(
+        annotateSpawnFailure(new Error("preparation failed"), failureStage),
+      );
+      const { pi, findTool } = makePi();
+      context.pi = pi as never;
+      registerWorkflowTool(pi as never, context);
+
+      try {
+        const result = await findTool().execute(
+          "call-preparation-failure",
+          {
+            script: SINGLE_AGENT_SCRIPT(`preparation-${failureStage}`),
+            async: false,
+          },
+          undefined,
+          vi.fn(),
+          { cwd: "/tmp", modelRegistry: {} },
+        );
+
+        expect(result.details.status).toBe("error");
+        const failures = payloads.filter(
+          (payload) =>
+            payload.event === "pi_subagentura_agent_spawn_failed" &&
+            payload.properties?.execution === "in-process",
+        );
+        expect(failures).toHaveLength(1);
+        expect(failures[0]?.properties).toMatchObject({
+          failure_stage: failureStage,
+        });
+        expect(
+          payloads.filter(
+            (payload) => payload.event === "pi_subagentura_agent_created",
+          ),
+        ).toHaveLength(0);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    },
+  );
+
   it("does not start an in-process child whose parent shut down mid-spawn", async () => {
+    const payloads = captureTelemetryPayloads();
     const { context } = liveSessionContext({ id: 7, sessionId: "session-a" });
     const start = vi.fn();
     const disposeBeforeStart = vi.fn();
@@ -568,13 +637,31 @@ describe("workflow supervisor integration", () => {
       disposeBeforeStart,
     });
 
-    const result = await execution;
+    try {
+      const result = await execution;
 
-    expect(start).not.toHaveBeenCalled();
-    expect(disposeBeforeStart).toHaveBeenCalledOnce();
-    expect(sessionAbort).toHaveBeenCalledOnce();
-    expect(jobRegistry.has("escaped-child")).toBe(false);
-    expect(result.details.status).toBe("error");
+      expect(start).not.toHaveBeenCalled();
+      expect(disposeBeforeStart).toHaveBeenCalledOnce();
+      expect(sessionAbort).toHaveBeenCalledOnce();
+      expect(jobRegistry.has("escaped-child")).toBe(false);
+      expect(result.details.status).toBe("error");
+      const failures = payloads.filter(
+        (payload) =>
+          payload.event === "pi_subagentura_agent_spawn_failed" &&
+          payload.properties?.execution === "in-process",
+      );
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.properties).toMatchObject({
+        failure_stage: "parent_shutdown",
+      });
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_agent_created",
+        ),
+      ).toHaveLength(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("leaves an unownable in-process child out of the registry", async () => {

--- a/tests/workflow-tree-ui.test.ts
+++ b/tests/workflow-tree-ui.test.ts
@@ -283,6 +283,8 @@ describe("WorkflowTreeComponent", () => {
 
     expect(abortSpy).toHaveBeenCalledTimes(1);
     expect(job.status).toBe("cancelled");
+    expect(job.telemetryTerminalReason).toBe("explicit_cancel");
+    expect(job.completedAt).toEqual(expect.any(Number));
     expect(job.snapshot.runningCount).toBe(0);
     expect(job.snapshot.agentRecords?.[0]?.status).toBe("cancelled");
     expect(notify).toHaveBeenCalledWith("Cancelled workflow wf_test.");

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   DEFAULT_WORKFLOW_OUTPUT_BUDGET,
   MAX_ITEMS_PER_CALL,
@@ -3942,7 +3943,10 @@ it("formats USD usage without floating-point artifacts", () => {
 });
 
 it("includes accumulated usage in async workflow error results", async () => {
-  const telemetryPayloads: Array<{ event?: string }> = [];
+  const telemetryPayloads: Array<{
+    event?: string;
+    properties?: Record<string, unknown>;
+  }> = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (_input, init) => {
@@ -4000,11 +4004,11 @@ it("includes accumulated usage in async workflow error results", async () => {
     });
     expect(result.content[0].text).toContain("↓7/20");
     expect(result.details.budgetTotal).toBe(20);
-    expect(
-      telemetryPayloads.filter(
-        (payload) => payload.event === "pi_subagentura_result_consumed",
-      ),
-    ).toHaveLength(0);
+    const reads = telemetryPayloads.filter(
+      (payload) => payload.event === "pi_subagentura_result_read",
+    );
+    expect(reads).toHaveLength(1);
+    expect(reads[0].properties?.outcome).toBe("error");
   } finally {
     vi.unstubAllGlobals();
     workflowJobRegistry.delete(job.id);
@@ -4012,9 +4016,12 @@ it("includes accumulated usage in async workflow error results", async () => {
   }
 });
 
-it("records only the first successful workflow result read", async () => {
+it("records successful and repeated workflow result reads", async () => {
   clearSessionScopes();
-  const telemetryPayloads: Array<{ event?: string }> = [];
+  const telemetryPayloads: Array<{
+    event?: string;
+    properties?: Record<string, unknown>;
+  }> = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (_input, init) => {
@@ -4055,11 +4062,14 @@ it("records only the first successful workflow result read", async () => {
     await getResult.execute("first", { workflowId: job.id });
     await getResult.execute("again", { workflowId: job.id });
 
-    expect(
-      telemetryPayloads.filter(
-        (payload) => payload.event === "pi_subagentura_result_consumed",
-      ),
-    ).toHaveLength(1);
+    const reads = telemetryPayloads.filter(
+      (payload) => payload.event === "pi_subagentura_result_read",
+    );
+    expect(reads).toHaveLength(2);
+    expect(reads.map((read) => read.properties?.outcome)).toEqual([
+      "consumed",
+      "already_consumed",
+    ]);
   } finally {
     vi.unstubAllGlobals();
     workflowJobRegistry.delete(job.id);
@@ -4787,5 +4797,561 @@ describe("canonical workflow usage formatting", () => {
       turns: 1,
     });
     expect(workflowUsageFromUsage(usage)).toBeUndefined();
+  });
+});
+describe("workflow aggregate telemetry", () => {
+  type Payload = {
+    event?: string;
+    properties?: Record<string, unknown>;
+  };
+  type WorkflowToolResult = {
+    details: { status?: string };
+    isError?: boolean;
+  };
+  type WorkflowToolDefinition = {
+    name: string;
+    execute: (
+      ...args: unknown[]
+    ) => WorkflowToolResult | Promise<WorkflowToolResult>;
+  };
+  type WorkflowTelemetryTestPi = {
+    registerTool: (definition: WorkflowToolDefinition) => void;
+    registerFlag: (...args: unknown[]) => void;
+    registerCommand: (...args: unknown[]) => void;
+    on: (...args: unknown[]) => void;
+  };
+
+  function makePi(tools: WorkflowToolDefinition[]): WorkflowTelemetryTestPi {
+    return {
+      registerTool: vi.fn((definition: WorkflowToolDefinition) =>
+        tools.push(definition),
+      ),
+      registerFlag: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+    };
+  }
+
+  function capturePayloads(): Payload[] {
+    const payloads: Payload[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        payloads.push(JSON.parse(String(init?.body)) as Payload);
+        return new Response(null, { status: 204 });
+      }),
+    );
+    return payloads;
+  }
+
+  function registerTelemetryScope(pi: WorkflowTelemetryTestPi, id: number) {
+    const scope = registerSessionScope({
+      id,
+      generation: 1,
+      lifecycle: "started",
+      pi: pi as unknown as ExtensionAPI,
+      telemetry: createTelemetrySession(true),
+    });
+    return { scope, owner: sessionOwner(scope) };
+  }
+
+  it("does not emit a start for pre-job validation failures", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: WorkflowToolDefinition[] = [];
+    const pi = makePi(tools);
+    const { scope } = registerTelemetryScope(pi, 1_100);
+    registerWorkflowTool(pi as unknown as ExtensionAPI, scope);
+    const workflow = tools.find((tool) => tool.name === "workflow")!;
+    const result = await workflow.execute(
+      "",
+      {
+        script:
+          'export const meta = { name: unknownName, description: "d" };\n' +
+          'return "never";',
+        async: true,
+      },
+      undefined,
+      undefined,
+      { cwd: "/tmp" },
+    );
+    try {
+      expect(result.isError).toBe(true);
+      expect(
+        payloads.filter(
+          (payload) => payload.event === "pi_subagentura_workflow_started",
+        ),
+      ).toHaveLength(0);
+    } finally {
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
+  });
+
+  it("emits one aggregate pair for foreground, background, and saved jobs", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: WorkflowToolDefinition[] = [];
+    const pi = makePi(tools);
+    const { owner } = registerTelemetryScope(pi, 1_101);
+    const script =
+      'export const meta = { name: "aggregate", description: "d" };\n' +
+      'return "ok";';
+    const start = (
+      mode: "async" | "sync",
+      invocation: "tool" | "saved_command",
+      completionPolicy: "inline" | "each",
+    ) =>
+      startWorkflowJob(
+        "aggregate",
+        script,
+        { runAgent: echoRunner() },
+        undefined,
+        undefined,
+        owner,
+        mode,
+        { invocation, async: mode === "async", completionPolicy },
+      );
+    const foreground = start("sync", "tool", "inline");
+    const background = start("async", "tool", "each");
+    const saved = start("async", "saved_command", "each");
+
+    try {
+      await Promise.all([
+        foreground.promise,
+        background.promise,
+        saved.promise,
+      ]);
+      const starts = payloads.filter(
+        (payload) => payload.event === "pi_subagentura_workflow_started",
+      );
+      const completions = payloads.filter(
+        (payload) => payload.event === "pi_subagentura_workflow_completed",
+      );
+      expect(starts).toHaveLength(3);
+      expect(completions).toHaveLength(3);
+      expect(starts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              invocation: "tool",
+              async: false,
+              completion_policy: "inline",
+            }),
+          }),
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              invocation: "tool",
+              async: true,
+              completion_policy: "each",
+            }),
+          }),
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              invocation: "saved_command",
+              async: true,
+              completion_policy: "each",
+            }),
+          }),
+        ]),
+      );
+      expect(
+        completions.every(
+          (payload) =>
+            payload.properties?.invocation === "tool" ||
+            payload.properties?.invocation === "saved_command",
+        ),
+      ).toBe(true);
+    } finally {
+      workflowJobRegistry.delete(background.id);
+      workflowJobRegistry.delete(saved.id);
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
+  });
+
+  it("classifies partial, thrown-error, and cancelled workflow settlements", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: WorkflowToolDefinition[] = [];
+    const pi = makePi(tools);
+    const { owner } = registerTelemetryScope(pi, 1_102);
+    const partial = startWorkflowJob(
+      "partial",
+      'export const meta = { name: "partial", description: "d" };\n' +
+        'return await parallel([() => agent("failed")]);',
+      { runAgent: async () => fail() },
+      undefined,
+      undefined,
+      owner,
+      "async",
+      { invocation: "tool", async: true, completionPolicy: "each" },
+    );
+    const thrown = startWorkflowJob(
+      "thrown",
+      'export const meta = { name: "thrown", description: "d" };\n' +
+        'throw new Error("workflow failure");',
+      { runAgent: echoRunner() },
+      undefined,
+      undefined,
+      owner,
+      "async",
+      { invocation: "tool", async: true, completionPolicy: "each" },
+    );
+    const cancellationController = new AbortController();
+    const cancelled = startWorkflowJob(
+      "cancelled",
+      'export const meta = { name: "cancelled", description: "d" };\n' +
+        'return await agent("waiting");',
+      {
+        signal: cancellationController.signal,
+        runAgent: ({ signal }) =>
+          new Promise<SubagentResult>((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => reject(new Error("agent aborted")),
+              { once: true },
+            );
+          }),
+      },
+      undefined,
+      undefined,
+      owner,
+      "async",
+      { invocation: "tool", async: true, completionPolicy: "each" },
+    );
+    cancelled.telemetryTerminalReason = "explicit_cancel";
+    cancellationController.abort();
+
+    try {
+      await partial.promise;
+      await expect(thrown.promise).rejects.toThrow("workflow failure");
+      await expect(cancelled.promise).rejects.toBeDefined();
+      const completions = payloads.filter(
+        (payload) => payload.event === "pi_subagentura_workflow_completed",
+      );
+      expect(completions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              status: "partial",
+              terminal_reason: "agent_error",
+            }),
+          }),
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              status: "error",
+              terminal_reason: "agent_error",
+            }),
+          }),
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              status: "cancelled",
+              terminal_reason: "explicit_cancel",
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      workflowJobRegistry.delete(partial.id);
+      workflowJobRegistry.delete(thrown.id);
+      workflowJobRegistry.delete(cancelled.id);
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
+  });
+
+  it("bounds counts and rounds aggregate duration", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: WorkflowToolDefinition[] = [];
+    const pi = makePi(tools);
+    const { owner } = registerTelemetryScope(pi, 1_103);
+    const now = vi.spyOn(Date, "now").mockReturnValue(2_501);
+    const job = startWorkflowJob(
+      "duration",
+      'export const meta = { name: "duration", description: "d" };\n' +
+        'return await agent("one");',
+      { runAgent: echoRunner() },
+      1_000,
+      undefined,
+      owner,
+      "async",
+      { invocation: "tool", async: true, completionPolicy: "each" },
+    );
+    try {
+      await job.promise;
+      const completion = payloads.find(
+        (payload) => payload.event === "pi_subagentura_workflow_completed",
+      );
+      expect(completion?.properties).toEqual(
+        expect.objectContaining({
+          duration_ms: 1_500,
+          duration_bucket: "1-5s",
+          agents_spawned: 1,
+          error_count: 0,
+        }),
+      );
+    } finally {
+      now.mockRestore();
+      workflowJobRegistry.delete(job.id);
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
+  });
+
+  it("records unavailable, empty, and wait-cancelled result reads", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: WorkflowToolDefinition[] = [];
+    const pi = makePi(tools);
+    const { scope, owner } = registerTelemetryScope(pi, 1_104);
+    registerWorkflowTool(pi as unknown as ExtensionAPI, scope);
+    const getResult = tools.find(
+      (tool) => tool.name === "get_workflow_result",
+    )!;
+    const unavailable = await getResult.execute("", {
+      workflowId: "missing",
+    });
+    expect(unavailable.details.status).toBe("not_found");
+
+    const empty = startWorkflowJob(
+      "empty",
+      'export const meta = { name: "empty", description: "d" };\nreturn "";',
+      { runAgent: echoRunner() },
+      undefined,
+      undefined,
+      owner,
+      "async",
+      { invocation: "tool", async: true, completionPolicy: "each" },
+    );
+    const blockedController = new AbortController();
+    const blocked = startWorkflowJob(
+      "blocked",
+      'export const meta = { name: "blocked", description: "d" };\n' +
+        'return await agent("blocked");',
+      {
+        signal: blockedController.signal,
+        runAgent: ({ signal }) =>
+          new Promise<SubagentResult>((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => reject(new Error("blocked aborted")),
+              { once: true },
+            );
+          }),
+      },
+      undefined,
+      undefined,
+      owner,
+      "async",
+      { invocation: "tool", async: true, completionPolicy: "each" },
+    );
+    await empty.promise;
+    await getResult.execute("", { workflowId: empty.id });
+    const waitController = new AbortController();
+    waitController.abort();
+    const wait = await getResult.execute(
+      "",
+      { workflowId: blocked.id },
+      waitController.signal,
+    );
+    expect(wait.details.status).toBe("wait_cancelled");
+    blockedController.abort();
+
+    try {
+      await expect(blocked.promise).rejects.toBeDefined();
+      const reads = payloads
+        .filter((payload) => payload.event === "pi_subagentura_result_read")
+        .map((payload) => payload.properties?.outcome);
+      expect(reads).toEqual(
+        expect.arrayContaining(["unavailable", "empty", "wait_cancelled"]),
+      );
+    } finally {
+      workflowJobRegistry.delete(empty.id);
+      workflowJobRegistry.delete(blocked.id);
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
+  });
+});
+
+describe("inline workflow telemetry", () => {
+  function capturePayloads(): Array<{
+    event?: string;
+    properties?: Record<string, unknown>;
+  }> {
+    const payloads: Array<{
+      event?: string;
+      properties?: Record<string, unknown>;
+    }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        payloads.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 204 });
+      }),
+    );
+    return payloads;
+  }
+
+  function registerTelemetryScopeForTest(
+    tools: Array<{ name: string; execute: Function }>,
+  ) {
+    const pi = {
+      registerTool: vi.fn((definition: { name: string; execute: Function }) =>
+        tools.push(definition),
+      ),
+      registerFlag: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+    };
+    const scope = registerSessionScope({
+      id: 1_200,
+      generation: 1,
+      lifecycle: "started",
+      pi: pi as never,
+      telemetry: createTelemetrySession(true),
+    });
+    registerWorkflowTool(pi as never, scope);
+    return {
+      workflow: tools.find((tool) => tool.name === "workflow")!,
+      owner: sessionOwner(scope),
+    };
+  }
+
+  it("emits consumed and empty reads for inline successes", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: Array<{ name: string; execute: Function }> = [];
+    const { workflow } = registerTelemetryScopeForTest(tools);
+    try {
+      await workflow.execute(
+        "",
+        {
+          script:
+            'export const meta = { name: "inline-consumed", description: "d" };\n' +
+            'return "result";',
+          async: false,
+        },
+        undefined,
+        undefined,
+        { cwd: "/tmp", modelRegistry: {} },
+      );
+      await workflow.execute(
+        "",
+        {
+          script:
+            'export const meta = { name: "inline-empty", description: "d" };\n' +
+            'return "";',
+          async: false,
+        },
+        undefined,
+        undefined,
+        { cwd: "/tmp", modelRegistry: {} },
+      );
+
+      const reads = payloads.filter(
+        (payload) => payload.event === "pi_subagentura_result_read",
+      );
+      expect(reads.map((read) => read.properties?.outcome)).toEqual([
+        "consumed",
+        "empty",
+      ]);
+      expect(
+        reads.every(
+          (read) => typeof read.properties?.read_latency_ms === "number",
+        ),
+      ).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
+  });
+
+  it("emits error and cancelled reads for inline terminal returns", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: Array<{ name: string; execute: Function }> = [];
+    const { workflow } = registerTelemetryScopeForTest(tools);
+    const cancelled = new AbortController();
+    cancelled.abort();
+    try {
+      const error = await workflow.execute(
+        "",
+        {
+          script:
+            'export const meta = { name: "inline-error", description: "d" };\n' +
+            'throw new Error("workflow failure");',
+          async: false,
+        },
+        undefined,
+        undefined,
+        { cwd: "/tmp", modelRegistry: {} },
+      );
+      const cancellation = await workflow.execute(
+        "",
+        {
+          script:
+            'export const meta = { name: "inline-cancelled", description: "d" };\n' +
+            'return "never";',
+          async: false,
+        },
+        cancelled.signal,
+        undefined,
+        { cwd: "/tmp", modelRegistry: {} },
+      );
+
+      expect(error.isError).toBe(true);
+      expect(cancellation.isError).toBe(true);
+      const reads = payloads.filter(
+        (payload) => payload.event === "pi_subagentura_result_read",
+      );
+      expect(reads.map((read) => read.properties?.outcome)).toEqual([
+        "error",
+        "cancelled",
+      ]);
+      expect(
+        reads.every(
+          (read) => typeof read.properties?.read_latency_ms === "number",
+        ),
+      ).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
+  });
+
+  it("maps only the workflow wall timer to timeout", async () => {
+    clearSessionScopes();
+    const payloads = capturePayloads();
+    const tools: Array<{ name: string; execute: Function }> = [];
+    const { owner } = registerTelemetryScopeForTest(tools);
+    const job = startWorkflowJob(
+      "wall-timeout",
+      'export const meta = { name: "wall-timeout", description: "d" };\nwhile (true) {}',
+      { runAgent: echoRunner(), workflowTimeoutMs: 20 },
+      undefined,
+      undefined,
+      owner,
+      "async",
+      { invocation: "tool", async: true, completionPolicy: "each" },
+    );
+    try {
+      await expect(job.promise).rejects.toThrow(/timed out/i);
+      const completion = payloads.find(
+        (payload) => payload.event === "pi_subagentura_workflow_completed",
+      );
+      expect(completion?.properties).toEqual(
+        expect.objectContaining({
+          status: "error",
+          terminal_reason: "timeout",
+        }),
+      );
+    } finally {
+      workflowJobRegistry.delete(job.id);
+      vi.unstubAllGlobals();
+      clearSessionScopes();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- bump the anonymous PostHog payload contract to schema version 3
- add closed, bounded `agent_spawn_failed` events with observable failure stages and spawn latency
- add terminal reasons to task completions across in-process, interactive, workflow, cancellation, process-exit, timeout, and fresh-session paths
- add aggregate `workflow_started` / `workflow_completed` events with status, duration, and bounded child/error counts
- add `session_recovered` events with eligible recovered/alive/terminal/unknown counts
- add maximum known completion-delivery latency and result-read latency buckets
- replace success-only `result_consumed` with closed `result_read` outcomes
- preserve queued work when optional analytics timestamps are malformed and preserve unknown latency for legacy recovered records
- document schema-v3 events, privacy limits, clock domains, and observability boundaries
- stabilize interactive launch failure mocks exposed by the latest-Pi CI run

## Privacy

Payloads remain session-anonymous and content-free. No prompts, tasks, personas, outputs, raw errors, paths, repository names, agent/job/workflow/session IDs, token/cost data, IP-derived identity, or stable installation IDs are added. Every new reason/stage/outcome is a closed enum; counts are bounded and durations are rounded/bucketed.

## Branch independence

This is a separate branch based directly on current `master` (`1863b10`) and does not depend on another feature branch. Master already contains PR #146.

## Validation

- `npm run typecheck`
- `npm test`: 82 files, 2,097 tests passed
- `npm run coverage:check`: 81 files, 2,087 tests passed
- `npm run test:unit`: 78 files, 2,041 tests passed
- `npm run format:check`
- `npm run pack:check`
- four independent review lanes accepted schema/privacy, spawn/terminal/read, workflow, and delivery/recovery behavior after remediation